### PR TITLE
Pass all the VSO environment variables to the docker instance.

### DIFF
--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -27,7 +27,7 @@ info "Using code from: $DOCKER_HOST_SHARE_DIR"
 docker run -t --rm --sig-proxy=true \
     --name $DOTNET_BUILD_CONTAINER_NAME \
     -v $DOCKER_HOST_SHARE_DIR:/opt/code \
-    -e DOTNET_BUILD_VERSION=$DOTNET_BUILD_VERSION \
+    -e DOTNET_BUILD_VERSION \
     -e SASTOKEN \
     -e STORAGE_ACCOUNT \
     -e STORAGE_CONTAINER \


### PR DESCRIPTION
These variables are required by the publish scripts to upload artifacts to azure blob storage.
