### PR TITLE
Let IlcArgs be an opaque string to dotnet native

### DIFF
--- a/src/Microsoft.DotNet.Tools.Compiler.Native/NativeCompileSettings.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/NativeCompileSettings.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         public string IlcArgs
         {
             get { return _ilcArgs; }
-            set { _ilcArgs = Path.GetFullPath(value); }
+            set { _ilcArgs = value; }
         }
         public IEnumerable<string> LinkLibPaths => _linkLibPaths;
 


### PR DESCRIPTION
IlcArgs are meant to be arguments to the ILCompiler and not path values

@brthor or @livarcocc PTAL

/Cc @gkhanna79