### PR TITLE
dotnet-publish '--framework' and '--runtime' options are made to be optional

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
@@ -13,7 +13,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ProjectModel.Graph
 {
-    internal static class LockFileReader
+    public static class LockFileReader
     {
         public static LockFile Read(string filePath)
         {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
@@ -13,7 +13,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ProjectModel.Graph
 {
-    public static class LockFileReader
+    internal static class LockFileReader
     {
         public static LockFile Read(string filePath)
         {

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.ProjectModel
         /// </summary>
         public static ProjectContext Create(string projectPath, NuGetFramework framework, IEnumerable<string> runtimeIdentifiers)
         {
-            if(projectPath.EndsWith(Project.FileName))
+            if (projectPath.EndsWith(Project.FileName))
             {
                 projectPath = Path.GetDirectoryName(projectPath);
             }
@@ -85,13 +85,13 @@ namespace Microsoft.DotNet.ProjectModel
         /// </summary>
         public static IEnumerable<ProjectContext> CreateContextForEachFramework(string projectPath)
         {
-            if(!projectPath.EndsWith(Project.FileName))
+            if (!projectPath.EndsWith(Project.FileName))
             {
                 projectPath = Path.Combine(projectPath, Project.FileName);
             }
             var project = ProjectReader.GetProject(projectPath);
 
-            foreach(var framework in project.GetTargetFrameworks())
+            foreach (var framework in project.GetTargetFrameworks())
             {
                 yield return new ProjectContextBuilder()
                                 .WithProject(project)
@@ -99,6 +99,23 @@ namespace Microsoft.DotNet.ProjectModel
                                 .Build();
             }
         }
+
+        /// <summary>
+        /// Creates a project context for each target located in the project at <paramref name="projectPath"/>
+        /// </summary>
+        public static IEnumerable<ProjectContext> CreateContextForEachTarget(string projectPath)
+        {
+            if (!projectPath.EndsWith(Project.FileName))
+            {
+                projectPath = Path.Combine(projectPath, Project.FileName);
+            }
+            var project = ProjectReader.GetProject(projectPath);
+
+            return new ProjectContextBuilder()
+                        .WithProject(project)
+                        .BuildAllTargets();
+        }
+
         public string GetAssemblyPath(string buildConfiguration)
         {
             return Path.Combine(

--- a/src/Microsoft.DotNet.Tools.Publish/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Publish/Program.cs
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Tools.Publish
 
         // return the matching framework/runtime ProjectContext.
         // if 'nugetframework' or 'runtime' is null or empty then it matches with any.
-        private static IEnumerable<ProjectContext> GetMatchingProjectContexts(IEnumerable<ProjectContext> contexts, NuGetframework framework, string runtimeIdentifier)
+        private static IEnumerable<ProjectContext> GetMatchingProjectContexts(IEnumerable<ProjectContext> contexts, NuGetFramework framework, string runtimeIdentifier)
         {
             var matchingContexts = contexts.Where(context =>
             {


### PR DESCRIPTION
When no `runtime` and `framework` are specified then publish for all `framework/runtime` targets found in project.lock.json. But currently when `runtime` is not specified then current OS runtime identifier is assumed. This will go away when xplat publish is enabled.
Example - `dotnet publish /home/sridhar/foo/project.json` -> Publish for all targets in project.lock.json.

User can also specify either `framework` or `runtime`. In that case all the corresponding `framework` or `runtime` targets in project.lock.json are published.
Example - `dotnet publish --framework dnxcore50 /home/sridhar/foo/project.json` -> Publish for all targets in project.lock.json with framework dnxcore50.
	   (or)
	  `dotnet publish --runtime win7-x64 /home/sridhar/foo/project.json` -> Publish for all targets in project.lock.json with runtime win7-x64.

I am also adding unit tests for publish in upcoming commits.

Fixes - #185

cc: @blackdwarf @piotrpMSFT @anurse @davidfowl 