### PR TITLE
Fix Microsoft.DotNet.ProjectModel namespace

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/ScriptExecutor.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ScriptExecutor.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils.CommandParsing;
-using Microsoft.Extensions.ProjectModel;
+using Microsoft.DotNet.ProjectModel;
 
 namespace Microsoft.DotNet.Cli.Utils
 {

--- a/src/Microsoft.DotNet.Compiler.Common/CommonCompilerOptionsExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/CommonCompilerOptionsExtensions.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.Linq;
 
-using Microsoft.Extensions.ProjectModel;
+using Microsoft.DotNet.ProjectModel;
 
 namespace Microsoft.DotNet.Cli.Compiler.Common
 {

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.Extensions.ProjectModel;
+using Microsoft.DotNet.ProjectModel;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.ProjectModel.Workspaces

--- a/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class CommonCompilerOptions
     {

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryAsset.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryAsset.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.Extensions.ProjectModel.Compilation
+namespace Microsoft.DotNet.ProjectModel.Compilation
 {
     public struct LibraryAsset
     {

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExport.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExport.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-namespace Microsoft.Extensions.ProjectModel.Compilation
+namespace Microsoft.DotNet.ProjectModel.Compilation
 {
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class LibraryExport

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -6,12 +6,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Microsoft.Extensions.ProjectModel.Graph;
-using Microsoft.Extensions.ProjectModel.Resolution;
-using Microsoft.Extensions.ProjectModel.Utilities;
+using Microsoft.DotNet.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Resolution;
+using Microsoft.DotNet.ProjectModel.Utilities;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel.Compilation
+namespace Microsoft.DotNet.ProjectModel.Compilation
 {
     public class LibraryExporter
     {

--- a/src/Microsoft.DotNet.ProjectModel/DiagnosticMessage.cs
+++ b/src/Microsoft.DotNet.ProjectModel/DiagnosticMessage.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     /// <summary>
     /// Represents a single diagnostic message, such as a compilation error or a project.json parsing error.

--- a/src/Microsoft.DotNet.ProjectModel/DiagnosticMessageSeverity.cs
+++ b/src/Microsoft.DotNet.ProjectModel/DiagnosticMessageSeverity.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     /// <summary>
     /// Specifies the severity of a <see cref="DiagnosticMessage"/>.

--- a/src/Microsoft.DotNet.ProjectModel/EnvironmentNames.cs
+++ b/src/Microsoft.DotNet.ProjectModel/EnvironmentNames.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class EnvironmentNames
     {

--- a/src/Microsoft.DotNet.ProjectModel/ErrorCodes.DotNet.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ErrorCodes.DotNet.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public static partial class ErrorCodes
     {

--- a/src/Microsoft.DotNet.ProjectModel/ErrorCodes.NuGet.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ErrorCodes.NuGet.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public static partial class ErrorCodes
     {

--- a/src/Microsoft.DotNet.ProjectModel/FileFormatException.cs
+++ b/src/Microsoft.DotNet.ProjectModel/FileFormatException.cs
@@ -4,7 +4,7 @@
 using System;
 using Microsoft.Extensions.JsonParser.Sources;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public sealed class FileFormatException : Exception
     {

--- a/src/Microsoft.DotNet.ProjectModel/Files/NamedResourceReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Files/NamedResourceReader.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.JsonParser.Sources;
 
-namespace Microsoft.Extensions.ProjectModel.Files
+namespace Microsoft.DotNet.ProjectModel.Files
 {
     internal static class NamedResourceReader
     {

--- a/src/Microsoft.DotNet.ProjectModel/Files/PackIncludeEntry.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Files/PackIncludeEntry.cs
@@ -4,7 +4,7 @@
 using System.Linq;
 using Microsoft.Extensions.JsonParser.Sources;
 
-namespace Microsoft.Extensions.ProjectModel.Files
+namespace Microsoft.DotNet.ProjectModel.Files
 {
     public class PackIncludeEntry
     {

--- a/src/Microsoft.DotNet.ProjectModel/Files/PatternGroup.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Files/PatternGroup.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.JsonParser.Sources;
 
-namespace Microsoft.Extensions.ProjectModel.Files
+namespace Microsoft.DotNet.ProjectModel.Files
 {
     public class PatternGroup
     {

--- a/src/Microsoft.DotNet.ProjectModel/Files/PatternsCollectionHelper.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Files/PatternsCollectionHelper.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Extensions.JsonParser.Sources;
 
-namespace Microsoft.Extensions.ProjectModel.Files
+namespace Microsoft.DotNet.ProjectModel.Files
 {
     internal static class PatternsCollectionHelper
     {

--- a/src/Microsoft.DotNet.ProjectModel/Files/ProjectFilesCollection.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Files/ProjectFilesCollection.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.JsonParser.Sources;
 
-namespace Microsoft.Extensions.ProjectModel.Files
+namespace Microsoft.DotNet.ProjectModel.Files
 {
     public class ProjectFilesCollection
     {

--- a/src/Microsoft.DotNet.ProjectModel/GlobalSettings.cs
+++ b/src/Microsoft.DotNet.ProjectModel/GlobalSettings.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.JsonParser.Sources;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class GlobalSettings
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LibraryDependencyType.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LibraryDependencyType.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public struct LibraryDependencyType
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LibraryDependencyTypeFlag.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LibraryDependencyTypeFlag.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     [Flags]
     public enum LibraryDependencyTypeFlag

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LibraryIdentity.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LibraryIdentity.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Internal;
 using NuGet;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public struct LibraryIdentity : IEquatable<LibraryIdentity>
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LibraryRange.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LibraryRange.cs
@@ -6,7 +6,7 @@ using System.Text;
 using Microsoft.Extensions.Internal;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public struct LibraryRange : IEquatable<LibraryRange>
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LibraryType.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LibraryType.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public struct LibraryType : IEquatable<LibraryType>
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
@@ -5,10 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Extensions.ProjectModel.Utilities;
+using Microsoft.DotNet.ProjectModel.Utilities;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public class LockFile
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileItem.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileItem.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public class LockFileItem
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileLookup.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileLookup.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public class LockFileLookup
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePackageLibrary.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePackageLibrary.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public class LockFilePackageLibrary
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileProjectLibrary.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileProjectLibrary.cs
@@ -3,7 +3,7 @@
 
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public class LockFileProjectLibrary
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
@@ -5,13 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.DotNet.ProjectModel.Utilities;
 using Microsoft.Extensions.JsonParser.Sources;
-using Microsoft.Extensions.ProjectModel.Utilities;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     internal static class LockFileReader
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileTarget.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileTarget.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public class LockFileTarget
     {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileTargetLibrary.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileTargetLibrary.cs
@@ -7,7 +7,7 @@ using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Graph
+namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public class LockFileTargetLibrary
     {

--- a/src/Microsoft.DotNet.ProjectModel/LibraryDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/LibraryDescription.cs
@@ -4,11 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.ProjectModel.Graph;
 using Microsoft.Extensions.Internal;
-using Microsoft.Extensions.ProjectModel.Graph;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     /// <summary>
     /// Represents the result of resolving the library

--- a/src/Microsoft.DotNet.ProjectModel/PackageDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/PackageDescription.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Microsoft.Extensions.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Graph;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class PackageDescription : LibraryDescription
     {

--- a/src/Microsoft.DotNet.ProjectModel/Project.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Project.cs
@@ -4,12 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Microsoft.Extensions.ProjectModel.Files;
-using Microsoft.Extensions.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Files;
+using Microsoft.DotNet.ProjectModel.Graph;
 using NuGet.Frameworks;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class Project
     {

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Extensions.ProjectModel.Compilation;
-using Microsoft.Extensions.ProjectModel.Resolution;
+using Microsoft.DotNet.ProjectModel.Compilation;
+using Microsoft.DotNet.ProjectModel.Resolution;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     // NOTE(anurse): Copied from ApplicationHostContext in DNX. This name seemed more appropriate for this :)
     public class ProjectContext

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
@@ -6,12 +6,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Resolution;
 using Microsoft.Extensions.Internal;
-using Microsoft.Extensions.ProjectModel.Graph;
-using Microsoft.Extensions.ProjectModel.Resolution;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class ProjectContextBuilder
     {

--- a/src/Microsoft.DotNet.ProjectModel/ProjectDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectDescription.cs
@@ -3,9 +3,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Graph;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class ProjectDescription : LibraryDescription
     {

--- a/src/Microsoft.DotNet.ProjectModel/ProjectFileDependencyGroup.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectFileDependencyGroup.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class ProjectFileDependencyGroup
     {

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
@@ -5,14 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.DotNet.ProjectModel.Files;
+using Microsoft.DotNet.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Utilities;
 using Microsoft.Extensions.JsonParser.Sources;
-using Microsoft.Extensions.ProjectModel.Files;
-using Microsoft.Extensions.ProjectModel.Graph;
-using Microsoft.Extensions.ProjectModel.Utilities;
 using NuGet.Frameworks;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class ProjectReader
     {

--- a/src/Microsoft.DotNet.ProjectModel/ProjectRootResolver.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectRootResolver.cs
@@ -3,7 +3,7 @@
 
 using System.IO;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public static class ProjectRootResolver
     {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/FrameworkInformation.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/FrameworkInformation.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace Microsoft.Extensions.ProjectModel.Resolution
+namespace Microsoft.DotNet.ProjectModel.Resolution
 {
     internal class FrameworkInformation
     {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/FrameworkReferenceResolver.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/FrameworkReferenceResolver.cs
@@ -7,10 +7,10 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Xml.Linq;
-using Microsoft.Extensions.ProjectModel.Utilities;
+using Microsoft.DotNet.ProjectModel.Utilities;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel.Resolution
+namespace Microsoft.DotNet.ProjectModel.Resolution
 {
     public class FrameworkReferenceResolver
     {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/LibraryManager.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/LibraryManager.cs
@@ -3,11 +3,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.ProjectModel.Graph;
-using Microsoft.Extensions.ProjectModel.Utilities;
+using Microsoft.DotNet.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Utilities;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Resolution
+namespace Microsoft.DotNet.ProjectModel.Resolution
 {
     public class LibraryManager
     {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Extensions.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Graph;
 using NuGet.Packaging;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Resolution
+namespace Microsoft.DotNet.ProjectModel.Resolution
 {
     public class PackageDependencyProvider
     {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/ProjectDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/ProjectDependencyProvider.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
-using Microsoft.Extensions.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Graph;
 using NuGet;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel.Resolution
+namespace Microsoft.DotNet.ProjectModel.Resolution
 {
     public class ProjectDependencyProvider
     {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/ReferenceAssemblyDependencyResolver.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/ReferenceAssemblyDependencyResolver.cs
@@ -4,12 +4,12 @@
 using System;
 using System.Linq;
 using System.Runtime.Versioning;
-using Microsoft.Extensions.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Graph;
 using NuGet;
 using NuGet.Frameworks;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Resolution
+namespace Microsoft.DotNet.ProjectModel.Resolution
 {
     public class ReferenceAssemblyDependencyResolver
     {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/UnresolvedDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/UnresolvedDependencyProvider.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
-using Microsoft.Extensions.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Graph;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel.Resolution
+namespace Microsoft.DotNet.ProjectModel.Resolution
 {
     public static class UnresolvedDependencyProvider
     {

--- a/src/Microsoft.DotNet.ProjectModel/RuntimeIdentifier.cs
+++ b/src/Microsoft.DotNet.ProjectModel/RuntimeIdentifier.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public static class RuntimeIdentifier
     {

--- a/src/Microsoft.DotNet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/Microsoft.DotNet.ProjectModel/TargetFrameworkInformation.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Microsoft.Extensions.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Graph;
 using NuGet.Frameworks;
 
-namespace Microsoft.Extensions.ProjectModel
+namespace Microsoft.DotNet.ProjectModel
 {
     public class TargetFrameworkInformation
     {

--- a/src/Microsoft.DotNet.ProjectModel/Utilities/PathUtility.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Utilities/PathUtility.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.Extensions.ProjectModel.Utilities
+namespace Microsoft.DotNet.ProjectModel.Utilities
 {
     internal static class PathUtility
     {

--- a/src/Microsoft.DotNet.ProjectModel/Utilities/VersionUtility.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Utilities/VersionUtility.cs
@@ -6,7 +6,7 @@ using System.Runtime.Loader;
 using System.Text;
 using NuGet.Versioning;
 
-namespace Microsoft.Extensions.ProjectModel.Utilities
+namespace Microsoft.DotNet.ProjectModel.Utilities
 {
     public static class VersionUtility
     {

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
@@ -12,7 +12,7 @@ using System.Text;
 
 using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.Extensions.ProjectModel;
+using Microsoft.DotNet.ProjectModel;
 
 namespace Microsoft.DotNet.Tools.Compiler.Csc
 {

--- a/src/Microsoft.DotNet.Tools.Compiler/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/Program.cs
@@ -11,8 +11,8 @@ using Microsoft.Dnx.Runtime.Common.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.Tools.Common;
-using Microsoft.Extensions.ProjectModel;
-using Microsoft.Extensions.ProjectModel.Compilation;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.ProjectModel.Compilation;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Tools.Compiler

--- a/src/Microsoft.DotNet.Tools.Pack/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Pack/Program.cs
@@ -7,18 +7,18 @@ using System.IO;
 using System.Linq;
 
 using System.Text;
-using Microsoft.Extensions.ProjectModel;
+using Microsoft.DotNet.ProjectModel;
 using NuGet;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using NuGet.Packaging.Core;
-using Microsoft.Extensions.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Graph;
 using NuGet.Versioning;
 using NuGet.Frameworks;
-using Microsoft.Extensions.ProjectModel.Files;
+using Microsoft.DotNet.ProjectModel.Files;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
-using Microsoft.Extensions.ProjectModel.Utilities;
+using Microsoft.DotNet.ProjectModel.Utilities;
 
 namespace Microsoft.DotNet.Tools.Compiler
 {

--- a/src/Microsoft.DotNet.Tools.Publish/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Publish/Program.cs
@@ -8,8 +8,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.Extensions.ProjectModel;
-using Microsoft.Extensions.ProjectModel.Compilation;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.ProjectModel.Compilation;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Tools.Publish

--- a/src/Microsoft.DotNet.Tools.Run/RunCommand.cs
+++ b/src/Microsoft.DotNet.Tools.Run/RunCommand.cs
@@ -7,7 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.Extensions.ProjectModel;
+using Microsoft.DotNet.ProjectModel;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Tools.Run


### PR DESCRIPTION
Microsoft.Extensions.ProjectModel was renamed to Microsoft.DotNet.ProjectModel, though the namespace in the core library was omitted. Updating namespace to expected value.