### PR TITLE
Set the app base in dotnet-run

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -78,12 +78,12 @@ export PATH=$STAGE1_DIR:$START_PATH
 [ -d "$STAGE2_DIR" ] && rm -Rf "$STAGE2_DIR"
 
 banner "Building stage2 dotnet using compiled stage1 ..."
-dotnet publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Cli"
-dotnet publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Compiler"
-dotnet publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Compiler.Csc"
-dotnet publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Publish"
-dotnet publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Resgen"
-dotnet publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Run"
+dotnet -v publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Cli"
+dotnet -v publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Compiler"
+dotnet -v publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Compiler.Csc"
+dotnet -v publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Publish"
+dotnet -v publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Resgen"
+dotnet -v publish --framework "$TFM" --runtime $RID --output "$STAGE2_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Tools.Run"
 
 echo "Crossgenning Roslyn compiler ..."
 $REPOROOT/scripts/crossgen/crossgen_roslyn.sh "$STAGE2_DIR"

--- a/src/Microsoft.DotNet.Tools.Run/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Run/Program.cs
@@ -102,7 +102,8 @@ namespace Microsoft.DotNet.Tools.Run
             result = Command.Create(outputName, string.Join(" ", remainingArguments))
                 .ForwardStdOut()
                 .ForwardStdErr()
-                .EnvironmentVariable("CLRHOST_CLR_PATH", AppContext.BaseDirectory)
+                .EnvironmentVariable("COREHOST_CLR_PATH", AppContext.BaseDirectory)
+                .EnvironmentVariable("COREHOST_APP_BASE", context.ProjectDirectory)
                 .Execute();
 
             // Clean up

--- a/src/corehost/inc/args.h
+++ b/src/corehost/inc/args.h
@@ -10,6 +10,7 @@ struct arguments_t
     pal::string_t own_path;
     pal::string_t managed_application;
     pal::string_t clr_path;
+    pal::string_t app_base;
 
     int app_argc;
     const pal::char_t** app_argv;

--- a/src/corehost/src/args.cpp
+++ b/src/corehost/src/args.cpp
@@ -6,18 +6,84 @@ arguments_t::arguments_t() :
     managed_application(_X("")),
     clr_path(_X("")),
     app_argc(0),
-    app_argv(nullptr)
+    app_argv(nullptr),
+    app_base(_X(""))
 {
 }
 
 void display_help()
 {
     xerr <<
-        _X("Usage: " HOST_EXE_NAME " [ASSEMBLY] [ARGUMENTS]\n")
+        _X("Usage: " HOST_EXE_NAME " [OPTIONS] [ASSEMBLY] [ARGUMENTS]\n")
         _X("Execute the specified managed assembly with the passed in arguments\n\n")
-        _X("The Host's behavior can be altered using the following environment variables:\n")
-        _X(" CLRHOST_CLR_PATH       Set the directory which contains the CoreCLR runtime. Overrides all other values for CLR search paths\n")
-        _X(" CLRHOST_TRACE          Set to affect trace levels (0 = Errors only (default), 1 = Warnings, 2 = Info, 3 = Verbose)\n");
+        _X("Options:\n")
+        _X(" -c,--clr-path <PATH>   Set the directory which contains the CoreCLR runtime. Overrides all other values for CLR search paths\n")
+        _X(" -a,--app-base <PATH>   Set the application base path\n")
+        _X(" -t,--trace <LEVEL>     Set the trace level emitted by corehost (0 = Errors only (default), 1 = Warnings, 2 = Info, 3 = Verbose)\n");
+        _X("\n")
+        _X("The Host's behavior can also be altered using the following environment variables:\n")
+        _X(" COREHOST_CLR_PATH      Set the directory which contains the CoreCLR runtime. Overrides default search paths, but NOT the -c option\n")
+        _X(" COREHOST_TRACE         Set the trace level emitted by corehost (0 = Errors only (default), 1 = Warnings, 2 = Info, 3 = Verbose)\n");
+}
+
+bool is_arg(const pal::char_t* value, const pal::char_t* short_name, const pal::char_t* long_name)
+{
+    return pal::strcmp(value, short_name) == 0 || pal::strcmp(value, long_name) == 0;
+}
+
+int parse_command_line(const int argc, const pal::char_t* argv[], arguments_t& args, pal::string_t& trace_string)
+{
+    for (int i = 1; i < argc; i++)
+    {
+        if (is_arg(argv[i], _X("-c"), _X("--clr-path")))
+        {
+            i++;
+            if (i >= argc)
+            {
+                trace::error(_X("argument `--clr-path` must have a value"));
+                return -1;
+            }
+            args.clr_path.assign(argv[i]);
+        }
+        else if(is_arg(argv[i], _X("-a"), _X("--app-base")))
+        {
+            i++;
+            if (i >= argc)
+            {
+                trace::error(_X("argument `--app-base` must have a value"));
+                return -1;
+            }
+            args.app_base.assign(argv[i]);
+        }
+        else if(is_arg(argv[i], _X("-t"), _X("--trace")))
+        {
+            i++;
+            if (i >= argc)
+            {
+                trace::error(_X("argument `--app-base` must have a value"));
+                return -1;
+            }
+            trace_string.assign(argv[i]);
+        }
+        else if(argv[i][0] == '-')
+        {
+            // Some unknown option
+            trace::error(_X("unknown option: `%s`"), argv[i]);
+            return -1;
+        }
+        else
+        {
+            // End of options! i is the managed application
+            args.managed_application.assign(argv[i]);
+
+            // i + 1 is the first managed application arg
+            return i + 1;
+        }
+    }
+
+    // Reached the end without a managed application
+    trace::error(_X("missing path to the managed application to run"));
+    return -1;
 }
 
 bool parse_arguments(const int argc, const pal::char_t* argv[], arguments_t& args)
@@ -29,20 +95,26 @@ bool parse_arguments(const int argc, const pal::char_t* argv[], arguments_t& arg
         return false;
     }
 
+    // Read environment variables
+    pal::string_t trace_str;
+    pal::getenv(_X("COREHOST_TRACE"), trace_str);
+    pal::getenv(_X("COREHOST_CLR_PATH"), args.clr_path);
+
     auto own_name = get_filename(args.own_path);
     auto own_dir = get_directory(args.own_path);
 
     if (own_name.compare(HOST_EXE_NAME) == 0)
     {
-        // corerun mode. First argument is managed app
-        if (argc < 2)
+        // The host exe is named corehost, which means we support command-line args and
+        // expect the managed app to be one
+        auto first_app_arg = parse_command_line(argc, argv, args, trace_str);
+        if (first_app_arg < 0)
         {
             display_help();
             return false;
         }
-        args.managed_application = pal::string_t(argv[1]);
-        args.app_argc = argc - 2;
-        args.app_argv = &argv[2];
+        args.app_argc = argc - first_app_arg;
+        args.app_argv = &argv[first_app_arg];
     }
     else
     {
@@ -56,9 +128,19 @@ bool parse_arguments(const int argc, const pal::char_t* argv[], arguments_t& arg
         args.app_argc = argc - 1;
     }
 
-    // Read trace environment variable
-    pal::string_t trace_str;
-    if (pal::getenv(_X("CLRHOST_TRACE"), trace_str))
+    if (!args.clr_path.empty() && !pal::realpath(args.clr_path))
+    {
+        trace::error(_X("clr path `%s` could not be located"), args.clr_path.c_str());
+        return -1;
+    }
+
+    if (!args.app_base.empty() && !pal::realpath(args.app_base))
+    {
+        trace::error(_X("app base `%s` could not be located"), args.app_base.c_str());
+        return -1;
+    }
+
+    if (!trace_str.empty())
     {
         auto trace_val = pal::xtoi(trace_str.c_str());
         if (trace_val >= (int)trace::level_t::Error && trace_val <= (int)trace::level_t::Verbose)
@@ -66,9 +148,6 @@ bool parse_arguments(const int argc, const pal::char_t* argv[], arguments_t& arg
             args.trace_level = (trace::level_t)trace_val;
         }
     }
-
-    // Read CLR path from environment variable
-    pal::getenv(_X("CLRHOST_CLR_PATH"), args.clr_path);
 
     return true;
 }

--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Diagnostics;
 
 namespace TestApp
@@ -8,6 +9,12 @@ namespace TestApp
         public static void Main(string[] args)
         {
             Console.WriteLine(TestLibrary.Helper.GetMessage());
+
+            var filePath = Path.Combine(AppContext.BaseDirectory, "TestFile.txt");
+            if (File.Exists(filePath))
+            {
+                Console.WriteLine(File.ReadAllText(filePath));
+            }
         }
     }
 }

--- a/test/TestApp/TestFile.txt
+++ b/test/TestApp/TestFile.txt
@@ -1,0 +1,1 @@
+This is the test file

--- a/test/TestApp/project.json
+++ b/test/TestApp/project.json
@@ -7,6 +7,8 @@
     "dependencies": {
         "TestLibrary": { "target": "project" },
         "System.IO": "4.0.11-beta-23420",
+        "System.IO.FileSystem": "4.0.1-beta-23420",
+        "System.AppContext": "4.0.1-beta-23420",
         "System.Console": "4.0.0-beta-23420",
         "System.Runtime": "4.0.21-beta-23420",
         "System.Diagnostics.Process": "4.1.0-beta-23420",


### PR DESCRIPTION
Even though we execute in a temp folder, we want the app base to be the project directory so that any assets uses by the project are available (i.e. the same things we'd copy to the output directory).

/cc @davidfowl 
