### PR TITLE
Enable running tests for CentOS

### DIFF
--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -37,15 +37,9 @@ fi
 header "Compiling"
 $REPOROOT/scripts/compile/compile.sh
 
-# Skipping tests for centos
-# tracked by issue - https://github.com/dotnet/corefx/issues/5066
-if [ "$OSNAME" != "centos"  ]; then
-    # Run tests on the stage2 output
-    header "Testing stage2..."
-    DOTNET_HOME=$STAGE2_DIR DOTNET_TOOLS=$STAGE2_DIR $REPOROOT/scripts/test/runtests.sh
-else
-    header "Skipping tests on CentOS due to corefx issue 5066"
-fi
+# Run tests on the stage2 output
+header "Testing stage2..."
+DOTNET_HOME=$STAGE2_DIR DOTNET_TOOLS=$STAGE2_DIR $REPOROOT/scripts/test/runtests.sh
 
 header "Validating Dependencies"
 $REPOROOT/scripts/test/validate-dependencies.sh

--- a/scripts/crossgen/crossgen_roslyn.cmd
+++ b/scripts/crossgen/crossgen_roslyn.cmd
@@ -9,7 +9,7 @@ set BIN_DIR=%CD%\bin
 popd
 
 REM Replace with a robust method for finding the right crossgen.exe
-set CROSSGEN_UTIL=%UserProfile%\.dnx\packages\runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR\1.0.1-rc2-23616\tools\crossgen.exe
+set CROSSGEN_UTIL=%UserProfile%\.dnx\packages\runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR\1.0.1-rc2-23704\tools\crossgen.exe
 
 REM Crossgen currently requires itself to be next to mscorlib
 copy %CROSSGEN_UTIL% /Y %BIN_DIR% > nul

--- a/scripts/crossgen/crossgen_roslyn.sh
+++ b/scripts/crossgen/crossgen_roslyn.sh
@@ -22,7 +22,7 @@ if [ -z "$RID" ]; then
 fi
 
 # Replace with a robust method for finding the right crossgen.exe
-CROSSGEN_UTIL=$HOME/.dnx/packages/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23616/tools/crossgen
+CROSSGEN_UTIL=$HOME/.dnx/packages/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23704/tools/crossgen
 
 cd $BIN_DIR
 

--- a/scripts/test/validate-dependencies.sh
+++ b/scripts/test/validate-dependencies.sh
@@ -17,7 +17,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 source "$DIR/../common/_common.sh"
 
 # Run Validation for Project.json dependencies
-dotnet publish "$REPOROOT/tools/MultiProjectValidator" -o "$STAGE2_DIR/../tools"
+dotnet publish "$REPOROOT/tools/MultiProjectValidator" -r "$RID" -o "$STAGE2_DIR/../tools"
 #TODO for release builds this should fail
 set +e
 "$STAGE2_DIR/../tools/pjvalidate" "$REPOROOT/src"

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -4,7 +4,7 @@
   "shared": "**/*.cs",
 
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23616",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "Microsoft.DotNet.ProjectModel": "1.0.0",
     "System.Reflection.Metadata": "1.1.0"
   },

--- a/src/Microsoft.DotNet.Cli/project.json
+++ b/src/Microsoft.DotNet.Cli/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         
         "Microsoft.DotNet.Cli.Utils": {
             "type": "build",

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -7,7 +7,7 @@
 
     "dependencies": {
         "System.Reflection": "4.0.10-rc2-23616",
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "System.CommandLine": "0.1.0-*",
         "Microsoft.CodeAnalysis.CSharp":  "1.1.1",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",

--- a/src/Microsoft.DotNet.ProjectModel.Loader/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/project.json
@@ -4,7 +4,7 @@
         "keyFile": "../../tools/Key.snk"
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "System.Runtime.Loader": "4.0.0-rc2-23616"
     },

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -4,7 +4,7 @@
         "keyFile": "../../tools/Key.snk"
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.1.0-*"
     },

--- a/src/Microsoft.DotNet.ProjectModel/RuntimeIdentifier.cs
+++ b/src/Microsoft.DotNet.ProjectModel/RuntimeIdentifier.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.ProjectModel
             {
                 if(IsCentOS())
                 {
-                    return "centos.7.1-x64";
+                    return "centos.7-x64";
                 }
                 else if(IsUbuntu())
                 {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -5,7 +5,7 @@
     },
     "description": "Types to model a .NET Project",
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "System.Threading.Thread": "4.0.0-rc2-23616",
         "System.Runtime.Loader": "4.0.0-rc2-23616",
         "System.Dynamic.Runtime": "4.0.11-rc2-23616",

--- a/src/Microsoft.DotNet.Runtime/project.json
+++ b/src/Microsoft.DotNet.Runtime/project.json
@@ -5,7 +5,7 @@
   },
 
   "dependencies": {
-    "NETStandard.Library" : "1.0.0-rc2-23616"
+    "NETStandard.Library" : "1.0.0-rc2-23704"
   },
 
   "frameworks": {

--- a/src/Microsoft.DotNet.Tools.Builder/project.json
+++ b/src/Microsoft.DotNet.Tools.Builder/project.json
@@ -5,7 +5,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23608",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Linq": "4.0.1-rc2-23608",
     "System.Reflection.Metadata": "1.1.0",
     

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         
         "Microsoft.Net.Compilers.netcore": "1.2.0-beta1-20151228-02",
 

--- a/src/Microsoft.DotNet.Tools.Compiler.Fsc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Fsc/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         
         "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-151218",
 

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         
         "Microsoft.DotNet.Cli.Utils": {
             "type": "build",

--- a/src/Microsoft.DotNet.Tools.Compiler/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler/project.json
@@ -5,7 +5,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23616",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Reflection.Metadata": "1.1.0",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",

--- a/src/Microsoft.DotNet.Tools.New/Template/project.json
+++ b/src/Microsoft.DotNet.Tools.New/Template/project.json
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616"
+        "NETStandard.Library": "1.0.0-rc2-23704"
     },
 
     "frameworks": {

--- a/src/Microsoft.DotNet.Tools.New/project.json
+++ b/src/Microsoft.DotNet.Tools.New/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
 
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.DotNet.Cli.Utils": {

--- a/src/Microsoft.DotNet.Tools.Pack/project.json
+++ b/src/Microsoft.DotNet.Tools.Pack/project.json
@@ -5,7 +5,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23616",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "System.IO.Compression.ZipFile": "4.0.1-rc2-23616",
     
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",

--- a/src/Microsoft.DotNet.Tools.Publish/project.json
+++ b/src/Microsoft.DotNet.Tools.Publish/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
 
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.DotNet.Cli.Utils": {

--- a/src/Microsoft.DotNet.Tools.Repl.Csi/project.json
+++ b/src/Microsoft.DotNet.Tools.Repl.Csi/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         
         "Microsoft.Net.CSharp.Interactive.netcore": "1.2.0-beta1-20151228-02",
 

--- a/src/Microsoft.DotNet.Tools.Repl/project.json
+++ b/src/Microsoft.DotNet.Tools.Repl/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.DotNet.Cli.Utils": {

--- a/src/Microsoft.DotNet.Tools.Resgen/project.json
+++ b/src/Microsoft.DotNet.Tools.Resgen/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "System.Xml.XDocument": "4.0.11-rc2-23616",
         "System.Resources.ReaderWriter": "4.0.0-rc2-23616",
 

--- a/src/Microsoft.DotNet.Tools.Run/project.json
+++ b/src/Microsoft.DotNet.Tools.Run/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         
         "Microsoft.Net.Compilers.netcore": "1.2.0-beta1-20151228-02",
         "System.CommandLine" : "0.1.0-d111815-3",

--- a/src/Microsoft.DotNet.Tools.Test/project.json
+++ b/src/Microsoft.DotNet.Tools.Test/project.json
@@ -40,7 +40,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23616",
         "System.Diagnostics.TraceSource": "4.0.0-rc2-23616",
         "System.Dynamic.Runtime": "4.0.11-rc2-23616",

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -19,7 +19,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "System.Resources.ResourceManager": "4.0.1-rc2-23616"
       }
     }

--- a/test/E2E/EndToEndTest.cs
+++ b/test/E2E/EndToEndTest.cs
@@ -50,6 +50,12 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         [ActiveIssue(712, PlatformID.Windows | PlatformID.OSX | PlatformID.Linux)]
         public void TestDotnetBuildNativeRyuJit()
         {
+            if(IsCentOS())
+            {
+                Console.WriteLine("Skipping native compilation tests on CentOS - https://github.com/dotnet/cli/issues/453");
+                return;
+            }
+
             var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true);
 
             buildCommand.Execute().Should().Pass();
@@ -61,6 +67,12 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         [Fact]
         public void TestDotnetBuildNativeCpp()
         {
+            if(IsCentOS())
+            {
+                Console.WriteLine("Skipping native compilation tests on CentOS - https://github.com/dotnet/cli/issues/453");
+                return;
+            }
+
             var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true, nativeCppMode: true);
 
             buildCommand.Execute().Should().Pass();
@@ -131,6 +143,21 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             result.Should().HaveStdOut(s_expectedOutput);
             result.Should().NotHaveStdErr();
             result.Should().Pass();
+        }
+
+        private bool IsCentOS()
+        {
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                const string OSIDFILE = "/etc/os-release";
+
+                if(File.Exists(OSIDFILE))
+                {
+                    return File.ReadAllText(OSIDFILE).ToLower().Contains("centos");
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/test/E2E/project.json
+++ b/test/E2E/project.json
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "NETStandard.Library" : "1.0.0-rc2-23616",
+        "NETStandard.Library" : "1.0.0-rc2-23704",
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",

--- a/test/Microsoft.DotNet.Tools.Publish.Tests/project.json
+++ b/test/Microsoft.DotNet.Tools.Publish.Tests/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",  
   
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23614",
+    "NETStandard.Library": "1.0.0-rc2-23704",
     "Microsoft.NETCore.TestHost" : "1.0.0-*",
 
     "xunit": "2.1.0",

--- a/tools/MultiProjectValidator/project.json
+++ b/tools/MultiProjectValidator/project.json
@@ -6,7 +6,7 @@
     },
 
     "dependencies": {
-      "NETStandard.Library": "1.0.0-rc2-23614",
+      "NETStandard.Library": "1.0.0-rc2-23704",
       "Microsoft.DotNet.ProjectModel": "1.0.0-*",
       "Microsoft.DotNet.Cli.Utils": "1.0.0-*", 
     },


### PR DESCRIPTION
CentOS tests were blocked due to issue https://github.com/dotnet/corefx/issues/5066.
It has been fixed with the latest NetStandardLibrary, hence upgrading from 1.0.0-rc2-23616 to 1.0.0-rc2-23704.
With this fix the native shims are correctly restored by dnx for RID centos.7-x64.