### PR TITLE
clean up project.json files

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,7 +5,7 @@
     <clear />
     <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
-    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="AspNetMaster" value="https://www.myget.org/F/aspnetmaster/api/v3/index.json" />
     <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
@@ -13,7 +13,4 @@
     <add key="corert" value="https://www.myget.org/F/dotnet/auth/3e4f1dbe-f43a-45a8-b029-3ad4d25605ac/api/v2" />
     <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
   </packageSources>
-  <activePackageSource>
-    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
-  </activePackageSource>
 </configuration>

--- a/scripts/crossgen/crossgen_roslyn.cmd
+++ b/scripts/crossgen/crossgen_roslyn.cmd
@@ -1,7 +1,7 @@
+@echo off
+
 REM Copyright (c) .NET Foundation and contributors. All rights reserved.
 REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-@echo off
 
 REM Get absolute path
 pushd %1
@@ -9,7 +9,7 @@ set BIN_DIR=%CD%\bin
 popd
 
 REM Replace with a robust method for finding the right crossgen.exe
-set CROSSGEN_UTIL=%UserProfile%\.dnx\packages\runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR\1.0.1-beta-23504\tools\crossgen.exe
+set CROSSGEN_UTIL=%UserProfile%\.dnx\packages\runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR\1.0.1-beta-23516\tools\crossgen.exe
 
 REM Crossgen currently requires itself to be next to mscorlib
 copy %CROSSGEN_UTIL% /Y %BIN_DIR% > nul

--- a/scripts/crossgen/crossgen_roslyn.sh
+++ b/scripts/crossgen/crossgen_roslyn.sh
@@ -22,7 +22,7 @@ if [ -z "$RID" ]; then
 fi
 
 # Replace with a robust method for finding the right crossgen.exe
-CROSSGEN_UTIL=~/.dnx/packages/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23504/tools/crossgen
+CROSSGEN_UTIL=~/.dnx/packages/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23516/tools/crossgen
 
 cd $BIN_DIR
 

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -1,16 +1,25 @@
 ﻿{
+    "description": "Common utilities for the .NET CLI",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
+    "compilationOptions": {
+        "warningsAsErrors": true
+    },
 
     "shared": "**/*.cs",
 
     "dependencies": {
-      "System.AppContext": "4.0.0",
-      "System.Console": "4.0.0-beta-23504",
-      "System.IO.FileSystem": "4.0.1-beta-23504",
-      "System.Threading": "4.0.11-beta-23504",
-      "System.Diagnostics.Process": "4.1.0-beta-23504",
-      "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23504",
-      "Microsoft.DotNet.ProjectModel": "1.0.0"
+        "System.AppContext": "4.0.0",
+        "System.Console": "4.0.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+        "System.Threading": "4.0.11-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23516",
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Cli/project.json
+++ b/src/Microsoft.DotNet.Cli/project.json
@@ -1,22 +1,29 @@
 {
     "name": "dotnet",
+    "description": ".NET CLI Driver",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
     "compilationOptions": {
+        "warningsAsErrors": true,
         "emitEntryPoint": true
     },
     "dependencies": {
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
+
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
         "Microsoft.Extensions.CommandLineUtils.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
-        }
+            "version": "1.0.0-rc1-final"
+        },
+
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -1,11 +1,18 @@
 ﻿{
+    "description": "Common utilities for compiler drivers in the .NET CLI",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
+    "compilationOptions": {
+        "warningsAsErrors": true
+    },
 
     "dependencies": {
         "System.CommandLine": "0.1.0-*",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Runtime": "4.0.21-beta-23504",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*"
+        "System.Linq": "4.0.1-beta-23516",
+        "Microsoft.DotNet.ProjectModel": { "target": "project" }
     },
 
     "frameworks": {

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -1,7 +1,17 @@
 {
+    "description": "Tools to create Roslyn Workspaces from project.json projects",
+    "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
+    "compilationOptions": {
+        "warningsAsErrors": true
+    },
     "dependencies": {
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.1.0-*"
+        "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.1.0-*",
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -1,26 +1,33 @@
 ﻿{
-    "version": "1.0.0-*",
     "description": "Types to model a .NET Project",
+    "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
+    "compilationOptions": {
+        "warningsAsErrors": true
+    },
     "dependencies": {
-        "Microsoft.CSharp": "4.0.1-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Threading.Thread": "4.0.0-beta-23504",
-        "System.Runtime.Loader": "4.0.0-beta-23504",
-        "System.Dynamic.Runtime": "4.0.11-beta-23504",
-        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23504",
-        "System.Security.Cryptography.Algorithms": "4.0.0-beta-23504",
+        "Microsoft.CSharp": "4.0.1-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Threading.Thread": "4.0.0-beta-23516",
+        "System.Runtime.Loader": "4.0.0-beta-23516",
+        "System.Dynamic.Runtime": "4.0.11-beta-23516",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23516",
+        "System.Security.Cryptography.Algorithms": "4.0.0-beta-23516",
 
-        "NuGet.Packaging": "3.3.0-*",
+        "NuGet.Packaging": "3.3.0",
 
-        "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15791",
+        "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc1-final",
         "Microsoft.Extensions.JsonParser.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
+            "version": "1.0.0-rc1-final"
         },
         "Microsoft.Extensions.HashCodeCombiner.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
+            "version": "1.0.0-rc1-final"
         }
     },
 

--- a/src/Microsoft.DotNet.Runtime/project.json
+++ b/src/Microsoft.DotNet.Runtime/project.json
@@ -1,13 +1,14 @@
 {
-  "compilationOptions": {
-      "emitEntryPoint": true
-  },
+    "description": "[NOT FOR PUBLISHING] Project used to publish the runtime into a folder during the build scripts",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
 
-  "dependencies": {
-    "Microsoft.NETCore.Runtime": "1.0.1-beta-23504"
-  },
+    "dependencies": {
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516"
+    },
 
-  "frameworks": {
-    "dnxcore50": { }
-  }
+    "frameworks": {
+        "dnxcore50": { }
+    }
 }

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
@@ -1,26 +1,33 @@
 {
     "name": "dotnet-compile-csc",
+    "description": "Adds support for compiling C# code using 'csc' in the .NET CLI",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
     "compilationOptions": {
+        "warningsAsErrors": true,
         "emitEntryPoint": true
     },
     "dependencies": {
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "System.IO.FileSystem": "4.0.1-beta-23504",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
 
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+
         "Microsoft.Extensions.CommandLineUtils.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
+            "version": "1.0.0-rc1-final"
         },
-        "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
-        "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151117-04"
+        "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151117-04",
+
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" },
+        "Microsoft.DotNet.Compiler.Common": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             {
                 File.Copy(sharedLibPath, outputSharedLibPath);
             }
-            catch(Exception e)
+            catch(Exception)
             {
                 Reporter.Error.WriteLine("Unable to copy System.Native.so to output");
             }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
@@ -1,32 +1,36 @@
 {
     "name": "dotnet-compile-native",
+    "description": "Performs native compilation on a managed binary",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
     "compilationOptions": {
+        "warningsAsErrors": true,
         "emitEntryPoint": true
     },
     "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1-beta-23504",
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "Microsoft.NETCore.TestHost": "1.0.0-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "System.IO": "4.0.11-beta-23504",
-        "System.IO.FileSystem": "4.0.1-beta-23504",
-        "System.AppContext": "4.0.1-beta-23504",
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
+
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO": "4.0.11-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+        "System.AppContext": "4.0.1-beta-23516",
         "Microsoft.Extensions.CommandLineUtils.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
+            "version": "1.0.0-rc1-final"
         },
-      "Microsoft.DotNet.ILCompiler": "1.0.2-*",
-      "Microsoft.DotNet.ObjectWriter": "1.0.2-*",
-      "Microsoft.DotNet.RyuJit": "1.0.0-*",
-      "Microsoft.DotNet.Compiler.Common": "1.0.0-*"
+        "Microsoft.DotNet.ILCompiler": "1.0.2-prerelease-00001",
+        "Microsoft.DotNet.ObjectWriter": "1.0.3-prerelease-00001",
+        "Microsoft.DotNet.RyuJit": "1.0.1-prerelease-00002",
+
+        "Microsoft.DotNet.Compiler.Common": { "target": "project" },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Compiler/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler/project.json
@@ -1,35 +1,42 @@
 ﻿{
-  "name": "dotnet-compile",
-  "version": "1.0.0-*",
-  "compilationOptions": {
-    "emitEntryPoint": true
-  },
-  "dependencies": {
-    "System.Console": "4.0.0-beta-23504",
-    "System.Collections": "4.0.11-beta-23504",
-    "System.Linq": "4.0.1-beta-23504",
-    "System.Diagnostics.Process": "4.1.0-beta-23504",
-    "System.IO.FileSystem": "4.0.1-beta-23504",
-    "System.AppContext": "4.0.1-beta-23504",
-
-    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
-    "Microsoft.DotNet.Cli.Utils": {
-      "type": "build",
-      "version": "1.0.0-*"
+    "name": "dotnet-compile",
+    "description": "Compiles code in any supported .NET language to a managed or native binary",
+    "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
     },
-    "Microsoft.Extensions.CommandLineUtils.Sources": {
-      "type": "build",
-      "version": "1.0.0-*"
+    "compilationOptions": {
+        "warningsAsErrors": true,
+        "emitEntryPoint": true
+    },
+    "dependencies": {
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
+
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+        "System.AppContext": "4.0.1-beta-23516",
+
+        "Microsoft.Extensions.CommandLineUtils.Sources": {
+            "type": "build",
+            "version": "1.0.0-rc1-final"
+        },
+
+        "Microsoft.DotNet.Compiler.Common": { "target": "project" },
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
+    },
+    "frameworks": {
+        "dnxcore50": { }
+    },
+    "scripts": {
+        "postcompile": [
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.dll\"",
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.pdb\""
+        ]
     }
-  },
-  "frameworks": {
-    "dnxcore50": { }
-  },
-  "scripts": {
-    "postcompile": [
-        "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.dll\"",
-        "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.pdb\""
-    ]
-  }
 }

--- a/src/Microsoft.DotNet.Tools.Init/project.json
+++ b/src/Microsoft.DotNet.Tools.Init/project.json
@@ -1,28 +1,33 @@
 ﻿{
     "name": "dotnet-init",
+    "description": "Creates a simple empty .NET project",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
     "compilationOptions": {
+        "warningsAsErrors": true,
         "emitEntryPoint": true
     },
     "dependencies": {
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
 
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "System.IO.FileSystem": "4.0.1-beta-23504",
-        "System.AppContext": "4.0.1-beta-23504",
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+        "System.AppContext": "4.0.1-beta-23516",
 
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
         "Microsoft.Extensions.CommandLineUtils.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
-        }
+            "version": "1.0.0-rc1-final"
+        },
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
     },
     "compileExclude": [ "Template/**" ],
     "resource": [ "Template/**" ],

--- a/src/Microsoft.DotNet.Tools.Pack/project.json
+++ b/src/Microsoft.DotNet.Tools.Pack/project.json
@@ -1,31 +1,42 @@
 {
-  "name": "dotnet-pack",
-  "version": "1.0.0-*",
-  "compilationOptions": {
-    "emitEntryPoint": true
-  },
-  "dependencies": {
-    "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
-    "System.IO.Compression.ZipFile": "4.0.1-beta-23504",
-    "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23511",
-
-    "System.Console": "4.0.0-beta-23504",
-    "System.Collections": "4.0.11-beta-23504",
-    "System.Linq": "4.0.1-beta-23504",
-    "System.Diagnostics.Process": "4.1.0-beta-23504",
-    "System.IO.FileSystem": "4.0.1-beta-23504",
-
-    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.DotNet.Cli.Utils": {
-      "type": "build",
-      "version": "1.0.0-*"
+    "name": "dotnet-pack",
+    "description": "Creates a NuGet package from a .NET project",
+    "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
     },
-    "Microsoft.Extensions.CommandLineUtils.Sources": {
-      "type": "build",
-      "version": "1.0.0-*"
+    "compilationOptions": {
+        "warningsAsErrors": true,
+        "emitEntryPoint": true
+    },
+    "dependencies": {
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
+
+        "System.IO.Compression.ZipFile": "4.0.1-beta-23516",
+
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+
+        "Microsoft.Extensions.CommandLineUtils.Sources": {
+            "type": "build",
+            "version": "1.0.0-rc1-final"
+        },
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
+    },
+    "frameworks": {
+        "dnxcore50": { }
+    },
+    "scripts": {
+        "postcompile": [
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.dll\"",
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.pdb\""
+        ]
     }
-  },
-  "frameworks": {
-    "dnxcore50": { }
-  }
 }

--- a/src/Microsoft.DotNet.Tools.Publish/project.json
+++ b/src/Microsoft.DotNet.Tools.Publish/project.json
@@ -1,28 +1,33 @@
 {
     "name": "dotnet-publish",
+    "description": "Publishes a .NET project into a self-contained application folder",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
     "compilationOptions": {
+        "warningsAsErrors": true,
         "emitEntryPoint": true
     },
     "dependencies": {
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-23504",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
 
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "System.IO.FileSystem": "4.0.1-beta-23504",
-        "System.AppContext": "4.0.1-beta-23504",
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+        "System.AppContext": "4.0.1-beta-23516",
 
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
         "Microsoft.Extensions.CommandLineUtils.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
-        }
+            "version": "1.0.0-rc1-final"
+        },
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Repl.Csi/project.json
+++ b/src/Microsoft.DotNet.Tools.Repl.Csi/project.json
@@ -1,26 +1,33 @@
 ﻿{
     "name": "dotnet-repl-csi",
+    "description": "Adds support for C# to the 'dotnet repl' command",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
     "compilationOptions": {
+        "warningsAsErrors": true,
         "emitEntryPoint": true
     },
     "dependencies": {
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "System.IO.FileSystem": "4.0.1-beta-23504",
-        "System.AppContext": "4.0.1-beta-23504",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
 
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+        "System.AppContext": "4.0.1-beta-23516",
+
         "Microsoft.Extensions.CommandLineUtils.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
+            "version": "1.0.0-rc1-final"
         },
-        "Microsoft.Net.CSharp.Interactive.netcore": "1.2.0-beta-20151106-02"
+        "Microsoft.Net.CSharp.Interactive.netcore": "1.2.0-beta-20151112-01",
+
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Repl/project.json
+++ b/src/Microsoft.DotNet.Tools.Repl/project.json
@@ -1,25 +1,32 @@
 ﻿{
     "name": "dotnet-repl",
+    "description": "Provides a interactive shell, or 'Read, Eval, Print Loop' (REPL), for any supported .NET language",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
     "compilationOptions": {
+        "warningsAsErrors": true,
         "emitEntryPoint": true
     },
     "dependencies": {
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "System.IO.FileSystem": "4.0.1-beta-23504",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
 
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+
         "Microsoft.Extensions.CommandLineUtils.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
-        }
+            "version": "1.0.0-rc1-final"
+        },
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Resgen/project.json
+++ b/src/Microsoft.DotNet.Tools.Resgen/project.json
@@ -1,26 +1,33 @@
 {
     "name": "dotnet-resgen",
+    "description": "Compiles RESX resource files into binary resources for embedding in managed DLLs",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
     "compilationOptions": {
+        "warningsAsErrors": true,
         "emitEntryPoint": true
     },
     "dependencies": {
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "System.IO.FileSystem": "4.0.1-beta-23504",
-        "System.Xml.XDocument": "4.0.11-beta-23504",
-        "System.Resources.ReaderWriter": "4.0.0-beta-23504",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
 
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+        "System.Xml.XDocument": "4.0.11-beta-23516",
+        "System.Resources.ReaderWriter": "4.0.0-beta-23516",
+
         "Microsoft.Extensions.CommandLineUtils.Sources": {
             "type": "build",
-            "version": "1.0.0-*"
-        }
+            "version": "1.0.0-rc1-final"
+        },
+
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Run/project.json
+++ b/src/Microsoft.DotNet.Tools.Run/project.json
@@ -1,23 +1,30 @@
 ﻿{
     "name": "dotnet-run",
+    "description": "Compiles and immediately runs a .NET project",
     "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
+    },
     "compilationOptions": {
+        "warningsAsErrors": true,
         "emitEntryPoint": true
     },
     "dependencies": {
-        "System.Console": "4.0.0-beta-23504",
-        "System.Collections": "4.0.11-beta-23504",
-        "System.Linq": "4.0.1-beta-23504",
-        "System.Diagnostics.Process": "4.1.0-beta-23504",
-        "System.IO.FileSystem": "4.0.1-beta-23504",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
 
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.DotNet.Cli.Utils": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
+        "System.Console": "4.0.0-beta-23516",
+        "System.Collections": "4.0.11-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "System.IO.FileSystem": "4.0.1-beta-23516",
+
         "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151117-04",
-        "System.CommandLine" : "0.1.0-d111815-3"
+        "System.CommandLine": "0.1.0-d111815-3",
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Test/project.json
+++ b/src/Microsoft.DotNet.Tools.Test/project.json
@@ -1,63 +1,59 @@
 {
-  "name": "dotnet-test",
-  "description": "Test host for discovering and running unit tests at design time, such as in Visual Studio.",
-  "version": "1.0.0-*",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/dotnet/cli"
-  },
-  "compilationOptions": {
-    "warningsAsErrors": true,
-    "emitEntryPoint": true
-  },
-  "dependencies": {
-    "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23409",
-    "Microsoft.NETCore.TestHost": "1.0.0-beta-23409",
-    "Microsoft.Extensions.Compilation.Abstractions": "1.0.0-*",
-    "Microsoft.DotNet.Cli.Utils": {
-      "type": "build",
-      "version": "1.0.0-*"
+    "name": "dotnet-test",
+    "description": "Test host for discovering and running unit tests at design time, such as in Visual Studio.",
+    "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
     },
-    "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
-      "version": "1.0.0-*",
-      "type": "build"
+    "compilationOptions": {
+        "warningsAsErrors": true,
+        "emitEntryPoint": true
     },
-    "Microsoft.Dnx.Runtime.Sources": {
-      "version": "1.0.0-*",
-      "type": "build"
+    "dependencies": {
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "Microsoft.NETCore.Platforms": "1.0.1-beta-23516",
+
+        "Microsoft.Dnx.Compilation.Abstractions": "1.0.0-rc1-final",
+        "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
+            "version": "1.0.0-rc1-final",
+            "type": "build"
+        },
+        "Microsoft.Dnx.Runtime.Sources": {
+            "version": "1.0.0-rc1-final",
+            "type": "build"
+        },
+        "Microsoft.Extensions.CommandLineUtils.Sources": {
+            "version": "1.0.0-rc1-final",
+            "type": "build"
+        },
+        "Microsoft.Extensions.Logging": "1.0.0-rc1-final",
+
+        "Newtonsoft.Json": "7.0.1",
+
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" },
+        "Microsoft.Extensions.Testing.Abstractions": { "target": "project" }
     },
-    "Microsoft.Extensions.Testing.Abstractions": {
-      "version": "1.0.0-*",
-      "type": "build"
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "System.Console": "4.0.0-beta-23516",
+                "System.Diagnostics.Process": "4.1.0-beta-23516",
+                "System.Diagnostics.TextWriterTraceListener": "4.0.0-beta-23516",
+                "System.Diagnostics.TraceSource": "4.0.0-beta-23516",
+                "System.Dynamic.Runtime": "4.0.11-beta-23516",
+                "System.Net.Primitives": "4.0.11-beta-23516",
+                "System.Net.Sockets": "4.1.0-beta-23516",
+                "System.Reflection.Extensions": "4.0.1-beta-23516",
+                "System.Reflection.TypeExtensions": "4.1.0-beta-23516",
+                "System.Threading.Thread": "4.0.0-beta-23516"
+            }
+        }
     },
-    "Microsoft.Extensions.CommandLineUtils.Sources": {
-      "version": "1.0.0-*",
-      "type": "build"
-    },
-    "Microsoft.Extensions.Logging": "1.0.0-*",
-    "Newtonsoft.Json": "7.0.1"
-  },
-  "frameworks": {
-    "dnxcore50": {
-      "dependencies": {
-        "System.Console": "4.0.0-beta-*",
-        "System.Diagnostics.Process": "4.1.0-beta-*",
-        "System.Diagnostics.TextWriterTraceListener": "4.0.0-beta-*",
-        "System.Diagnostics.TraceSource": "4.0.0-beta-*",
-        "System.Dynamic.Runtime": "4.0.11-beta-*",
-        "System.Net.Primitives": "4.0.11-beta-*",
-        "System.Net.Sockets": "4.1.0-beta-*",
-        "System.Runtime": "4.0.21-rc2-*",
-        "System.Reflection.Extensions": "4.0.1-beta-*",
-        "System.Reflection.TypeExtensions": "4.0.1-beta-*",
-        "System.Threading.Thread": "4.0.0-beta-*"
-      }
+    "scripts": {
+        "postcompile": [
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.dll\"",
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.pdb\""
+        ]
     }
-  },
-  "scripts": {
-    "postcompile": [
-      "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.dll\"",
-      "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.pdb\""
-    ]
-  }
 }

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -1,38 +1,37 @@
 {
-  "description": "Abstractions for test runners to communicate to a tool, such as Visual Studio.",
-  "version": "1.0.0-*",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/dotnet/cli"
-  },
-  "compilationOptions": {
-    "warningsAsErrors": true
-  },
-  "dependencies": {
-    "Newtonsoft.Json": "7.0.1",
-    "Microsoft.DotNet.ProjectModel": {
-      "version": "1.0.0",
-      "type": "build"
+    "description": "Abstractions for test runners to communicate to a tool, such as Visual Studio.",
+    "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/dotnet/cli"
     },
-    "Microsoft.Extensions.Compilation.Abstractions": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
-    "System.Runtime.Serialization.Primitives": "4.0.11-beta-*"
-  },
-  "frameworks": {
-    "dnxcore50": {
-      "dependencies": {
-        "System.Collections": "4.0.11-rc2-*",
-        "System.Reflection": "4.1.0-beta-*",
-        "System.Resources.ResourceManager": "4.0.1-beta-*",
-        "System.Runtime": "4.0.21-rc2-*",
-        "System.Runtime.Extensions": "4.0.11-rc2-*"
-      }
+    "compilationOptions": {
+        "warningsAsErrors": true
+    },
+    "dependencies": {
+        "System.Runtime.Serialization.Primitives": "4.1.0-beta-23516",
+
+        "Microsoft.Dnx.Compilation.Abstractions": "1.0.0-rc1-final",
+        "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc1-final",
+
+        "Newtonsoft.Json": "7.0.1",
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" }
+    },
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "System.Collections": "4.0.11-beta-23516",
+                "System.Reflection": "4.1.0-beta-23516",
+                "System.Resources.ResourceManager": "4.0.1-beta-23516",
+                "System.Runtime.Extensions": "4.0.11-beta-23516"
+            }
+        }
+    },
+    "scripts": {
+        "postcompile": [
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.dll\"",
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.pdb\""
+        ]
     }
-  },
-  "scripts": {
-      "postcompile": [
-          "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.dll\"",
-          "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.pdb\""
-      ]
-  }
 }

--- a/test/E2E/project.json
+++ b/test/E2E/project.json
@@ -5,21 +5,18 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.Platforms":"1.0.1-beta-*",
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
-        "System.Console": "4.0.0-beta-*",
-        "System.Runtime": "4.0.21-beta-*",
-        "System.AppContext": "4.0.1-beta-*",
+        "Microsoft.NETCore.Platforms":"1.0.1-beta-23516",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "System.Console": "4.0.0-beta-23516",
+        "System.Runtime": "4.0.21-beta-23516",
+        "System.AppContext": "4.0.1-beta-23516",
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",
         "xunit.runner.utility": "2.1.0",
 
         "Microsoft.DotNet.ProjectModel": { "target": "project" },
-        "Microsoft.DotNet.Cli.Utils": {
-          "type": "build",
-          "version": "1.0.0-*"
-        },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" }
     },
 
     "frameworks": {

--- a/test/TestApp/project.json
+++ b/test/TestApp/project.json
@@ -6,11 +6,11 @@
 
     "dependencies": {
         "TestLibrary": { "target": "project" },
-        "System.IO": "4.0.11-beta-23428",
-        "System.Console": "4.0.0-beta-23428",
-        "System.Runtime": "4.0.21-beta-23428",
-        "System.Diagnostics.Process": "4.1.0-beta-23428",
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-23428"
+        "System.IO": "4.0.11-beta-23516",
+        "System.Console": "4.0.0-beta-23516",
+        "System.Runtime": "4.0.21-beta-23516",
+        "System.Diagnostics.Process": "4.1.0-beta-23516",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516"
     },
 
     "frameworks": {

--- a/test/TestAppWithArgs/project.json
+++ b/test/TestAppWithArgs/project.json
@@ -5,10 +5,10 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
-        "System.IO": "4.0.10-beta-*",
-        "System.Console": "4.0.0-beta-*",
-        "System.Runtime": "4.0.21-beta-*"
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "System.IO": "4.0.10-beta-23516",
+        "System.Console": "4.0.0-beta-23516",
+        "System.Runtime": "4.0.21-beta-23516"
     },
 
     "frameworks": {

--- a/test/TestLibrary/project.json
+++ b/test/TestLibrary/project.json
@@ -1,7 +1,7 @@
 ﻿{
     "version": "1.0.0-*",
     "dependencies": {
-        "System.Runtime": "4.0.21-beta-23428"
+        "System.Runtime": "4.0.21-beta-23516"
     },
 
     "frameworks": {

--- a/test/compile/failing/SimpleCompilerError/project.json
+++ b/test/compile/failing/SimpleCompilerError/project.json
@@ -5,9 +5,9 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.ConsoleHost": "1.0.0-23428",
-        "Microsoft.NETCore.Runtime": "1.0.1-23428",
-        "System.Console": "4.0.0-beta-23109"
+        "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23516",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23516",
+        "System.Console": "4.0.0-beta-23516"
     },
 
     "frameworks": {


### PR DESCRIPTION
1. Pinned DNX dependencies to 1.0.0-rc1-final and aspnetmaster feed
(some of the internal DNX packages we're using aren't on nuget.org)
2. Made the "description", "repository" and "compilationOptions" sections for each project consistent
3. Reformatted all JSON files according to VS defaults for JSON
4. Synchronized all package versions and removed `*` from external dependencies.
5. Updated crossgen scripts to use correct version

/cc @krwq @davidfowl 