### PR TITLE
Fix nuget warnings by ugrading the references to 23504.

### DIFF
--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -3,8 +3,8 @@
 
   "dependencies": {
     "System.CommandLine": "0.1.0-*",
-    "System.Linq": "4.0.1-beta-23502",
-    "System.Runtime": "4.0.21-beta-23502",
+    "System.Linq": "4.0.1-beta-23504",
+    "System.Runtime": "4.0.21-beta-23504",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*"
   },
 


### PR DESCRIPTION
This project.json was missed when the update was done before.
