### PR TITLE
Resolve dotnet-nightly cannot find coreclr issue

### DIFF
--- a/packaging/debian/dotnet-nightly-debian_config.json
+++ b/packaging/debian/dotnet-nightly-debian_config.json
@@ -38,6 +38,7 @@
     ],
 
     "symlinks": {
+        "/usr/share/dotnet-nightly" : "/usr/share/dotnet",
         "bin/dotnet" : "usr/bin/dotnet",
         "bin/dotnet-build" : "usr/bin/dotnet-build",
         "bin/dotnet-compile" : "usr/bin/dotnet-compile",


### PR DESCRIPTION
Fixes #862 

NOTE: I tested this change and it seems make us incompatible with some mono package. We will need to investigate this more, because we are creating a file we already create in the release package, and that package is not incompatible. 

cc @piotrpMSFT @schellap 