### PR TITLE
compile-native and compile-csc crash when invoked with --help

### DIFF
--- a/src/Microsoft.DotNet.Tools.Compiler.Native/ArgValues.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/ArgValues.cs
@@ -17,6 +17,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         public string AppDepSDKPath { get; set; }
         public string IlcPath { get; set; }
 
+        public bool IsHelp { get; set; }
+        public int ReturnCode { get; set; }
+
         public NativeCompileSettings GetNativeCompileSettings()
         {
             var config = NativeCompileSettings.Default;

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/Program.cs
@@ -32,6 +32,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             try
             {
                 var cmdLineArgs = ArgumentsParser.Parse(args);
+
+                if (cmdLineArgs.IsHelp) return cmdLineArgs.ReturnCode;
+
                 var config = cmdLineArgs.GetNativeCompileSettings();
 
                 DirectoryExtensions.CleanOrCreateDirectory(config.OutputDirectory);


### PR DESCRIPTION
System.CommandLine uses Environment.FailFast when help or ReportError is detected. This causes the debugger to get invoked in windows and is not desirable. The fix here is to handle error and help ourselves, but still use the getHelpText from System.CommandLine to generate the help content.