### PR TITLE
Fixed a few issues around bootstrapping

### DIFF
--- a/scripts/dnxhost/dotnet-compile.cmd
+++ b/scripts/dnxhost/dotnet-compile.cmd
@@ -3,7 +3,7 @@ SETLOCAL
 SET ERRORLEVEL=
 
 REM makes testing easier for now
-set PATH=%PATH%;%~dp0
+set PATH=%ProgramFiles(x86)%\MSBuild\14.0\Bin;%PATH%;%~dp0
 
 dnx %DOTNET_OPTIONS% -p %~dp0..\..\src\Microsoft.DotNet.Tools.Compiler run %*
 

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -77,9 +77,9 @@ namespace Microsoft.DotNet.Cli.Utils
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 var extension = Path.GetExtension(executable);
-                if (!string.IsNullOrEmpty(executable))
+                if (!string.IsNullOrEmpty(extension))
                 {
-                    return string.Equals(executable, ".exe", StringComparison.Ordinal);
+                    return !string.Equals(extension, ".exe", StringComparison.Ordinal);
                 }
                 else if (executable.Contains(Path.DirectorySeparatorChar))
                 {

--- a/src/Microsoft.DotNet.Tools.Compiler/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/Program.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                 var projectDependency = dependency.Library as ProjectDescription;
                 if (projectDependency != null && !string.Equals(projectDependency.Identity.Name, context.RootProject.Identity.Name, StringComparison.Ordinal))
                 {
-                    var compileResult = Command.Create("dotnet-compile", $"--framework \"{projectDependency.Framework}\" --configuration \"{configuration}\" {projectDependency.Project.ProjectDirectory}")
+                    var compileResult = Command.Create("dotnet-compile", $"--framework {projectDependency.Framework} --configuration {configuration} {projectDependency.Project.ProjectDirectory}")
                         .ForwardStdOut()
                         .ForwardStdErr()
                         .RunAsync()


### PR DESCRIPTION
- Work aronud coreconsole issue in the bootstrap.cmd
- Use msbuild 14 roslyn csc until we have it
- Remove quoting args when building project refs, it wasn't working
- Fixed logic that launched exe's directly
