### PR TITLE
Work around NuGet packaging error

### DIFF
--- a/src/dotnet-restore/project.json
+++ b/src/dotnet-restore/project.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "NuGet.CommandLine.XPlat": "3.4.0-*",
+    "NuGet.Common": "3.4.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23608",
     "NETStandard.Library": "1.0.0-rc2-23608",
     "System.Linq": "4.0.1-beta-23504",

--- a/src/dotnet-restore/project.json
+++ b/src/dotnet-restore/project.json
@@ -11,8 +11,14 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NuGet.CommandLine.XPlat": "3.4.0-*",
-    "NuGet.Common": "3.4.0-*",
+    "NuGet.CommandLine.XPlat": "3.4.0-beta-*",
+    "NuGet.Common": "3.4.0-beta-*",
+    "NuGet.Frameworks": "3.4.0-beta-*",
+    "NuGet.Logging": "3.4.0-beta-*",
+    "NuGet.Packaging": "3.4.0-beta-*",
+    "NuGet.Packaging.Core": "3.4.0-beta-*",
+    "NuGet.Packaging.Core.Types": "3.4.0-beta-*",
+    "NuGet.Versioning": "3.4.0-beta-*",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23608",
     "NETStandard.Library": "1.0.0-rc2-23608",
     "System.Linq": "4.0.1-beta-23504",


### PR DESCRIPTION
The NuGet cross platform executable has a packaging error. They are fixing it, but in the meantime we need to try and get the build working. This fixes it by forcing all packages to the latest version. It ain't pretty but it ensures that even though each package keeps stomping on the other packages, they all get the latest version :)

Fixes #900 

/cc @davidfowl @piotrpMSFT @brthor @Sridhar-MS 