### PR TITLE
delete staging directory before bringing down bats to avoid conflicts

### DIFF
--- a/scripts/package/package-debian.sh
+++ b/scripts/package/package-debian.sh
@@ -74,6 +74,7 @@ create_debian_package(){
 test_debian_package(){
     header "Testing debian package"
 
+    rm -rf $TEST_STAGE_DIR
     git clone https://github.com/sstephenson/bats.git $TEST_STAGE_DIR
     
     $TEST_STAGE_DIR/bin/bats $PACKAGE_OUTPUT_DIR/test_package.bats


### PR DESCRIPTION
Directory Conflict is happening here on the VSO builds.

Difficult to diagnose why this particular directory already exists, given it doesn't repro on Jenkins, so try just removing it.

cc @Sridhar-MS 