### PR TITLE
Downgrade the runtime to -23413

### DIFF
--- a/src/Microsoft.DotNet.Cli/project.json
+++ b/src/Microsoft.DotNet.Cli/project.json
@@ -8,7 +8,7 @@
     "dotnet": "Microsoft.DotNet.Cli"
   },
   "dependencies": {
-    "Microsoft.NETCore.Runtime": "1.0.1-*",
+    "Microsoft.NETCore.Runtime": "1.0.1-beta-23413",
 
     "System.Console": "4.0.0-*",
     "System.Collections": "4.0.11-*",

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.TestHost": "1.0.0-*",
-    "Microsoft.NETCore.Runtime": "1.0.1-*",
+    "Microsoft.NETCore.Runtime": "1.0.1-beta-23413",
 
     "System.Console": "4.0.0-*",
     "System.Collections": "4.0.11-*",

--- a/src/Microsoft.DotNet.Tools.Compiler/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler/project.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.TestHost": "1.0.0-*",
-    "Microsoft.NETCore.Runtime": "1.0.1-*",
+    "Microsoft.NETCore.Runtime": "1.0.1-beta-23413",
 
     "System.Console": "4.0.0-*",
     "System.Collections": "4.0.11-*",

--- a/src/Microsoft.DotNet.Tools.Publish/project.json
+++ b/src/Microsoft.DotNet.Tools.Publish/project.json
@@ -8,7 +8,7 @@
     "dotnet-publish": "Microsoft.DotNet.Tools.Publish"
   },
   "dependencies": {
-    "Microsoft.NETCore.Runtime": "1.0.1-*",
+    "Microsoft.NETCore.Runtime": "1.0.1-beta-23413",
     "System.Console": "4.0.0-*",
     "System.Collections": "4.0.11-*",
     "System.Linq": "4.0.1-*",

--- a/src/Microsoft.DotNet.Tools.Resgen/project.json
+++ b/src/Microsoft.DotNet.Tools.Resgen/project.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.TestHost": "1.0.0-*",
-    "Microsoft.NETCore.Runtime": "1.0.1-*",
+    "Microsoft.NETCore.Runtime": "1.0.1-beta-23413",
     "System.Console": "4.0.0-*",
     "System.Collections": "4.0.11-*",
     "System.Linq": "4.0.1-*",


### PR DESCRIPTION
It appears the compiler is crashing with an ExecutionEngineException
while trying to load the resource satellite assembly on coreclr -23419 on Linux. Until
this is fixed we should downgrade to -23413.

Tracked by https://github.com/dotnet/roslyn/issues/6187
