### PR TITLE
dotnet pack returns the wrong exit code

### DIFF
--- a/src/Microsoft.DotNet.Tools.Pack/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Pack/Program.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                 var configValue = configuration.Value() ?? Cli.Utils.Constants.DefaultConfiguration;
                 var outputValue = output.Value();
 
-                return BuildPackage(path, configValue, outputValue, intermediateOutput.Value()) ? 1 : 0;
+                return BuildPackage(path, configValue, outputValue, intermediateOutput.Value()) ? 0 : 1;
             });
 
             try


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/333

Because true is false

Please review @anurse @davidfowl 