### PR TITLE
Add analyzer support

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/AnalyzerOptions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/AnalyzerOptions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.ProjectModel
+{
+    public class AnalyzerOptions
+    {
+        /// <summary>
+        /// The identifier indicating the project language as defined by NuGet.
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.nuget.org/create/analyzers-conventions for valid values
+        /// </remarks>
+        public string LanguageId { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/AnalyzerAssembly.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/AnalyzerAssembly.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.ProjectModel.Compilation
+{
+    public class AnalyzerReference
+    {
+        /// <summary>
+        /// The fully-qualified path to the analyzer assembly.
+        /// </summary>
+        public string AssemblyPath { get; }
+        
+        /// <summary>
+        /// The supported language of the analyzer assembly.
+        /// </summary>
+        public string AnalyzerLanguage { get; }
+        
+        /// <summary>
+        /// The required framework for hosting the analyzer assembly.
+        /// </summary>
+        public NuGetFramework RequiredFramework { get; }
+        
+        /// <summary>
+        /// The required runtime for hosting the analyzer assembly.
+        /// </summary>
+        public string RuntimeIdentifier { get; }
+        
+        public AnalyzerReference(
+            string assembly,
+            NuGetFramework framework,
+            string language,
+            string runtimeIdentifier)
+        {
+            AnalyzerLanguage = language;
+            AssemblyPath = assembly;
+            RequiredFramework = framework;
+            RuntimeIdentifier = runtimeIdentifier;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExport.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExport.cs
@@ -33,14 +33,25 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         /// Gets a list of fully-qualified paths to source code file references
         /// </summary>
         public IEnumerable<string> SourceReferences { get; }
+        
+       /// <summary>
+       /// Get a list of analyzers provided by this export.
+       /// </summary>
+       public IEnumerable<AnalyzerReference> AnalyzerReferences { get; }
 
-        public LibraryExport(LibraryDescription library, IEnumerable<LibraryAsset> compileAssemblies, IEnumerable<string> sourceReferences, IEnumerable<LibraryAsset> runtimeAssemblies, IEnumerable<LibraryAsset> nativeLibraries)
+        public LibraryExport(LibraryDescription library,
+                             IEnumerable<LibraryAsset> compileAssemblies,
+                             IEnumerable<string> sourceReferences,
+                             IEnumerable<LibraryAsset> runtimeAssemblies,
+                             IEnumerable<LibraryAsset> nativeLibraries,
+                             IEnumerable<AnalyzerReference> analyzers)
         {
             Library = library;
             CompilationAssemblies = compileAssemblies;
             SourceReferences = sourceReferences;
             RuntimeAssemblies = runtimeAssemblies;
             NativeLibraries = nativeLibraries;
+            AnalyzerReferences = analyzers;
         }
 
         private string DebuggerDisplay => Library.Identity.ToString();

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                     }
                 }
 
-                // Source references and analyzers are not transitive
+                // Source references are not transitive
                 if (library.Parents.Contains(_rootProject))
                 {
                     sourceReferences.AddRange(libraryExport.SourceReferences);

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -80,6 +80,8 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                 var compilationAssemblies = new List<LibraryAsset>();
                 var sourceReferences = new List<string>();
                 var libraryExport = GetExport(library);
+                
+                var analyzerReferences = libraryExport.AnalyzerReferences;
 
                 // We need to filter out source references from non-root libraries,
                 // so we rebuild the library export
@@ -91,16 +93,14 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                     }
                 }
 
+                // Source references and analyzers are not transitive
                 if (library.Parents.Contains(_rootProject))
                 {
-                    // Only process source references for direct dependencies
-                    foreach (var sourceReference in libraryExport.SourceReferences)
-                    {
-                        sourceReferences.Add(sourceReference);
-                    }
+                    sourceReferences.AddRange(libraryExport.SourceReferences);
                 }
 
-                yield return new LibraryExport(library, compilationAssemblies, sourceReferences, libraryExport.RuntimeAssemblies, libraryExport.NativeLibraries);
+                yield return new LibraryExport(library, compilationAssemblies, sourceReferences,
+                    libraryExport.RuntimeAssemblies, libraryExport.NativeLibraries, analyzerReferences);
             }
         }
 
@@ -141,8 +141,11 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
             {
                 sourceReferences.Add(sharedSource);
             }
+            
+            var analyzers = GetAnalyzerReferences(package);
 
-            return new LibraryExport(package, compileAssemblies, sourceReferences, runtimeAssemblies, nativeLibraries);
+            return new LibraryExport(package, compileAssemblies,
+                sourceReferences, runtimeAssemblies, nativeLibraries, analyzers);
         }
 
         private LibraryExport ExportProject(ProjectDescription project)
@@ -166,8 +169,11 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                 sourceReferences.Add(sharedFile);
             }
 
-            // No support for ref or native in projects, so runtimeAssemblies is just the same as compileAssemblies and nativeLibraries are empty
-            return new LibraryExport(project, compileAssemblies, sourceReferences, compileAssemblies, Enumerable.Empty<LibraryAsset>());
+            // No support for ref or native in projects, so runtimeAssemblies is
+            // just the same as compileAssemblies and nativeLibraries are empty
+            // Also no support for analyzer projects
+            return new LibraryExport(project, compileAssemblies, sourceReferences,
+                compileAssemblies, Array.Empty<LibraryAsset>(), Array.Empty<AnalyzerReference>());
         }
 
         private static string ResolvePath(Project project, string configuration, string path)
@@ -191,11 +197,12 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
             return new LibraryExport(
                 library,
                 string.IsNullOrEmpty(library.Path) ?
-                    Enumerable.Empty<LibraryAsset>() :
+                    Array.Empty<LibraryAsset>() :
                     new[] { new LibraryAsset(library.Identity.Name, library.Path, library.Path) },
-                Enumerable.Empty<string>(),
-                Enumerable.Empty<LibraryAsset>(),
-                Enumerable.Empty<LibraryAsset>());
+                Array.Empty<string>(),
+                Array.Empty<LibraryAsset>(),
+                Array.Empty<LibraryAsset>(),
+                Array.Empty<AnalyzerReference>());
         }
 
         private IEnumerable<string> GetSharedSources(PackageDescription package)
@@ -205,6 +212,74 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                 .Files
                 .Where(path => path.StartsWith("shared" + Path.DirectorySeparatorChar))
                 .Select(path => Path.Combine(package.Path, path));
+        }
+        
+        private IEnumerable<AnalyzerReference> GetAnalyzerReferences(PackageDescription package)
+        {
+            var analyzers = package
+                .Library
+                .Files
+                .Where(path => path.StartsWith("analyzers" + Path.DirectorySeparatorChar) &&
+                               path.EndsWith(".dll"));
+                               
+            var analyzerRefs = new List<AnalyzerReference>();
+            // See https://docs.nuget.org/create/analyzers-conventions for the analyzer
+            // NuGet specification
+            foreach (var analyzer in analyzers)
+            {
+                var specifiers = analyzer.Split(Path.DirectorySeparatorChar);
+                
+                var assemblyPath = Path.Combine(package.Path, analyzer);
+                
+                // $/analyzers/{Framework Name}{Version}/{Supported Architecture}/{Supported Programming Language}/{Analyzer}.dll 
+                switch (specifiers.Length)
+                {
+                    // $/analyzers/{analyzer}.dll
+                    case 2:
+                        analyzerRefs.Add(new AnalyzerReference(
+                            assembly: assemblyPath,
+                            framework: null,
+                            language: null,
+                            runtimeIdentifier: null
+                        ));
+                        break;
+                        
+                    // $/analyzers/{framework}/{analyzer}.dll
+                    case 3:
+                        analyzerRefs.Add(new AnalyzerReference(
+                            assembly: assemblyPath,
+                            framework: NuGetFramework.Parse(specifiers[1]),
+                            language: null,
+                            runtimeIdentifier: null
+                        ));
+                        break;
+                        
+                    // $/analyzers/{framework}/{language}/{analyzer}.dll
+                    case 4:
+                        analyzerRefs.Add(new AnalyzerReference(
+                            assembly: assemblyPath,
+                            framework: NuGetFramework.Parse(specifiers[1]),
+                            language: specifiers[2],
+                            runtimeIdentifier: null
+                        ));
+                        break;
+                    
+                    // $/analyzers/{framework}/{runtime}/{language}/{analyzer}.dll
+                    case 5:
+                        analyzerRefs.Add(new AnalyzerReference(
+                            assembly: assemblyPath,
+                            framework: NuGetFramework.Parse(specifiers[1]),
+                            language: specifiers[3],
+                            runtimeIdentifier: specifiers[2]
+                        ));
+                        break;
+                        
+                    // Anything less than 2 specifiers or more than 4 is
+                    // illegal according to the specification and will be
+                    // ignored
+                }
+            }
+            return analyzerRefs;
         }
 
 

--- a/src/Microsoft.DotNet.ProjectModel/Project.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Project.cs
@@ -35,6 +35,8 @@ namespace Microsoft.DotNet.ProjectModel
                 return Path.GetDirectoryName(ProjectFilePath);
             }
         }
+        
+        public AnalyzerOptions AnalyzerOptions { get; set; }
 
         public string Name { get; set; }
 

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
@@ -132,6 +132,37 @@ namespace Microsoft.DotNet.ProjectModel
                     throw new FormatException("The assembly file version is invalid: " + fileVersion, ex);
                 }
             }
+            
+            var analyzerOptionsJson = rawProject.Value("analyzerOptions") as JsonObject;
+            if (analyzerOptionsJson != null)
+            {
+                var analyzerOptions = new AnalyzerOptions();
+                
+                foreach (var key in analyzerOptionsJson.Keys)
+                {
+                    switch (key)
+                    {
+                        case "languageId":
+                            var languageId = analyzerOptionsJson.ValueAsString(key);
+                            if (languageId == null)
+                            {
+                                throw FileFormatException.Create(
+                                    "The analyzer languageId must be a string",
+                                    analyzerOptionsJson.Value(key),
+                                    project.ProjectFilePath);
+                            }
+                            analyzerOptions.LanguageId = languageId;
+                            break;
+                            
+                        default:;
+                            throw FileFormatException.Create(
+                               $"Unrecognized analyzerOption key: {key}",
+                               project.ProjectFilePath);
+                    }
+                }
+                
+                project.AnalyzerOptions = analyzerOptions;
+            }
 
             project.Description = rawProject.ValueAsString("description");
             project.Summary = rawProject.ValueAsString("summary");

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
@@ -29,6 +29,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             IReadOnlyList<string> references = Array.Empty<string>();
             IReadOnlyList<string> resources = Array.Empty<string>();
             IReadOnlyList<string> sources = Array.Empty<string>();
+            IReadOnlyList<string> analyzers = Array.Empty<string>();
             string outputName = null;
             var help = false;
             var returnCode = 0;
@@ -50,6 +51,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                     syntax.DefineOption("out", ref outputName, "Name of the output assembly");
 
                     syntax.DefineOptionList("reference", ref references, "Path to a compiler metadata reference");
+                    
+                    syntax.DefineOptionList("analyzer", ref analyzers, "Path to an analyzer assembly");
 
                     syntax.DefineOptionList("resource", ref resources, "Resources to embed");
 
@@ -94,6 +97,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 allArgs.Add($"-out:\"{outputName}\"");
             }
 
+            allArgs.AddRange(analyzers.Select(a => $"-a:\"{a}\""));
             allArgs.AddRange(references.Select(r => $"-r:\"{r}\""));
             allArgs.AddRange(resources.Select(resource => $"-resource:{resource}"));
             allArgs.AddRange(sources.Select(s => $"\"{s}\""));

--- a/src/Microsoft.DotNet.Tools.Compiler/CompilerUtil.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/CompilerUtil.cs
@@ -27,6 +27,14 @@ namespace Microsoft.DotNet.Tools.Compiler
 
             return compilerName;
         }
+        
+        public static string ResolveLanguageId(ProjectContext context)
+        {
+            var languageId = context.ProjectFile.AnalyzerOptions?.LanguageId;
+            languageId = languageId ?? "cs";
+            
+            return languageId;
+        }
 
         public struct NonCultureResgenIO
         {

--- a/src/Microsoft.DotNet.Tools.Compiler/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler/project.json
@@ -19,7 +19,7 @@
         "Microsoft.Extensions.DependencyModel": {
             "type": "build",
             "version": "1.0.0-*"
-        }
+        },
     },
     "frameworks": {
         "dnxcore50": { }

--- a/test/Microsoft.DotNet.Tools.Compiler.Tests/CompilerTests.cs
+++ b/test/Microsoft.DotNet.Tools.Compiler.Tests/CompilerTests.cs
@@ -34,6 +34,24 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             Assert.True(File.Exists(outputXml));
             Assert.Contains("Gets the message from the helper", File.ReadAllText(outputXml));
         }
+        
+        [Fact]
+        public void LibraryWithAnalyzer()
+        {
+            var root = Temp.CreateDirectory();
+            var testLibDir = root.CreateDirectory("TestLibraryWithAnalyzer");
+            
+            CopyProjectToTempDir(Path.Combine(_testProjectsRoot, "TestLibraryWithAnalyzer"), testLibDir);
+            RunRestore(testLibDir.Path);
+            
+            // run compile
+            var outputDir = Path.Combine(testLibDir.Path, "bin");
+            var testProject = GetProjectPath(testLibDir);
+            var buildCmd = new BuildCommand(testProject, output: outputDir);
+            var result = buildCmd.ExecuteWithCapturedOutput();
+            result.Should().Pass();
+            Assert.Contains("CA1018", result.StdErr);
+        }
 
         private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)
         {

--- a/test/TestProjects/TestLibraryWithAnalyzer/NuGet.Config
+++ b/test/TestProjects/TestLibraryWithAnalyzer/NuGet.Config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/test/TestProjects/TestLibraryWithAnalyzer/Program.cs
+++ b/test/TestProjects/TestLibraryWithAnalyzer/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+
+    public class TT : Attribute
+    {}
+}

--- a/test/TestProjects/TestLibraryWithAnalyzer/project.json
+++ b/test/TestProjects/TestLibraryWithAnalyzer/project.json
@@ -1,0 +1,15 @@
+﻿{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23704",
+        "System.Runtime.Analyzers": "1.1.0"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
With this change, any referenced analyzer project will be parsed by the
project system and the assemblies will be passed down to the compiler.
By default, the analyzer language is considered to be "cs". If another
language is used, the "languageID" option should be specified inside the
"analyzerOptions" section of the project.json file.

Resolves #83