### PR TITLE
workaround powershell bug

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,4 +3,4 @@
 REM Copyright (c) .NET Foundation and contributors. All rights reserved.
 REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-powershell -NoProfile -NoLogo -File %~dp0scripts\build.ps1 %*
+powershell -NoProfile -NoLogo -Command "%~dp0scripts\build.ps1 %*; exit $LastExitCode;"


### PR DESCRIPTION
powershell loses exit code when the script was auto-stopped using: $ErrorActionPreference="Stop"
