### PR TITLE
Debian Package Testing and Build Fixes

### DIFF
--- a/packaging/debian/package_tool/package_tool
+++ b/packaging/debian/package_tool/package_tool
@@ -199,7 +199,7 @@ generate_sample_manifest(){
     if [[ -d "$INPUT_SAMPLES_DIR" ]]; then
         generated_manpages=( $(_get_files_in_dir_tree $INPUT_SAMPLES_DIR) )
 
-        rm sample_manifest
+        rm -f sample_manifest
         for sample in $samples
         do
             echo "$sample" >> "${DEBIAN_DIR}/${PACKAGE_NAME}.examples"

--- a/packaging/debian/package_tool/package_tool
+++ b/packaging/debian/package_tool/package_tool
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
@@ -8,6 +8,8 @@
 #   $1 = Input Directory
 #   $2 = Output Directory
 #   $3 = Package Version
+
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,6 +5,14 @@
 
 # Source this to add some fancy stuff to your scripts
 
+COMMONSOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  COMMONDIR="$( cd -P "$( dirname "$COMMONSOURCE" )" && pwd )"
+  COMMONSOURCE="$(readlink "$COMMONSOURCE")"
+  [[ $COMMONSOURCE != /* ]] && COMMONSOURCE="$COMMONDIR/$COMMONSOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+COMMONDIR="$( cd -P "$( dirname "$COMMONSOURCE" )" && pwd )"
+
 # Detect build servers
 if [[ ! -z "$JENKINS_URL" || ! -z "$BUILD_BUILDID" ]]; then
     # Jenkins or VSO build, disable colors because they make things gross.
@@ -79,6 +87,7 @@ if [ -z "$RID" ]; then
     fi
 fi
 
+export REPOROOT=$(cd $COMMONDIR/.. && pwd)
 export OUTPUT_ROOT=$REPOROOT/artifacts/$RID
 export DNX_DIR=$OUTPUT_ROOT/dnx
 export STAGE1_DIR=$OUTPUT_ROOT/stage1

--- a/scripts/docker/dockerbuild.sh
+++ b/scripts/docker/dockerbuild.sh
@@ -4,6 +4,8 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
+set -e
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"

--- a/scripts/package/package-debian.sh
+++ b/scripts/package/package-debian.sh
@@ -6,6 +6,8 @@
 # Debian Packaging Script
 # Currently Intended to build on ubuntu14.04
 
+set -e
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
@@ -21,18 +23,22 @@ if [ "$UNAME" != "Linux" ]; then
     exit 1
 fi
 
-REPO_ROOT=$(readlink -f $DIR/../..)
-PACKAGING_ROOT=$REPO_ROOT/packaging/debian
+PACKAGING_ROOT=$REPOROOT/packaging/debian
 
-OUTPUT_DIR="$REPO_ROOT/artifacts"
+OUTPUT_DIR="$REPOROOT/artifacts"
 PACKAGE_LAYOUT_DIR="$OUTPUT_DIR/deb_intermediate"
 PACKAGE_OUTPUT_DIR="$OUTPUT_DIR/packages/debian"
-REPO_BINARIES_DIR="$REPO_ROOT/artifacts/ubuntu.14.04-x64/stage2"
+TEST_STAGE_DIR="$PACKAGE_OUTPUT_DIR/test"
+REPO_BINARIES_DIR="$REPOROOT/artifacts/ubuntu.14.04-x64/stage2"
 
-execute(){
+execute_build(){
     create_empty_debian_layout
     copy_files_to_debian_layout
     create_debian_package
+    test_debian_package
+}
+
+execute_test(){
     test_debian_package
 }
 
@@ -69,15 +75,30 @@ create_debian_package(){
 test_debian_package(){
     header "Testing debian package"
 
-    git clone https://github.com/sstephenson/bats.git /tmp/bats
-    pushd /tmp/bats
-    ./install.sh /usr/local
-    popd
+    git clone https://github.com/sstephenson/bats.git $TEST_STAGE_DIR
+    
+    $TEST_STAGE_DIR/bin/bats $PACKAGE_OUTPUT_DIR/test_package.bats
 
-    bats $PACKAGE_OUTPUT_DIR/test_package.bats
+    # E2E Testing of package surface area
+    run_e2e_test
 }
 
-execute
+run_e2e_test(){
+    set +e    
+    sudo dpkg -i $DEBIAN_FILE
+    $REPOROOT/scripts/test/e2e-test.sh
+    result=$?
+    sudo dpkg -r dotnet
+    set -e
+    
+    return result
+}
+
+execute_build
 
 DEBIAN_FILE=$(find $PACKAGE_OUTPUT_DIR -iname "*.deb")
-$DIR/../publish/publish.sh $DEBIAN_FILE 
+
+execute_test
+
+# Publish
+$REPOROOT/scripts/publish/publish.sh $DEBIAN_FILE 

--- a/scripts/package/package-debian.sh
+++ b/scripts/package/package-debian.sh
@@ -79,7 +79,8 @@ test_debian_package(){
     $TEST_STAGE_DIR/bin/bats $PACKAGE_OUTPUT_DIR/test_package.bats
 
     # E2E Testing of package surface area
-    run_e2e_test
+    # Disabled: https://github.com/dotnet/cli/issues/381
+    #run_e2e_test
 }
 
 run_e2e_test(){

--- a/scripts/package/package-debian.sh
+++ b/scripts/package/package-debian.sh
@@ -35,7 +35,6 @@ execute_build(){
     create_empty_debian_layout
     copy_files_to_debian_layout
     create_debian_package
-    test_debian_package
 }
 
 execute_test(){

--- a/scripts/package/package.sh
+++ b/scripts/package/package.sh
@@ -4,6 +4,8 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
+set -e
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"

--- a/scripts/test/e2e-test.sh
+++ b/scripts/test/e2e-test.sh
@@ -13,7 +13,6 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-REPOROOT="$( cd -P "$DIR/../.." && pwd )"
 
 source "$DIR/../_common.sh"
 

--- a/scripts/test/e2e-test.sh
+++ b/scripts/test/e2e-test.sh
@@ -17,7 +17,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 source "$DIR/../_common.sh"
 
 rm "$REPOROOT/test/E2E/project.lock.json"
-dotnet restore "$REPOROOT/test/E2E" --runtime "osx.10.10-x64" --runtime "ubuntu.14.04-x64" --runtime "win7-x64"
+dotnet restore --quiet "$REPOROOT/test/E2E" --runtime "osx.10.10-x64" --runtime "ubuntu.14.04-x64" --runtime "win7-x64"
 dotnet publish --framework dnxcore50 --runtime "$RID" --output "$REPOROOT/artifacts/$RID/e2etest" "$REPOROOT/test/E2E" 
 
 # set -e will abort if the exit code of this is non-zero

--- a/test/E2E/E2ETest.cs
+++ b/test/E2E/E2ETest.cs
@@ -117,7 +117,7 @@ namespace ConsoleApplication
             Directory.SetCurrentDirectory(TestDirectory);
 
             TestRunCommand("dotnet", "init");
-            TestRunCommand("dotnet", "restore");
+            TestRunCommand("dotnet", "restore --quiet");
         }
 
         private bool SkipForOS(OSPlatform os, string reason)

--- a/test/E2E/project.json
+++ b/test/E2E/project.json
@@ -5,11 +5,11 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.Platforms":"1.0.1-beta-*",
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
-        "System.Console": "4.0.0-beta-*",
-        "System.Runtime": "4.0.21-beta-*",
-        "System.AppContext": "4.0.1-beta-*",
+        "Microsoft.NETCore.Platforms":"1.0.1-*",
+        "Microsoft.NETCore.Runtime": "1.0.1-*",
+        "System.Console": "4.0.0-*",
+        "System.Runtime": "4.0.21-*",
+        "System.AppContext": "4.0.1-*",
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",


### PR DESCRIPTION
Changes to make the debian package build much more robust.

* Errors at any stage will fail the build.
* General Cleanup
* Don't do machine install of bats
* ~~Run E2E Tests against package installed bits~~ https://github.com/dotnet/cli/issues/381

/cc @Sridhar-MS @krwq @anurse @piotrpMSFT 