### PR TITLE
Add NuGet.config to Test Projects in Temp Directory

### DIFF
--- a/test/TestProjects/CompileFail/NuGet.Config
+++ b/test/TestProjects/CompileFail/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>

--- a/test/TestProjects/TestApp/NuGet.Config
+++ b/test/TestProjects/TestApp/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>

--- a/test/TestProjects/TestAppWithArgs/NuGet.Config
+++ b/test/TestProjects/TestAppWithArgs/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>

--- a/test/TestProjects/TestAppWithContents/NuGet.Config
+++ b/test/TestProjects/TestAppWithContents/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>

--- a/test/TestProjects/TestLibrary/NuGet.Config
+++ b/test/TestProjects/TestLibrary/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>


### PR DESCRIPTION
Resolves #659 

This fixes Windows VSO build failures. I am planning to merge this quickly (after tests pass) to unblock our VSO builds and publishing.

PTAL @Sridhar-MS @piotrpMSFT 

cc @gkhanna79 @schellap 