### PR TITLE
Update Microsoft.Net.CSharp.Interactive.netcore version

### DIFF
--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
@@ -22,7 +22,7 @@
             "version": "1.0.0-*"
         },
         "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
-        "Microsoft.Net.Compilers.netcore": "1.1.0-*"
+        "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151106-02"
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Repl.Csi/project.json
+++ b/src/Microsoft.DotNet.Tools.Repl.Csi/project.json
@@ -22,7 +22,7 @@
       "type": "build",
       "version": "1.0.0-*"
     },
-    "Microsoft.Net.CSharp.Interactive.netcore": "1.1.0-*"
+    "Microsoft.Net.CSharp.Interactive.netcore": "1.2.0-beta-20151106-02"
   },
   "frameworks": {
     "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Run/project.json
+++ b/src/Microsoft.DotNet.Tools.Run/project.json
@@ -22,7 +22,7 @@
       "type": "build",
       "version": "1.0.0-*"
     },
-    "Microsoft.Net.Compilers.netcore": "1.1.0-*"
+    "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151106-02"
   },
   "frameworks": {
     "dnxcore50": { }


### PR DESCRIPTION
csi.exe requires a more recent version of Microsoft.CodeAnalysis.dll.
