### PR TITLE
Add a temporary step to cp corehost to /usr/local/bin

### DIFF
--- a/packaging/osx/scripts/postinstall
+++ b/packaging/osx/scripts/postinstall
@@ -12,4 +12,8 @@ ln -s $2/bin/dotnet-restore /usr/local/bin/
 ln -s $2/bin/dotnet-restore /usr/local/bin/
 ln -s $2/bin/resgen /usr/local/bin/
 
+# A temporary solution to unblock dotnet compile
+cp $2/bin/corehost /usr/local/bin/
+
+
 exit 0

--- a/packaging/osx/scripts/postinstall
+++ b/packaging/osx/scripts/postinstall
@@ -10,6 +10,7 @@ ln -s $2/bin/dotnet-compile-csc /usr/local/bin/
 ln -s $2/bin/dotnet-publish /usr/local/bin/
 ln -s $2/bin/dotnet-restore /usr/local/bin/
 ln -s $2/bin/dotnet-restore /usr/local/bin/
+ln -s $2/bin/dotnet-init /usr/local/bin/
 ln -s $2/bin/resgen /usr/local/bin/
 
 # A temporary solution to unblock dotnet compile


### PR DESCRIPTION
This is a temporary fix to unblock dotnet compile on OS X. It copies the corehost
from the install location to /usr/local/bin in postinstall.

Fix #294 

/cc @brthor @Sridhar-MS @anurse 