### PR TITLE
CoreHost Changes for Linux

### DIFF
--- a/src/corehost/inc/args.h
+++ b/src/corehost/inc/args.h
@@ -9,7 +9,6 @@
 
 struct arguments_t
 {
-    trace::level_t trace_level;
     pal::string_t own_path;
     pal::string_t managed_application;
     pal::string_t clr_path;

--- a/src/corehost/inc/pal.h
+++ b/src/corehost/inc/pal.h
@@ -108,6 +108,8 @@ namespace pal
     bool load_library(const char_t* path, dll_t& dll);
     proc_t get_symbol(dll_t library, const char* name);
     void unload_library(dll_t library);
+
+    bool find_coreclr(pal::string_t& recv);
 }
 
 #endif // PAL_H

--- a/src/corehost/inc/trace.h
+++ b/src/corehost/inc/trace.h
@@ -8,16 +8,8 @@
 
 namespace trace
 {
-    enum class level_t
-    {
-        Error = 0,
-        Warning = 1,
-        Info = 2,
-        Verbose = 3
-    };
-
-    void set_level(level_t level);
-    bool is_enabled(level_t level);
+    void enable();
+    bool is_enabled();
     void verbose(const pal::char_t* format, ...);
     void info(const pal::char_t* format, ...);
     void warning(const pal::char_t* format, ...);

--- a/src/corehost/inc/utils.h
+++ b/src/corehost/inc/utils.h
@@ -11,5 +11,6 @@ pal::string_t get_executable(const pal::string_t& filename);
 pal::string_t get_directory(const pal::string_t& path);
 pal::string_t get_filename(const pal::string_t& path);
 void append_path(pal::string_t& path1, const pal::char_t* path2);
+bool coreclr_exists_in_dir(const pal::string_t& candidate);
 
 #endif

--- a/src/corehost/src/args.cpp
+++ b/src/corehost/src/args.cpp
@@ -5,7 +5,6 @@
 #include "utils.h"
 
 arguments_t::arguments_t() :
-    trace_level(trace::level_t::Error),
     managed_application(_X("")),
     clr_path(_X("")),
     app_argc(0),
@@ -20,7 +19,7 @@ void display_help()
         _X("Execute the specified managed assembly with the passed in arguments\n\n")
         _X("The Host's behavior can be altered using the following environment variables:\n")
         _X(" DOTNET_HOME            Set the dotnet home directory. The CLR is expected to be in the runtime subdirectory of this directory. Overrides all other values for CLR search paths\n")
-        _X(" CLRHOST_TRACE          Set to affect trace levels (0 = Errors only (default), 1 = Warnings, 2 = Info, 3 = Verbose)\n");
+        _X(" COREHOST_TRACE          Set to affect trace levels (0 = Errors only (default), 1 = Warnings, 2 = Info, 3 = Verbose)\n");
 }
 
 bool parse_arguments(const int argc, const pal::char_t* argv[], arguments_t& args)
@@ -61,12 +60,13 @@ bool parse_arguments(const int argc, const pal::char_t* argv[], arguments_t& arg
 
     // Read trace environment variable
     pal::string_t trace_str;
-    if (pal::getenv(_X("CLRHOST_TRACE"), trace_str))
+    if (pal::getenv(_X("COREHOST_TRACE"), trace_str))
     {
         auto trace_val = pal::xtoi(trace_str.c_str());
-        if (trace_val >= (int)trace::level_t::Error && trace_val <= (int)trace::level_t::Verbose)
+        if (trace_val > 0)
         {
-            args.trace_level = (trace::level_t)trace_val;
+            trace::enable();
+            trace::info(_X("tracing enabled"));
         }
     }
 

--- a/src/corehost/src/args.cpp
+++ b/src/corehost/src/args.cpp
@@ -79,6 +79,14 @@ bool parse_arguments(const int argc, const pal::char_t* argv[], arguments_t& arg
         append_path(home_str, _X("coreclr"));
         args.clr_path.assign(home_str);
     }
+    else
+    {
+        // Use platform-specific search algorithm
+        if (pal::find_coreclr(home_str))
+        {
+            args.clr_path.assign(home_str);
+        }
+    }
 
     return true;
 }

--- a/src/corehost/src/main.cpp
+++ b/src/corehost/src/main.cpp
@@ -214,14 +214,14 @@ int main(const int argc, const pal::char_t* argv[])
     trace::info(_X("preparing to launch: %s"), app_name.c_str());
     trace::info(_X("using app base: %s"), app_base.c_str());
 
-    // Check for and load tpa file
+    // Check for and load deps file
     pal::string_t tpafile_path;
     get_tpafile_path(app_base, app_name, tpafile_path);
-    trace::info(_X("checking for TPA File at: %s"), tpafile_path.c_str());
+    trace::info(_X("checking for .deps File at: %s"), tpafile_path.c_str());
     tpafile tpa;
     if (!tpa.load(tpafile_path))
     {
-        trace::error(_X("invalid TPA file"));
+        trace::error(_X("invalid .deps file"));
         return 1;
     }
     return run(args, app_base, tpa);

--- a/src/corehost/src/main.cpp
+++ b/src/corehost/src/main.cpp
@@ -161,10 +161,6 @@ int main(const int argc, const pal::char_t* argv[])
         return 1;
     }
 
-    // Configure tracing
-    trace::set_level(args.trace_level);
-    trace::info(_X("tracing enabled"));
-
     // Resolve paths
     if (!pal::realpath(args.managed_application))
     {

--- a/src/corehost/src/pal.unix.cpp
+++ b/src/corehost/src/pal.unix.cpp
@@ -19,6 +19,32 @@
 #define symlinkEntrypointExecutable "/proc/curproc/exe"
 #endif
 
+bool coreclr_exists_in_dir(const pal::string_t& candidate)
+{
+    pal::string_t test(candidate);
+    append_path(test, _X("runtime"));
+    append_path(test, LIBCORECLR_NAME);
+    return pal::file_exists(test);
+}
+
+bool pal::find_coreclr(pal::string_t& recv)
+{
+    pal::string_t candidate;
+    pal::string_t test;
+
+    // Try %LocalAppData%\dotnet
+    if (pal::getenv(_X("LocalAppData"), candidate)) {
+        append_path(candidate, _X("dotnet"));
+        if (coreclr_exists_in_dir(candidate)) {
+            recv.assign(candidate);
+            return true;
+        }
+    }
+
+    // TODO: Try somewhere in Program Files, see https://github.com/dotnet/cli/issues/249
+    return false;
+}
+
 bool pal::load_library(const char_t* path, dll_t& dll)
 {
     dll = dlopen(path, RTLD_LAZY);

--- a/src/corehost/src/pal.unix.cpp
+++ b/src/corehost/src/pal.unix.cpp
@@ -19,29 +19,23 @@
 #define symlinkEntrypointExecutable "/proc/curproc/exe"
 #endif
 
-bool coreclr_exists_in_dir(const pal::string_t& candidate)
-{
-    pal::string_t test(candidate);
-    append_path(test, _X("runtime"));
-    append_path(test, LIBCORECLR_NAME);
-    return pal::file_exists(test);
-}
-
 bool pal::find_coreclr(pal::string_t& recv)
 {
     pal::string_t candidate;
     pal::string_t test;
 
-    // Try %LocalAppData%\dotnet
-    if (pal::getenv(_X("LocalAppData"), candidate)) {
-        append_path(candidate, _X("dotnet"));
-        if (coreclr_exists_in_dir(candidate)) {
-            recv.assign(candidate);
-            return true;
-        }
+    // Try /usr/share/dotnet and /usr/local/share/dotnet
+    candidate.assign("/usr/share/dotnet/runtime/coreclr");
+    if (coreclr_exists_in_dir(candidate)) {
+        recv.assign(candidate);
+        return true;
     }
 
-    // TODO: Try somewhere in Program Files, see https://github.com/dotnet/cli/issues/249
+    candidate.assign("/usr/local/share/dotnet/runtime/coreclr");
+    if (coreclr_exists_in_dir(candidate)) {
+        recv.assign(candidate);
+        return true;
+    }
     return false;
 }
 

--- a/src/corehost/src/pal.windows.cpp
+++ b/src/corehost/src/pal.windows.cpp
@@ -10,6 +10,24 @@
 
 static std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> g_converter;
 
+bool pal::find_coreclr(pal::string_t& recv)
+{
+    pal::string_t candidate;
+    pal::string_t test;
+
+    // Try %LocalAppData%\dotnet
+    if (pal::getenv(_X("LocalAppData"), candidate)) {
+        append_path(candidate, _X("dotnet"));
+        if (coreclr_exists_in_dir(candidate)) {
+            recv.assign(candidate);
+            return true;
+        }
+    }
+
+    // TODO: Try somewhere in Program Files, see https://github.com/dotnet/cli/issues/249
+    return false;
+}
+
 bool pal::load_library(const char_t* path, dll_t& dll)
 {
     dll = ::LoadLibraryW(path);

--- a/src/corehost/src/pal.windows.cpp
+++ b/src/corehost/src/pal.windows.cpp
@@ -18,6 +18,8 @@ bool pal::find_coreclr(pal::string_t& recv)
     // Try %LocalAppData%\dotnet
     if (pal::getenv(_X("LocalAppData"), candidate)) {
         append_path(candidate, _X("dotnet"));
+        append_path(candidate, _X("runtime"));
+        append_path(candidate, _X("coreclr"));
         if (coreclr_exists_in_dir(candidate)) {
             recv.assign(candidate);
             return true;

--- a/src/corehost/src/pal.windows.cpp
+++ b/src/corehost/src/pal.windows.cpp
@@ -45,7 +45,7 @@ bool pal::load_library(const char_t* path, dll_t& dll)
         return false;
     }
 
-    if (trace::is_enabled(trace::level_t::Info))
+    if (trace::is_enabled())
     {
         pal::char_t buf[PATH_MAX];
         ::GetModuleFileNameW(dll, buf, PATH_MAX);

--- a/src/corehost/src/trace.cpp
+++ b/src/corehost/src/trace.cpp
@@ -3,21 +3,21 @@
 
 #include "trace.h"
 
-static trace::level_t g_level = trace::level_t::Error;
+static bool g_enabled = false;
 
-void trace::set_level(trace::level_t new_level)
+void trace::enable()
 {
-    g_level = new_level;
+    g_enabled = true;
 }
 
-bool trace::is_enabled(trace::level_t level)
+bool trace::is_enabled()
 {
-    return level <= g_level;
+    return g_enabled;
 }
 
 void trace::verbose(const pal::char_t* format, ...)
 {
-    if (trace::is_enabled(trace::level_t::Verbose))
+    if (g_enabled)
     {
         va_list args;
         va_start(args, format);
@@ -28,7 +28,7 @@ void trace::verbose(const pal::char_t* format, ...)
 
 void trace::info(const pal::char_t* format, ...)
 {
-    if (trace::is_enabled(trace::level_t::Info))
+    if (g_enabled)
     {
         va_list args;
         va_start(args, format);
@@ -39,18 +39,16 @@ void trace::info(const pal::char_t* format, ...)
 
 void trace::error(const pal::char_t* format, ...)
 {
-    if (trace::is_enabled(trace::level_t::Error))
-    {
-        va_list args;
-        va_start(args, format);
-        pal::err_vprintf(format, args);
-        va_end(args);
-    }
+    // Always print errors
+    va_list args;
+    va_start(args, format);
+    pal::err_vprintf(format, args);
+    va_end(args);
 }
 
 void trace::warning(const pal::char_t* format, ...)
 {
-    if (trace::is_enabled(trace::level_t::Warning))
+    if (g_enabled)
     {
         va_list args;
         va_start(args, format);

--- a/src/corehost/src/utils.cpp
+++ b/src/corehost/src/utils.cpp
@@ -7,7 +7,6 @@
 bool coreclr_exists_in_dir(const pal::string_t& candidate)
 {
     pal::string_t test(candidate);
-    append_path(test, _X("runtime"));
     append_path(test, LIBCORECLR_NAME);
     trace::verbose(_X("checking for CoreCLR in default location: %s"), test.c_str());
     return pal::file_exists(test);

--- a/src/corehost/src/utils.cpp
+++ b/src/corehost/src/utils.cpp
@@ -3,6 +3,14 @@
 
 #include "utils.h"
 
+bool coreclr_exists_in_dir(const pal::string_t& candidate)
+{
+    pal::string_t test(candidate);
+    append_path(test, _X("runtime"));
+    append_path(test, LIBCORECLR_NAME);
+    return pal::file_exists(test);
+}
+
 bool ends_with(const pal::string_t& value, const pal::string_t& suffix)
 {
     return suffix.length() <= value.length() &&

--- a/src/corehost/src/utils.cpp
+++ b/src/corehost/src/utils.cpp
@@ -2,12 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include "utils.h"
+#include "trace.h"
 
 bool coreclr_exists_in_dir(const pal::string_t& candidate)
 {
     pal::string_t test(candidate);
     append_path(test, _X("runtime"));
     append_path(test, LIBCORECLR_NAME);
+    trace::verbose(_X("checking for CoreCLR in default location: %s"), test.c_str());
     return pal::file_exists(test);
 }
 


### PR DESCRIPTION
Took the branch @anurse had pushed up, made some small changes and verified that Corehost will function on Ubuntu without the DOTNET_HOME variable set.

/cc @anurse @davidfowl @piotrpMSFT 

Windows is not verified, but as I understand it the MSI already sets the $DOTNET_HOME environment variable, so nothing will break. 

Fixes #234 