### PR TITLE
fix #408 by moving XDoc dependency down

### DIFF
--- a/src/Microsoft.DotNet.Tools.Resgen/project.json
+++ b/src/Microsoft.DotNet.Tools.Resgen/project.json
@@ -10,7 +10,7 @@
         "System.Linq": "4.0.1-beta-23504",
         "System.Diagnostics.Process": "4.1.0-beta-23504",
         "System.IO.FileSystem": "4.0.1-beta-23504",
-        "System.Xml.XDocument": "4.0.11-beta-23504",
+        "System.Xml.XDocument": "4.0.10",
         "System.Resources.ReaderWriter": "4.0.0-beta-23504",
 
         "Microsoft.DotNet.Cli.Utils": {


### PR DESCRIPTION
Looks like this works. I no longer get assembly load errors using `dotnet resgen`.

Fixes #408 