### PR TITLE
Fix dotnet driver on windows to deal with spaces

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -88,14 +88,8 @@ namespace Microsoft.DotNet.Cli.Utils
             if (useCmd)
             {
                 var comSpec = Environment.GetEnvironmentVariable("ComSpec");
-
-                // cmd doesn't like "foo.exe ", so we need to ensure that if
-                // args is empty, we just run "foo.exe"
-                if (!string.IsNullOrEmpty(args))
-                {
-                    executable = (executable + " " + args).Replace("\"", "\\\"");
-                }
-                args = $"/C \"{executable}\"";
+                // wrap 'executable' within quotes to deal woth space in its path.
+                args = $"/S /C \"\"{executable}\" {args}\"";
                 executable = comSpec;
             }
 


### PR DESCRIPTION
dotnet driver fails running dotnet-restore.cmd if this file is in a path
containing spaces. Use the magic "/S" switch in cmd to fix this.