### PR TITLE
Small fixes for dotnet compile --native

### DIFF
--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         // TODO: debug/release support
         private readonly string cLibsFlags = "-lm -ldl";
-        private readonly string cflags = "-g -lstdc++ -lrt -Xlinker -lrt -Wno-invalid-offsetof -pthread";
+        private readonly string cflags = "-g -lstdc++ -lrt -Wno-invalid-offsetof -pthread";
 
         private readonly string[] libs = new string[]
         {

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         // TODO: debug/release support
         private readonly string cLibsFlags = "-lm -ldl";
-        private readonly string cflags = "-g -lstdc++ -lrt -Wno-invalid-offsetof -pthread";
+        private readonly string cflags = "-g -lstdc++ -lrt -Xlinker -lrt -Wno-invalid-offsetof -pthread";
 
         private readonly string[] libs = new string[]
         {

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         private readonly string CompilerOutputExtension = "";
 
         // TODO: debug/release support
-        private readonly string cflags = "-lstdc++ -lpthread -ldl -lm";
+        private readonly string cflags = "-lstdc++ -lpthread -ldl -lm -lrt";
 
         private readonly string[] libs = new string[]
         {

--- a/src/Microsoft.DotNet.Tools.Compiler/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/Program.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             // Native Args
             var native = app.Option("-n|--native", "Compiles source to native machine code.", CommandOptionType.NoValue);
             var arch = app.Option("-a|--arch <ARCH>", "The architecture for which to compile. x64 only currently supported.", CommandOptionType.SingleValue);
-            var ilcArgs = app.Option("--ilc-args <ARGS>", "String to pass directory to ilc in native compilation.", CommandOptionType.SingleValue);
+            var ilcArgs = app.Option("--ilcargs <ARGS>", "String to pass directory to ilc in native compilation.", CommandOptionType.SingleValue);
             var cppMode = app.Option("--cpp", "Flag to do native compilation with C++ code generator.", CommandOptionType.NoValue);
 
             app.OnExecute(() =>


### PR DESCRIPTION
Add -Xlinker -lrt to Linux Clang Invocation to bypass issues with linking CoreFX Static libs.
/cc @schellap 

Change --ilc-args to --ilcargs in `dotnet compile`
