### PR TITLE
Workaround for corefx symlink resolution on Unix

### DIFF
--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -78,7 +78,7 @@ bool parse_arguments(const int argc, const pal::char_t* argv[], arguments_t& arg
         args.app_argc = argc - 1;
     }
 
-    if(args.app_argc > 0)
+    if (args.app_argc > 0)
     {
         auto depsfile_candidate = pal::string_t(args.app_argv[0]);
         

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -196,6 +196,8 @@ int run(const arguments_t& args, const pal::string_t& clr_path)
         argv[i] = argv_strs[i].c_str();
     }
 
+    std::string managed_app = pal::to_stdstring(args.managed_application);
+
     // Execute the application
     unsigned int exit_code = 1;
     hr = coreclr::execute_assembly(
@@ -203,7 +205,7 @@ int run(const arguments_t& args, const pal::string_t& clr_path)
         domain_id,
         argv.size(),
         argv.data(),
-        pal::to_stdstring(args.managed_application).c_str(),
+        managed_app.c_str(),
         &exit_code);
     if (!SUCCEEDED(hr))
     {
@@ -225,6 +227,8 @@ int run(const arguments_t& args, const pal::string_t& clr_path)
 
 SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
 {
+    trace::setup();
+
     // Take care of arguments
     arguments_t args;
     if (!parse_arguments(argc, argv, args))
@@ -239,5 +243,6 @@ SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
         trace::error(_X("Could not resolve coreclr path"));
         return StatusCode::CoreClrResolveFailure;
     }
+    pal::realpath(&clr_path);
     return run(args, clr_path);
 }

--- a/src/corehost/common/trace.cpp
+++ b/src/corehost/common/trace.cpp
@@ -5,6 +5,26 @@
 
 static bool g_enabled = false;
 
+//
+// Turn on tracing for the corehost based on "COREHOST_TRACE" env.
+//
+void trace::setup()
+{
+    // Read trace environment variable
+    pal::string_t trace_str;
+    if (!pal::getenv(_X("COREHOST_TRACE"), &trace_str))
+    {
+        return;
+    }
+
+    auto trace_val = pal::xtoi(trace_str.c_str());
+    if (trace_val > 0)
+    {
+        trace::enable();
+        trace::info(_X("Tracing enabled"));
+    }
+}
+
 void trace::enable()
 {
     g_enabled = true;

--- a/src/corehost/common/trace.h
+++ b/src/corehost/common/trace.h
@@ -8,6 +8,7 @@
 
 namespace trace
 {
+    void setup();
     void enable();
     bool is_enabled();
     void verbose(const pal::char_t* format, ...);

--- a/src/corehost/corehost.cpp
+++ b/src/corehost/corehost.cpp
@@ -59,26 +59,6 @@ StatusCode load_host_lib(const pal::string_t& lib_dir, pal::dll_t* h_host, coreh
                 : StatusCode::CoreHostEntryPointFailure;
 }
 
-//
-// Turn on tracing for the corehost based on "COREHOST_TRACE" env.
-//
-void setup_tracing()
-{
-    // Read trace environment variable
-    pal::string_t trace_str;
-    if (!pal::getenv(_X("COREHOST_TRACE"), &trace_str))
-    {
-        return;
-    }
-
-    auto trace_val = pal::xtoi(trace_str.c_str());
-    if (trace_val > 0)
-    {
-        trace::enable();
-        trace::info(_X("Tracing enabled"));
-    }
-}
-
 }; // end of anonymous namespace
 
 #if defined(_WIN32)
@@ -87,7 +67,7 @@ int __cdecl wmain(const int argc, const pal::char_t* argv[])
 int main(const int argc, const pal::char_t* argv[])
 #endif
 {
-    setup_tracing();
+    trace::setup();
 
     pal::dll_t corehost;
 


### PR DESCRIPTION
CoreHost works correctly for app local because app_dir is already realpath'ed on Unix. I could fix servicing separately as well for path resolution. But since this is a workaround I wanted to keep it just before the point of passing it on to CoreCLR.

Corrects a potential bad pointer read.

@gkhanna79 PTAL.
/Cc @anurse @brthor 