### PR TITLE
Fix Symlinks to dotnet binaries

### DIFF
--- a/debian_config.json
+++ b/debian_config.json
@@ -40,6 +40,7 @@
         "bin/dotnet-repl-csi" : "usr/bin/dotnet-repl-csi",
         "bin/dotnet-restore" : "usr/bin/dotnet-restore",
         "bin/dotnet-compile-native" : "/usr/bin/dotnet-compile-native",
-        "bin/resgen" : "usr/bin/resgen"
+        "bin/resgen" : "usr/bin/resgen",
+	"bin/dotnet-init":"usr/bin/dotnet-init"
     }
 }


### PR DESCRIPTION
Just like it sounds. The restructuring caused the deb package to be totally unusable.
