### PR TITLE
Update dotnet-publish README.md

### DIFF
--- a/src/Microsoft.DotNet.Tools.Publish/README.md
+++ b/src/Microsoft.DotNet.Tools.Publish/README.md
@@ -20,6 +20,8 @@ This directory can then be moved to a different machine and the application will
 If it is not specified on invocation via [project], _project.json_ in the current directory will be the default. 
 If no _project.json_ can be found, `dotnet-publish` will error out. 
 
+`dotnet-publish` command also requires certain dependencies in the _project.json_ to work. Namely the `Microsoft.NETCore.Runtime` package must be referenced as a dependency in order for the command to copy the runtime files as well as the application's files to the published location. 
+
 The command also requires information on the targeted framework and runtime, both of which can be specified on the command line. 
 If the runtime is not specified, the command will default to the runtime for the current operating system. 
 If the framework is not specified, the command will read the information from the _project.json_ file. 


### PR DESCRIPTION
Update the README.md for dotnet-publish and add the information about the Microsoft.NETCore.Runtime dependency.

Fixes #289 

/cc @brthor @Sridhar-MS