### PR TITLE
Dotnet commands command

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public static readonly string StaticLibSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".lib" : ".a" ;
         
-        public static readonly string CommandPrefix = "dotnet-";
+        public static readonly string CommandPrefix = "dotnet";
         public static readonly string CommandSearchPattern = CommandPrefix + "*";
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -23,5 +23,8 @@ namespace Microsoft.DotNet.Cli.Utils
                                                          RuntimeInformation.IsOSPlatform(OSPlatform.OSX)     ? ".dylib" : ".so";
 
         public static readonly string StaticLibSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".lib" : ".a" ;
+        
+        public static readonly string CommandPrefix = "dotnet-";
+        public static readonly string CommandSearchPattern = CommandPrefix + "*";
     }
 }

--- a/src/Microsoft.DotNet.Tools.Commands/Microsoft.DotNet.Tools.Commands.xproj
+++ b/src/Microsoft.DotNet.Tools.Commands/Microsoft.DotNet.Tools.Commands.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>0a309227-a9d8-4ddf-88dd-326b57b04378</ProjectGuid>
+    <RootNamespace>Microsoft.DotNet.Tools.Commands</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.DotNet.Tools.Commands/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Commands/Program.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Commands
         
         private static CommandLineApplication SetupApp()
         {
-             var app = new CommandLineApplication();
+            var app = new CommandLineApplication();
             app.Name = "dotnet commands";
             app.FullName = ".NET Commands Listing";
             app.Description = "List all available commands in the dotnet tool";
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Tools.Commands
 #if DEBUG
                 Console.Error.WriteLine(ex);
 #else
-                Console.Error.WriteLine(ex.Message);
+                Reporter.Error.WriteLine(ex.Message);
 #endif
                 return 1;
             }
@@ -56,12 +56,12 @@ namespace Microsoft.DotNet.Tools.Commands
         
         private static void PrintCommandList()
         {
-            List<string> availableCommands = GetAvailableCommands();
+            var availableCommands = GetAvailableCommands();
             availableCommands.Sort();
             
             PrintHeader();
             
-            foreach (string command in availableCommands)
+            foreach (var command in availableCommands)
             {
                 System.Console.WriteLine(command);
             }
@@ -69,25 +69,29 @@ namespace Microsoft.DotNet.Tools.Commands
         
         private static void PrintHeader()
         {
-            System.Console.WriteLine("Dotnet Tool Available Commands:");
+            System.Console.WriteLine("dotnet available commands:");
         }
         
         private static List<string> GetAvailableCommands()
         {
-            List<string> available = new List<string>();
+            var available = new List<string>();
             
-            string pathValue = Environment.GetEnvironmentVariable("PATH");
-            string[] pathDirs = pathValue.Split(Path.PathSeparator);
+            var pathValue = Environment.GetEnvironmentVariable("PATH");
+            var pathDirs = pathValue.Split(Path.PathSeparator);
             
-            foreach(string dir in pathDirs)
+            foreach(var dir in pathDirs)
             {
-                string[] files = Directory.GetFiles(dir, Constants.CommandSearchPattern);
-                
-                foreach(string filepath in files){
-                    string filename = Path.GetFileNameWithoutExtension(filepath);
-                    string commandName = FileNameToCommandName(filename);
+                if (Directory.Exists(dir))
+                {
+                    var files = Directory.GetFiles(dir, Constants.CommandSearchPattern);
                     
-                    available.Add(commandName);
+                    foreach(var filepath in files)
+                    {
+                        var filename = Path.GetFileNameWithoutExtension(filepath);
+                        var commandName = FileNameToCommandName(filename);
+                        
+                        available.Add(commandName);
+                    }
                 }
             }
             
@@ -96,7 +100,7 @@ namespace Microsoft.DotNet.Tools.Commands
         
         private static string FileNameToCommandName(string filename)
         {
-             return filename.Replace(Constants.CommandPrefix, "");
+             return filename.Replace(Constants.CommandPrefix + "-", "");
         }
         
     }

--- a/src/Microsoft.DotNet.Tools.Commands/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Commands/Program.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.Dnx.Runtime.Common.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Common;
+
+namespace Microsoft.DotNet.Tools.Commands
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            DebugHelper.HandleDebugSwitch(ref args);
+            
+            var app = SetupApp();
+            return Execute(app, args);
+        }
+        
+        private static CommandLineApplication SetupApp()
+        {
+             var app = new CommandLineApplication();
+            app.Name = "dotnet commands";
+            app.FullName = ".NET Commands Listing";
+            app.Description = "List all available commands in the dotnet tool";
+            app.HelpOption("-h|--help");
+
+            app.OnExecute(() =>
+            {
+                PrintCommandList();
+                
+                return 0;
+            });
+            
+            return app;
+        }
+        
+        private static int Execute(CommandLineApplication app, string[] args)
+        {
+            try
+            {
+                return app.Execute(args);
+            }
+            catch (Exception ex)
+            {
+#if DEBUG
+                Console.Error.WriteLine(ex);
+#else
+                Console.Error.WriteLine(ex.Message);
+#endif
+                return 1;
+            }
+        }
+        
+        private static void PrintCommandList()
+        {
+            List<string> availableCommands = GetAvailableCommands();
+            availableCommands.Sort();
+            
+            PrintHeader();
+            
+            foreach (string command in availableCommands)
+            {
+                System.Console.WriteLine(command);
+            }
+        }
+        
+        private static void PrintHeader()
+        {
+            System.Console.WriteLine("Dotnet Tool Available Commands:");
+        }
+        
+        private static List<string> GetAvailableCommands()
+        {
+            List<string> available = new List<string>();
+            
+            string pathValue = Environment.GetEnvironmentVariable("PATH");
+            string[] pathDirs = pathValue.Split(Path.PathSeparator);
+            
+            foreach(string dir in pathDirs)
+            {
+                string[] files = Directory.GetFiles(dir, Constants.CommandSearchPattern);
+                
+                foreach(string filepath in files){
+                    string filename = Path.GetFileNameWithoutExtension(filepath);
+                    string commandName = FileNameToCommandName(filename);
+                    
+                    available.Add(commandName);
+                }
+            }
+            
+            return available;
+        }
+        
+        private static string FileNameToCommandName(string filename)
+        {
+             return filename.Replace(Constants.CommandPrefix, "");
+        }
+        
+    }
+}

--- a/src/Microsoft.DotNet.Tools.Commands/project.json
+++ b/src/Microsoft.DotNet.Tools.Commands/project.json
@@ -1,0 +1,30 @@
+﻿{
+  "name": "dotnet-commands",
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "commands": {
+    "dotnet-commands": "Microsoft.DotNet.Tools.Commands"
+  },
+  "dependencies": {
+    "Microsoft.NETCore.Runtime": "1.0.1-beta-23428",
+    "System.Console": "4.0.0-beta-23428",
+    "System.Collections": "4.0.11-beta-23428",
+    "System.Linq": "4.0.1-beta-23428",
+    "System.Diagnostics.Process": "4.1.0-beta-23428",
+    "System.IO.FileSystem": "4.0.1-beta-23428",
+
+    "Microsoft.DotNet.Cli.Utils": {
+      "type": "build",
+      "version": "1.0.0-*"
+    },
+    "Microsoft.Extensions.CommandLineUtils.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    }
+  },
+  "frameworks": {
+    "dnxcore50": { }
+  }
+}

--- a/src/Microsoft.DotNet.Tools.Commands/project.json
+++ b/src/Microsoft.DotNet.Tools.Commands/project.json
@@ -8,12 +8,12 @@
     "dotnet-commands": "Microsoft.DotNet.Tools.Commands"
   },
   "dependencies": {
-    "Microsoft.NETCore.Runtime": "1.0.1-beta-23428",
-    "System.Console": "4.0.0-beta-23428",
-    "System.Collections": "4.0.11-beta-23428",
-    "System.Linq": "4.0.1-beta-23428",
-    "System.Diagnostics.Process": "4.1.0-beta-23428",
-    "System.IO.FileSystem": "4.0.1-beta-23428",
+    "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
+    "System.Console": "4.0.0-beta-23504",
+    "System.Collections": "4.0.11-beta-23504",
+    "System.Linq": "4.0.1-beta-23504",
+    "System.Diagnostics.Process": "4.1.0-beta-23504",
+    "System.IO.FileSystem": "4.0.1-beta-23504",
 
     "Microsoft.DotNet.Cli.Utils": {
       "type": "build",


### PR DESCRIPTION
This is a command to list out all the available commands by searching the path for any files with a "dotnet-" prefix.

I had a short bash script doing this at one point but thought it should probably be a CoreCLR app like the rest of our commands.

Resolves #2 

/cc @piotrpMSFT @anurse @davidfowl 