### PR TITLE
update NuGet.Packaging reference

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,7 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
     <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -11,7 +11,7 @@
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23504",
     "System.Security.Cryptography.Algorithms": "4.0.0-beta-23504",
 
-    "NuGet.Packaging": "3.2.0",
+    "NuGet.Packaging": "3.3.0-*",
 
     "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15791",
     "Microsoft.Extensions.JsonParser.Sources": {


### PR DESCRIPTION
This fixes an issue where ".NETPlatform, Version=X.Y" was being rendered as `dotnetXY` instead of the correct `dotnetX.Y`.

/cc @piotrpMSFT @davidfowl 
