### PR TITLE
fix dotnet-repl-csi

### DIFF
--- a/src/Microsoft.DotNet.Tools.Repl.Csi/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Repl.Csi/Program.cs
@@ -30,11 +30,10 @@ namespace Microsoft.DotNet.Tools.Repl.Csi
             var corerun = Path.Combine(AppContext.BaseDirectory, Constants.HostExecutableName);
             var csiExe = Path.Combine(AppContext.BaseDirectory, "csi.exe");
             var csiArgs = string.IsNullOrEmpty(scriptOpt) ? "-i" : scriptOpt;
-            var command = File.Exists(corerun) && File.Exists(csiExe) ?
-                Command.Create(corerun, $@"""{csiExe}"" {csiArgs}") :
-                Command.Create(csiExe, csiArgs);
-            command = command.ForwardStdOut().ForwardStdErr();
-            var result = command.Execute();
+            var result = Command.Create(csiExe, csiArgs)
+                .ForwardStdOut()
+                .ForwardStdErr()
+                .Execute();
             return result.ExitCode;
         }
     }


### PR DESCRIPTION
`csi` was added to the list of binaries that get `corehost`-ified during the build, but unfortunately `dotnet-repl-csi` wasn't updated, so it ends up running `corehost csi.exe`, which fails with a BadImageFormatException because `csi.exe` is the native host, not the managed binary.

This PR fixes `dotnet-repl-csi` to directly invoke `csi.exe` now that it is present.