### PR TITLE
Assert StdErr is empty for E2E Test

### DIFF
--- a/test/E2E/E2ETest.cs
+++ b/test/E2E/E2ETest.cs
@@ -147,6 +147,9 @@ namespace ConsoleApplication
                 .Execute();
 
             var outText = result.StdOut;
+            var errText = result.StdErr;
+            
+            Assert.Equal("", errText);
             Assert.Equal(EXPECTED_OUTPUT, outText);
         }
 


### PR DESCRIPTION
This is a quick fix to improve test diagnosability with the E2E Test. 

We see situations where the output executable fails and we are left without any error output. 

This addition should output any stderr output from the output executable.

cc @piotrpMSFT