### PR TITLE
Fixing environment value name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Basic usage
 
 When you have the .NET Command Line Interface installed on your OS of choice, you can try it out using some of the samples on the [dotnet/core repo](https://github.com/dotnet/core/tree/master/samples). You can download the sample in a directory, and then do you can kick the tires of the CLI.
 
-**Note:** on Linux, post-install, please set up the `DOTNET_HOME` environment: `export DOTNET_HOME=/usr/share/dotnet/`.
+**Note:** on Linux, post-install, please set up the `DOTNET_TOOLS` environment: `export DOTNET_TOOLS=/usr/share/dotnet/cli`.
 
-**Note:** on OS X, post-install, please set up the `DOTNET_HOME` environment: `export DOTNET_HOME=/usr/local/share/dotnet/cli`.
+**Note:** on OS X, post-install, please set up the `DOTNET_TOOLS` environment: `export DOTNET_TOOLS=/usr/local/share/dotnet/cli`.
 
 
 First, you will need to restore the packages:


### PR DESCRIPTION
- DNX_HOME -> DNX_TOOLS
- Fixed the location for the Linux instructions