### PR TITLE
 End to End Test Refactoring. Use Test Infrastructure

### DIFF
--- a/test/E2E/E2ETest.xproj
+++ b/test/E2E/E2ETest.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>386d412c-003c-47b1-8258-0e35865cb7c4</ProjectGuid>
+    <RootNamespace>E2ETest</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/E2E/EndToEndTest.cs
+++ b/test/E2E/EndToEndTest.cs
@@ -9,110 +9,120 @@ using System.Text;
 using Xunit;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Test.Utilities;
 
-namespace ConsoleApplication
+namespace Microsoft.DotNet.Tests.EndToEnd
 {
-    public class E2ETest
+    public class EndToEndTest : TestBase
     {
-        private static readonly string EXPECTED_OUTPUT = "Hello World!" + Environment.NewLine;
-        private static readonly string TESTDIR_NAME = "hellotest";
-        private static readonly string OUTPUTDIR_NAME = "testbin";
-
-        private static string RootPath { get; set; }
-        private string TestDirectory { get; set; }
-        private string OutputDirectory { get; set; }
+        private static readonly string s_expectedOutput = "Hello World!" + Environment.NewLine;
+        private static readonly string s_testdirName = "e2etestroot";
+        private static readonly string s_outputdirName = "testbin";
+        
         private string Rid { get; set; }
+        private string TestDirectory { get; set; }
+        private string TestProject { get; set; }
+        private string OutputDirectory { get; set; }
 
         public static void Main()
         {
             Console.WriteLine("Dummy Entrypoint.");
         }
        
-        public E2ETest()
+        public EndToEndTest()
         {
-            if (RootPath == null)
-            {
-                RootPath = Directory.GetCurrentDirectory();
-            }
-
-            TestDirectory = Path.Combine(RootPath, TESTDIR_NAME);
-            OutputDirectory = Path.Combine(RootPath, OUTPUTDIR_NAME);
+            TestSetup();
 
             Rid = RuntimeIdentifier.Current;
         }
 
         [Fact]
-        public void TestDotnetCompile()
+        public void TestDotnetBuild()
         {
-            TestSetup();
+            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory);
 
-            TestRunCommand("dotnet", $"build -o {OutputDirectory}");
-            TestOutputExecutable(OutputDirectory);
+            buildCommand.Execute().Should().Pass();
+
+            TestOutputExecutable(OutputDirectory, buildCommand.GetOutputExecutableName());
         }
 
         [Fact]
-        public void TestDotnetCompileNativeRyuJit()
+        [ActiveIssue(712, PlatformID.Windows | PlatformID.OSX | PlatformID.Linux)]
+        public void TestDotnetBuildNativeRyuJit()
         {
             if(SkipForOS(OSPlatform.Linux, "https://github.com/dotnet/cli/issues/527"))
             {
                 return;
             }
 
-            TestSetup();
+            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true);
 
-            TestRunCommand("dotnet", $"build --native -o {OutputDirectory}");
+            buildCommand.Execute().Should().Pass();
 
             var nativeOut = Path.Combine(OutputDirectory, "native");
-            TestOutputExecutable(nativeOut);
+            TestOutputExecutable(nativeOut, buildCommand.GetOutputExecutableName());
         }
 
         [Fact]
-        public void TestDotnetCompileNativeCpp()
+        public void TestDotnetBuildNativeCpp()
         {
-            TestSetup();
+            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true, nativeCppMode: true);
 
-            TestRunCommand("dotnet", $"build --native --cpp -o {OutputDirectory}");
-            
+            buildCommand.Execute().Should().Pass();
+
             var nativeOut = Path.Combine(OutputDirectory, "native");
-            TestOutputExecutable(nativeOut);
+            TestOutputExecutable(nativeOut, buildCommand.GetOutputExecutableName());
         }
 
         [Fact]
         public void TestDotnetRun()
         {
-            TestSetup();
+            var runCommand = new RunCommand(TestProject);
 
-            TestRunCommand("dotnet", $"run");
+            runCommand.Execute()
+                .Should()
+                .Pass();
         }
         
         [Fact]
         public void TestDotnetPack()
         {
-            TestSetup();
+            var packCommand = new PackCommand(TestDirectory, output: OutputDirectory);
 
-            TestRunCommand("dotnet", $"pack");
+            packCommand.Execute()
+                .Should()
+                .Pass();
         }
 
         [Fact]
         public void TestDotnetPublish()
         {
-            TestSetup();
+            var publishCommand = new PublishCommand(TestProject, output: OutputDirectory);
+            publishCommand.Execute().Should().Pass();
 
-            TestRunCommand("dotnet", $"publish --framework dnxcore50 --runtime {Rid} -o {OutputDirectory}");
-            TestOutputExecutable(OutputDirectory);    
+            TestOutputExecutable(OutputDirectory, publishCommand.GetOutputExecutable());    
         }
 
         private void TestSetup()
         {
-            Directory.SetCurrentDirectory(RootPath);
+            var root = Temp.CreateDirectory();
 
-            CleanOrCreateDirectory(TestDirectory);
-            CleanOrCreateDirectory(OutputDirectory);
+            TestDirectory = root.CreateDirectory(s_testdirName).Path;
+            TestProject = Path.Combine(TestDirectory, "project.json");
+            OutputDirectory = Path.Combine(TestDirectory, s_outputdirName);
 
+            InitializeTestDirectory();   
+        }
+
+        private void InitializeTestDirectory()
+        {
+            var currentDirectory = Directory.GetCurrentDirectory();
             Directory.SetCurrentDirectory(TestDirectory);
 
-            TestRunCommand("dotnet", "new");
-            TestRunCommand("dotnet", "restore --quiet");
+            new NewCommand().Execute().Should().Pass();
+            new RestoreCommand().Execute("--quiet").Should().Pass();
+
+            Directory.SetCurrentDirectory(currentDirectory);
         }
 
         private bool SkipForOS(OSPlatform os, string reason)
@@ -125,41 +135,17 @@ namespace ConsoleApplication
             return false;
         }
 
-        private void TestRunCommand(string command, string args)
+        private void TestOutputExecutable(string outputDir, string executableName)
         {
-            var result = Command.Create(command, args)
-                .ForwardStdErr()
-                .ForwardStdOut()
-                .Execute();
-
-            Assert.Equal(0, result.ExitCode);
-        }
-
-        private void TestOutputExecutable(string outputDir)
-        {
-            var executableName = TESTDIR_NAME + Constants.ExeSuffix;
-
             var executablePath = Path.Combine(outputDir, executableName);
 
-            var result = Command.Create(executablePath, "")
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute();
+            var executableCommand = new TestCommand(executablePath);
 
-            var outText = result.StdOut;
-            var errText = result.StdErr;
-            
-            Assert.Equal("", errText);
-            Assert.Equal(EXPECTED_OUTPUT, outText);
-        }
+            var result = executableCommand.ExecuteWithCapturedOutput("");
 
-        private void CleanOrCreateDirectory(string path)
-        {
-            if (Directory.Exists(path))
-            {
-                Directory.Delete(path, true);
-            }
-            Directory.CreateDirectory(path);
+            result.Should().HaveStdOut(s_expectedOutput);
+            result.Should().NotHaveStdErr();
+            result.Should().Pass();
         }
     }
 }

--- a/test/E2E/EndToEndTest.cs
+++ b/test/E2E/EndToEndTest.cs
@@ -50,11 +50,6 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         [ActiveIssue(712, PlatformID.Windows | PlatformID.OSX | PlatformID.Linux)]
         public void TestDotnetBuildNativeRyuJit()
         {
-            if(SkipForOS(OSPlatform.Linux, "https://github.com/dotnet/cli/issues/527"))
-            {
-                return;
-            }
-
             var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true);
 
             buildCommand.Execute().Should().Pass();
@@ -123,16 +118,6 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             new RestoreCommand().Execute("--quiet").Should().Pass();
 
             Directory.SetCurrentDirectory(currentDirectory);
-        }
-
-        private bool SkipForOS(OSPlatform os, string reason)
-        {
-            if (RuntimeInformation.IsOSPlatform(os))
-            {
-                Console.WriteLine("Skipping Test for reason: " + reason);
-                return true;
-            }
-            return false;
         }
 
         private void TestOutputExecutable(string outputDir, string executableName)

--- a/test/E2E/project.json
+++ b/test/E2E/project.json
@@ -9,13 +9,13 @@
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",
+        "xunit.netcore.extensions": "1.0.0-prerelease-*",
         "xunit.runner.utility": "2.1.0",
 
         "Microsoft.DotNet.ProjectModel": { "target": "project" },
-        "Microsoft.DotNet.Cli.Utils": {
-          "type": "build",
-          "version": "1.0.0-*"
-        },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" },
+
+        "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" }
     },
 
     "frameworks": {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/CommandResultAssertions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/CommandResultAssertions.cs
@@ -48,6 +48,13 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
+        public AndConstraint<CommandResultAssertions> HaveStdOut(string expectedOutput)
+        {
+            Execute.Assertion.ForCondition(_commandResult.StdOut.Equals(expectedOutput, StringComparison.Ordinal))
+                .FailWith($"Command did not output with Expected Output. Expected: {expectedOutput} Actual: {_commandResult.StdOut}");
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
         public AndConstraint<CommandResultAssertions> HaveStdErr()
         {
             Execute.Assertion.ForCondition(!string.IsNullOrEmpty(_commandResult.StdErr))

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
@@ -1,0 +1,190 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.ProjectModel;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public sealed class BuildCommand : TestCommand
+    {
+        private Project _project;
+        private string _projectPath;
+        private string _outputDirectory;
+        private string _tempOutputDirectory;
+        private string _configuration;
+        private bool _noHost;
+        private bool _native;
+        private string _architecture;
+        private string _ilcArgs;
+        private string _ilcPath;
+        private string _appDepSDKPath;
+        private bool _nativeCppMode;
+        private string _cppCompilerFlags;
+
+        private string OutputOption
+        {
+            get
+            {
+                return _outputDirectory == string.Empty ?
+                                           "" :
+                                           $"-o {_outputDirectory}";
+            }
+        }
+
+        private string TempOutputOption
+        {
+            get
+            {
+                return _tempOutputDirectory == string.Empty ?
+                                           "" :
+                                           $"-t {_tempOutputDirectory}";
+            }
+        }
+
+        private string ConfigurationOption
+        {
+            get
+            {
+                return _configuration == string.Empty ?
+                                           "" :
+                                           $"-c {_configuration}";
+            }
+        }
+
+        private string NoHostOption
+        {
+            get
+            {
+                return _noHost ?
+                        "--no-host" :
+                        "";
+            }
+        }
+
+        private string NativeOption
+        {
+            get
+            {
+                return _native ?
+                        "--native" :
+                        "";
+            }
+        }
+
+        private string ArchitectureOption
+        {
+            get
+            {
+                return _architecture == string.Empty ?
+                                           "" :
+                                           $"--arch {_architecture}";
+            }
+        }
+
+        private string IlcArgsOption
+        {
+            get
+            {
+                return _ilcArgs == string.Empty ?
+                                           "" :
+                                           $"--ilcargs {_ilcArgs}";
+            }
+        }
+
+        private string IlcPathOption
+        {
+            get
+            {
+                return _ilcPath == string.Empty ?
+                                           "" :
+                                           $"--ilcpath {_ilcPath}";
+            }
+        }
+
+        private string AppDepSDKPathOption
+        {
+            get
+            {
+                return _appDepSDKPath == string.Empty ?
+                                           "" :
+                                           $"--appdepsdkpath {_appDepSDKPath}";
+            }
+        }
+
+        private string NativeCppModeOption
+        {
+            get
+            {
+                return _nativeCppMode ?
+                        "--cpp" :
+                        "";
+            }
+        }
+
+        private string CppCompilerFlagsOption
+        {
+            get
+            {
+                return _cppCompilerFlags == string.Empty ?
+                                           "" :
+                                           $"--cppcompilerflags {_cppCompilerFlags}";
+            }
+        }
+
+        public BuildCommand(
+            string projectPath,
+            string output="",
+            string tempOutput="",
+            string configuration="",
+            bool noHost=false,
+            bool native=false,
+            string architecture="",
+            string ilcArgs="",
+            string ilcPath="",
+            string appDepSDKPath="",
+            bool nativeCppMode=false,
+            string cppCompilerFlags=""
+            )
+            : base("dotnet")
+        {
+
+            _projectPath = projectPath;
+            _project = ProjectReader.GetProject(projectPath);
+
+            _outputDirectory = output;
+            _tempOutputDirectory = tempOutput;
+            _configuration = configuration;
+            _noHost = noHost;
+            _native = native;
+            _architecture = architecture;
+            _ilcArgs = ilcArgs;
+            _ilcPath = ilcPath;
+            _appDepSDKPath = appDepSDKPath;
+            _nativeCppMode = nativeCppMode;
+            _cppCompilerFlags = cppCompilerFlags;
+
+        }
+
+        public override CommandResult Execute(string args = "")
+        {
+            args = $"build {BuildArgs()} {args}";
+            return base.Execute(args);
+        }
+
+        public string GetOutputExecutableName()
+        {
+            var result = _project.Name;
+            result += RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
+            return result;
+        }
+
+        private string BuildArgs()
+        {
+            return $"{_projectPath} {OutputOption} {TempOutputOption} {ConfigurationOption} {NoHostOption} {NativeOption} {ArchitectureOption} {IlcArgsOption} {IlcPathOption} {AppDepSDKPathOption} {NativeCppModeOption} {CppCompilerFlagsOption}";
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Test.Utilities;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.ProjectModel;
 

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/NewCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/NewCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Test.Utilities;
 
 namespace Microsoft.DotNet.Tools.Test.Utilities
 {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/NewCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/NewCommand.cs
@@ -6,17 +6,17 @@ using Microsoft.DotNet.Tools.Test.Utilities;
 
 namespace Microsoft.DotNet.Tools.Test.Utilities
 {
-    public sealed class RestoreCommand : TestCommand
+    public sealed class NewCommand : TestCommand
     {
-        public RestoreCommand()
+        public NewCommand()
             : base("dotnet")
         {
 
         }
 
-        public override CommandResult Execute(string args="")
+        public override CommandResult Execute(string args = "")
         {
-            args = $"restore {args}";
+            args = $"new {args}";
             return base.Execute(args);
         }
     }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PackCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PackCommand.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Test.Utilities;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public sealed class PackCommand : TestCommand
+    {
+        private string _projectPath;
+        private string _outputDirectory;
+        private string _tempOutputDirectory;
+        private string _configuration;
+        private string _versionSuffix;
+
+        private string OutputOption
+        {
+            get
+            {
+                return _outputDirectory == string.Empty ?
+                                           "" :
+                                           $"-o {_outputDirectory}";
+            }
+        }
+
+        private string TempOutputOption
+        {
+            get
+            {
+                return _tempOutputDirectory == string.Empty ?
+                                           "" :
+                                           $"-t {_tempOutputDirectory}";
+            }
+        }
+
+        private string ConfigurationOption
+        {
+            get
+            {
+                return _configuration == string.Empty ?
+                                           "" :
+                                           $"-c {_configuration}";
+            }
+        }
+
+        private string VersionSuffixOption
+        {
+            get
+            {
+                return _versionSuffix == string.Empty ?
+                                           "" :
+                                           $"--version-suffix {_versionSuffix}";
+            }
+        }
+
+        public PackCommand(
+            string projectPath, 
+            string output="", 
+            string tempOutput="", 
+            string configuration="", 
+            string versionSuffix="")
+            : base("dotnet")
+        {
+            _projectPath = projectPath;
+            _outputDirectory = output;
+            _tempOutputDirectory = tempOutput;
+            _configuration = configuration;
+            _versionSuffix = versionSuffix;
+        }
+
+        public override CommandResult Execute(string args = "")
+        {
+            args = $"pack {BuildArgs()} {args}";
+            return base.Execute(args);
+        }
+
+        private string BuildArgs()
+        {
+            return $"{_projectPath} {OutputOption} {TempOutputOption} {ConfigurationOption} {VersionSuffixOption}";
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PackCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PackCommand.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Test.Utilities;
 
 namespace Microsoft.DotNet.Tools.Test.Utilities
 {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
@@ -11,7 +11,7 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.DotNet.Tools.Test.Utilities;
 
-namespace Microsoft.DotNet.Tools.Publish.Tests
+namespace Microsoft.DotNet.Tools.Test.Utilities
 {
     public sealed class PublishCommand : TestCommand
     {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Test.Utilities;
 
 namespace Microsoft.DotNet.Tools.Test.Utilities
 {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RunCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RunCommand.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Test.Utilities;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public sealed class RunCommand : TestCommand
+    {
+        private string _projectPath;
+        private string _framework;
+        private string _configuration;
+        private bool _preserveTemporary;
+        private string _appArgs;
+
+        private string ProjectPathOption
+        {
+            get
+            {
+                return _projectPath == string.Empty ?
+                                       "" :
+                                       $"-p {_projectPath}";
+            }
+        }
+
+        private string FrameworkOption
+        {
+            get
+            {
+                return _framework == string.Empty ?
+                                       "" :
+                                       $"-f {_framework}";
+            }
+        }
+
+        private string ConfigurationOption
+        {
+            get
+            {
+                return _configuration == string.Empty ?
+                                       "" :
+                                       $"-c {_configuration}";
+            }
+        }
+
+        private string PreserveTemporaryOption
+        {
+            get
+            {
+                return _preserveTemporary ?
+                                       $"-t {_projectPath}" :
+                                       "";
+            }
+        }
+
+        private string AppArgsArgument
+        {
+            get { return _appArgs; }
+        }
+
+        public RunCommand(
+            string projectPath,
+            string framework="",
+            string configuration="",
+            bool preserveTemporary=false,
+            string appArgs="")
+            : base("dotnet")
+        {
+            _projectPath = projectPath;
+            _framework = framework;
+            _configuration = configuration;
+            _preserveTemporary = preserveTemporary;
+            _appArgs = appArgs;
+        }
+
+        public override CommandResult Execute(string args = "")
+        {
+            args = $"run {BuildArgs()} {args}";
+            return base.Execute(args);
+        }
+
+        private string BuildArgs()
+        {
+            return $"{ProjectPathOption} {FrameworkOption} {ConfigurationOption} {PreserveTemporaryOption} {AppArgsArgument}";
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RunCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RunCommand.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Test.Utilities;
 
 namespace Microsoft.DotNet.Tools.Test.Utilities
 {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -26,5 +26,16 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
             return commandResult;
         }
+
+        public virtual CommandResult ExecuteWithCapturedOutput(string args)
+        {
+            Console.WriteLine($"Executing (Captured Output) - {_command} {args}");
+            var commandResult = Command.Create(_command, args)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute();
+
+            return commandResult;
+        }
     }
 }


### PR DESCRIPTION
This PR is intended to improve End to End Test diagnosability, refactor the E2E test code to use the Publish Tests Infrastructure, and expand the infrastructure to provide capability for further (more detailed) command tests.

PTAL @Sridhar-MS @piotrpMSFT 