### PR TITLE
Run tests for specific stage

### DIFF
--- a/scripts/build/build.ps1
+++ b/scripts/build/build.ps1
@@ -38,8 +38,8 @@ _ "$RepoRoot\scripts\compile\compile.ps1" @("$Configuration")
 $env:PATH = "$Stage2Dir\bin;$env:PATH"
 $env:DOTNET_HOME = "$Stage2Dir"
 
-header "Running Tests"
-_ "$RepoRoot\scripts\test\runtests.ps1"
+header "Running Tests on Stage 2"
+_ "$RepoRoot\scripts\test\runtests.ps1" @("$Stage2Dir")
 
 header "Validating Dependencies"
 _ "$RepoRoot\scripts\test\validate-dependencies.ps1"

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -42,7 +42,7 @@ export DOTNET_TOOLS=$STAGE1_DIR
 export PATH=$STAGE2_DIR/bin:$PATH
 
 header "Testing stage2..."
-DOTNET_HOME=$STAGE2_DIR DOTNET_TOOLS=$STAGE2_DIR $REPOROOT/scripts/test/runtests.sh
+$REPOROOT/scripts/test/runtests.sh $STAGE2_DIR
 
 header "Validating Dependencies"
 $REPOROOT/scripts/test/validate-dependencies.sh

--- a/scripts/test/runtests.ps1
+++ b/scripts/test/runtests.ps1
@@ -3,7 +3,16 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
+param(
+    [string]$StageToTest)
+
 . "$PSScriptRoot\..\common\_common.ps1"
+
+$StartPath = $env:PATH
+if ($StageToTest){
+    $env:DOTNET_HOME = $StageToTest
+    $env:PATH = "$StageToTest\bin;$env:PATH"
+}
 
 $failCount = 0
 
@@ -67,5 +76,7 @@ if ($failCount -ne 0) {
 } else {
     Write-Host -ForegroundColor Green "All the tests passed!"
 }
+
+$env:PATH=$StartPath
 
 Exit $failCount

--- a/scripts/test/runtests.sh
+++ b/scripts/test/runtests.sh
@@ -16,6 +16,12 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 source "$DIR/../common/_common.sh"
 
+if [ ! -z "$1" ]; then
+    export DOTNET_HOME=$1
+    export DOTNET_TOOLS=$1
+    export PATH=$1/bin:$PATH
+fi
+
 TestBinRoot="$REPOROOT/artifacts/tests"
 
 TestProjects=( \


### PR DESCRIPTION
Previously, on Windows, the tests would test for stage0 (it happened to be on the path)
I modified the runtests.ps1 to accept a parameter that specifies the stage to test.

I did not modify the *unix scripts because they are already passing the stage to test to runtests.sh

PR #676 is blocked on this (its tests are failing because the functionality is not in stage 0)