### PR TITLE
add dotnet-init to linux build script

### DIFF
--- a/scripts/build/build-stage.sh
+++ b/scripts/build/build-stage.sh
@@ -33,6 +33,7 @@ PROJECTS=( \
     Microsoft.DotNet.Tools.Repl.Csi \
     Microsoft.DotNet.Tools.Resgen \
     Microsoft.DotNet.Tools.Run \
+    Microsoft.DotNet.Tools.Init \
     Microsoft.DotNet.Tools.Compiler.Native \
 )
 


### PR DESCRIPTION
I'm not sure how this went past the last CI build