### PR TITLE
Enable Debian package upgrade tests.

### DIFF
--- a/packaging/debian/package_tool/test/integration_tests/test_package.bats
+++ b/packaging/debian/package_tool/test/integration_tests/test_package.bats
@@ -3,11 +3,15 @@
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
+# This script is used to test the debian package after it's creation.
+# The package tool will drop it next to the .deb file it creates.
+# Environment Variables:
+#   LAST_VERSION_URL: Url for last version .deb (to test upgrades) [required for upgrade test]
 
 #Ensure running with superuser privileges
 current_user=$(whoami)
 if [ $current_user != "root" ]; then
-	echo "WARNING: test_package.sh requires superuser privileges to run"
+	echo "WARNING: test_package.bats requires superuser privileges to run, trying sudo..."
 	SUDO_PREFIX="sudo"
 fi
 
@@ -33,6 +37,16 @@ purge_package(){
 	$SUDO_PREFIX dpkg -P $PACKAGE_NAME
 }
 
+install_last_version(){
+	$SUDO_PREFIX dpkg -i last_version.deb
+}
+
+download_and_install_last_version(){
+	curl -O "$LAST_VERSION_URL" -o last_version.deb
+	
+	install_last_version
+}
+
 @test "package install + removal test" {
 	install_package
 	remove_package
@@ -46,5 +60,13 @@ purge_package(){
 # Ultimate Package Test
 # https://www.debian.org/doc/manuals/maint-guide/checkit.en.html#pmaintscripts
 @test "package install + upgrade + purge + install + remove + install + purge test" {
-	# TODO: need to figure out how to mock upgrades
+	if [ ! -z "$LAST_VERSION_URL" ]; then
+		download_and_install_last_version
+		install_package
+		purge_package
+		install_package
+		remove_package
+		install_package
+		purge_package
+	fi
 }

--- a/packaging/debian/package_tool/test/integration_tests/test_package.bats
+++ b/packaging/debian/package_tool/test/integration_tests/test_package.bats
@@ -38,11 +38,11 @@ purge_package(){
 }
 
 install_last_version(){
-	$SUDO_PREFIX dpkg -i last_version.deb
+	$SUDO_PREFIX dpkg -i "$DIR/last_version.deb"
 }
 
 download_and_install_last_version(){
-	curl -O "$LAST_VERSION_URL" -o last_version.deb
+	curl "$LAST_VERSION_URL" -o "$DIR/last_version.deb"
 	
 	install_last_version
 }

--- a/scripts/package/package-debian.sh
+++ b/scripts/package/package-debian.sh
@@ -35,6 +35,8 @@ MANPAGE_DIR="$REPOROOT/Documentation/manpages"
 NIGHTLY_PACKAGE_NAME="dotnet-nightly"
 RELEASE_PACKAGE_NAME="dotnet"
 
+[ -z "$CHANNEL" ] && CHANNEL="dev"
+
 execute_build(){
     determine_package_name
     create_empty_debian_layout
@@ -93,6 +95,9 @@ create_debian_package(){
 
 test_debian_package(){
     header "Testing debian package"
+    
+    # Set LAST_VERSION_URL to enable upgrade tests
+    export LAST_VERSION_URL="https://dotnetcli.blob.core.windows.net/dotnet/$CHANNEL/Installers/Latest/dotnet-ubuntu-x64.latest.deb"
 
     rm -rf $TEST_STAGE_DIR
     git clone https://github.com/sstephenson/bats.git $TEST_STAGE_DIR


### PR DESCRIPTION
This implements the recommended uber test for debian packages specified here:
https://www.debian.org/doc/manuals/maint-guide/checkit.en.html#pmaintscripts

Ultimately it guarantees whatever is currently being built will maintain upgrade compatibility with the most recently published package. It uses the $CHANNEL environment variable to pull down the correct package depending on which branch it is building.

Fixes #28 