### PR TITLE
Enable build-to-build major upgrades for MSI.

### DIFF
--- a/packaging/windows/dotnet.wxs
+++ b/packaging/windows/dotnet.wxs
@@ -3,13 +3,9 @@
     <?include "Variables.wxi" ?>
     <Product Id="*" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
         <Package Compressed="yes" InstallerVersion="200" />
-        <Upgrade Id="$(var.UpgradeCode)">
-          <UpgradeVersion Minimum="$(var.ProductVersion)" IncludeMinimum="no" OnlyDetect="yes" Property="NEWERVERSIONDETECTED" Language="$(var.LCID)" />
-          <UpgradeVersion Minimum="0.0.0.0" Maximum="$(var.ProductVersion)" IncludeMinimum="no" IncludeMaximum="no" Property="WIX_DOWNGRADE_DETECTED" Language="$(var.LCID)" />
-        </Upgrade>
-        <InstallExecuteSequence>
-            <RemoveExistingProducts Before="InstallInitialize" />
-        </InstallExecuteSequence>
+
+        <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
+
         <MediaTemplate CompressionLevel="mszip" EmbedCab="yes"/>
         <Feature Id="MainFeature" Title="Main Feature" Level="1">
             <ComponentGroupRef Id="InstallFiles" />
@@ -22,7 +18,6 @@
         <Property Id="ProductEdition" Value="$(var.ProductEdition)" />
         <Property Id="ProductCPU" Value="$(var.Platform)" />
         <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />
-        <!--Property Id="ARPNOMODIFY" Value="1" /-->
 
         <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
 

--- a/packaging/windows/generatemsi.ps1
+++ b/packaging/windows/generatemsi.ps1
@@ -63,7 +63,11 @@ function RunCandle
     Write-Host Running candle..
     $AuthWsxRoot =  Join-Path $RepoRoot "packaging\windows"
 
-    .\candle.exe -dDotnetSrc="$inputDir" -dMicrosoftEula="$RepoRoot\packaging\osx\resources\en.lproj\eula.rtf" -dBuildVersion="$env:DOTNET_CLI_VERSION" -arch x64 `
+    .\candle.exe -dDotnetSrc="$inputDir" `
+        -dMicrosoftEula="$RepoRoot\packaging\osx\resources\en.lproj\eula.rtf" `
+        -dBuildVersion="$env:DOTNET_MSI_VERSION" `
+        -dDisplayVersion="$env:DOTNET_CLI_VERSION" `
+        -arch x64 `
         -ext WixDependencyExtension.dll `
         "$AuthWsxRoot\dotnet.wxs" `
         "$AuthWsxRoot\provider.wxs" `

--- a/packaging/windows/variables.wxi
+++ b/packaging/windows/variables.wxi
@@ -7,12 +7,13 @@
   <?define Dotnet_DisplayVersion   =   "1.0" ?>
   <?define Dotnet_BuildVersion   =   "$(var.BuildVersion)" ?>
   <?define Manufacturer     =   "Microsoft Corporation" ?>
-  <?define ProductName      =   "Microsoft Dotnet CLI for Windows" ?>
+  <?define ProductName      =   "Microsoft Dotnet CLI for Windows ($(var.DisplayVersion))" ?>
   <?define ProductLanguage  =   "1033" ?>
   <?define ProductVersion   =   "$(var.Dotnet_ProductVersion)" ?>
   <?define ProductFamily    =   "dotnet" ?>
   <?define ProductEdition   =   "001dotnet" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>
+  <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
   
   <?define Platform   =   "$(sys.BUILDARCH)" ?>
   <?if $(var.Platform)=x86?>  

--- a/scripts/build/generate-version.ps1
+++ b/scripts/build/generate-version.ps1
@@ -3,14 +3,62 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
+# MSI versioning
+# Encode the CLI version to fit into the MSI versioning scheme - https://msdn.microsoft.com/en-us/library/windows/desktop/aa370859(v=vs.85).aspx
+# MSI versions are 3 part
+#                           major.minor.build
+# Size(bits) of each part     8     8    16
+# So we have 32 bits to encode the CLI version
+# Starting with most significant bit this how the CLI version is going to be encoded as MSI Version
+# CLI major  -> 6 bits
+# CLI minor  -> 6 bits
+# CLI patch  -> 6 bits
+# CLI commitcount -> 14 bits
+function GetMSIVersionFromCLIVersion([uint32]$Major, [uint32]$Minor, [uint32]$Patch, [uint32]$CommitCount)
+{
+    if($Major -ge 0x40)
+    {
+        throw [System.NotSupportedException] "Invalid Major version - $Major. Major version must be less than 64."
+    }
+
+    if($Minor -ge 0x40)
+    {
+        throw [System.NotSupportedException] "Invalid Minor version - $Minor. Minor version must be less than 64."
+    }
+
+    if($Patch -ge 0x40)
+    {
+        throw [System.NotSupportedException] "Invalid Patch version - $Patch. Patch version must be less than 64."
+    }
+
+    if($CommitCount -ge 0x4000)
+    {
+        throw [System.NotSupportedException] "Invalid CommitCount version - $CommitCount. CommitCount version must be less than 16384."
+    }
+
+    $Major = ($Major -shl 26)
+    $Minor = ($Minor -shl 20)
+    $Patch = ($Patch -shl 14)
+    [System.UInt32]$MSIVersionNumber = ($Major -bor $Minor -bor $Patch -bor $CommitCount)
+
+    $MSIMajor = ($MSIVersionNumber -shr 24) -band 0xFF
+    $MSIMinor = ($MSIVersionNumber -shr 16) -band 0xFF
+    $MSIBuild = $MSIVersionNumber -band 0xFFFF
+    $MSIVersion = "$MSIMajor.$MSIMinor.$MSIBuild"
+
+    return $MSIVersion
+}
+
 $env:ReleaseSuffix = "dev"
 $env:MajorVersion = 1
 $env:MinorVersion = 0
 $env:PatchVersion = 0
 
-$env:CommitCountVersion = (git rev-list --count HEAD).PadLeft(6, "0")
+$CommitCount = [int32](git rev-list --count HEAD)
+$env:CommitCountVersion = ([string]$CommitCount).PadLeft(6, "0")
 
 # Zero Padded Suffix for use with Nuget
 $env:VersionSuffix = "$env:ReleaseSuffix-$env:CommitCountVersion"
 
 $env:DOTNET_CLI_VERSION = "$env:MajorVersion.$env:MinorVersion.$env:PatchVersion.$env:CommitCountVersion"
+$env:DOTNET_MSI_VERSION = GetMSIVersionFromCLIVersion $env:MajorVersion $env:MinorVersion $env:PatchVersion $CommitCount


### PR DESCRIPTION
Encode the CLI version into MSI supported ProductVersion documented here -
https://msdn.microsoft.com/en-us/library/windows/desktop/aa370859(v=vs.85).aspx
Example: CLI Version - 1.0.0.000930 is encoded in MSI as 4.0.930

Prevent downgrading by failing installation with error message.
Also display the original CLI version in the ProductName.

//cc: @piotrpMSFT @Petermarcu @joeloff