### PR TITLE
End to End Test First Pass

### DIFF
--- a/scripts/compile.ps1
+++ b/scripts/compile.ps1
@@ -132,12 +132,18 @@ Download it from https://www.cmake.org
         Exit 1
     }
 
-
     # Smoke test stage2
     $env:DOTNET_HOME = "$Stage2Dir"
     & "$PSScriptRoot\test\smoke-test.ps1"
     if (!$?) {
         Write-Host "Command failed: $PSScriptRoot\test\smoke-test.ps1"
+        Exit 1
+    }
+
+    # E2E Test of stage2
+    & "$PSScriptRoot\test\e2e-test.ps1"
+    if (!$?) {
+        Write-Host "Command failed: $PSScriptRoot\test\e2e-test.ps1"
         Exit 1
     }
 

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -117,3 +117,7 @@ echo $COMMIT_ID > $STAGE2_DIR/.commit
 # Smoke-test the output
 header "Testing stage2 ..."
 DOTNET_HOME=$STAGE2_DIR DOTNET_TOOLS=$STAGE2_DIR $DIR/test/smoke-test.sh
+
+# E2E test on the output
+header "Testing stage2 End to End ..."
+DOTNET_HOME=$STAGE2_DIR DOTNET_TOOLS=$STAGE2_DIR $DIR/test/e2e-test.sh

--- a/scripts/test/e2e-test.ps1
+++ b/scripts/test/e2e-test.ps1
@@ -25,14 +25,14 @@ pushd "$env:VS140COMNTOOLS\..\..\VC"
 cmd /c "vcvarsall.bat x64&set" |
 foreach {
   if ($_ -match "=") {
-    $v = $_.split("="); set-item -force -path "ENV:\$($v[0])"  -value "$($v[1])"
+    $v = $_.split("="); set-item -force -path "ENV:\$($v[0])" -value "$($v[1])"
   }
 }
 popd
 
 # Run the app and check the exit code
 pushd "$RepoRoot\artifacts\$Rid\e2etest"
-& "CoreRun.exe" "xunit.console.netcore.exe" "E2E.dll"
+& "CoreRun.exe" "xunit.console.netcore.exe" "E2E.dll" -xml ..\..\e2etest.xml
 if (!$?) {
     Write-Host "E2E Test Failure"
     popd

--- a/scripts/test/e2e-test.ps1
+++ b/scripts/test/e2e-test.ps1
@@ -1,0 +1,43 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+. "$PSScriptRoot\..\_common.ps1"
+
+# Restore and compile the test app
+dotnet restore "$RepoRoot\test\E2E" --runtime "osx.10.10-x64" --runtime "ubuntu.14.04-x64" --runtime "win7-x64"
+if (!$?) {
+    Write-Host "Command failed: dotnet restore"
+    Exit 1
+}
+
+dotnet publish --framework dnxcore50 --runtime "$Rid" --output "$RepoRoot\artifacts\$Rid\e2etest" "$RepoRoot\test\E2E"
+if (!$?) {
+    Write-Host "Command failed: dotnet publish"
+    Exit 1
+}
+
+## Temporary Workaround for Native Compilation
+## Need x64 Native Tools Dev Prompt Env Vars
+## Tracked Here: https://github.com/dotnet/cli/issues/301
+pushd "$env:VS140COMNTOOLS\..\..\VC"
+cmd /c "vcvarsall.bat x64&set" |
+foreach {
+  if ($_ -match "=") {
+    $v = $_.split("="); set-item -force -path "ENV:\$($v[0])"  -value "$($v[1])"
+  }
+}
+popd
+
+# Run the app and check the exit code
+pushd "$RepoRoot\artifacts\$Rid\e2etest"
+& "CoreRun.exe" "xunit.console.netcore.exe" "E2E.dll"
+if (!$?) {
+    Write-Host "E2E Test Failure"
+    popd
+    Exit 1
+}
+else {
+    popd
+}

--- a/scripts/test/e2e-test.ps1
+++ b/scripts/test/e2e-test.ps1
@@ -32,7 +32,8 @@ popd
 
 # Run the app and check the exit code
 pushd "$RepoRoot\artifacts\$Rid\e2etest"
-& "CoreRun.exe" "xunit.console.netcore.exe" "E2E.dll" -xml ..\..\e2etest.xml
+mv E2E.exe corehost.exe
+& "corehost.exe" "xunit.console.netcore.exe" "E2E.dll" -xml ..\..\e2etest.xml
 if (!$?) {
     Write-Host "E2E Test Failure"
     popd

--- a/scripts/test/e2e-test.sh
+++ b/scripts/test/e2e-test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+REPOROOT="$( cd -P "$DIR/../.." && pwd )"
+
+source "$DIR/../_common.sh"
+
+rm "$REPOROOT/test/E2E/project.lock.json"
+dotnet restore "$REPOROOT/test/E2E" --runtime "osx.10.10-x64" --runtime "ubuntu.14.04-x64" --runtime "win7-x64"
+dotnet publish --framework dnxcore50 \
+        --runtime "$Rid" \
+        --output "$RepoRoot/artifacts/$Rid/e2etest" \
+        "$RepoRoot/test/E2E" \
+
+# set -e will abort if the exit code of this is non-zero
+pushd "$REPOROOT/artifacts/$RID/e2etest"
+./corerun xunit.console.netcore.exe E2E.dll
+popd

--- a/scripts/test/e2e-test.sh
+++ b/scripts/test/e2e-test.sh
@@ -23,5 +23,6 @@ dotnet publish --framework dnxcore50 --runtime "$RID" --output "$REPOROOT/artifa
 
 # set -e will abort if the exit code of this is non-zero
 pushd "$REPOROOT/artifacts/$RID/e2etest"
-./corerun xunit.console.netcore.exe E2E.dll
+mv ./E2E ./corehost
+./corehost xunit.console.netcore.exe E2E.dll
 popd

--- a/scripts/test/e2e-test.sh
+++ b/scripts/test/e2e-test.sh
@@ -19,10 +19,7 @@ source "$DIR/../_common.sh"
 
 rm "$REPOROOT/test/E2E/project.lock.json"
 dotnet restore "$REPOROOT/test/E2E" --runtime "osx.10.10-x64" --runtime "ubuntu.14.04-x64" --runtime "win7-x64"
-dotnet publish --framework dnxcore50 \
-        --runtime "$Rid" \
-        --output "$RepoRoot/artifacts/$Rid/e2etest" \
-        "$RepoRoot/test/E2E" \
+dotnet publish --framework dnxcore50 --runtime "$RID" --output "$REPOROOT/artifacts/$RID/e2etest" "$REPOROOT/test/E2E" 
 
 # set -e will abort if the exit code of this is non-zero
 pushd "$REPOROOT/artifacts/$RID/e2etest"

--- a/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
@@ -141,7 +141,3 @@ namespace Microsoft.DotNet.Cli.Utils
         }
     }
 }
-<<<<<<< HEAD
-=======
-
->>>>>>> 8a53c73... E2E Testing First pass. Test each command in a sequence to mock what a user might do.

--- a/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -141,3 +141,7 @@ namespace Microsoft.DotNet.Cli.Utils
         }
     }
 }
+<<<<<<< HEAD
+=======
+
+>>>>>>> 8a53c73... E2E Testing First pass. Test each command in a sequence to mock what a user might do.

--- a/test/E2E/E2ETest.cs
+++ b/test/E2E/E2ETest.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.IO;
+using Xunit;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.ProjectModel;
+
+namespace ConsoleApplication
+{
+    public class E2ETest
+    {
+        private static readonly string EXPECTED_OUTPUT = "Hello World!";
+        private static readonly string TEST_PROJECT_NAME = "hellotest";
+        private static readonly string OUTPUT_FOLDER_NAME = "testbin";
+
+        public static void Main()
+        {
+            Console.WriteLine("Dummy Entrypoint.");
+        }
+
+        [Fact]
+        public static void TestE2E()
+        {
+            // Setup Paths
+            var rootPath = GetRootPath();
+            var testDir = Path.Combine(rootPath, TEST_PROJECT_NAME);
+            var outputDir = Path.Combine(testDir, OUTPUT_FOLDER_NAME);
+
+            // Setup RID
+            var rid = RuntimeIdentifier.Current;
+
+            // Create Test Directory and cd there
+            CleanOrCreateDirectory(testDir);
+            Directory.SetCurrentDirectory(TEST_PROJECT_NAME);
+
+            // Base Set of Commands
+            TestRunCommand("dotnet", "init");
+
+            TestRunCommand("dotnet", "restore");
+            TestRunCommand("dotnet", "run");
+
+            // Compile
+            TestRunCommand("dotnet", $"compile -o {outputDir}");
+            TestOutputExecutable(outputDir);
+
+            // Native Compilation
+            CleanOrCreateDirectory(outputDir);
+            TestRunCommand("dotnet", $"compile --native -o {outputDir}");
+            TestOutputExecutable(outputDir);
+
+            // Native Compilation w/ CPP backend
+            CleanOrCreateDirectory(outputDir);
+            TestRunCommand("dotnet", $"compile --native --cpp -o {outputDir}");
+            TestOutputExecutable(outputDir);
+
+            // Publish
+            CleanOrCreateDirectory(outputDir);
+            TestRunCommand("dotnet", $"publish --framework dnxcore50 --runtime {rid} -o {outputDir}");
+            TestOutputExecutable(outputDir);
+
+            TestRunCommand("dotnet", "pack");
+        }
+
+        public static void TestRunCommand(string command, string args)
+        {
+            var result = Command.Create(command, args)
+                .ForwardStdErr()
+                .ForwardStdOut()
+                .Execute();
+
+            Assert.Equal(0, result.ExitCode);
+        }
+
+        public static void TestOutputExecutable(string outputDir)
+        {
+            var executableName = TEST_PROJECT_NAME + Constants.ExeSuffix;
+
+            var executablePath = Path.Combine(outputDir, executableName);
+
+            var result = Command.Create(executablePath, "")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute();
+
+            var outText = result.StdOut;
+
+            var expectedText = EXPECTED_OUTPUT + Environment.NewLine;
+            Assert.Equal(expectedText, outText);
+        }
+
+        public static string GetRootPath()
+        {
+            var cwd = Directory.GetCurrentDirectory();
+
+            return cwd;
+        }
+
+        public static void CleanOrCreateDirectory(string path)
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, true);
+            }
+            Directory.CreateDirectory(path);
+        }
+    }
+}

--- a/test/E2E/E2ETest.cs
+++ b/test/E2E/E2ETest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using Xunit;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.ProjectModel;
@@ -11,59 +12,119 @@ namespace ConsoleApplication
 {
     public class E2ETest
     {
-        private static readonly string EXPECTED_OUTPUT = "Hello World!";
-        private static readonly string TEST_PROJECT_NAME = "hellotest";
-        private static readonly string OUTPUT_FOLDER_NAME = "testbin";
+        private static readonly string EXPECTED_OUTPUT = "Hello World!" + Environment.NewLine;
+        private static readonly string TESTDIR_NAME = "hellotest";
+        private static readonly string OUTPUTDIR_NAME = "testbin";
+
+        private static string RootPath { get; set; }
+        private string TestDirectory { get; set; }
+        private string OutputDirectory { get; set; }
+        private string Rid { get; set; }
 
         public static void Main()
         {
             Console.WriteLine("Dummy Entrypoint.");
         }
-
-        [Fact]
-        public static void TestE2E()
+       
+        public E2ETest()
         {
-            // Setup Paths
-            var rootPath = GetRootPath();
-            var testDir = Path.Combine(rootPath, TEST_PROJECT_NAME);
-            var outputDir = Path.Combine(testDir, OUTPUT_FOLDER_NAME);
+            if (RootPath == null)
+            {
+                RootPath = Directory.GetCurrentDirectory();
+            }
 
-            // Setup RID
-            var rid = RuntimeIdentifier.Current;
+            TestDirectory = Path.Combine(RootPath, TESTDIR_NAME);
+            OutputDirectory = Path.Combine(RootPath, OUTPUTDIR_NAME);
 
-            // Create Test Directory and cd there
-            CleanOrCreateDirectory(testDir);
-            Directory.SetCurrentDirectory(TEST_PROJECT_NAME);
-
-            // Base Set of Commands
-            TestRunCommand("dotnet", "init");
-
-            TestRunCommand("dotnet", "restore");
-            TestRunCommand("dotnet", "run");
-
-            // Compile
-            TestRunCommand("dotnet", $"compile -o {outputDir}");
-            TestOutputExecutable(outputDir);
-
-            // Native Compilation
-            CleanOrCreateDirectory(outputDir);
-            TestRunCommand("dotnet", $"compile --native -o {outputDir}");
-            TestOutputExecutable(outputDir);
-
-            // Native Compilation w/ CPP backend
-            CleanOrCreateDirectory(outputDir);
-            TestRunCommand("dotnet", $"compile --native --cpp -o {outputDir}");
-            TestOutputExecutable(outputDir);
-
-            // Publish
-            CleanOrCreateDirectory(outputDir);
-            TestRunCommand("dotnet", $"publish --framework dnxcore50 --runtime {rid} -o {outputDir}");
-            TestOutputExecutable(outputDir);
-
-            TestRunCommand("dotnet", "pack");
+            Rid = RuntimeIdentifier.Current;
         }
 
-        public static void TestRunCommand(string command, string args)
+        [Fact]
+        public void TestDotnetCompile()
+        {
+            TestSetup();
+
+            TestRunCommand("dotnet", $"compile -o {OutputDirectory}");
+            TestOutputExecutable(OutputDirectory);
+        }
+
+        [Fact]
+        public void TestDotnetCompileNativeRyuJit()
+        {
+            // Skip this test on mac
+            if(SkipForOS(OSPlatform.OSX, "https://github.com/dotnet/cli/issues/246"))
+            {
+                return;
+            }
+
+            TestSetup();
+
+            TestRunCommand("dotnet", $"compile --native -o {OutputDirectory}");
+
+            var nativeOut = Path.Combine(OutputDirectory, "native");
+            TestOutputExecutable(nativeOut);
+        }
+
+        [Fact]
+        public void TestDotnetCompileNativeCpp()
+        {
+            TestSetup();
+
+            TestRunCommand("dotnet", $"compile --native --cpp -o {OutputDirectory}");
+            
+            var nativeOut = Path.Combine(OutputDirectory, "native");
+            TestOutputExecutable(nativeOut);
+        }
+
+        [Fact]
+        public void TestDotnetRun()
+        {
+            TestSetup();
+
+            TestRunCommand("dotnet", $"run");
+        }
+
+        [Fact(Skip="https://github.com/dotnet/cli/issues/333")]
+        public void TestDotnetPack()
+        {
+            TestSetup();
+
+            TestRunCommand("dotnet", $"pack");
+        }
+
+        [Fact]
+        public void TestDotnetPublish()
+        {
+            TestSetup();
+
+            TestRunCommand("dotnet", $"publish --framework dnxcore50 --runtime {Rid} -o {OutputDirectory}");
+            TestOutputExecutable(OutputDirectory);    
+        }
+
+        private void TestSetup()
+        {
+            Directory.SetCurrentDirectory(RootPath);
+
+            CleanOrCreateDirectory(TestDirectory);
+            CleanOrCreateDirectory(OutputDirectory);
+
+            Directory.SetCurrentDirectory(TestDirectory);
+
+            TestRunCommand("dotnet", "init");
+            TestRunCommand("dotnet", "restore");
+        }
+
+        private bool SkipForOS(OSPlatform os, string reason)
+        {
+            if (RuntimeInformation.IsOSPlatform(os))
+            {
+                Console.WriteLine("Skipping Test for reason: " + reason);
+                return true;
+            }
+            return false;
+        }
+
+        private void TestRunCommand(string command, string args)
         {
             var result = Command.Create(command, args)
                 .ForwardStdErr()
@@ -73,9 +134,9 @@ namespace ConsoleApplication
             Assert.Equal(0, result.ExitCode);
         }
 
-        public static void TestOutputExecutable(string outputDir)
+        private void TestOutputExecutable(string outputDir)
         {
-            var executableName = TEST_PROJECT_NAME + Constants.ExeSuffix;
+            var executableName = TESTDIR_NAME + Constants.ExeSuffix;
 
             var executablePath = Path.Combine(outputDir, executableName);
 
@@ -85,19 +146,10 @@ namespace ConsoleApplication
                 .Execute();
 
             var outText = result.StdOut;
-
-            var expectedText = EXPECTED_OUTPUT + Environment.NewLine;
-            Assert.Equal(expectedText, outText);
+            Assert.Equal(EXPECTED_OUTPUT, outText);
         }
 
-        public static string GetRootPath()
-        {
-            var cwd = Directory.GetCurrentDirectory();
-
-            return cwd;
-        }
-
-        public static void CleanOrCreateDirectory(string path)
+        private void CleanOrCreateDirectory(string path)
         {
             if (Directory.Exists(path))
             {

--- a/test/E2E/E2ETest.cs
+++ b/test/E2E/E2ETest.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.IO;
 using Xunit;
 using Microsoft.DotNet.Cli.Utils;

--- a/test/E2E/E2ETest.cs
+++ b/test/E2E/E2ETest.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Xunit;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.Extensions.ProjectModel;
+using Microsoft.DotNet.ProjectModel;
 
 namespace ConsoleApplication
 {

--- a/test/E2E/E2ETest.cs
+++ b/test/E2E/E2ETest.cs
@@ -68,6 +68,12 @@ namespace ConsoleApplication
         [Fact]
         public void TestDotnetCompileNativeCpp()
         {
+            // Skip this test on windows
+            if(SkipForOS(OSPlatform.Windows, "https://github.com/dotnet/cli/issues/335"))
+            {
+                return;
+            }
+
             TestSetup();
 
             TestRunCommand("dotnet", $"compile --native --cpp -o {OutputDirectory}");

--- a/test/E2E/project.json
+++ b/test/E2E/project.json
@@ -6,21 +6,20 @@
 
     "dependencies": {
         "Microsoft.NETCore.Platforms":"1.0.1-beta-*",
-        "Microsoft.NETCore.TestHost": "1.0.0-beta-*",
         "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
-        "Microsoft.NETCore.Console": "1.0.0-beta-*",
-        "System.IO": "4.0.11-beta-*",
         "System.Console": "4.0.0-beta-*",
         "System.Runtime": "4.0.21-beta-*",
+        "System.AppContext": "4.0.1-beta-*",
+
         "xunit": "2.1.0",
+        "xunit.console.netcore": "1.0.2-prerelease-00101",
+        "xunit.runner.utility": "2.1.0",
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
         "Microsoft.DotNet.Cli.Utils": {
           "type": "build",
           "version": "1.0.0-*"
         },
-        "System.AppContext": "4.0.1-beta-*",
-        "xunit.console.netcore": "1.0.2-prerelease-00101",
-        "xunit.runner.utility": "2.1.0",
-        "Microsoft.DotNet.ProjectModel": { "target": "project" }
     },
 
     "frameworks": {

--- a/test/E2E/project.json
+++ b/test/E2E/project.json
@@ -1,0 +1,29 @@
+﻿{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "Microsoft.NETCore.Platforms":"1.0.1-beta-*",
+        "Microsoft.NETCore.TestHost": "1.0.0-beta-*",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
+        "Microsoft.NETCore.Console": "1.0.0-beta-*",
+        "System.IO": "4.0.11-beta-*",
+        "System.Console": "4.0.0-beta-*",
+        "System.Runtime": "4.0.21-beta-*",
+        "xunit": "2.1.0",
+        "Microsoft.DotNet.Cli.Utils": {
+          "type": "build",
+          "version": "1.0.0-*"
+        },
+        "System.AppContext": "4.0.1-beta-*",
+        "xunit.console.netcore": "1.0.2-prerelease-00101",
+        "xunit.runner.utility": "2.1.0",
+        "Microsoft.DotNet.ProjectModel": { "target": "project" }
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
First pass on the End To End Tests

Built in C# and uses XUnit with xunit.console.netcore to run the End to End Test.

I had to make changes to the Reporter and add the AnsiConsole in order to get a working publish of the utils project. Not sure how master is succeeding right now without it...

Known Failures:
'dotnet pack' seems to be succeeding and exiting with non-zero anyways (on windows). Have not done an investigation, as these are the kinds of things this is meant to catch.

Fixes #283 

Take a look
@krwq @Sridhar-MS @piotrpMSFT @anurse @davidfowl 