### PR TITLE
Prevent upgrades between 'nightly' and 'release' builds of Dotnet CLI.

### DIFF
--- a/packaging/windows/checkbuildtype.wxs
+++ b/packaging/windows/checkbuildtype.wxs
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
+  <?include "Variables.wxi" ?>
+  <Fragment>
+    <Property Id="INSTALLEDCLIBUILDTYPE">
+        <RegistrySearch Id="DotnetCLI_BuildType" Type="raw"
+            Root="HKLM" Key="SOFTWARE\dotnet\Setup" Name="BuildType" Win64="$(var.Win64AttributeValue)"/>
+    </Property>
+    <SetProperty Before="LaunchConditions" Id="EXPECTEDCLIBUILDTYPE" Value="$(var.BuildType)" />
+  </Fragment>
+</Wix>

--- a/packaging/windows/dotnet.wxs
+++ b/packaging/windows/dotnet.wxs
@@ -25,6 +25,11 @@
         <UIRef Id="WixUI_InstallDir" />
 
         <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+
+        <PropertyRef Id="INSTALLEDCLIBUILDTYPE"/>
+        <Condition Message="$(var.IncompatibleBuildTypeError)">
+            <![CDATA[NOT INSTALLEDCLIBUILDTYPE OR INSTALLEDCLIBUILDTYPE ~= EXPECTEDCLIBUILDTYPE]]>
+        </Condition>
     </Product>
     <Fragment>
         <Directory Id="TARGETDIR" Name="SourceDir">

--- a/packaging/windows/generatemsi.ps1
+++ b/packaging/windows/generatemsi.ps1
@@ -67,11 +67,13 @@ function RunCandle
         -dMicrosoftEula="$RepoRoot\packaging\osx\resources\en.lproj\eula.rtf" `
         -dBuildVersion="$env:DOTNET_MSI_VERSION" `
         -dDisplayVersion="$env:DOTNET_CLI_VERSION" `
+        -dReleaseSuffix="$env:ReleaseSuffix" `
         -arch x64 `
         -ext WixDependencyExtension.dll `
         "$AuthWsxRoot\dotnet.wxs" `
         "$AuthWsxRoot\provider.wxs" `
         "$AuthWsxRoot\registrykeys.wxs" `
+        "$AuthWsxRoot\checkbuildtype.wxs" `
         $InstallFileswsx | Out-Host
 
     if($LastExitCode -ne 0)
@@ -96,6 +98,7 @@ function RunLight
         dotnet.wixobj `
         provider.wixobj `
         registrykeys.wixobj `
+        checkbuildtype.wixobj `
         $InstallFilesWixobj `
         -out $DotnetMSIOutput | Out-Host
 

--- a/packaging/windows/registrykeys.wxs
+++ b/packaging/windows/registrykeys.wxs
@@ -10,6 +10,7 @@
           <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
           <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
           <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.Dotnet_ProductVersion)" />
+          <RegistryValue Action="write" Name="BuildType" Type="string" Value="$(var.BuildType)" />
         </RegistryKey>
         <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]bin" Permanent="no" Part="last" Action="set" System="yes" />
         <Environment Id="E_DOTNET_HOME" Name="DOTNET_HOME" Value="[DOTNETHOME]" Permanent="no" Part="all" Action="set" System="yes" />
@@ -20,6 +21,7 @@
           <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
           <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
           <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.Dotnet_ProductVersion)" />
+          <RegistryValue Action="write" Name="BuildType" Type="string" Value="$(var.BuildType)" />
         </RegistryKey>
 		<!--In case of x64 installer these env vars are already set above-->
 		<?if $(var.Platform) = x86?>

--- a/packaging/windows/variables.wxi
+++ b/packaging/windows/variables.wxi
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?if $(var.ReleaseSuffix) ~= "beta" OR $(var.ReleaseSuffix) ~= "rc1" OR $(var.ReleaseSuffix) ~= "rtm" OR $(var.ReleaseSuffix) ~= ""?>
+  <?define BuildType="Release"?>
+  <?else?>
+  <?define BuildType="Nightly"?>
+  <?endif?>
+
   <?define Servicing_Key_SP   =   "0" ?>
   <?define Servicing_Key_SPIndex   =   "0" ?>
   <?define Servicing_Key_SPName   =   "Beta" ?>
@@ -7,13 +13,14 @@
   <?define Dotnet_DisplayVersion   =   "1.0" ?>
   <?define Dotnet_BuildVersion   =   "$(var.BuildVersion)" ?>
   <?define Manufacturer     =   "Microsoft Corporation" ?>
-  <?define ProductName      =   "Microsoft Dotnet CLI for Windows ($(var.DisplayVersion))" ?>
+  <?define ProductName      =   "Microsoft Dotnet CLI for Windows ($(var.DisplayVersion) $(var.ReleaseSuffix))" ?>
   <?define ProductLanguage  =   "1033" ?>
   <?define ProductVersion   =   "$(var.Dotnet_ProductVersion)" ?>
   <?define ProductFamily    =   "dotnet" ?>
   <?define ProductEdition   =   "001dotnet" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>
   <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
+  <?define IncompatibleBuildTypeError = "You have installed '[INSTALLEDCLIBUILDTYPE]' build of Dotnet CLI. It is cannot be upgraded to a '[EXPECTEDCLIBUILDTYPE]' build of Dotnet CLI. Please uninstall it and re-run setup."?>
   
   <?define Platform   =   "$(sys.BUILDARCH)" ?>
   <?if $(var.Platform)=x86?>  

--- a/packaging/windows/variables.wxi
+++ b/packaging/windows/variables.wxi
@@ -20,7 +20,7 @@
   <?define ProductEdition   =   "001dotnet" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>
   <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
-  <?define IncompatibleBuildTypeError = "You have installed '[INSTALLEDCLIBUILDTYPE]' build of Dotnet CLI. It is cannot be upgraded to a '[EXPECTEDCLIBUILDTYPE]' build of Dotnet CLI. Please uninstall it and re-run setup."?>
+  <?define IncompatibleBuildTypeError = "You have installed '[INSTALLEDCLIBUILDTYPE]' build of Dotnet CLI. It cannot be upgraded to a '[EXPECTEDCLIBUILDTYPE]' build of Dotnet CLI. Please uninstall it and re-run setup."?>
   
   <?define Platform   =   "$(sys.BUILDARCH)" ?>
   <?if $(var.Platform)=x86?>  


### PR DESCRIPTION
Set a new registry 'BuildType' when installing. Check for this reg key
when upgrading to a newer version. Show error message and exit
if the previous installation does not have the same 'BuildType'.

/cc @piotrpMSFT 

![image](https://cloud.githubusercontent.com/assets/9423246/12340709/624140da-bad1-11e5-8411-4364ca76894d.png)
