### PR TITLE
Adjusting build.ps1 to work in VSO with the -NoPackage flag

### DIFF
--- a/scripts/build/build.ps1
+++ b/scripts/build/build.ps1
@@ -45,6 +45,7 @@ _ "$RepoRoot\scripts\test\validate-dependencies.ps1"
 
 if ($NoPackage){
     info "Skipping Packaging"
+    exit 0
 }
 else {
     _ "$RepoRoot\scripts\package\package.ps1"

--- a/scripts/package/package.cmd
+++ b/scripts/package/package.cmd
@@ -1,0 +1,6 @@
+@echo off
+
+REM Copyright (c) .NET Foundation and contributors. All rights reserved.
+REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+powershell -NoProfile -NoLogo -Command "%~dp0package.ps1 %*; exit $LastExitCode;"


### PR DESCRIPTION
Adding an explicit exit 0 when NoPackage is used so that VSO knows it succeeded.

Also added a package.cmd to be used by VSO as well.