### PR TITLE
link dotnet-dnx

### DIFF
--- a/packaging/osx/scripts/postinstall
+++ b/packaging/osx/scripts/postinstall
@@ -24,6 +24,7 @@ ln -s $INSTALL_DESTINATION/bin/dotnet-restore /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-resgen /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-run /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-test /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/dotnet-dnx /usr/local/bin/
 
 # A temporary solution to unblock dotnet compile
 cp $INSTALL_DESTINATION/bin/corehost /usr/local/bin/


### PR DESCRIPTION
link dotnet-dnx so that `dotnet restore` works when installed from pkg.

Without this restore cannot find the dnx command to actually restore anything.