### PR TITLE
Explicitly specify NuGet.Config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,8 +25,8 @@ if test ! -e .nuget; then
 fi
 
 if test ! -d packages/KoreBuild; then
-    mono .nuget/nuget.exe install KoreBuild -ExcludeVersion -o packages -nocache -pre
-    mono .nuget/nuget.exe install Sake -ExcludeVersion -Out packages
+    mono .nuget/nuget.exe install KoreBuild -ExcludeVersion -o packages -nocache -pre -config NuGet.Config
+    mono .nuget/nuget.exe install Sake -ExcludeVersion -Out packages -config NuGet.Config
 fi
 
 if ! type dnvm > /dev/null 2>&1; then


### PR DESCRIPTION
The nuget install portion of build.sh is failing on Linux due to
apparently not reading NuGet.Config.  The script was depending on it
being implicitly picked up but it appears a casing issue was preventing
that from happening.

The current casing is NuGet.Config but it looks like nuget 3.2.0
recognizes only NuGet.config.  These two changes which update the casing
logic seem to come after 3.2.0
- https://github.com/NuGet/NuGet3/commit/39c7f5173f5acc5999fc7aaea436df449e72cce9
- https://github.com/NuGet/NuGet3/commit/fdf204fa74ab3a336eb0ce11ac4eb0e87309bb0d

For now passing the config file explicitly to work around this.
