### PR TITLE
[donotmerge] [osx] Detect the major/minor at runtime, instead of hard coding it

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -56,7 +56,8 @@ UNAME=$(uname)
 if [ -z "$RID" ]; then
     if [ "$UNAME" == "Darwin" ]; then
         OSNAME=osx
-        RID=osx.10.10-x64
+        MAJOR_MAC_VERSION=$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')
+        RID=osx.${MAJOR_MAC_VERSION}-x64
     elif [ "$UNAME" == "Linux" ]; then
         # Detect Distro?
         OSNAME=linux

--- a/scripts/dev-install.sh
+++ b/scripts/dev-install.sh
@@ -15,7 +15,8 @@ if [ -z "$RID" ]; then
     UNAME=$(uname)
     if [ "$UNAME" == "Darwin" ]; then
         OSNAME=osx
-        RID=osx.10.10-x64
+        MAJOR_MAC_VERSION=$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')
+        RID=osx.${MAJOR_MAC_VERSION}-x64
     elif [ "$UNAME" == "Linux" ]; then
         # Detect Distro?
         OSNAME=linux

--- a/scripts/dotnet-restore.sh
+++ b/scripts/dotnet-restore.sh
@@ -12,4 +12,11 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 # work around restore timeouts on Mono
 [ -z "$MONO_THREADS_PER_CPU" ] && export MONO_THREADS_PER_CPU=50
 
-exec "$DIR/dnx/dnx" "$DIR/dnx/lib/Microsoft.Dnx.Tooling/Microsoft.Dnx.Tooling.dll" "restore" --runtime "osx.10.10-x64" --runtime "ubuntu.14.04-x64" "$@"
+if [ "$(uname)" == "Darwin" ]; then
+  MAJOR_MAC_VERSION=$(sw_vers -productVersion | awk -F '.' '{print $1 "." $2}')
+  RUNTIME="osx.${MAJOR_MAC_VERSION}-x64"
+else
+  RUNTIME="ubuntu.14.04-x64"
+fi
+
+exec "$DIR/dnx/dnx" "$DIR/dnx/lib/Microsoft.Dnx.Tooling/Microsoft.Dnx.Tooling.dll" "restore" --runtime ${RUNTIME} "$@"

--- a/src/Microsoft.DotNet.ProjectModel/RuntimeIdentifier.cs
+++ b/src/Microsoft.DotNet.ProjectModel/RuntimeIdentifier.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.ProjectModel
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                return "osx.10.10-x64";
+                return "osx.10.11-x64";
             }
             return "unknown";
         }


### PR DESCRIPTION
The shell scripts are probably safe to merge, but the current RuntimeIdentifier.cs is horrible.  Given that we don't have OSVersion in .NET core, I'm not sure how we want to proceed.

This patch does let the tree build on El Capitan though.
