### PR TITLE
Newline before "For OS X"

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -18,6 +18,7 @@ In order to build .NET Command Line Interface, you need the following installed 
 1. CMake (available from https://cmake.org/) is required to build the native host `corehost`. Make sure to add it to the PATH.
 2. git (available from http://www.git-scm.com/) on the PATH.
 3. clang (available from http://clang.llvm.org) on the PATH.
+
 ### For OS X
 
 1. Xcode


### PR DESCRIPTION
Markdown does not render properly without it.