### PR TITLE
Add correct permissions and symlinks to PKG generation

### DIFF
--- a/packaging/osx/package-osx.sh
+++ b/packaging/osx/package-osx.sh
@@ -41,6 +41,7 @@ PACKAGE_NAME=$PACKAGE_DIR/dotnet-cli-x64.${DOTNET_BUILD_VERSION}.pkg
 pkgbuild --root $STAGE2_DIR \
          --version $DOTNET_BUILD_VERSION \
          --scripts $DIR/scripts \
+         --ownership preserve \
          --identifier com.microsoft.dotnet.cli.pkg.dotnet-osx-x64 \
          --install-location /usr/local/share/dotnet/cli \
          $DIR/dotnet-osx-x64.$DOTNET_BUILD_VERSION.pkg

--- a/packaging/osx/scripts/postinstall
+++ b/packaging/osx/scripts/postinstall
@@ -4,12 +4,12 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-ln -s $2/dotnet /usr/local/bin/
-ln -s $2/dotnet-compile /usr/local/bin/
-ln -s $2/dotnet-compile-csc /usr/local/bin/
-ln -s $2/dotnet-publish /usr/local/bin/
-ln -s $2/dotnet-restore /usr/local/bin/
-ln -s $2/dotnet-restore /usr/local/bin/
-ln -s $2/resgen /usr/local/bin/
+ln -s $2/bin/dotnet /usr/local/bin/
+ln -s $2/bin/dotnet-compile /usr/local/bin/
+ln -s $2/bin/dotnet-compile-csc /usr/local/bin/
+ln -s $2/bin/dotnet-publish /usr/local/bin/
+ln -s $2/bin/dotnet-restore /usr/local/bin/
+ln -s $2/bin/dotnet-restore /usr/local/bin/
+ln -s $2/bin/resgen /usr/local/bin/
 
 exit 0


### PR DESCRIPTION
Add proper symlinks to the postinstall script. Also, the permissions of the
resulting directory post-install were wrong (set to root:wheel). This is fixed
by using the --ownership preserve switch to pkgbuild.

Fix #247 

/cc @piotrpMSFT @anurse @glennc @brthor 