### PR TITLE
Fixes for dotnet compile --native.

### DIFF
--- a/scripts/build/build_appdeps.cmd
+++ b/scripts/build/build_appdeps.cmd
@@ -12,10 +12,20 @@ pushd %1
 set __OutputPath=%CD%\bin
 popd
 
+
+rmdir /S /Q %AppDepsProjectDir%\packages
+
 pushd %__AppDepsProjectDir%
 dotnet restore --packages %AppDepsProjectDir%\packages
-set __AppDepSDK=%AppDepsProjectDir%\packages\toolchain*\*\
+set __AppDepSDK=%AppDepsProjectDir%\packages\toolchain*\
 popd
 
 mkdir %__OutputPath%\appdepsdk
-xcopy /S/E/H/Y %__AppDepSDK% %__OutputPath%\appdepsdk
+cd %__AppDepSDK%
+FOR /D %%a IN (*) DO (
+  CD %%a
+  GOTO :Copy
+)
+
+:Copy
+xcopy /S/E/H/Y * %__OutputPath%\appdepsdk

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/DirectoryExtensions.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/DirectoryExtensions.cs
@@ -29,6 +29,10 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
                     Console.WriteLine(e.Message);
                 }
             }
+            else
+            {
+                Directory.CreateDirectory(path);
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             
             // Add Includes
             argsList.Add("/I");
-            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk\\Windows_NT"));
+            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk\\win7"));
             
             argsList.Add("/I");
             argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk"));

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
@@ -10,19 +10,19 @@ using Microsoft.DotNet.Tools.Common;
 
 namespace Microsoft.DotNet.Tools.Compiler.Native
 {
-	public class WindowsLinkStep : IPlatformNativeStep
-	{
-		private readonly string LinkerName = "link.exe";
-		private readonly string LinkerOutputExtension = ".exe";
+    public class WindowsLinkStep : IPlatformNativeStep
+    {
+        private readonly string LinkerName = "link.exe";
+        private readonly string LinkerOutputExtension = ".exe";
         private readonly string VSBin = "..\\..\\VC\\bin\\amd64";
 
         private readonly string InputExtension = ".obj";
 
         private static readonly Dictionary<BuildConfiguration, string> ConfigurationLinkerOptionsMap = new Dictionary<BuildConfiguration, string>
-		{
-			{ BuildConfiguration.debug, "/NOLOGO /ERRORREPORT:PROMPT /MANIFEST /MANIFESTUAC:\"level='asInvoker' uiAccess='false'\" /manifest:embed /Debug /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT" },
-			{ BuildConfiguration.release, "/NOLOGO /ERRORREPORT:PROMPT /INCREMENTAL:NO /OPT:REF /OPT:ICF /LTCG:incremental /MANIFEST /MANIFESTUAC:\"level='asInvoker' uiAccess='false'\" /manifest:embed /Debug /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT" }
-		};
+        {
+            { BuildConfiguration.debug, "/NOLOGO /ERRORREPORT:PROMPT /MANIFEST /MANIFESTUAC:\"level='asInvoker' uiAccess='false'\" /manifest:embed /Debug /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT" },
+            { BuildConfiguration.release, "/NOLOGO /ERRORREPORT:PROMPT /INCREMENTAL:NO /OPT:REF /OPT:ICF /LTCG:incremental /MANIFEST /MANIFESTUAC:\"level='asInvoker' uiAccess='false'\" /manifest:embed /Debug /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT" }
+        };
 
         private static readonly Dictionary<NativeIntermediateMode, string[]> ModeLibMap = new Dictionary<NativeIntermediateMode, string[]>
         {
@@ -48,108 +48,108 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         private static readonly Dictionary<BuildConfiguration, string[]> ConfigurationLinkLibMap = new Dictionary<BuildConfiguration, string[]>()
         {
-        	{ BuildConfiguration.debug , new string[] { "msvcrtd.lib" } },
-        	{ BuildConfiguration.release , new string[] { "msvcrt.lib" } }
+            { BuildConfiguration.debug , new string[] { "msvcrtd.lib" } },
+            { BuildConfiguration.release , new string[] { "msvcrt.lib" } }
         };
-		
-		private string ArgStr { get; set; }
-		private NativeCompileSettings config;
-		
-		public WindowsLinkStep(NativeCompileSettings config)
-		{
-			this.config = config;
-			InitializeArgs(config);
-		}
-		
-		public int Invoke()
-		{
-			var result = WindowsCommon.SetVCVars();
-			if (result != 0)
-			{
-				Reporter.Error.WriteLine("vcvarsall.bat invocation failed.");
-				return result;
-			}
-			
-			result = InvokeLinker();
-			if (result != 0)
-			{
+        
+        private string ArgStr { get; set; }
+        private NativeCompileSettings config;
+        
+        public WindowsLinkStep(NativeCompileSettings config)
+        {
+            this.config = config;
+            InitializeArgs(config);
+        }
+        
+        public int Invoke()
+        {
+            var result = WindowsCommon.SetVCVars();
+            if (result != 0)
+            {
+                Reporter.Error.WriteLine("vcvarsall.bat invocation failed.");
+                return result;
+            }
+            
+            result = InvokeLinker();
+            if (result != 0)
+            {
                 Reporter.Error.WriteLine("Linking of intermediate files failed.");
-			}
-			return result;
-		}
-		
-		public bool CheckPreReqs()
-		{
+            }
+            return result;
+        }
+        
+        public bool CheckPreReqs()
+        {
             var vcInstallDir = Environment.GetEnvironmentVariable("VS140COMNTOOLS");
             return !string.IsNullOrEmpty(vcInstallDir);
         }
-		
-		private void InitializeArgs(NativeCompileSettings config)
-		{
-			var argsList = new List<string>();
-			
-			// Configuration Based Linker Options 
-			argsList.Add(ConfigurationLinkerOptionsMap[config.BuildType]);
-			
-			//Output
-			var outFile = DetermineOutputFile(config);
-			argsList.Add($"/out:\"{outFile}\"");
-			
-			// Constant Libs
-			argsList.Add(string.Join(" ", ConstantLinkLibs));
+        
+        private void InitializeArgs(NativeCompileSettings config)
+        {
+            var argsList = new List<string>();
+            
+            // Configuration Based Linker Options 
+            argsList.Add(ConfigurationLinkerOptionsMap[config.BuildType]);
+            
+            //Output
+            var outFile = DetermineOutputFile(config);
+            argsList.Add($"/out:\"{outFile}\"");
+            
+            // Constant Libs
+            argsList.Add(string.Join(" ", ConstantLinkLibs));
 
             // SDK Libs
             var SDKLibs = ModeLibMap[config.NativeMode];
-			foreach (var lib in SDKLibs)
-			{
-				argsList.Add(Path.Combine(config.IlcPath, lib));
-			}
+            foreach (var lib in SDKLibs)
+            {
+                argsList.Add(Path.Combine(config.IlcPath, lib));
+            }
 
-			// Configuration Based Libs
-			var configLibs = ConfigurationLinkLibMap[config.BuildType];
-			foreach (var lib in configLibs)
-			{
-				argsList.Add(lib);
-			}
+            // Configuration Based Libs
+            var configLibs = ConfigurationLinkLibMap[config.BuildType];
+            foreach (var lib in configLibs)
+            {
+                argsList.Add(lib);
+            }
 
-			// Link Libs
-			foreach(var path in config.LinkLibPaths){
-				argsList.Add($"\"{path}\"");
-			}
-			
-			//arch
-			argsList.Add($"/MACHINE:{config.Architecture}");
+            // Link Libs
+            foreach(var path in config.LinkLibPaths){
+                argsList.Add($"\"{path}\"");
+            }
+            
+            //arch
+            argsList.Add($"/MACHINE:{config.Architecture}");
 
             //Input Obj file
             var inputFile = DetermineInputFile(config);
-			argsList.Add($"\"{inputFile}\"");
-			
-			this.ArgStr = string.Join(" ", argsList);
-		}
-		
-		private int InvokeLinker()
-		{
-			var vcInstallDir = Environment.GetEnvironmentVariable("VS140COMNTOOLS");
-			var linkerPath = Path.Combine(vcInstallDir, VSBin, LinkerName);
-			
-			var result = Command.Create(linkerPath, ArgStr)
-				.ForwardStdErr()
-				.ForwardStdOut()
-				.Execute();
-			
-			return result.ExitCode;
-		}
-		
-		public string DetermineOutputFile(NativeCompileSettings config)
-		{
-			var outputDirectory = config.OutputDirectory;
-			
-			var filename = Path.GetFileNameWithoutExtension(config.InputManagedAssemblyPath);
-		
-			var outFile = Path.Combine(outputDirectory, filename + LinkerOutputExtension);
-			
-			return outFile;
-		}
+            argsList.Add($"\"{inputFile}\"");
+            
+            this.ArgStr = string.Join(" ", argsList);
+        }
+        
+        private int InvokeLinker()
+        {
+            var vcInstallDir = Environment.GetEnvironmentVariable("VS140COMNTOOLS");
+            var linkerPath = Path.Combine(vcInstallDir, VSBin, LinkerName);
+            
+            var result = Command.Create(linkerPath, ArgStr)
+                .ForwardStdErr()
+                .ForwardStdOut()
+                .Execute();
+            
+            return result.ExitCode;
+        }
+        
+        public string DetermineOutputFile(NativeCompileSettings config)
+        {
+            var outputDirectory = config.OutputDirectory;
+            
+            var filename = Path.GetFileNameWithoutExtension(config.InputManagedAssemblyPath);
+        
+            var outFile = Path.Combine(outputDirectory, filename + LinkerOutputExtension);
+            
+            return outFile;
+        }
 
         private string DetermineInputFile(NativeCompileSettings config)
         {
@@ -161,6 +161,6 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
             return infile;
         }
-		
-	}
+        
+    }
 }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
@@ -48,8 +48,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         private static readonly Dictionary<BuildConfiguration, string[]> ConfigurationLinkLibMap = new Dictionary<BuildConfiguration, string[]>()
         {
-        	{ BuildConfiguration.debug , new string[] { "msvcrtd" } },
-        	{ BuildConfiguration.release , new string[] { "msvcrt" } }
+        	{ BuildConfiguration.debug , new string[] { "msvcrtd.lib" } },
+        	{ BuildConfiguration.release , new string[] { "msvcrt.lib" } }
         };
 		
 		private string ArgStr { get; set; }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
@@ -45,6 +45,12 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             "odbc32.lib",
             "odbccp32.lib"
         };
+
+        private static readonly Dictionary<BuildConfiguration, string[]> ConfigurationLinkLibMap = new Dictionary<BuildConfiguration, string[]>()
+        {
+        	{ BuildConfiguration.debug , new string[] { "msvcrtd" } },
+        	{ BuildConfiguration.release , new string[] { "msvcrt" } }
+        };
 		
 		private string ArgStr { get; set; }
 		private NativeCompileSettings config;
@@ -97,6 +103,13 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 			foreach (var lib in SDKLibs)
 			{
 				argsList.Add(Path.Combine(config.IlcPath, lib));
+			}
+
+			// Configuration Based Libs
+			var configLibs = ConfigurationLinkLibMap[config.BuildType];
+			foreach (var lib in configLibs)
+			{
+				argsList.Add(lib);
 			}
 
 			// Link Libs

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
 using System.IO;
-using Microsoft.Dnx.Runtime.Common.CommandLine;
+using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.Compiler.Native
@@ -10,13 +12,76 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         public static int Main(string[] args)
         {
             DebugHelper.HandleDebugSwitch(ref args);
-            
-            var app = SetupApp();
-            
-            return ExecuteApp(app, args);
+
+            return ExecuteApp(args);
         }
-        
-        private static int ExecuteApp(CommandLineApplication app, string[] args)
+
+        private static ArgValues GetArgs(string[] args)
+        {
+            string inputAssembly = null;
+            string outputDirectory = null;
+            string temporaryOutputDirectory = null;
+            string configuration = null;
+            string mode = null;
+            string ilcArgs = null;
+            string ilcPath = null;
+            string appDepSdk = null;
+            string logPath = null;
+
+            IReadOnlyList<string> references = Array.Empty<string>();
+            IReadOnlyList<string> linklib = Array.Empty<string>();
+
+            try
+            {                
+                ArgumentSyntax.Parse(args, syntax =>
+                {                                        
+                    syntax.DefineOption("output", ref outputDirectory, "Output Directory for native executable.");
+                    syntax.DefineOption("temp-output", ref temporaryOutputDirectory, "Directory for intermediate files.");
+
+                    syntax.DefineOption("configuration", ref configuration, "debug/release build configuration. Defaults to debug.");
+                    syntax.DefineOption("mode", ref mode, "Code Generation mode. Defaults to ryujit.");
+
+                    syntax.DefineOptionList("reference", ref references, "Use to specify Managed DLL references of the app.");
+
+                    // Custom Extensibility Points to support CoreRT workflow TODO better descriptions
+                    syntax.DefineOption("ilcargs", ref ilcArgs, "Use to specify custom arguments for the IL Compiler.");
+                    syntax.DefineOption("ilcpath", ref ilcPath, "Use to plug in a custom built ilc.exe");
+                    syntax.DefineOptionList("linklib", ref linklib, "Use to link in additional static libs");
+
+                    // TEMPORARY Hack until CoreRT compatible Framework Libs are available 
+                    syntax.DefineOption("appdepsdk", ref appDepSdk, "Use to plug in custom appdepsdk path");
+
+                    // Optional Log Path
+                    syntax.DefineOption("logpath", ref logPath, "Use to dump Native Compilation Logs to a file.");
+
+                    syntax.DefineParameter("INPUT_ASSEMBLY", ref inputAssembly, "The managed input assembly to compile to native.");
+                });
+            }
+            catch (ArgumentSyntaxException)
+            {
+                //return ExitFailed;
+            }
+
+            Console.WriteLine($"Input Assembly: {inputAssembly}");
+
+            return new ArgValues()
+            {
+                InputManagedAssemblyPath = inputAssembly,
+                OutputDirectory = outputDirectory,
+                IntermediateDirectory = temporaryOutputDirectory,
+                Architecture = "x64",
+                BuildConfiguration = configuration,
+                NativeMode = mode,
+                ReferencePaths = references.ToList(),
+                IlcArgs = ilcArgs,
+                IlcPath = ilcPath,
+                LinkLibPaths = linklib.ToList(),
+                AppDepSDKPath = appDepSdk,
+                LogPath = logPath
+            };
+        }
+
+        private static int ExecuteApp(string[] args)
         {   
             // Support Response File
             foreach(var arg in args)
@@ -34,7 +99,17 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
             try
             {
-                return app.Execute(args);
+                var cmdLineArgs = GetArgs(args);
+                var config = ParseAndValidateArgs(cmdLineArgs);
+
+                DirectoryExtensions.CleanOrCreateDirectory(config.OutputDirectory);
+                DirectoryExtensions.CleanOrCreateDirectory(config.IntermediateDirectory);
+
+                var nativeCompiler = NativeCompiler.Create(config);
+
+                var result = nativeCompiler.CompileToNative(config);
+
+                return result ? 0 : 1;
             }
             catch (Exception ex)
             {
@@ -66,71 +141,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
                 return null;
             }
 
-            string[] nArgs = content.Split('\n');
+            string[] nArgs = content.Split(new [] {"\r\n", "\n"}, StringSplitOptions.RemoveEmptyEntries);
             return nArgs;
-        }
-
-        private static CommandLineApplication SetupApp()
-        {
-            var app = new CommandLineApplication
-            {
-                Name = "dotnet compile native",
-                FullName = "IL to Native compiler",
-                Description = "IL to Native compiler Compiler for the .NET Platform"
-            };
-
-            app.HelpOption("-h|--help");
-
-            var managedInputArg = app.Argument("<INPUT_ASSEMBLY>", "The managed input assembly to compile to native.");
-            var outputArg = app.Option("-o|--out <OUTPUT_DIR>", "Output Directory for native executable.", CommandOptionType.SingleValue);
-            var intermediateArg = app.Option("-t|--temp-output <OUTPUT_DIR>", "Directory for intermediate files.", CommandOptionType.SingleValue);
-            var buildConfigArg = app.Option("-c|--configuration <TYPE>", "debug/release build configuration. Defaults to debug.", CommandOptionType.SingleValue);
-            var modeArg = app.Option("-m|--mode <MODE>", "Code Generation mode. Defaults to ryujit. ", CommandOptionType.SingleValue);
-
-            var referencesArg = app.Option("-r|--reference <REF_PATH>", "Use to specify Managed DLL references of the app.", CommandOptionType.MultipleValue);
-            
-            // Custom Extensibility Points to support CoreRT workflow TODO better descriptions
-            var ilcArgs = app.Option("--ilcargs <CODEGEN>", "Use to specify custom arguments for the IL Compiler.", CommandOptionType.SingleValue);
-            var ilcPathArg = app.Option("--ilcpath <ILC_PATH>", "Use to plug in a custom built ilc.exe", CommandOptionType.SingleValue);
-            var linklibArg = app.Option("--linklib <LINKLIB>", "Use to link in additional static libs", CommandOptionType.MultipleValue);
-            
-            // TEMPORARY Hack until CoreRT compatible Framework Libs are available 
-            var appdepSdkPathArg = app.Option("--appdepsdk <SDK>", "Use to plug in custom appdepsdk path", CommandOptionType.SingleValue);
-            
-            // Optional Log Path
-            var logpathArg = app.Option("--logpath <LOG_PATH>", "Use to dump Native Compilation Logs to a file.", CommandOptionType.SingleValue);
-            
-            app.OnExecute(() =>
-            {
-                var cmdLineArgs = new ArgValues()
-                {
-                    InputManagedAssemblyPath = managedInputArg.Value,
-                    OutputDirectory = outputArg.Value(),
-                    IntermediateDirectory = intermediateArg.Value(),
-                    Architecture = "x64",
-                    BuildConfiguration = buildConfigArg.Value(),
-                    NativeMode = modeArg.Value(),
-                    ReferencePaths = referencesArg.Values,
-                    IlcArgs = ilcArgs.Value(),
-                    IlcPath = ilcPathArg.Value(),
-                    LinkLibPaths = linklibArg.Values,
-                    AppDepSDKPath = appdepSdkPathArg.Value(),
-                    LogPath = logpathArg.Value()
-                };
-
-                var config = ParseAndValidateArgs(cmdLineArgs);
-                
-                DirectoryExtensions.CleanOrCreateDirectory(config.OutputDirectory);
-                DirectoryExtensions.CleanOrCreateDirectory(config.IntermediateDirectory);
-                
-                var nativeCompiler = NativeCompiler.Create(config);
-                
-                var result = nativeCompiler.CompileToNative(config);
-
-                return result ? 0 : 1;
-            });
-            
-            return app;
         }
         
         private static NativeCompileSettings ParseAndValidateArgs(ArgValues args)

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
@@ -23,9 +23,10 @@
             "type": "build",
             "version": "1.0.0-*"
         },
-        "Microsoft.DotNet.ILCompiler": "1.0.1-*",
-        "Microsoft.DotNet.ObjectWriter": "1.0.2-*",
-        "Microsoft.DotNet.RyuJit": "1.0.0-*"
+      "Microsoft.DotNet.ILCompiler": "1.0.1-*",
+      "Microsoft.DotNet.ObjectWriter": "1.0.2-*",
+      "Microsoft.DotNet.RyuJit": "1.0.0-*",
+      "Microsoft.DotNet.Compiler.Common": "1.0.0-*"
     },
     "frameworks": {
         "dnxcore50": { }


### PR DESCRIPTION
Changing native out flag to output flag to match compiler. Also changing the rsp file spliting to handle both /r/n and /r.

More coming.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/243)
<!-- Reviewable:end -->
