### PR TITLE
Scripts changes to accomodate centos builds.

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -79,10 +79,17 @@ if [ -z "$RID" ]; then
         export RID=osx.10.10-x64
         export DNX_FLAVOR="dnx-coreclr-darwin-x64"
     elif [ "$UNAME" == "Linux" ]; then
-        # Detect Distro?
-        export OSNAME=linux
-        export RID=ubuntu.14.04-x64
-        export DNX_FLAVOR="dnx-coreclr-linux-x64"
+        # Detect Distro
+        if [ "$(cat /etc/*-release | grep -cim1 ubuntu)" -eq 1 ]; then
+            export OSNAME=ubuntu
+            export RID=ubuntu.14.04-x64
+            export DNX_FLAVOR="dnx-coreclr-linux-x64"
+        elif [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
+            export OSNAME=centos
+            export RID=centos.7-x64
+        else
+            error "unknown Linux Distro" 1>&2
+        fi
     else
         error "unknown OS: $UNAME" 1>&2
         exit 1

--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -48,7 +48,7 @@ DOTNET_PATH=$(which dotnet)
 PREFIX="$(cd -P "$(dirname "$DOTNET_PATH")/.." && pwd)"
 
 header "Restoring packages"
-$DNX_ROOT/dnu restore "$REPOROOT" --quiet --runtime "osx.10.10-x64" --runtime "ubuntu.14.04-x64" --runtime "win7-x64" --no-cache
+$DNX_ROOT/dnu restore "$REPOROOT" --quiet --runtime "$RID" --no-cache
 
 header "Building corehost"
 

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -4,21 +4,26 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM debian:jessie
+FROM ubuntu:14.04
 
 # This could become a "microsoft/coreclr" image, since it just installs the dependencies for CoreCLR (and stdlib)
-# Install CoreCLR dependencies
+# Install CoreCLR and CoreFx dependencies
 RUN apt-get update && \
-    apt-get -qqy install unzip curl libicu-dev libunwind8 gettext libssl-dev libcurl3-gnutls zlib1g
+    apt-get -qqy install unzip curl libicu-dev libunwind8 gettext libssl-dev libcurl3-gnutls zlib1g liblttng-ust-dev lldb-3.6-dev lldb-3.6 
+
+# Install Dotnet CLI dependencies.
+# clang is required for dotnet-compile-native
+RUN apt-get -qqy install clang-3.5
 
 # Install Build Prereqs
 RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | tee /etc/apt/sources.list.d/llvm.list && \
     curl http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update && \
-    apt-get install -y debhelper build-essential devscripts git liblttng-ust-dev lldb-3.6-dev lldb-3.6 clang cmake
+    apt-get install -y debhelper build-essential devscripts git cmake
 
 # Use clang as c++ compiler
-RUN update-alternatives --set c++ /usr/bin/clang++
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.5 100
+RUN update-alternatives --set c++ /usr/bin/clang++-3.5
 
 # Install azure cli. We need this to publish artifacts.
 RUN apt-get -y install nodejs-legacy && \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,7 +87,12 @@ current_os()
     if [ "$uname" = "Darwin" ]; then
         echo "osx"
     else
-        echo "linux"
+        # Detect Distro
+        if [ "$(cat /etc/*-release | grep -cim1 ubuntu)" -eq 1 ]; then
+            echo "ubuntu"
+        elif [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
+            echo "centos"
+        fi
     fi
 }
 
@@ -107,7 +112,7 @@ check_pre_reqs() {
         return 0
     fi
 
-    if [ "$os" = "linux" ]; then
+    if [ "$(uname)" = "Linux" ]; then
         [ -z "$(ldconfig -p | grep libunwind)" ] && say_err "Unable to locate libunwind. Install libunwind to continue" && _failing=true
         [ -z "$(ldconfig -p | grep libssl)" ] && say_err "Unable to locate libssl. Install libssl to continue" && _failing=true
         [ -z "$(ldconfig -p | grep libcurl)" ] && say_err "Unable to locate libcurl. Install libcurl to continue" && _failing=true

--- a/scripts/package/package.sh
+++ b/scripts/package/package.sh
@@ -32,11 +32,10 @@ echo $DOTNET_BUILD_VERSION >> $STAGE2_DIR/.version
 # Create Dnvm Package
 $DIR/package-dnvm.sh
 
-if [[ "$UNAME" == "Linux" ]]; then
+if [[ "$OSNAME" == "ubuntu" ]]; then
     # Create Debian package
     $DIR/package-debian.sh
-elif [[ "$UNAME" == "Darwin" ]]; then
+elif [[ "$OSNAME" == "osx" ]]; then
     # Create OSX PKG
     $DIR/../../packaging/osx/package-osx.sh
 fi
-

--- a/scripts/test/e2e-test.sh
+++ b/scripts/test/e2e-test.sh
@@ -17,7 +17,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 source "$DIR/../_common.sh"
 
 rm "$REPOROOT/test/E2E/project.lock.json"
-dotnet restore --quiet "$REPOROOT/test/E2E" --runtime "osx.10.10-x64" --runtime "ubuntu.14.04-x64" --runtime "win7-x64"
+dotnet restore --quiet "$REPOROOT/test/E2E" --runtime "$RID"
 dotnet publish --framework dnxcore50 --runtime "$RID" --output "$REPOROOT/artifacts/$RID/e2etest" "$REPOROOT/test/E2E" 
 
 # set -e will abort if the exit code of this is non-zero


### PR DESCRIPTION
Does not contain changes to actually build CLI on centos.

cc: @brthor for docker changes. With this fix the docker container runs ubuntu images instead of debian.

cc: @anurse With this change the build scripts no longer restore for all the rids, instead it only restores for current RID. 

cc: @piotrpMSFT @blackdwarf With this change the ubuntu tarball will be called as `dotnet-ubuntu-x64.1.0.0.1450212991.tar.gz` instead of `dotnet-linux-x64.1.0.0.1450212991.tar.gz`. We need this to distinguish between distros.