### PR TITLE
Multi Project Validation

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.DotNet.Cli", "src\Microsoft.DotNet.Cli\Microsoft.DotNet.Cli.xproj", "{60CF7E6C-D6C8-439D-B7B7-D8A27E29BE2C}"
 EndProject
@@ -56,6 +56,10 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "LoadContextTest", "test\LoadContextTest\LoadContextTest.xproj", "{7A75ACC4-3C2F-44E1-B492-0EC08704E9FF}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.DotNet.Tools.New", "src\Microsoft.DotNet.Tools.New\Microsoft.DotNet.Tools.New.xproj", "{BC765FBF-AD7A-4A99-9902-5540C5A74181}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{0722D325-24C8-4E83-B5AF-0A083E7F0749}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MultiProjectValidator", "tools\MultiProjectValidator\MultiProjectValidator.xproj", "{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -421,6 +425,22 @@ Global
 		{BC765FBF-AD7A-4A99-9902-5540C5A74181}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{BC765FBF-AD7A-4A99-9902-5540C5A74181}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{BC765FBF-AD7A-4A99-9902-5540C5A74181}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Debug|x64.Build.0 = Debug|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Release|x64.ActiveCfg = Release|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Release|x64.Build.0 = Release|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -448,5 +468,6 @@ Global
 		{947DD232-8D9B-4B78-9C6A-94F807D2DD58} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{7A75ACC4-3C2F-44E1-B492-0EC08704E9FF} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{BC765FBF-AD7A-4A99-9902-5540C5A74181} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
+		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85} = {0722D325-24C8-4E83-B5AF-0A083E7F0749}
 	EndGlobalSection
 EndGlobal

--- a/scripts/compile.ps1
+++ b/scripts/compile.ps1
@@ -146,6 +146,14 @@ Download it from https://www.cmake.org
         Exit 1
     }
 
+    # Run Validation for Project.json dependencies
+    dotnet publish $RepoRoot\tools\MultiProjectValidator -o $Stage2Dir\..\tools
+    & "$Stage2Dir\..\tools\pjvalidate" "$RepoRoot\src"
+    if (!$?) {
+        Write-Host "Project Validation Failed"
+        Exit 1
+    }
+
 } finally {
     $env:PATH = $StartPath
     $env:DOTNET_HOME = $StartDotNetHome

--- a/scripts/compile.ps1
+++ b/scripts/compile.ps1
@@ -149,10 +149,11 @@ Download it from https://www.cmake.org
     # Run Validation for Project.json dependencies
     dotnet publish $RepoRoot\tools\MultiProjectValidator -o $Stage2Dir\..\tools
     & "$Stage2Dir\..\tools\pjvalidate" "$RepoRoot\src"
-    if (!$?) {
-        Write-Host "Project Validation Failed"
-        Exit 1
-    }
+    # TODO For release builds, this should be uncommented and fail.
+    # if (!$?) {
+    #     Write-Host "Project Validation Failed"
+    #     Exit 1
+    # }
 
 } finally {
     $env:PATH = $StartPath

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -121,4 +121,7 @@ DOTNET_HOME=$STAGE2_DIR DOTNET_TOOLS=$STAGE2_DIR $DIR/test/e2e-test.sh
 
 # Run Validation for Project.json dependencies
 dotnet publish "$REPOROOT/tools/MultiProjectValidator" -o "$OUTPUT_DIR/../tools"
+#TODO for release builds this should fail
+set +e
 "$OUTPUT_DIR/tools/pjvalidate" "$REPOROOT/src"
+set -e

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -120,8 +120,8 @@ header "Testing stage2 End to End ..."
 DOTNET_HOME=$STAGE2_DIR DOTNET_TOOLS=$STAGE2_DIR $DIR/test/e2e-test.sh
 
 # Run Validation for Project.json dependencies
-dotnet publish "$REPOROOT/tools/MultiProjectValidator" -o "$OUTPUT_DIR/../tools"
+dotnet publish "$REPOROOT/tools/MultiProjectValidator" -o "$STAGE2_DIR/../tools"
 #TODO for release builds this should fail
 set +e
-"$OUTPUT_DIR/tools/pjvalidate" "$REPOROOT/src"
+"$STAGE2_DIR/../tools/pjvalidate" "$REPOROOT/src"
 set -e

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -118,3 +118,7 @@ DOTNET_HOME=$STAGE2_DIR DOTNET_TOOLS=$STAGE2_DIR $DIR/test/smoke-test.sh
 # E2E test on the output
 header "Testing stage2 End to End ..."
 DOTNET_HOME=$STAGE2_DIR DOTNET_TOOLS=$STAGE2_DIR $DIR/test/e2e-test.sh
+
+# Run Validation for Project.json dependencies
+dotnet publish "$REPOROOT/tools/MultiProjectValidator" -o "$OUTPUT_DIR/../tools"
+"$OUTPUT_DIR/tools/pjvalidate" "$REPOROOT/src"

--- a/src/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     internal static class Constants
     {
+        public static readonly string ProjectFileName = "project.json";
         public static readonly string ExeSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty;
 
         // Priority order of runnable suffixes to look for and run

--- a/tools/MultiProjectValidator/AnalysisResult.cs
+++ b/tools/MultiProjectValidator/AnalysisResult.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace MultiProjectValidator
 {

--- a/tools/MultiProjectValidator/AnalysisResult.cs
+++ b/tools/MultiProjectValidator/AnalysisResult.cs
@@ -10,8 +10,8 @@ namespace MultiProjectValidator
 
         public AnalysisResult(List<string> messages, bool passed)
         {
-            this._messages = messages;
-            this._passed = passed;
+            _messages = messages;
+            _passed = passed;
         }
 
         public List<string> Messages

--- a/tools/MultiProjectValidator/AnalysisResult.cs
+++ b/tools/MultiProjectValidator/AnalysisResult.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MultiProjectValidator
+{
+    public class AnalysisResult
+    {
+
+        private List<string> _messages;
+        private bool _passed;
+
+        public AnalysisResult(List<string> messages, bool passed)
+        {
+            this._messages = messages;
+            this._passed = passed;
+        }
+
+        public List<string> Messages
+        {
+            get
+            {
+                return _messages;
+            }
+        }
+
+        public bool Passed
+        {
+            get
+            {
+                return _passed;
+            }
+        }
+    }
+}

--- a/tools/MultiProjectValidator/AnalysisRules/DependencyMismatch/DependencyGroup.cs
+++ b/tools/MultiProjectValidator/AnalysisRules/DependencyMismatch/DependencyGroup.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ProjectSanity.AnalysisRules.DependencyMismatch
+{
+    internal class DependencyGroup
+    {
+        public static DependencyGroup CreateWithEntry(DependencyInfo dependencyInfo)
+        {
+            var dependencyGroup = new DependencyGroup
+            {
+                DependencyName = dependencyInfo.Name,
+                VersionDependencyInfoMap = new Dictionary<string, List<DependencyInfo>>()
+            };
+
+            dependencyGroup.AddEntry(dependencyInfo);
+
+            return dependencyGroup;
+        }
+
+        public string DependencyName { get; private set; }
+        public Dictionary<string, List<DependencyInfo>> VersionDependencyInfoMap { get; private set; }
+
+        public bool HasConflict
+        {
+            get
+            {
+                return VersionDependencyInfoMap.Count > 1;
+            }
+        }
+
+        public void AddEntry(DependencyInfo dependencyInfo)
+        {
+            if (!dependencyInfo.Name.Equals(DependencyName, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new Exception("Added dependency does not match group");
+            }
+
+            if (VersionDependencyInfoMap.ContainsKey(dependencyInfo.Version))
+            {
+                VersionDependencyInfoMap[dependencyInfo.Version].Add(dependencyInfo);
+            }
+            else
+            {
+                VersionDependencyInfoMap[dependencyInfo.Version] = new List<DependencyInfo>()
+                {
+                    dependencyInfo
+                };
+            }
+        }
+
+    }
+}

--- a/tools/MultiProjectValidator/AnalysisRules/DependencyMismatch/DependencyInfo.cs
+++ b/tools/MultiProjectValidator/AnalysisRules/DependencyMismatch/DependencyInfo.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.DotNet.ProjectModel;
+
+namespace ProjectSanity.AnalysisRules.DependencyMismatch
+{
+    internal class DependencyInfo
+    {
+        public static DependencyInfo Create(ProjectContext context, LibraryDescription library)
+        {
+            return new DependencyInfo
+            {
+                ProjectPath = context.ProjectFile.ProjectFilePath,
+                Version = library.Identity.Version.ToString(),
+                Name = library.Identity.Name
+            };
+        }
+
+        public string ProjectPath { get; private set; }
+        public string Version { get; private set; }
+        public string Name { get; private set; }
+    }
+}

--- a/tools/MultiProjectValidator/AnalysisRules/DependencyMismatchRule.cs
+++ b/tools/MultiProjectValidator/AnalysisRules/DependencyMismatchRule.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ProjectModel;
+
+namespace MultiProjectValidator.AnalysisRules
+{
+    public class DependencyMismatchRule : IAnalysisRule
+    {
+        public AnalysisResult Evaluate(List<ProjectContext> projectContexts)
+        {
+            var targetGroupedContexts = GroupContextsByTarget(projectContexts);
+
+            var failureMessages = EvaluateTargetContextGroups(targetGroupedContexts);
+            var pass = failureMessages.Count == 0;
+
+            var result = new AnalysisResult(failureMessages, pass);
+            return result;
+        }
+
+        private List<string> EvaluateTargetContextGroups(Dictionary<string, List<ProjectContext>> targetGroupedContexts)
+        {
+            var failureMessages = new List<string>();
+
+            foreach (var target in targetGroupedContexts.Keys)
+            {
+                var targetContexts = targetGroupedContexts[target];
+
+                failureMessages.AddRange(EvaluateTargetContextGroup(targetContexts));
+            }
+
+            return failureMessages;
+        }
+
+        private List<string> EvaluateTargetContextGroup(List<ProjectContext> targetContexts)
+        {
+            var failedMessages = new List<string>();
+            var assemblyVersionMap = new Dictionary<string, string>();
+
+            foreach(var context in targetContexts)
+            {
+                var libraries = context.LibraryManager.GetLibraries();
+
+                foreach(var library in libraries)
+                {
+                    var name = library.Identity.Name;
+                    var version = library.Identity.Version.ToString();
+
+                    if (assemblyVersionMap.ContainsKey(name))
+                    {
+                        var existingVersion = assemblyVersionMap[name];
+                        if (!string.Equals(existingVersion, version, StringComparison.OrdinalIgnoreCase))
+                        {
+                            string message = 
+                                $"Dependency mismatch in {context.ProjectFile.ProjectFilePath} for dependency {name}. Versions {version}, {existingVersion}";
+
+                            failedMessages.Add(message);
+                        }
+                    }
+                    else
+                    {
+                        assemblyVersionMap[name] = version;
+                    }
+                }
+            }
+
+            return failedMessages;
+        }
+
+        private Dictionary<string, List<ProjectContext>> GroupContextsByTarget(List<ProjectContext> projectContexts)
+        {
+            var targetContextMap = new Dictionary<string, List<ProjectContext>>();
+            foreach (var context in projectContexts)
+            {
+                var target = context.TargetFramework + context.RuntimeIdentifier;
+
+                if (targetContextMap.ContainsKey(target))
+                {
+                    targetContextMap[target].Add(context);
+                }
+                else
+                {
+                    targetContextMap[target] = new List<ProjectContext>()
+                    {
+                        context
+                    };
+                }
+            }
+
+            return targetContextMap;
+        }
+    }
+}

--- a/tools/MultiProjectValidator/IAnalysisRule.cs
+++ b/tools/MultiProjectValidator/IAnalysisRule.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Microsoft.DotNet.ProjectModel;
 
 namespace MultiProjectValidator

--- a/tools/MultiProjectValidator/IAnalysisRule.cs
+++ b/tools/MultiProjectValidator/IAnalysisRule.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ProjectModel;
+
+namespace MultiProjectValidator
+{
+    public interface IAnalysisRule
+    {
+        AnalysisResult Evaluate(List<ProjectContext> projectContexts);
+    }
+}

--- a/tools/MultiProjectValidator/MultiProjectValidator.xproj
+++ b/tools/MultiProjectValidator/MultiProjectValidator.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>08a68c6a-86f6-4ed2-89a7-b166d33e9f85</ProjectGuid>
+    <RootNamespace>ProjectSanity</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\tools\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tools/MultiProjectValidator/Program.cs
+++ b/tools/MultiProjectValidator/Program.cs
@@ -114,6 +114,9 @@ This tool recursively searches for project.json's from the given root path.
 It then applies a set of analysis rules, determines whether they pass/fail
 and then sets exit code to reflect.
 
+Note:
+Ensure all analyzed project.json have been restored prior to running this tool.
+
 Usage:
 pjvalidate [root path of recursive search]";
 

--- a/tools/MultiProjectValidator/Program.cs
+++ b/tools/MultiProjectValidator/Program.cs
@@ -10,7 +10,17 @@ namespace MultiProjectValidator
     {
         public static int Main(string[] args)
         {
-            var rootPath = ParseAndValidateArgs(args);
+
+            string rootPath = null;
+
+            try
+            {
+                rootPath = ParseAndValidateArgs(args);
+            }
+            catch
+            {
+                return 1;
+            }
 
             List<ProjectContext> projects = null;
             try
@@ -20,7 +30,7 @@ namespace MultiProjectValidator
             catch(Exception e)
             {
                 Console.WriteLine("Failed to load projects from path: " + rootPath);
-                Exit(1);
+                return 1;
             }
 
             var analyzer = ProjectAnalyzer.Create(projects);
@@ -80,7 +90,7 @@ namespace MultiProjectValidator
             if (args.Length != 1)
             {
                 PrintHelp();
-                Exit(1);
+                throw new Exception();
             }
 
             string rootPath = args[0];
@@ -88,15 +98,10 @@ namespace MultiProjectValidator
             if (!Directory.Exists(rootPath))
             {
                 Console.WriteLine("Root Directory does not exist: " + rootPath);
-                Exit(1);
+                throw new Exception();
             }
 
             return rootPath;
-        }
-
-        private static void Exit(int code)
-        {
-            Environment.Exit(code);
         }
         
         private static void PrintHelp()

--- a/tools/MultiProjectValidator/Program.cs
+++ b/tools/MultiProjectValidator/Program.cs
@@ -39,10 +39,13 @@ namespace MultiProjectValidator
             var failedCount = analysisResults.Where((a) => !a.Passed).Count();
             var passedCount = analysisResults.Where((a) => a.Passed).Count();
 
+            Console.ForegroundColor = ConsoleColor.Green;
             Console.WriteLine($"{passedCount} Successful Analysis Rules");
-            Console.WriteLine($"{failedCount} Failed Analysis Rules");
 
-            if(failedCount != 0)
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            Console.WriteLine($"{failedCount} Failed Analysis Rules");
+            
+            if (failedCount != 0)
             {
                 Console.WriteLine("Failure Messages");
 
@@ -57,6 +60,7 @@ namespace MultiProjectValidator
                     }
                 }
             }
+            Console.ForegroundColor = ConsoleColor.White;
         }
 
         private static bool AnyAnalysisFailed(List<AnalysisResult> analysisResults)

--- a/tools/MultiProjectValidator/Program.cs
+++ b/tools/MultiProjectValidator/Program.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using Microsoft.DotNet.ProjectModel;
+using System.Linq;
+
+namespace MultiProjectValidator
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            var rootPath = ParseAndValidateArgs(args);
+
+            List<ProjectContext> projects = null;
+            try
+            {
+                projects = ProjectLoader.Load(rootPath);
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine("Failed to load projects from path: " + rootPath);
+                Exit(1);
+            }
+
+            var analyzer = ProjectAnalyzer.Create(projects);
+            var analysisResults = analyzer.DoAnalysis();
+            var failed = analysisResults.Where((a) => !a.Passed).Any();
+
+            PrintAnalysisResults(analysisResults);
+
+            return failed ? 1 : 0;
+        }
+
+        private static void PrintAnalysisResults(List<AnalysisResult> analysisResults)
+        {
+            Console.WriteLine("Project Validation Results");
+
+            var failedCount = analysisResults.Where((a) => !a.Passed).Count();
+            var passedCount = analysisResults.Where((a) => a.Passed).Count();
+
+            Console.WriteLine($"{passedCount} Successful Analysis Rules");
+            Console.WriteLine($"{failedCount} Failed Analysis Rules");
+
+            if(failedCount != 0)
+            {
+                Console.WriteLine("Failure Messages");
+
+                foreach(var result in analysisResults)
+                {
+                    if (!result.Passed)
+                    {
+                        foreach(var message in result.Messages)
+                        {
+                            Console.WriteLine(message);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static bool AnyAnalysisFailed(List<AnalysisResult> analysisResults)
+        {
+            foreach (var result in analysisResults)
+            {
+                if (!result.Passed)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static string ParseAndValidateArgs(string[] args)
+        {
+            if (args.Length != 1)
+            {
+                PrintHelp();
+                Exit(1);
+            }
+
+            string rootPath = args[0];
+
+            if (!Directory.Exists(rootPath))
+            {
+                Console.WriteLine("Root Directory does not exist: " + rootPath);
+                Exit(1);
+            }
+
+            return rootPath;
+        }
+
+        private static void Exit(int code)
+        {
+            Environment.Exit(code);
+        }
+        
+        private static void PrintHelp()
+        {
+            var help = @"
+Multi-Project Validator
+
+Description:
+This tool recursively searches for project.json's from the given root path.
+It then applies a set of analysis rules, determines whether they pass/fail
+and then sets exit code to reflect.
+
+Usage:
+pjvalidate [root path of recursive search]";
+
+            Console.WriteLine(help);
+        }
+    }
+}

--- a/tools/MultiProjectValidator/ProjectAnalyzer.cs
+++ b/tools/MultiProjectValidator/ProjectAnalyzer.cs
@@ -18,22 +18,22 @@ namespace MultiProjectValidator
             return new ProjectAnalyzer(rules, projectContexts);
         }
 
-        private List<ProjectContext> projectContexts;
-        private List<IAnalysisRule> rules;
+        private List<ProjectContext> _projectContexts;
+        private List<IAnalysisRule> _rules;
         
         private ProjectAnalyzer(List<IAnalysisRule> rules, List<ProjectContext> projectContexts)
         {
-            this.rules = rules;
-            this.projectContexts = projectContexts;
+            _rules = rules;
+            _projectContexts = projectContexts;
         }
 
         public List<AnalysisResult> DoAnalysis()
         {
             var results = new List<AnalysisResult>();
 
-            foreach(var rule in rules)
+            foreach(var rule in _rules)
             {
-                results.Add(rule.Evaluate(projectContexts));
+                results.Add(rule.Evaluate(_projectContexts));
             }
 
             return results;

--- a/tools/MultiProjectValidator/ProjectAnalyzer.cs
+++ b/tools/MultiProjectValidator/ProjectAnalyzer.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Microsoft.DotNet.ProjectModel;
 using MultiProjectValidator.AnalysisRules;
 

--- a/tools/MultiProjectValidator/ProjectAnalyzer.cs
+++ b/tools/MultiProjectValidator/ProjectAnalyzer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ProjectModel;
+using MultiProjectValidator.AnalysisRules;
+
+namespace MultiProjectValidator
+{
+    public class ProjectAnalyzer
+    {
+
+        public static ProjectAnalyzer Create(List<ProjectContext> projectContexts)
+        {
+            // Any Additional rules would be added here
+            var rules = new List<IAnalysisRule>
+            {
+                new DependencyMismatchRule()
+            };
+
+            return new ProjectAnalyzer(rules, projectContexts);
+        }
+
+        private List<ProjectContext> projectContexts;
+        private List<IAnalysisRule> rules;
+        
+        private ProjectAnalyzer(List<IAnalysisRule> rules, List<ProjectContext> projectContexts)
+        {
+            this.rules = rules;
+            this.projectContexts = projectContexts;
+        }
+
+        public List<AnalysisResult> DoAnalysis()
+        {
+            var results = new List<AnalysisResult>();
+
+            foreach(var rule in rules)
+            {
+                results.Add(rule.Evaluate(projectContexts));
+            }
+
+            return results;
+        }
+
+    }
+}

--- a/tools/MultiProjectValidator/ProjectLoader.cs
+++ b/tools/MultiProjectValidator/ProjectLoader.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.DotNet.ProjectModel;
 
 namespace MultiProjectValidator

--- a/tools/MultiProjectValidator/ProjectLoader.cs
+++ b/tools/MultiProjectValidator/ProjectLoader.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ProjectModel;
+
+namespace MultiProjectValidator
+{
+    public class ProjectLoader
+    {
+        private static readonly string PROJECT_FILENAME = "project.json";
+
+        public static List<ProjectContext> Load(string rootPath, bool recursive=true)
+        {
+            var projectFiles = DiscoverProjectFiles(rootPath);
+            var projectContextList = LoadProjectContexts(projectFiles);
+
+            return projectContextList;
+        }
+
+        private static string[] DiscoverProjectFiles(string rootPath)
+        {
+            return Directory.GetFiles(rootPath, PROJECT_FILENAME, SearchOption.AllDirectories);
+        }
+
+        private static List<ProjectContext> LoadProjectContexts(string[] projectFiles)
+        {
+            var projectContexts = new List<ProjectContext>();
+
+            foreach (var file in projectFiles)
+            {
+                var fileTargetContexts = ProjectContext.CreateContextForEachTarget(file);
+
+                projectContexts.AddRange(fileTargetContexts);    
+            }
+
+            return projectContexts;
+        }
+    }
+}

--- a/tools/MultiProjectValidator/project.json
+++ b/tools/MultiProjectValidator/project.json
@@ -6,11 +6,9 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
-      "NETStandard.Library": "1.0.0-rc2-23608",
+      "NETStandard.Library": "1.0.0-rc2-23614",
       "Microsoft.DotNet.ProjectModel": "1.0.0-*",
       "Microsoft.DotNet.Cli.Utils": "1.0.0-*", 
-        "System.Linq": "4.0.1-rc2-23608"
     },
 
     "frameworks": {

--- a/tools/MultiProjectValidator/project.json
+++ b/tools/MultiProjectValidator/project.json
@@ -1,0 +1,19 @@
+﻿{
+    "version": "1.0.0-*",
+    "name": "pjvalidate",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
+      "NETStandard.Library": "1.0.0-rc2-23608",
+      "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+      "Microsoft.DotNet.Cli.Utils": "1.0.0-*", 
+        "System.Linq": "4.0.1-rc2-23608"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
Fixes #445 

These changes will essentially analyze all of the project.json files inside the cli `src` folder, construct a `ProjectContext` for each, and analyze the set of dependencies for each target.

If any two projects clash on dependencies for a given target, it will give a warning.

Thanks for the advice on this @anurse !

Currently this is failing because there are tons of conflicts. We need to sort through that.

@piotrpMSFT @Sridhar-MS @krwq PTAL