### PR TITLE
Enable to initialize a project before restore

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/WorkspaceContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/WorkspaceContext.cs
@@ -193,17 +193,21 @@ namespace Microsoft.DotNet.ProjectModel
             {
                 currentEntry = new FileModelEntry<LockFile>();
             }
-            else if (!File.Exists(Path.Combine(projectDirectory, LockFile.FileName)))
-            {
-                currentEntry.Reset();
-                return currentEntry;
-            }
 
             if (currentEntry.IsInvalid)
             {
-                currentEntry.FilePath = Path.Combine(projectDirectory, LockFile.FileName);
-                currentEntry.Model = LockFileReader.Read(currentEntry.FilePath);
-                currentEntry.UpdateLastWriteTime();
+                currentEntry.Reset();
+
+                if (!File.Exists(Path.Combine(projectDirectory, LockFile.FileName)))
+                {
+                    return currentEntry;
+                }
+                else
+                {
+                    currentEntry.FilePath = Path.Combine(projectDirectory, LockFile.FileName);
+                    currentEntry.Model = LockFileReader.Read(currentEntry.FilePath);
+                    currentEntry.UpdateLastWriteTime();
+                }
             }
 
             return currentEntry;
@@ -241,7 +245,7 @@ namespace Microsoft.DotNet.ProjectModel
 
                     currentEntry.ProjectContexts.Add(builder.Build());
                 }
- 
+
                 currentEntry.Project = project;
                 currentEntry.ProjectFilePath = project.ProjectFilePath;
                 currentEntry.LastProjectFileWriteTime = File.GetLastWriteTime(currentEntry.ProjectFilePath);

--- a/test/Microsoft.DotNet.ProjectModel.Server.Tests/Helpers/TestHelper.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Server.Tests/Helpers/TestHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Microsoft.DotNet.ProjectModel.Graph;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.ProjectModel.Server.Tests.Helpers
@@ -11,7 +12,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests.Helpers
         public TestHelper()
         {
             LoggerFactory = new LoggerFactory();
-            
+
             var testVerbose = Environment.GetEnvironmentVariable("DOTNET_TEST_VERBOSE");
             if (testVerbose == "2")
             {
@@ -63,13 +64,22 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests.Helpers
             return target;
         }
 
-        public string MoveProject(string projectName)
+        public string BuildProjectCopy(string projectName)
         {
             var projectPath = FindSampleProject(projectName);
             var movedProjectPath = Path.Combine(CreateTempFolder(), projectName);
             CopyFiles(projectPath, movedProjectPath);
 
             return movedProjectPath;
+        }
+
+        public void DeleteLockFile(string folder)
+        {
+            var lockFilePath = Path.Combine(folder, LockFile.FileName);
+            if (File.Exists(lockFilePath))
+            {
+                File.Delete(lockFilePath);
+            }
         }
 
         private static string FindRoot()


### PR DESCRIPTION
1. Check the lock file path first.
2. Update tests

https://github.com/dotnet/cli/issues/858
/cc @abpiskunov
/review @davidfowl @anurse 