### PR TITLE
Don't require all dotnet tools to be on the path

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -5,8 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
-using Microsoft.Dnx.Runtime.Common.CommandLine;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -49,6 +47,20 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public static Command Create(string executable, string args)
         {
+            ResolveExecutablePath(ref executable, ref args);
+
+            return new Command(executable, args);
+        }
+
+        private static void ResolveExecutablePath(ref string executable, ref string args)
+        {
+            var fullExecutable = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, executable + Constants.ExeSuffix));
+
+            if (File.Exists(fullExecutable))
+            {
+                executable = fullExecutable;
+            }
+
             // On Windows, we want to avoid using "cmd" if possible (it mangles the colors, and a bunch of other things)
             // So, do a quick path search to see if we can just directly invoke it
             var useCmd = ShouldUseCmd(executable);
@@ -66,14 +78,17 @@ namespace Microsoft.DotNet.Cli.Utils
                 args = $"/C \"{executable}\"";
                 executable = comSpec;
             }
-
-            return new Command(executable, args);
         }
 
         private static bool ShouldUseCmd(string executable)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                if (Path.IsPathRooted(executable))
+                {
+                    return false;
+                }
+
                 var extension = Path.GetExtension(executable);
                 if (!string.IsNullOrEmpty(extension))
                 {

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -84,11 +84,6 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                if (Path.IsPathRooted(executable))
-                {
-                    return false;
-                }
-
                 var extension = Path.GetExtension(executable);
                 if (!string.IsNullOrEmpty(extension))
                 {

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -4,6 +4,7 @@
     "shared": "**/*.cs",
 
     "dependencies": {
+        "System.AppContext": "4.0.0-beta-23504",
         "System.Console": "4.0.0-beta-23504",
         "System.IO.FileSystem": "4.0.1-beta-23504",
         "System.Diagnostics.Process": "4.1.0-beta-23504",


### PR DESCRIPTION
- Try resolving full path to executable in the local directory first.

#186