### PR TITLE
workaround #901 by using corerun instead of corehost

### DIFF
--- a/src/dotnet-restore/NuGet3.cs
+++ b/src/dotnet-restore/NuGet3.cs
@@ -30,7 +30,10 @@ namespace Microsoft.DotNet.Tools.Restore
 
         private static Command Run(IEnumerable<string> nugetArgs)
         {
-            return Command.Create(CoreHost.LocalHostExePath, Enumerable.Concat(
+            var corerun = Path.Combine(
+                AppContext.BaseDirectory,
+                "corerun" + Constants.ExeSuffix);
+            return Command.Create(corerun, Enumerable.Concat(
                 new[] { Path.Combine(AppContext.BaseDirectory, "NuGet.CommandLine.XPlat.dll") },
                 nugetArgs));
         }

--- a/src/dotnet-restore/project.json
+++ b/src/dotnet-restore/project.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "NuGet.CommandLine.XPlat": "3.4.0-*",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23608",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23608",
     "NETStandard.Library": "1.0.0-rc2-23608",
     "System.Linq": "4.0.1-beta-23504",
     "System.Collections": "4.0.11-beta-23504",


### PR DESCRIPTION
This works around a segfault that was occurring on the CI Ubuntu agent when using corehost to run NuGet3.

For now, we'll use `corerun`.