### PR TITLE
No delete intermediate folder after dotnet compile --native

### DIFF
--- a/src/Microsoft.DotNet.Tools.Compiler/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/Program.cs
@@ -63,9 +63,9 @@ namespace Microsoft.DotNet.Tools.Compiler
             var nativeOutputPath = Path.Combine(outputPath, "native");
             var intermediateOutputPath = 
                 context.GetIntermediateOutputPath(args.ConfigValue, args.IntermediateValue, outputPath);
-
+            var nativeIntermediateOutputPath = Path.Combine(intermediateOutputPath, "native");
             Directory.CreateDirectory(nativeOutputPath);
-            Directory.CreateDirectory(intermediateOutputPath);
+            Directory.CreateDirectory(nativeIntermediateOutputPath);
 
             var compilationOptions = context.ProjectFile.GetCompilerOptions(context.TargetFramework, args.ConfigValue);
             var managedOutput = 
@@ -133,14 +133,14 @@ namespace Microsoft.DotNet.Tools.Compiler
 
             // Intermediate Path
             nativeArgs.Add("--temp-output");
-            nativeArgs.Add($"{intermediateOutputPath}");
+            nativeArgs.Add($"{nativeIntermediateOutputPath}");
 
             // Output Path
             nativeArgs.Add("--output");
             nativeArgs.Add($"{nativeOutputPath}");            
 
             // Write Response File
-            var rsp = Path.Combine(intermediateOutputPath, $"dotnet-compile-native.{context.ProjectFile.Name}.rsp");
+            var rsp = Path.Combine(nativeIntermediateOutputPath, $"dotnet-compile-native.{context.ProjectFile.Name}.rsp");
             File.WriteAllLines(rsp, nativeArgs);
 
             // TODO Add -r assembly.dll for all Nuget References


### PR DESCRIPTION
Currently we elide all intermediate .rsp and .obj from the this run.
Instead, we keep them for easier debugging.