### PR TITLE
Add rest of the command to the driver

### DIFF
--- a/src/Microsoft.DotNet.Cli/Program.cs
+++ b/src/Microsoft.DotNet.Cli/Program.cs
@@ -22,9 +22,12 @@ Common Options (passed before the command):
   -v|--verbose  Enable verbose output
 
 Common Commands:
+  init          Initialize a basic .NET project
+  restore       Restore dependencies specified in the .NET project
   compile       Compiles a .NET project
-  publish       Publishes a .NET project for deployment
-  run           Compiles and immediately executes a .NET project";
+  publish       Publishes a .NET project for deployment (including the runtime)
+  run           Compiles and immediately executes a .NET project
+  pack          Package a NuGet package of the application";
 
         public static int Main(string[] args)
         {

--- a/src/Microsoft.DotNet.Cli/Program.cs
+++ b/src/Microsoft.DotNet.Cli/Program.cs
@@ -27,7 +27,7 @@ Common Commands:
   compile       Compiles a .NET project
   publish       Publishes a .NET project for deployment (including the runtime)
   run           Compiles and immediately executes a .NET project
-  pack          Package a NuGet package of the application";
+  pack          Creates a NuGet package";
 
         public static int Main(string[] args)
         {


### PR DESCRIPTION
Currently, the driver just shows information about compile, publish and run. Add
info for init, pack and restore as well.

/cc @piotrpMSFT @brthor @anurse 