### PR TITLE
Exclude symbols packages from upload

### DIFF
--- a/packaging/nuget/package.ps1
+++ b/packaging/nuget/package.ps1
@@ -44,4 +44,4 @@ foreach ($ProjectName in $Projects) {
     }
 }
 
-Get-ChildItem $IntermediatePackagesDir -Filter *.nupkg | Copy-Item -Destination $PackagesDir
+Get-ChildItem $IntermediatePackagesDir -Filter *.nupkg | ? {$_.Name -NotLike "*.symbols.nupkg"} | Copy-Item -Destination $PackagesDir


### PR DESCRIPTION
Nuget has a bug where it treats uploading single symbol package differently than when sending them in bulk which effects in symbols packages replacing the actual packages.