### PR TITLE
rename resgen to dotnet-resgen

### DIFF
--- a/packaging/debian/debian_config.json
+++ b/packaging/debian/debian_config.json
@@ -47,6 +47,6 @@ compilers, package managers and other utilities that developers need.",
         "bin/dotnet-repl-csi" : "usr/bin/dotnet-repl-csi",
         "bin/dotnet-restore" : "usr/bin/dotnet-restore",
         "bin/dotnet-test" : "usr/bin/dotnet-test",
-        "bin/resgen" : "usr/bin/resgen"
+        "bin/dotnet-resgen" : "usr/bin/dotnet-resgen"
     }
 }

--- a/packaging/osx/scripts/postinstall
+++ b/packaging/osx/scripts/postinstall
@@ -11,7 +11,7 @@ ln -s $2/bin/dotnet-publish /usr/local/bin/
 ln -s $2/bin/dotnet-restore /usr/local/bin/
 ln -s $2/bin/dotnet-restore /usr/local/bin/
 ln -s $2/bin/dotnet-init /usr/local/bin/
-ln -s $2/bin/resgen /usr/local/bin/
+ln -s $2/bin/dotnet-resgen /usr/local/bin/
 
 # A temporary solution to unblock dotnet compile
 cp $2/bin/corehost /usr/local/bin/

--- a/src/Microsoft.DotNet.Tools.Compiler/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/Program.cs
@@ -619,7 +619,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                         // {file}.resx -> {file}.resources
                         var resourcesFile = Path.Combine(intermediateOutputPath, name);
 
-                        var result = Command.Create("resgen", $"\"{fileName}\" \"{resourcesFile}\"")
+                        var result = Command.Create("dotnet-resgen", $"\"{fileName}\" \"{resourcesFile}\"")
                                             .ForwardStdErr()
                                             .ForwardStdOut()
                                             .Execute();

--- a/src/Microsoft.DotNet.Tools.Resgen/project.json
+++ b/src/Microsoft.DotNet.Tools.Resgen/project.json
@@ -1,5 +1,5 @@
 {
-    "name": "resgen",
+    "name": "dotnet-resgen",
     "version": "1.0.0-*",
     "compilationOptions": {
         "emitEntryPoint": true


### PR DESCRIPTION
The issue was hanging around for some time so i thought i will give it a try.  The rename was suggested in #313 . Does any other places needs changing ?