### PR TITLE
Initial support for Mac dotnet-compile-native

### DIFF
--- a/scripts/build/build_appdeps.sh
+++ b/scripts/build/build_appdeps.sh
@@ -7,11 +7,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source $SCRIPT_DIR/../_common.sh
 
-# Dotnet-compile-native doesn't work for mac yet
-if [[ "$(uname)" != "Linux" ]]; then
-	exit 0
-fi
-
 REPO_ROOT="$SCRIPT_DIR/../.."
 APPDEPS_PROJECT_DIR=$REPO_ROOT/src/Microsoft.DotNet.Tools.Compiler.Native/appdep
 

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/ILCompilerInvoker.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/ILCompilerInvoker.cs
@@ -42,6 +42,11 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var argsList = new List<string>();
 
             var managedPath = Path.Combine(config.IlcPath, ILCompiler);
+            if (!File.Exists(managedPath))
+            {
+                throw new FileNotFoundException("Unable to find ILCompiler at " + managedPath);
+            }
+
             argsList.Add($"\"{managedPath}\"");
             
             // Input File 

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/IntermediateCompiler.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/IntermediateCompiler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 			}
 			else if (config.OS == OSMode.Mac)
 			{
-                throw new NotImplementedException("Mac not yet supported.");
+				stepList.Add(new MacCppCompileStep(config));
 			}
 			else
 			{

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
@@ -87,10 +87,11 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             }
 
             // AppDep Libs
+            var baseAppDeplibPath = Path.Combine(config.AppDepSDKPath, "CPPSdk/ubuntu.14.04/x64");
             foreach (var lib in appdeplibs)
             {
-                var libPath = Path.Combine(config.AppDepSDKPath, lib);
-                argsList.Add(libPath);
+                var appDeplibPath = Path.Combine(baseAppDeplibPath, lib);
+                argsList.Add(appDeplibPath);
             }
 
             argsList.Add(cLibsFlags);

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Mac/MacCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Mac/MacCppCompileStep.cs
@@ -10,31 +10,136 @@ using Microsoft.DotNet.Tools.Common;
 
 namespace Microsoft.DotNet.Tools.Compiler.Native
 {
-	public class MacCppCompileStep : IPlatformNativeStep
-	{
+    public class MacCppCompileStep : IPlatformNativeStep
+    {
+        private readonly string CompilerName = "clang";
+        private readonly string InputExtension = ".cpp";
+
+        // TODO: debug/release support
+        private readonly string cflags = "-g -lstdc++ -Wno-invalid-offsetof -pthread";
+        
+        // Link to iconv APIs
+        private readonly string libFlags = "-liconv";
+
+        private readonly string[] libs = new string[]
+        {
+            "libbootstrappercpp.a",
+            "libPortableRuntime.a",
+            "libSystem.Private.CoreLib.Native.a"
+        };
+
+        private readonly string[] appdeplibs = new string[]
+        {
+            "libSystem.Native.a"
+        };
+
+        
+        private string CompilerArgStr { get; set; }
+        private NativeCompileSettings config;
+
         public MacCppCompileStep(NativeCompileSettings config)
         {
-            throw new NotImplementedException("Mac Cpp Not Supported Yet");
+            this.config = config;
+            InitializeArgs(config);
         }
 
         public int Invoke()
-		{
-			throw new NotImplementedException("mac cpp Not supported yet.");
-		}
-		
-		public bool CheckPreReqs()
-		{
-			throw new NotImplementedException("mac cpp Not supported yet.");
-		}
-		
-		public string DetermineOutputFile(NativeCompileSettings config)
-		{
-			throw new NotImplementedException("Mac cpp Not supported yet.");
-		}
-
-        public bool RequiresLinkStep()
         {
-            return false;
-        }		
-	}
+            var result = InvokeCompiler();
+            if (result != 0)
+            {
+                Reporter.Error.WriteLine("Compilation of intermediate files failed.");
+            }
+
+            return result;
+        }
+
+        public bool CheckPreReqs()
+        {
+            // TODO check for clang
+            return true;
+        }
+
+        private void InitializeArgs(NativeCompileSettings config)
+        {
+            var argsList = new List<string>();
+            
+            // Flags
+            argsList.Add(cflags);
+
+            // Add Includes
+            argsList.Add("-I");
+            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk/osx.10.10"));
+
+            argsList.Add("-I");
+            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk"));
+
+            // Input File
+            var inCppFile = DetermineInFile(config);
+            argsList.Add(inCppFile);
+
+            // Add Stubs
+            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk/osx.10.10/osxstubs.cpp"));
+
+            // Lib flags
+            argsList.Add(libFlags);
+
+            // Libs
+            foreach (var lib in libs)
+            {
+                var libPath = Path.Combine(config.IlcPath, lib);
+
+                // Forward the library to linked to the linker
+                argsList.Add("-Xlinker");
+                argsList.Add(libPath);
+            }
+
+            // AppDep Libs
+            var baseAppDeplibPath = Path.Combine(config.AppDepSDKPath, "CPPSdk/osx.10.10/x64");
+            foreach (var lib in appdeplibs)
+            {
+                var appDeplibPath = Path.Combine(baseAppDeplibPath, lib);
+                argsList.Add("-Xlinker");
+                argsList.Add(appDeplibPath);
+            }
+
+            // Output
+            var libOut = DetermineOutputFile(config);
+            argsList.Add($"-o \"{libOut}\"");
+
+            this.CompilerArgStr = string.Join(" ", argsList);
+        }
+
+        private int InvokeCompiler()
+        {
+            var result = Command.Create(CompilerName, CompilerArgStr)
+                .ForwardStdErr()
+                .ForwardStdOut()
+                .Execute();
+
+            return result.ExitCode;
+        }
+
+        private string DetermineInFile(NativeCompileSettings config)
+        {
+            var intermediateDirectory = config.IntermediateDirectory;
+
+            var filename = Path.GetFileNameWithoutExtension(config.InputManagedAssemblyPath);
+
+            var infile = Path.Combine(intermediateDirectory, filename + InputExtension);
+
+            return infile;
+        }
+
+        public string DetermineOutputFile(NativeCompileSettings config)
+        {
+            var intermediateDirectory = config.OutputDirectory;
+
+            var filename = Path.GetFileNameWithoutExtension(config.InputManagedAssemblyPath);
+
+            var outfile = Path.Combine(intermediateDirectory, filename);
+
+            return outfile;
+        }
+    }
 }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "Microsoft.DotNet.AppDep":"1.0.1-*"
+        "Microsoft.DotNet.AppDep":"1.0.2-*"
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
@@ -23,7 +23,7 @@
             "type": "build",
             "version": "1.0.0-*"
         },
-      "Microsoft.DotNet.ILCompiler": "1.0.1-*",
+      "Microsoft.DotNet.ILCompiler": "1.0.2-*",
       "Microsoft.DotNet.ObjectWriter": "1.0.2-*",
       "Microsoft.DotNet.RyuJit": "1.0.0-*",
       "Microsoft.DotNet.Compiler.Common": "1.0.0-*"


### PR DESCRIPTION
@brthor @schellap - PTAL

A key change here is that AppDep sdk libs will now come from a x64 subfolder instead of package root. @schellap - I will coordinate with you in getting the updated package uploaded.