### PR TITLE
Fix restore for appdepsdk

### DIFF
--- a/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
@@ -5,6 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-*",
         "Microsoft.DotNet.AppDep":"1.0.4-*"
     },
     "frameworks": {


### PR DESCRIPTION
Added `Microsoft.NETCore.Platforms` to get the correct appsdk. I'm going to merge this since it's blocking the build.

/cc @schellap @piotrpMSFT @anurse 