### PR TITLE
Add F# ( command dotnet-compile-fsc )

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -63,6 +63,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MultiProjectValidator", "to
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.DependencyModel", "src\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.xproj", "{688870C8-9843-4F9E-8576-D39290AD0F25}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.DotNet.Tools.Compiler.Fsc", "src\Microsoft.DotNet.Tools.Compiler.Fsc\Microsoft.DotNet.Tools.Compiler.Fsc.xproj", "{74F25188-BF63-4BF3-879B-B6CDB11ED608}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -459,6 +461,22 @@ Global
 		{688870C8-9843-4F9E-8576-D39290AD0F25}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{688870C8-9843-4F9E-8576-D39290AD0F25}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{688870C8-9843-4F9E-8576-D39290AD0F25}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.Debug|x64.Build.0 = Debug|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.Release|x64.ActiveCfg = Release|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.Release|x64.Build.0 = Release|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -488,5 +506,6 @@ Global
 		{BC765FBF-AD7A-4A99-9902-5540C5A74181} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85} = {0722D325-24C8-4E83-B5AF-0A083E7F0749}
 		{688870C8-9843-4F9E-8576-D39290AD0F25} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
+		{74F25188-BF63-4BF3-879B-B6CDB11ED608} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 	EndGlobalSection
 EndGlobal

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -12,6 +12,7 @@
     <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
     <add key="corert" value="https://www.myget.org/F/dotnet/auth/3e4f1dbe-f43a-45a8-b029-3ad4d25605ac/api/v2" />
     <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />

--- a/packaging/debian/debian_config.json
+++ b/packaging/debian/debian_config.json
@@ -37,6 +37,7 @@
         "bin/dotnet" : "usr/bin/dotnet",
         "bin/dotnet-compile" : "usr/bin/dotnet-compile",
         "bin/dotnet-compile-csc" : "usr/bin/dotnet-compile-csc",
+        "bin/dotnet-compile-fsc" : "usr/bin/dotnet-compile-fsc",
         "bin/dotnet-compile-native" : "/usr/bin/dotnet-compile-native",
         "bin/dotnet-init":"usr/bin/dotnet-new",
         "bin/dotnet-publish" : "usr/bin/dotnet-publish",

--- a/packaging/osx/scripts/postinstall
+++ b/packaging/osx/scripts/postinstall
@@ -14,6 +14,7 @@ chmod -R 755 $INSTALL_DESTINATION
 ln -s $INSTALL_DESTINATION/bin/dotnet /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-compile /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-compile-csc /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-compile-fsc /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-new /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-pack /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-publish /usr/local/bin/

--- a/scripts/build/build-stage.ps1
+++ b/scripts/build/build-stage.ps1
@@ -15,6 +15,7 @@ $Projects = @(
     "Microsoft.DotNet.Cli",
     "Microsoft.DotNet.Tools.Compiler",
     "Microsoft.DotNet.Tools.Compiler.Csc",
+    "Microsoft.DotNet.Tools.Compiler.Fsc",
     "Microsoft.DotNet.Tools.Compiler.Native",
     "Microsoft.DotNet.Tools.New",
     "Microsoft.DotNet.Tools.Pack",

--- a/scripts/build/build-stage.sh
+++ b/scripts/build/build-stage.sh
@@ -27,6 +27,7 @@ PROJECTS=( \
     Microsoft.DotNet.Cli \
     Microsoft.DotNet.Tools.Compiler \
     Microsoft.DotNet.Tools.Compiler.Csc \
+    Microsoft.DotNet.Tools.Compiler.Fsc \
     Microsoft.DotNet.Tools.Compiler.Native \
     Microsoft.DotNet.Tools.New \
     Microsoft.DotNet.Tools.Pack \

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
@@ -17,18 +17,7 @@ namespace Microsoft.Dotnet.Cli.Compiler.Common
     {
         public static string Generate(AssemblyInfoOptions metadata, IEnumerable<string> sourceFiles)
         {
-            var projectAttributes = new Dictionary<Type, string>()
-            {
-                [typeof(AssemblyTitleAttribute)] = EscapeCharacters(metadata.Title),
-                [typeof(AssemblyDescriptionAttribute)] = EscapeCharacters(metadata.Description),
-                [typeof(AssemblyCopyrightAttribute)] = EscapeCharacters(metadata.Copyright),
-                [typeof(AssemblyFileVersionAttribute)] = EscapeCharacters(metadata.AssemblyFileVersion?.ToString()),
-                [typeof(AssemblyVersionAttribute)] = EscapeCharacters(metadata.AssemblyVersion?.ToString()),
-                [typeof(AssemblyInformationalVersionAttribute)] = EscapeCharacters(metadata.InformationalVersion),
-                [typeof(AssemblyCultureAttribute)] = EscapeCharacters(metadata.Culture),
-                [typeof(NeutralResourcesLanguageAttribute)] = EscapeCharacters(metadata.NeutralLanguage),
-                [typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework)
-            };
+            var projectAttributes = GetProjectAttributes(metadata);
 
             var existingAttributes = new List<Type>();
             foreach (var sourceFile in sourceFiles)
@@ -56,6 +45,32 @@ namespace Microsoft.Dotnet.Cli.Compiler.Common
             return string.Join(Environment.NewLine, projectAttributes
                 .Where(projectAttribute => projectAttribute.Value != null && !existingAttributes.Contains(projectAttribute.Key))
                 .Select(projectAttribute => $"[assembly:{projectAttribute.Key.FullName}(\"{projectAttribute.Value}\")]"));
+        }
+
+        public static string GenerateFSharp(AssemblyInfoOptions metadata)
+        {
+            var projectAttributes = GetProjectAttributes(metadata);
+
+            return string.Join(Environment.NewLine,
+                new[] { "namespace System", Environment.NewLine, Environment.NewLine } 
+                .Concat(projectAttributes.Select(projectAttribute => $"[<assembly:{projectAttribute.Key.FullName}(\"{projectAttribute.Value}\")>]"))
+                .Concat(new[] { "do ()", Environment.NewLine }));
+        }
+
+        private static Dictionary<Type, string> GetProjectAttributes(AssemblyInfoOptions metadata)
+        {
+            return new Dictionary<Type, string>()
+            {
+                [typeof(AssemblyTitleAttribute)] = EscapeCharacters(metadata.Title),
+                [typeof(AssemblyDescriptionAttribute)] = EscapeCharacters(metadata.Description),
+                [typeof(AssemblyCopyrightAttribute)] = EscapeCharacters(metadata.Copyright),
+                [typeof(AssemblyFileVersionAttribute)] = EscapeCharacters(metadata.AssemblyFileVersion?.ToString()),
+                [typeof(AssemblyVersionAttribute)] = EscapeCharacters(metadata.AssemblyVersion?.ToString()),
+                [typeof(AssemblyInformationalVersionAttribute)] = EscapeCharacters(metadata.InformationalVersion),
+                [typeof(AssemblyCultureAttribute)] = EscapeCharacters(metadata.Culture),
+                [typeof(NeutralResourcesLanguageAttribute)] = EscapeCharacters(metadata.NeutralLanguage),
+                [typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework)
+            };
         }
 
         private static bool IsSameAttribute(Type attributeType, AttributeSyntax attributeSyntax)

--- a/src/Microsoft.DotNet.Tools.Compiler.Fsc/Microsoft.DotNet.Tools.Compiler.Fsc.xproj
+++ b/src/Microsoft.DotNet.Tools.Compiler.Fsc/Microsoft.DotNet.Tools.Compiler.Fsc.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>74f25188-bf63-4bf3-879b-b6cdb11ed608</ProjectGuid>
+    <RootNamespace>Microsoft.DotNet.Tools.Compiler.Fsc</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.DotNet.Tools.Compiler.Fsc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Fsc/Program.cs
@@ -1,0 +1,198 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.CommandLine;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+using Microsoft.DotNet.Cli.Compiler.Common;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.Dotnet.Cli.Compiler.Common;
+
+namespace Microsoft.DotNet.Tools.Compiler.Fsc
+{
+    public class Program
+    {
+        private const int ExitFailed = 1;
+
+        public static int Main(string[] args)
+        {
+            DebugHelper.HandleDebugSwitch(ref args);
+
+            CommonCompilerOptions commonOptions = null;
+            AssemblyInfoOptions assemblyInfoOptions = null;
+            string tempOutDir = null;
+            IReadOnlyList<string> references = Array.Empty<string>();
+            IReadOnlyList<string> resources = Array.Empty<string>();
+            IReadOnlyList<string> sources = Array.Empty<string>();
+            string outputName = null;
+            var help = false;
+            var returnCode = 0;
+            string helpText = null;
+
+            try
+            {
+                ArgumentSyntax.Parse(args, syntax =>
+                {
+                    syntax.HandleHelp = false;
+                    syntax.HandleErrors = false;
+
+                    commonOptions = CommonCompilerOptionsExtensions.Parse(syntax);
+
+                    assemblyInfoOptions = AssemblyInfoOptions.Parse(syntax);
+
+                    syntax.DefineOption("temp-output", ref tempOutDir, "Compilation temporary directory");
+
+                    syntax.DefineOption("out", ref outputName, "Name of the output assembly");
+
+                    syntax.DefineOptionList("reference", ref references, "Path to a compiler metadata reference");
+
+                    syntax.DefineOptionList("resource", ref resources, "Resources to embed");
+
+                    syntax.DefineOption("h|help", ref help, "Help for compile native.");
+
+                    syntax.DefineParameterList("source-files", ref sources, "Compilation sources");
+
+                    helpText = syntax.GetHelpText();
+
+                    if (tempOutDir == null)
+                    {
+                        syntax.ReportError("Option '--temp-output' is required");
+                    }
+                });
+            }
+            catch (ArgumentSyntaxException exception)
+            {
+                Console.Error.WriteLine(exception.Message);
+                help = true;
+                returnCode = ExitFailed;
+            }
+
+            if (help)
+            {
+                Console.WriteLine(helpText);
+
+                return returnCode;
+            }
+
+            var translated = TranslateCommonOptions(commonOptions);
+
+            var allArgs = new List<string>(translated);
+            allArgs.AddRange(GetDefaultOptions());
+
+            // Generate assembly info
+            var assemblyInfo = Path.Combine(tempOutDir, $"dotnet-compile.assemblyinfo.fs");
+            File.WriteAllText(assemblyInfo, AssemblyInfoFileGenerator.GenerateFSharp(assemblyInfoOptions));
+            allArgs.Add($"\"{assemblyInfo}\"");
+
+            //HACK fsc raise error FS0208 if target exe doesnt have extension .exe
+            bool hackFS0208 = commonOptions.EmitEntryPoint == true;
+            string originalOutputName = outputName;
+
+            if (outputName != null)
+            {
+                if (hackFS0208)
+                {
+                    outputName = Path.ChangeExtension(outputName, ".exe");
+                }
+
+                allArgs.Add($"--out:\"{outputName}\"");
+            }
+
+            allArgs.AddRange(references.Select(r => $"-r:\"{r}\""));
+            allArgs.AddRange(resources.Select(resource => $"--resource:{resource}"));
+            allArgs.AddRange(sources.Select(s => $"\"{s}\""));
+
+            var rsp = Path.Combine(tempOutDir, "dotnet-compile-fsc.rsp");
+            File.WriteAllLines(rsp, allArgs, Encoding.UTF8);
+
+            // Execute FSC!
+            var result = RunFsc(string.Join(" ", allArgs))
+                .ForwardStdErr()
+                .ForwardStdOut()
+                .Execute();
+
+            if (hackFS0208 && File.Exists(outputName))
+            {
+                if (File.Exists(originalOutputName))
+                    File.Delete(originalOutputName);
+                File.Move(outputName, originalOutputName);
+            }
+
+            return result.ExitCode;
+        }
+
+        // TODO: Review if this is the place for default options
+        private static IEnumerable<string> GetDefaultOptions()
+        {
+            var args = new List<string>()
+            {
+                "--noframework",
+                "--nologo",
+                "--simpleresolution"
+            };
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                args.Add("--debug:full");
+            else
+                args.Add("--debug-");
+
+            return args;
+        }
+
+        private static IEnumerable<string> TranslateCommonOptions(CommonCompilerOptions options)
+        {
+            List<string> commonArgs = new List<string>();
+
+            if (options.Defines != null)
+            {
+                commonArgs.AddRange(options.Defines.Select(def => $"-d:{def}"));
+            }
+
+            if (options.Platform != null)
+            {
+                commonArgs.Add($"--platform:{options.Platform}");
+            }
+
+            if (options.WarningsAsErrors == true)
+            {
+                commonArgs.Add("--warnaserror");
+            }
+
+            if (options.Optimize == true)
+            {
+                commonArgs.Add("--optimize");
+            }
+
+            if (options.EmitEntryPoint != true)
+            {
+                commonArgs.Add("--target:library");
+            }
+            else
+            {
+                commonArgs.Add("--target:exe");
+
+                //HACK we need default.win32manifest for exe
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    var win32manifestPath = Path.Combine(AppContext.BaseDirectory, "default.win32manifest");
+                    commonArgs.Add($"--win32manifest:\"{win32manifestPath}\"");
+                }
+            }
+            return commonArgs;
+        }
+
+        private static Command RunFsc(string fscArgs)
+        {
+            var corerun = Path.Combine(AppContext.BaseDirectory, Constants.HostExecutableName);
+            var fscExe = Path.Combine(AppContext.BaseDirectory, "fsc.exe");
+            return Command.Create(corerun, $"\"{fscExe}\" {fscArgs}");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Tools.Compiler.Fsc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Fsc/project.json
@@ -1,0 +1,31 @@
+{
+    "name": "dotnet-compile-fsc",
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23616",
+        
+        "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-151218",
+
+        "Microsoft.DotNet.Cli.Utils": {
+            "type": "build",
+            "version": "1.0.0-*"
+        },
+        "Microsoft.Extensions.CommandLineUtils.Sources": {
+            "type": "build",
+            "version": "1.0.0-*"
+        },
+        "Microsoft.DotNet.Compiler.Common": "1.0.0-*"
+    },
+    "frameworks": {
+        "dnxcore50": { }
+    },
+    "scripts": {
+        "postcompile": [
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.dll\"",
+            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.pdb\""
+        ]
+    }
+}

--- a/test/FSharpTestProjects/CompileFail/Program.fs
+++ b/test/FSharpTestProjects/CompileFail/Program.fs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace TestApp
+
+open System
+open System.Diagnostics
+
+module Program =
+
+    [<EntryPoint>]
+    let Main (args: string array) =
+        this will not compile !
+
+        0

--- a/test/FSharpTestProjects/CompileFail/project.json
+++ b/test/FSharpTestProjects/CompileFail/project.json
@@ -1,0 +1,20 @@
+﻿{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+    "compilerName": "fsc",
+    "compileFiles": [
+        "Program.fs"
+    ],
+    "dependencies": {
+        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+        "Microsoft.NETCore.ConsoleHost": "1.0.0-23428",
+        "Microsoft.NETCore.Runtime": "1.0.1-23428",
+        "System.Console": "4.0.0-beta-23109"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/test/FSharpTestProjects/TestApp/FSharpTestApp.xproj
+++ b/test/FSharpTestProjects/TestApp/FSharpTestApp.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>a666217d-2aca-4866-b109-ea476e51c7aa</ProjectGuid>
+    <RootNamespace>FSharpTestApp</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/FSharpTestProjects/TestApp/Program.fs
+++ b/test/FSharpTestProjects/TestApp/Program.fs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace TestApp
+
+open System
+open System.Diagnostics
+
+module Program =
+
+    open TestLibrary
+
+    [<EntryPoint>]
+    let Main (args: string array) =
+        printfn "%s" (TestLibrary.Helper.GetMessage())
+        0

--- a/test/FSharpTestProjects/TestApp/project.json
+++ b/test/FSharpTestProjects/TestApp/project.json
@@ -1,0 +1,23 @@
+﻿{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+    "compilerName": "fsc",
+    "compileFiles": [
+        "Program.fs"
+    ],
+    "dependencies": {
+        "TestLibrary": { "target": "project" },
+        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+        "System.IO": "4.0.11-beta-23428",
+        "System.Console": "4.0.0-beta-23428",
+        "System.Runtime": "4.0.21-beta-23428",
+        "System.Diagnostics.Process": "4.1.0-beta-23428",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23428"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/test/FSharpTestProjects/TestAppWithArgs/Program.fs
+++ b/test/FSharpTestProjects/TestAppWithArgs/Program.fs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace TestApp
+
+open System
+open System.Diagnostics
+
+module Program =
+
+    [<EntryPoint>]
+    let Main args =
+        printfn "Hello World!"
+
+        printfn "I was passed %d args:" args.Length
+
+        args |> Array.iter (printfn "arg: [%s]")
+
+        0

--- a/test/FSharpTestProjects/TestAppWithArgs/project.json
+++ b/test/FSharpTestProjects/TestAppWithArgs/project.json
@@ -1,0 +1,22 @@
+﻿{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+    "compilerName": "fsc",
+    "compileFiles": [
+        "Program.fs"
+    ],
+    "dependencies": {
+        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+        "System.IO": "4.0.11-beta-23428",
+        "System.Console": "4.0.0-beta-23428",
+        "System.Runtime": "4.0.21-beta-23428",
+        "System.Diagnostics.Process": "4.1.0-beta-23428",
+        "Microsoft.NETCore.Runtime": "1.0.1-beta-23428"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/test/FSharpTestProjects/TestLibrary/FSharpTestLibrary.xproj
+++ b/test/FSharpTestProjects/TestLibrary/FSharpTestLibrary.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>ec801982-096b-4af3-a42b-7881b1a7380e</ProjectGuid>
+    <RootNamespace>FSharpTestLibrary</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/FSharpTestProjects/TestLibrary/Helper.fs
+++ b/test/FSharpTestProjects/TestLibrary/Helper.fs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace TestLibrary
+
+open Lib
+
+type Helper() =
+
+    static member GetMessage () = Lib.message ()
+
+    static member SayHi () = Lib.sayHi ()

--- a/test/FSharpTestProjects/TestLibrary/Helper2.fs
+++ b/test/FSharpTestProjects/TestLibrary/Helper2.fs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+module Lib
+
+open System
+
+let message () =
+    "This string came from the test library!"
+
+let sayHi () =
+    Console.WriteLine("Hello there!")

--- a/test/FSharpTestProjects/TestLibrary/project.json
+++ b/test/FSharpTestProjects/TestLibrary/project.json
@@ -1,0 +1,16 @@
+﻿{
+    "version": "1.0.0-*",
+    "dependencies": {
+        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+        "System.Runtime": "4.0.21-beta-23428",
+        "System.Console": "4.0.0-beta-23428"
+    },
+    "compilerName": "fsc",
+    "compileFiles": [
+        "Helper2.fs",
+        "Helper.fs"
+    ],
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
add command `dotnet-compile-fsc`

It's used with `"compilerName": "fsc"` in project.json

use`fsc.exe` from `Microsoft.FSharp.Compiler.netcore` package ( ref http://myget.org/gallery/fsharp-daily )

the FSharp.Core.netcore package is in the same feed
