### PR TITLE
Get ReadyToRun working on -23428

### DIFF
--- a/scripts/crossgen/crossgen_roslyn.cmd
+++ b/scripts/crossgen/crossgen_roslyn.cmd
@@ -8,27 +8,35 @@ popd
 REM Replace with a robust method for finding the right crossgen.exe
 set CROSSGEN_UTIL=%UserProfile%\.dnx\packages\runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR\1.0.1-beta-23428\tools\crossgen.exe
 
+REM Crossgen currently requires itself to be next to mscorlib
+copy %CROSSGEN_UTIL% /Y %BIN_DIR% > nul
+
 pushd %BIN_DIR%
 
-%CROSSGEN_UTIL% /nologo /Platform_Assemblies_Paths %BIN_DIR% System.Collections.Immutable.dll
+REM It must also be called mscorlib, not mscorlib.ni
+if exist mscorlib.ni.dll (
+    copy /Y mscorlib.ni.dll mscorlib.dll > nul
+)
+
+crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% System.Collections.Immutable.dll
 if not %errorlevel% EQU 0 goto fail
 
-%CROSSGEN_UTIL% /nologo /Platform_Assemblies_Paths %BIN_DIR% System.Reflection.Metadata.dll
+crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% System.Reflection.Metadata.dll
 if not %errorlevel% EQU 0 goto fail
 
-%CROSSGEN_UTIL% /nologo /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.dll
+crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.dll
 if not %errorlevel% EQU 0 goto fail
 
-%CROSSGEN_UTIL% /nologo /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.CSharp.dll
+crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.CSharp.dll
 if not %errorlevel% EQU 0 goto fail
 
-%CROSSGEN_UTIL% /nologo /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.VisualBasic.dll
+crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.VisualBasic.dll
 if not %errorlevel% EQU 0 goto fail
 
-%CROSSGEN_UTIL% /nologo /Platform_Assemblies_Paths %BIN_DIR% csc.exe
+crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% csc.exe
 if not %errorlevel% EQU 0 goto fail
 
-%CROSSGEN_UTIL% /nologo /Platform_Assemblies_Paths %BIN_DIR% vbc.exe
+crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% vbc.exe
 if not %errorlevel% EQU 0 goto fail
 
 popd


### PR DESCRIPTION
Implements some workarounds to get ReadyToRun working

1) copy crossgen to the output directory. This requirement makes it even more likely that we should implement `dotnet publish --include-tools`.

2) Rename mscorlib.ni.dll to mscorlib.dll.

/cc @davidfowl @anurse @brthor 
