### PR TITLE
Enable visual xunit results.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -66,6 +66,7 @@ def static getBuildJobName(def configuration, def os) {
 
 
             Utilities.standardJobSetup(newJob, project, isPR)
+            Utilities.addXUnitDotNETResults(newJob, '**/*-testResults.xml')
             if (isPR) {
                 Utilities.addGithubPRTrigger(newJob, "${os} ${configuration} Build")
             }

--- a/scripts/test/runtests.ps1
+++ b/scripts/test/runtests.ps1
@@ -44,7 +44,7 @@ pushd "$TestBinRoot"
 
 # Run each test project
 $TestProjects | ForEach-Object {
-    & "corerun.exe"  "xunit.console.netcore.exe" "$_.dll" -xml "$_.xml" -notrait category=failing
+    & "corerun.exe"  "xunit.console.netcore.exe" "$_.dll" -xml "$_-testResults.xml" -notrait category=failing
     $exitCode = $LastExitCode
     if ($exitCode -ne 0) {
         $failingTests += "$_"
@@ -58,7 +58,7 @@ popd
 if ($failCount -ne 0) {
     Write-Host -ForegroundColor Red "The following tests failed."
     $failingTests | ForEach-Object {
-        Write-Host -ForegroundColor Red "$_.dll failed. Logs in '$TestBinRoot\$_.xml'"
+        Write-Host -ForegroundColor Red "$_.dll failed. Logs in '$TestBinRoot\$_-testResults.xml'"
     }
 }
 else {

--- a/scripts/test/runtests.sh
+++ b/scripts/test/runtests.sh
@@ -42,7 +42,7 @@ failCount=0
 
 for project in ${TestProjects[@]}
 do
-    ./corerun  "xunit.console.netcore.exe" "$project.dll" -xml "project.xml" -notrait category=failing
+    ./corerun  "xunit.console.netcore.exe" "$project.dll" -xml "${project}-testResults.xml" -notrait category=failing
     exitCode=$?
     failCount+=$exitCode
     if [ $exitCode -ne 0 ]; then
@@ -52,7 +52,7 @@ done
 
 for test in ${failedTests[@]}
 do
-    error "$test.dll failed. Logs in '$TestBinRoot/$test.xml'"
+    error "$test.dll failed. Logs in '$TestBinRoot/${test}-testResults.xml'"
 done
 
 popd


### PR DESCRIPTION
These changes should enable visual xunit results in our CI so we don't need to crawl through the build log every time. :smile: 

cc @Sridhar-MS @piotrpMSFT @mmitche 