### PR TITLE
Fix the PKG permission issue and change the install location

### DIFF
--- a/packaging/osx/package-osx.sh
+++ b/packaging/osx/package-osx.sh
@@ -41,9 +41,8 @@ PACKAGE_NAME=$PACKAGE_DIR/dotnet-cli-x64.${DOTNET_BUILD_VERSION}.pkg
 pkgbuild --root $STAGE2_DIR \
          --version $DOTNET_BUILD_VERSION \
          --scripts $DIR/scripts \
-         --ownership preserve \
          --identifier com.microsoft.dotnet.cli.pkg.dotnet-osx-x64 \
-         --install-location /usr/local/share/dotnet/cli \
+         --install-location /usr/local/share/dotnet \
          $DIR/dotnet-osx-x64.$DOTNET_BUILD_VERSION.pkg
 
 cat $DIR/Distribution-Template | sed "/{VERSION}/s//$DOTNET_BUILD_VERSION/g" > $DIR/Dist

--- a/packaging/osx/scripts/postinstall
+++ b/packaging/osx/scripts/postinstall
@@ -4,6 +4,9 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
+# A temporary fix for the permissions issue(s)
+chmod -R 755 $2
+
 ln -s $2/bin/dotnet /usr/local/bin/
 ln -s $2/bin/dotnet-compile /usr/local/bin/
 ln -s $2/bin/dotnet-compile-csc /usr/local/bin/

--- a/packaging/osx/scripts/postinstall
+++ b/packaging/osx/scripts/postinstall
@@ -4,23 +4,27 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-# A temporary fix for the permissions issue(s)
-chmod -R 755 $2
+PACKAGE=$1
+INSTALL_DESTINATION=$2
 
-ln -s $2/bin/dotnet /usr/local/bin/
-ln -s $2/bin/dotnet-compile /usr/local/bin/
-ln -s $2/bin/dotnet-compile-csc /usr/local/bin/
-ln -s $2/bin/dotnet-new /usr/local/bin/
-ln -s $2/bin/dotnet-pack /usr/local/bin/
-ln -s $2/bin/dotnet-publish /usr/local/bin/
-ln -s $2/bin/dotnet-repl /usr/local/bin/
-ln -s $2/bin/dotnet-restore /usr/local/bin/
-ln -s $2/bin/dotnet-resgen /usr/local/bin/
-ln -s $2/bin/dotnet-run /usr/local/bin/
-ln -s $2/bin/dotnet-test /usr/local/bin/
+
+# A temporary fix for the permissions issue(s)
+chmod -R 755 $INSTALL_DESTINATION
+
+ln -s $INSTALL_DESTINATION/bin/dotnet /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-compile /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-compile-csc /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-new /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-pack /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-publish /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-repl /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-restore /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-resgen /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-run /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-test /usr/local/bin/
 
 # A temporary solution to unblock dotnet compile
-cp $2/bin/corehost /usr/local/bin/
+cp $INSTALL_DESTINATION/bin/corehost /usr/local/bin/
 
 
 exit 0

--- a/src/corehost/src/pal.unix.cpp
+++ b/src/corehost/src/pal.unix.cpp
@@ -32,7 +32,7 @@ bool pal::find_coreclr(pal::string_t& recv)
         return true;
     }
      
-    candidate.assign("/usr/local/share/dotnet/cli/runtime/coreclr");
+    candidate.assign("/usr/local/share/dotnet/runtime/coreclr");
     if (coreclr_exists_in_dir(candidate)) {
         recv.assign(candidate);
         return true;


### PR DESCRIPTION
A temporary fix for the PKG permission issue by using chmod -R 755 in the postinstall
script. Change the install location to remove the "cli" part of the path. Also
change the corehost to reflect this change.

Fixes #492 and #390 

/cc @piotrpMSFT @anurse @brthor 