### PR TITLE
Fix build breaks due to automatic upgrade of Rosyln "Microsoft.CodeAnalysis.Compilers" package.

### DIFF
--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
@@ -8,7 +8,7 @@
         "NETStandard.Library": "1.0.0-rc2-23608",
         "System.Linq": "4.0.1-rc2-23608",
         
-        "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151117-04",
+        "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151215-01",
 
         "Microsoft.DotNet.Cli.Utils": {
             "type": "build",

--- a/src/Microsoft.DotNet.Tools.Run/project.json
+++ b/src/Microsoft.DotNet.Tools.Run/project.json
@@ -8,7 +8,7 @@
         "NETStandard.Library": "1.0.0-rc2-23608",
         "System.Linq": "4.0.1-beta-23504",
         
-        "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151117-04",
+        "Microsoft.Net.Compilers.netcore": "1.2.0-beta-20151215-01",
         "System.CommandLine" : "0.1.0-d111815-3",
 
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",


### PR DESCRIPTION
So upgrading "Microsoft.Net.Compilers.netcore" to work with the newer versions.

cc: @agocke  @piotrpMSFT @brthor 