### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ Basic usage
 
 When you have the .NET Command Line Interface installed on your OS of choice, you can try it out using some of the samples on the [dotnet/core repo](https://github.com/dotnet/core/tree/master/samples). You can download the sample in a directory, and then you can kick the tires of the CLI.
 
-**Note:** on Linux, post-install, please set up the `DOTNET_HOME` environment: `export DOTNET_HOME=/usr/share/dotnet/`.
-
-**Note:** on OS X, post-install, please set up the `DOTNET_HOME` environment: `export DOTNET_HOME=/usr/local/share/dotnet/cli`.
-
 
 First, you will need to restore the packages:
 	


### PR DESCRIPTION
Remove the instructions to add DOTNET_HOME env variable post-install for Linux and OS X since it is not needed anymore. 

Fixes #685 

/cc @piotrpMSFT @brthor 