### PR TITLE
Upgrade compiler version and fix crossgen

### DIFF
--- a/scripts/crossgen/crossgen_roslyn.cmd
+++ b/scripts/crossgen/crossgen_roslyn.cmd
@@ -33,10 +33,10 @@ if not %errorlevel% EQU 0 goto fail
 crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.VisualBasic.dll >nul 2>nul
 if not %errorlevel% EQU 0 goto fail
 
-crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% csc.exe >nul 2>nul
+crossgen /MissingDependenciesOK /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% csc.exe >nul 2>nul
 if not %errorlevel% EQU 0 goto fail
 
-crossgen /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% vbc.exe >nul 2>nul
+crossgen /MissingDependenciesOK /nologo /ReadyToRun /Platform_Assemblies_Paths %BIN_DIR% vbc.exe >nul 2>nul
 if not %errorlevel% EQU 0 goto fail
 
 popd

--- a/scripts/crossgen/crossgen_roslyn.sh
+++ b/scripts/crossgen/crossgen_roslyn.sh
@@ -38,7 +38,7 @@ chmod +x crossgen
 
 ./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.VisualBasic.dll 
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR csc.exe 
+./crossgen -MissingDependenciesOK -nologo -platform_assemblies_paths $BIN_DIR csc.exe
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR vbc.exe 
+./crossgen -MissingDependenciesOK -nologo -platform_assemblies_paths $BIN_DIR vbc.exe
 

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
@@ -1,30 +1,30 @@
 {
-    "name": "dotnet-compile-csc",
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-    "dependencies": {
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
+  "name": "dotnet-compile-csc",
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
 
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "System.IO.FileSystem": "4.0.1-beta-23504",
+    "System.Console": "4.0.0-beta-23504",
+    "System.Collections": "4.0.11-beta-23504",
+    "System.Linq": "4.0.1-beta-23504",
+    "System.Diagnostics.Process": "4.1.0-beta-23504",
+    "System.IO.FileSystem": "4.0.1-beta-23504",
 
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
-        "Microsoft.Extensions.CommandLineUtils.Sources": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
-        "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
-        "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151106-02"
+    "Microsoft.DotNet.Cli.Utils": {
+      "type": "build",
+      "version": "1.0.0-*"
     },
-    "frameworks": {
-        "dnxcore50": { }
-    }
+    "Microsoft.Extensions.CommandLineUtils.Sources": {
+      "type": "build",
+      "version": "1.0.0-*"
+    },
+    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
+    "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151111-02"
+  },
+  "frameworks": {
+    "dnxcore50": { }
+  }
 }

--- a/src/Microsoft.DotNet.Tools.Run/project.json
+++ b/src/Microsoft.DotNet.Tools.Run/project.json
@@ -1,30 +1,30 @@
-﻿{
-  "name": "dotnet-run",
-  "version": "1.0.0-*",
-  "compilationOptions": {
-    "emitEntryPoint": true
-  },
-  "dependencies": {
-    "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
-
-    "System.Console": "4.0.0-beta-23504",
-    "System.Collections": "4.0.11-beta-23504",
-    "System.Linq": "4.0.1-beta-23504",
-    "System.Diagnostics.Process": "4.1.0-beta-23504",
-    "System.IO.FileSystem": "4.0.1-beta-23504",
-
-    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.DotNet.Cli.Utils": {
-      "type": "build",
-      "version": "1.0.0-*"
+{
+    "name": "dotnet-run",
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
     },
-    "Microsoft.Extensions.CommandLineUtils.Sources": {
-      "type": "build",
-      "version": "1.0.0-*"
+    "dependencies": {
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
+
+        "System.Console": "4.0.0-beta-23504",
+        "System.Collections": "4.0.11-beta-23504",
+        "System.Linq": "4.0.1-beta-23504",
+        "System.Diagnostics.Process": "4.1.0-beta-23504",
+        "System.IO.FileSystem": "4.0.1-beta-23504",
+
+        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+        "Microsoft.DotNet.Cli.Utils": {
+            "type": "build",
+            "version": "1.0.0-*"
+        },
+        "Microsoft.Extensions.CommandLineUtils.Sources": {
+            "type": "build",
+            "version": "1.0.0-*"
+        },
+        "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151111-02"
     },
-    "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151106-02"
-  },
-  "frameworks": {
-    "dnxcore50": { }
-  }
+    "frameworks": {
+        "dnxcore50": { }
+    }
 }


### PR DESCRIPTION
The latest compiler nugets have missing dependencies, so
this temporarily turns on -MissingDependenciesOK for crossgen.

Fix coming for the NuGet package.
