### PR TITLE
Fixing csiExe to use the proper extension (or lack-there-of) on Linux/Mac.

### DIFF
--- a/src/Microsoft.DotNet.Tools.Repl.Csi/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Repl.Csi/Program.cs
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Tools.Repl.Csi
         private static int Run(string script, string targetFramework, string buildConfiguration, bool preserveTemporaryOutput, string projectPath, IEnumerable<string> remainingArguments)
         {
             var corerun = Path.Combine(AppContext.BaseDirectory, Constants.HostExecutableName);
-            var csiExe = Path.Combine(AppContext.BaseDirectory, "csi.exe");
+            var csiExe = Path.Combine(AppContext.BaseDirectory, $"csi{Constants.ExeSuffix}");
             var csiArgs = new StringBuilder();
 
             if (buildConfiguration == null)


### PR DESCRIPTION
FYI. @ManishJayaswal, @cston, @dotnet/roslyn-interactive 