### PR TITLE
Adding more symlinks to postinstall

### DIFF
--- a/packaging/osx/scripts/postinstall
+++ b/packaging/osx/scripts/postinstall
@@ -25,6 +25,8 @@ ln -s $INSTALL_DESTINATION/bin/dotnet-resgen /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-run /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-test /usr/local/bin/
 ln -s $INSTALL_DESTINATION/bin/dotnet-dnx /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/csc /usr/local/bin/
+ln -s $INSTALL_DESTINATION/bin/libclihost.dylib /usr/local/bin/
 
 # A temporary solution to unblock dotnet compile
 cp $INSTALL_DESTINATION/bin/corehost /usr/local/bin/


### PR DESCRIPTION
Adding symlinks for the following commands:

* dotnet-dnx
* csc

Also adding symlink for libclihost.dylib because it is needed
for the corehost.

Fix #823, #786 
/cc @brthor @schellap @piotrpMSFT 