### PR TITLE
Add libcurl3 dependency

### DIFF
--- a/packaging/debian/debian_config.json
+++ b/packaging/debian/debian_config.json
@@ -29,7 +29,8 @@
 
     "debian_dependencies":{
         "libssl-dev" : {},
-        "clang-3.5" : {}
+        "clang-3.5" : {},
+        "libcurl3" : {}
     },
 
     "symlinks": {


### PR DESCRIPTION
The debian package build usually detects dependencies of executables packaged inside, and adds those as dependencies of the package accordingly. It doesn't detect this for managed executables though, so libcurl3 needs to be added to support `dotnet restore` on Ubuntu.

Fixes #293 