### PR TITLE
Project model cleanup

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.ProjectModel
             }
 
             var libraries = new Dictionary<LibraryKey, LibraryDescription>();
-            var projectResolver = new ProjectDependencyProvider(Settings);
+            var projectResolver = new ProjectDependencyProvider(ProjectResolver);
 
             var mainProject = projectResolver.GetDescription(TargetFramework, Project);
 
@@ -382,10 +382,11 @@ namespace Microsoft.DotNet.ProjectModel
             return null;
         }
 
-        private static Project ResolveProject(string projectDirectory)
+        private Project ResolveProject(string projectDirectory)
         {
+            // TODO: Handle diagnostics
             Project project;
-            if (ProjectReader.TryGetProject(projectDirectory, out project))
+            if (ProjectReader.TryGetProject(projectDirectory, out project, diagnostics: null, settings: Settings))
             {
                 return project;
             }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.ProjectModel
             {
                 try
                 {
-                    var buildVersion = settings.VersionSuffix ?? Environment.GetEnvironmentVariable("DOTNET_BUILD_VERSION");
+                    var buildVersion = settings.VersionSuffix;
                     project.Version = SpecifySnapshot(version, buildVersion);
                 }
                 catch (Exception ex)
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.ProjectModel
                 }
             }
 
-            var fileVersion = Environment.GetEnvironmentVariable("DOTNET_ASSEMBLY_FILE_VERSION");
+            var fileVersion = settings.AssemblyFileVersion;
             if (string.IsNullOrWhiteSpace(fileVersion))
             {
                 project.AssemblyFileVersion = project.Version.Version;

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReaderSettings.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReaderSettings.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Microsoft.DotNet.ProjectModel
+﻿namespace Microsoft.DotNet.ProjectModel
 {
     public class ProjectReaderSettings
     {
-        public string VersionSuffix = null;
+        public string VersionSuffix { get; set; }
+        public string AssemblyFileVersion { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using Microsoft.DotNet.ProjectModel.Graph;
 using NuGet.Packaging;
-using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ProjectModel.Resolution
 {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/ProjectDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/ProjectDependencyProvider.cs
@@ -5,9 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.Versioning;
 using Microsoft.DotNet.ProjectModel.Graph;
-using NuGet;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.ProjectModel.Resolution
@@ -15,18 +13,10 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
     public class ProjectDependencyProvider
     {
         private Func<string, Project> _resolveProject;
-        private ProjectReaderSettings _settings;
 
-        public ProjectDependencyProvider(ProjectReaderSettings settings = null)
-        {
-            _resolveProject = ResolveProject;
-            _settings = settings;
-        }
-
-        public ProjectDependencyProvider(Func<string, Project> projectCacheResolver, ProjectReaderSettings settings = null)
+        public ProjectDependencyProvider(Func<string, Project> projectCacheResolver)
         {
             _resolveProject = projectCacheResolver;
-            _settings = settings;
         }
 
         public ProjectDescription GetDescription(string name,
@@ -85,19 +75,6 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
                 dependencies,
                 targetFrameworkInfo,
                 !unresolved);
-        }
-
-        private Project ResolveProject(string path)
-        {
-            Project project;
-            if (ProjectReader.TryGetProject(path, out project, settings: _settings))
-            {
-                return project;
-            }
-            else
-            {
-                return null;
-            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Tools.Pack/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Pack/Program.cs
@@ -9,7 +9,6 @@ using System.Text;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Cli.Compiler.Common;
 
 namespace Microsoft.DotNet.Tools.Compiler
 {
@@ -51,10 +50,13 @@ namespace Microsoft.DotNet.Tools.Compiler
                     return 1;
                 }
 
-                ProjectReaderSettings settings = null;
+                // Set defaults based on the environment
+                var settings = new ProjectReaderSettings();
+                settings.VersionSuffix = Environment.GetEnvironmentVariable("DOTNET_BUILD_VERSION");
+                settings.AssemblyFileVersion = Environment.GetEnvironmentVariable("DOTNET_ASSEMBLY_FILE_VERSION");
+
                 if (versionSuffix.HasValue())
                 {
-                    settings = new ProjectReaderSettings();
                     settings.VersionSuffix = versionSuffix.Value();
                 }
 


### PR DESCRIPTION
- Use ProjectResolver in the ProjectDependencyProvider
- Remove environment variable reading in the project reader and moved it to dotnet-pack