### PR TITLE
[WIP - Do no merge] Pickup headers from ILCompiler.SDK

### DIFF
--- a/src/Microsoft.DotNet.Tools.Compiler.Native/ArgValues.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/ArgValues.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         public string AppDepSDKPath { get; set; }
         public string IlcPath { get; set; }
         public string IlcSdkPath { get; set; }
+        public string CppCompilerFlags { get; set; }
 
         public bool IsHelp { get; set; }
         public int ReturnCode { get; set; }
@@ -56,12 +57,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             if (!string.IsNullOrEmpty(IlcPath))
             {
                 config.IlcPath = IlcPath;
-
-                // If ILCSdkPath is not specified, then default it to be the same as the overridden ILCPath
-                if (string.IsNullOrEmpty(IlcSdkPath))
-                {
-                    IlcSdkPath = IlcPath;
-                }
+                config.IlcSdkPath = IlcPath;
             }
 
             if (!string.IsNullOrEmpty(IlcSdkPath))
@@ -77,6 +73,11 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             if (!string.IsNullOrEmpty(IlcArgs))
             {
                 config.IlcArgs = IlcArgs;
+            }
+
+            if (!string.IsNullOrWhiteSpace(CppCompilerFlags))
+            {
+                config.CppCompilerFlags = CppCompilerFlags;
             }
 
             foreach (var reference in ReferencePaths)

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/ArgumentsParser.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/ArgumentsParser.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var help = false;
             string helpText = null;
             var returnCode = 0;
+            string cppCompilerFlags = null;
 
             IReadOnlyList<string> references = Array.Empty<string>();
             IReadOnlyList<string> linklib = Array.Empty<string>();            
@@ -56,6 +57,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
                     // Optional Log Path
                     syntax.DefineOption("logpath", ref logPath, "Use to dump Native Compilation Logs to a file.");
+
+                    // Optional flags to be passed to the native compiler
+                    syntax.DefineOption("cppcompilerflags", ref cppCompilerFlags, "Additional flags to be passed to the native compiler.");
 
                     syntax.DefineOption("h|help", ref help, "Help for compile native.");
 
@@ -131,7 +135,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
                 IlcSdkPath = ilcSdkPath,
                 LinkLibPaths = linklib,
                 AppDepSDKPath = appDepSdk,
-                LogPath = logPath
+                LogPath = logPath,
+                CppCompilerFlags = cppCompilerFlags
             };
         }
     }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
@@ -65,20 +65,25 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             // Flags
             argsList.Add(cflags);
 
-            // Add Includes
+            // TODO: Enable this when https://github.com/dotnet/cli/pull/469 goes through.
+            // var ilcSdkIncPath = Path.Combine(config.IlcSdkPath, "inc");
+            //
+            // Get the directory name to ensure there are no trailing slashes as they may conflict
+            // with the terminating "  we suffix to account for paths with spaces in them.
+            var ilcSdkIncPath = Path.GetDirectoryName(config.IlcSdkPath);
             argsList.Add("-I");
-            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk/ubuntu.14.04"));
-
-            argsList.Add("-I");
-            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk"));
+            argsList.Add($"\"{ilcSdkIncPath}\"");
 
             // Input File
             var inCppFile = DetermineInFile(config);
             argsList.Add(inCppFile);
 
-            // Add Stubs
-            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk/ubuntu.14.04/lxstubs.cpp"));
-
+            // Pass the optional native compiler flags if specified
+            if (!string.IsNullOrWhiteSpace(config.CppCompilerFlags))
+            {
+                argsList.Add(config.CppCompilerFlags);
+            }
+            
             // ILC SDK Libs
             foreach (var lib in IlcSdkLibs)
             {

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
@@ -70,6 +70,12 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var inLibFile = DetermineInFile(config);
             argsList.Add(inLibFile);
 
+            // Pass the optional native compiler flags if specified
+            if (!string.IsNullOrWhiteSpace(config.CppCompilerFlags))
+            {
+                argsList.Add(config.CppCompilerFlags);
+            }
+            
             // ILC SDK Libs
             foreach (var lib in IlcSdkLibs)
             {

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Mac/MacCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Mac/MacCppCompileStep.cs
@@ -67,23 +67,28 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             // Flags
             argsList.Add(cflags);
 
-            // Add Includes
+            // TODO: Enable this when https://github.com/dotnet/cli/pull/469 goes through.
+            // var ilcSdkIncPath = Path.Combine(config.IlcSdkPath, "inc");
+            //
+            // Get the directory name to ensure there are no trailing slashes as they may conflict
+            // with the terminating "  we suffix to account for paths with spaces in them.
+            var ilcSdkIncPath = Path.GetDirectoryName(config.IlcSdkPath);
             argsList.Add("-I");
-            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk/osx.10.10"));
-
-            argsList.Add("-I");
-            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk"));
+            argsList.Add($"\"{ilcSdkIncPath}\"");
 
             // Input File
             var inCppFile = DetermineInFile(config);
             argsList.Add(inCppFile);
 
-            // Add Stubs
-            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk/osx.10.10/osxstubs.cpp"));
-
             // Lib flags
             argsList.Add(libFlags);
 
+            // Pass the optional native compiler flags if specified
+            if (!string.IsNullOrWhiteSpace(config.CppCompilerFlags))
+            {
+                argsList.Add(config.CppCompilerFlags);
+            }
+            
             // ILC SDK Libs
             foreach (var lib in IlcSdkLibs)
             {

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
@@ -66,11 +66,12 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             // Flags
             argsList.Add(cflags);
             
-            // Add Stubs
-            argsList.Add("-I "+Path.Combine(config.AppDepSDKPath, "CPPSdk/osx.10.10"));
-            argsList.Add("-I "+Path.Combine(config.AppDepSDKPath, "CPPSdk"));
-            argsList.Add(Path.Combine(config.AppDepSDKPath, "CPPSdk/osx.10.10/osxstubs.cpp"));
-
+            // Pass the optional native compiler flags if specified
+            if (!string.IsNullOrWhiteSpace(config.CppCompilerFlags))
+            {
+                argsList.Add(config.CppCompilerFlags);
+            }
+            
             // Input File
             var inLibFile = DetermineInFile(config);
             argsList.Add("-Xlinker "+inLibFile);

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         
         private static readonly Dictionary<BuildConfiguration, string> ConfigurationCompilerOptionsMap = new Dictionary<BuildConfiguration, string>
         {
-            { BuildConfiguration.debug, "/ZI /nologo /W3 /WX- /sdl /Od /D CPPCODEGEN /D WIN32 /D _DEBUG /D _CONSOLE /D _LIB /D _UNICODE /D UNICODE /Gm /EHsc /RTC1 /MDd /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Gd /TP /wd4477 /errorReport:prompt" },
+            { BuildConfiguration.debug, "/ZI /nologo /W3 /WX- /sdl /Od /D CPPCODEGEN /D WIN32 /D _CONSOLE /D _LIB /D _UNICODE /D UNICODE /Gm /EHsc /RTC1 /MD /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Gd /TP /wd4477 /errorReport:prompt" },
             { BuildConfiguration.release, "/Zi /nologo /W3 /WX- /sdl /O2 /Oi /GL /D CPPCODEGEN /D WIN32 /D NDEBUG /D _CONSOLE /D _LIB /D _UNICODE /D UNICODE /Gm- /EHsc /MD /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Gd /TP /wd4477 /errorReport:prompt" }
         };
         
@@ -68,17 +68,26 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             argsList.Add("/c");
             
             // Add Includes
-            var win7CppSdkPath = Path.Combine(config.AppDepSDKPath, "CPPSdk\\win7");
+            // 
+            // TODO: Enable this when https://github.com/dotnet/cli/pull/469 goes through.
+            // var ilcSdkIncPath = Path.Combine(config.IlcSdkPath, "inc");
+            //
+            // Get the directory name to ensure there are no trailing slashes as they may conflict
+            // with the terminating "  we suffix to account for paths with spaces in them.
+            var ilcSdkIncPath = config.IlcSdkPath;
+            ilcSdkIncPath = ilcSdkIncPath.TrimEnd(new char[] {'\\'});
             argsList.Add("/I");
-            argsList.Add($"\"{win7CppSdkPath}\"");
-            
-            var cppSdkPath = Path.Combine(config.AppDepSDKPath, "CPPSdk");
-            argsList.Add("/I");
-            argsList.Add($"\"{cppSdkPath}\"");
+            argsList.Add($"\"{ilcSdkIncPath}\"");
             
             // Configuration Based Compiler Options 
             argsList.Add(ConfigurationCompilerOptionsMap[config.BuildType]);
             
+            // Pass the optional native compiler flags if specified
+            if (!string.IsNullOrWhiteSpace(config.CppCompilerFlags))
+            {
+                argsList.Add(config.CppCompilerFlags);
+            }
+
             // Output
             var objOut = DetermineOutputFile(config);
             argsList.Add($"/Fo\"{objOut}\"");

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
@@ -46,9 +46,11 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             "odbccp32.lib"
         };
 
+        // We will always link against msvcrt.lib since the runtime libraries are also built against msvcrt.lib as we are not interested in assertions
+        // from CRT code.
         private static readonly Dictionary<BuildConfiguration, string[]> ConfigurationLinkLibMap = new Dictionary<BuildConfiguration, string[]>()
         {
-            { BuildConfiguration.debug , new string[] { "msvcrtd.lib" } },
+            { BuildConfiguration.debug , new string[] { "msvcrt.lib" } },
             { BuildConfiguration.release , new string[] { "msvcrt.lib" } }
         };
         

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/NativeCompileSettings.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/NativeCompileSettings.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         private string _ilcArgs;
         private readonly List<string> _referencePaths;
         private readonly List<string> _linkLibPaths;
+        private string _cppCompilerFlags;
 
         public string LogPath
         {
@@ -144,6 +145,18 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
                 }
 
                 _ilcSdkPath = value;
+            }
+        }
+
+        public string CppCompilerFlags
+        {
+            get
+            {
+                return _cppCompilerFlags;
+            }
+            set
+            {
+                _cppCompilerFlags = value;
             }
         }
 

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "Microsoft.DotNet.AppDep":"1.0.2-*"
+        "Microsoft.DotNet.AppDep":"1.0.3-*"
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
@@ -15,8 +15,8 @@
             "type": "build",
             "version": "1.0.0-*"
         },
-        "Microsoft.DotNet.ILCompiler": "1.0.3-*",
-        "Microsoft.DotNet.ILCompiler.SDK": "1.0.3-*",
+        "Microsoft.DotNet.ILCompiler": "1.0.4-*",
+        "Microsoft.DotNet.ILCompiler.SDK": "1.0.4-*",
         "Microsoft.DotNet.Compiler.Common": "1.0.0-*"
     },
     "frameworks": {

--- a/src/Microsoft.DotNet.Tools.Compiler/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/Program.cs
@@ -48,6 +48,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             var ilcSdkPath = app.Option("--ilcsdkpath <PATH>", "Path to the folder containing custom built ILCompiler SDK.", CommandOptionType.SingleValue);
             var appDepSdkPath = app.Option("--appdepsdkpath <PATH>", "Path to the folder containing ILCompiler application dependencies.", CommandOptionType.SingleValue);
             var cppMode = app.Option("--cpp", "Flag to do native compilation with C++ code generator.", CommandOptionType.NoValue);
+            var cppCompilerFlags = app.Option("--cppcompilerflags <flags>", "Additional flags to be passed to the native compiler.", CommandOptionType.SingleValue);
 
             app.OnExecute(() =>
             {
@@ -69,6 +70,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                 var configValue = configuration.Value() ?? Constants.DefaultConfiguration;
                 var outputValue = output.Value();
                 var intermediateValue = intermediateOutput.Value();
+                var cppCompilerFlagsValue = cppCompilerFlags.Value();
 
                 // Load project contexts for each framework and compile them
                 bool success = true;
@@ -80,7 +82,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                     success &= Compile(context, configValue, outputValue, intermediateValue, buildProjectReferences, noHost.HasValue());
                     if (isNative && success)
                     {
-                        success &= CompileNative(context, configValue, outputValue, buildProjectReferences, intermediateValue, archValue, ilcArgsValue, ilcPathValue, ilcSdkPathValue, appDepSdkPathValue, isCppMode);
+                        success &= CompileNative(context, configValue, outputValue, buildProjectReferences, intermediateValue, archValue, ilcArgsValue, ilcPathValue, ilcSdkPathValue, appDepSdkPathValue, isCppMode, cppCompilerFlagsValue);
                     }
                 }
 
@@ -113,7 +115,8 @@ namespace Microsoft.DotNet.Tools.Compiler
             string ilcPathValue,
             string ilcSdkPathValue,
             string appDepSdkPathValue,
-            bool isCppMode)
+            bool isCppMode,
+            string cppCompilerFlagsValue)
         {
             var outputPath = GetOutputPath(context, configuration, outputOptionValue);
             var nativeOutputPath = Path.Combine(GetOutputPath(context, configuration, outputOptionValue), "native");
@@ -165,6 +168,12 @@ namespace Microsoft.DotNet.Tools.Compiler
             {
                 nativeArgs.Add("--mode");
                 nativeArgs.Add("cpp");
+            }
+
+            if (!string.IsNullOrWhiteSpace(cppCompilerFlagsValue))
+            {
+                nativeArgs.Add("--cppcompilerflags");
+                nativeArgs.Add(cppCompilerFlagsValue);
             }
 
             // Configuration

--- a/test/E2E/E2ETest.cs
+++ b/test/E2E/E2ETest.cs
@@ -69,12 +69,6 @@ namespace ConsoleApplication
         [Fact]
         public void TestDotnetCompileNativeCpp()
         {
-            // Skip this test on windows
-            if(SkipForOS(OSPlatform.Windows, "https://github.com/dotnet/cli/issues/335"))
-            {
-                return;
-            }
-
             TestSetup();
 
             TestRunCommand("dotnet", $"compile --native --cpp -o {OutputDirectory}");


### PR DESCRIPTION
Enables consumption of the header files from ILCompiler.SDK. 

Need to add support for Unix.

@schellap PTAL.

@brthor This is dependent upon your change for publishing the native folder and its contents recursively. When can it come online?