### PR TITLE
Create the temp folder for 'tools' restoration in the project directory.

### DIFF
--- a/src/dotnet-restore/Program.cs
+++ b/src/dotnet-restore/Program.cs
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Tools.Restore
 
         private static void RestoreTool(LibraryRange tooldep, RestoreTask restoreTask, bool quiet)
         {
-            var tempRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var tempRoot = Path.Combine(restoreTask.ProjectDirectory, Guid.NewGuid().ToString());
             try
             {
                 var tempPath = Path.Combine(tempRoot, "bin");


### PR DESCRIPTION
This is a fix for regression caused by #877. It is required to create the
temp folder in the project directory so that same nuget.config resolution
happens for both 'dependencies' and 'tools'. See #844.