### PR TITLE
Fix cmake dependency on Ubuntu

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -12,15 +12,7 @@ RUN apt-get update && \
 RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | tee /etc/apt/sources.list.d/llvm.list && \
     curl http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update && \
-    apt-get install -y debhelper build-essential devscripts git liblttng-ust-dev lldb-3.6-dev lldb-3.6 clang
-
-# Install latest cmake
-RUN mkdir -p /opt/src/cmake && \
-    cd /opt/src/cmake && \
-    curl -O https://cmake.org/files/v3.4/cmake-3.4.0-rc2-Linux-x86_64.tar.gz && \
-    tar xzf cmake-3.4.0-rc2-Linux-x86_64.tar.gz && \
-    cd cmake-3.4.0-rc2-Linux-x86_64 && \
-    ln -s /opt/src/cmake/cmake-3.4.0-rc2-Linux-x86_64/bin/cmake /usr/local/bin/cmake
+    apt-get install -y debhelper build-essential devscripts git liblttng-ust-dev lldb-3.6-dev lldb-3.6 clang cmake
 
 # Use clang as c++ compiler
 RUN update-alternatives --set c++ /usr/bin/clang++

--- a/src/corehost/CMakeLists.txt
+++ b/src/corehost/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 2.6)
 project (corehost)
 set (CMAKE_CXX_STANDARD 11)
 include_directories(inc)
@@ -26,6 +26,11 @@ else()
 endif()
 
 add_executable(corehost ${SOURCES})
+
+# Older CMake doesn't support CMAKE_CXX_STANDARD and GCC/Clang need a switch to enable C++ 11
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "(Clang|GCC)")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     add_definitions(-D__LINUX__)


### PR DESCRIPTION
Ubuntu embeds a pre-3.1 version of cmake so I dropped the required version down and changed the use of `CMAKE_CXX_STANDARD` variable to have a fallback

@agocke this should fix your Ubuntu build issues (outside of docker)
