### PR TITLE
Steps to boostrapping with NuGet

### DIFF
--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -6,7 +6,6 @@
     },
 
     "dependencies": {
-        "System.Reflection": "4.0.10-rc2-23616",
         "NETStandard.Library": "1.0.0-rc2-23704",
         "System.CommandLine": "0.1.0-*",
         "Microsoft.CodeAnalysis.CSharp":  "1.2.0-beta1-20160108-01",
@@ -14,7 +13,9 @@
         "Microsoft.DotNet.Cli.Utils": "1.0.0-*"
     },
     "frameworks": {
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "imports": "portable-win8+net45"
+        }
     },
     "scripts": {
     }

--- a/src/Microsoft.DotNet.ProjectModel.Loader/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/project.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23704",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "System.Runtime.Loader": "4.0.0-rc2-23616"
+        "System.Runtime.Loader": "4.0.0-rc2-23704"
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/Microsoft.DotNet.ProjectModel.Server/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Server/project.json
@@ -5,14 +5,9 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "System.Console": "4.0.0-beta-23504",
-    "System.Collections": "4.0.11-beta-23504",
-    "System.Diagnostics.Process": "4.1.0-beta-23504",
-    "System.Linq": "4.0.1-beta-23504",
-    "System.Linq.Expressions": "4.0.11-beta-23504",
-    "System.Net.Sockets": "4.1.0-beta-23504",
-    "System.Runtime.Serialization.Primitives": "4.1.0-beta-23504",
-    "System.Threading.ThreadPool": "4.0.10-beta-23504",
+    "NETStandard.Library": "1.0.0-rc2-23704",
+    "System.Threading.ThreadPool": "4.0.10-beta-23704",
+    "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23704",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils.Sources": {
       "type": "build",

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -6,15 +6,14 @@
     "description": "Types to model a .NET Project",
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23704",
-        "System.Threading.Thread": "4.0.0-rc2-23616",
-        "System.Runtime.Loader": "4.0.0-rc2-23616",
-        "System.Dynamic.Runtime": "4.0.11-rc2-23616",
-        "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23616",
-        "Microsoft.CSharp": "4.0.1-rc2-23616",
-        "System.Xml.XDocument": "4.0.11-rc2-23616",
-        "NuGet.Packaging": "3.4.0-*",
+        "System.Runtime.Loader": "4.0.0-rc2-23704",
+        "System.Dynamic.Runtime": "4.0.11-rc2-23704",
+        "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23704",
+        "Microsoft.CSharp": "4.0.1-rc2-23704",
+        "System.Xml.XDocument": "4.0.11-rc2-23704",
+        "NuGet.Packaging": "3.4.0-beta-*",
 
-        "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15882",
+        "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15964",
         "Microsoft.Extensions.JsonParser.Sources": {
             "type": "build",
             "version": "1.0.0-*"

--- a/src/Microsoft.DotNet.Tools.Builder/project.json
+++ b/src/Microsoft.DotNet.Tools.Builder/project.json
@@ -5,10 +5,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.Linq": "4.0.1-rc2-23704",
-    "System.Reflection.Metadata": "1.1.0",
-    
+    "NETStandard.Library": "1.0.0-rc2-23704",    
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.DotNet.Tools.Compiler": "1.0.0-*",
@@ -19,7 +16,9 @@
     }
   },
   "frameworks": {
-    "dnxcore50": { }
+    "dnxcore50": { 
+        "imports": "portable-win8+net45"
+    }
   },
   "scripts": {
   }

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/project.json
@@ -17,7 +17,9 @@
         "Microsoft.DotNet.Compiler.Common": "1.0.0-*"
     },
     "frameworks": {
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "imports": "portable-net451+win8"
+        }
     },
     "scripts": {
     }

--- a/src/Microsoft.DotNet.Tools.Compiler.Fsc/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Fsc/project.json
@@ -17,7 +17,9 @@
         "Microsoft.DotNet.Compiler.Common": "1.0.0-*"
     },
     "frameworks": {
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "imports": "portable-net451+win8"
+        }
     },
     "scripts": {
     }

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
@@ -5,6 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
+        "Microsoft.NETCore.Platforms": "1.0.1-*",
         "Microsoft.DotNet.AppDep":"1.0.4-*"
     },
     "frameworks": {

--- a/src/Microsoft.DotNet.Tools.Compiler/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler/project.json
@@ -6,7 +6,6 @@
     },
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23704",
-        "System.Reflection.Metadata": "1.1.0",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
         "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
@@ -22,7 +21,9 @@
         }
     },
     "frameworks": {
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "imports": "portable-net451+win8"
+        }
     },
     "scripts": {
     }

--- a/src/Microsoft.DotNet.Tools.Pack/project.json
+++ b/src/Microsoft.DotNet.Tools.Pack/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.IO.Compression.ZipFile": "4.0.1-rc2-23616",
+    "System.IO.Compression.ZipFile": "4.0.1-rc2-23704",
     
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
@@ -17,7 +17,9 @@
     }
   },
   "frameworks": {
-    "dnxcore50": { }
+    "dnxcore50": { 
+        "imports": "portable-net451+win8"
+    }
   },
   "scripts": {
   }

--- a/src/Microsoft.DotNet.Tools.Repl.Csi/project.json
+++ b/src/Microsoft.DotNet.Tools.Repl.Csi/project.json
@@ -16,7 +16,9 @@
         }
     },
     "frameworks": {
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "imports": "portable-net451+win8"
+        }
     },
     "scripts": {
     }

--- a/src/Microsoft.DotNet.Tools.Resgen/project.json
+++ b/src/Microsoft.DotNet.Tools.Resgen/project.json
@@ -6,8 +6,8 @@
     },
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23704",
-        "System.Xml.XDocument": "4.0.11-rc2-23616",
-        "System.Resources.ReaderWriter": "4.0.0-rc2-23616",
+        "System.Xml.XDocument": "4.0.11-rc2-23704",
+        "System.Resources.ReaderWriter": "4.0.0-rc2-23704",
 
         "Microsoft.CodeAnalysis.CSharp":  "1.2.0-beta1-20160108-01",
         "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
@@ -18,7 +18,9 @@
         }
     },
     "frameworks": {
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "imports": "portable-net451+win8"
+        }
     },
     "scripts": {
     }

--- a/src/Microsoft.DotNet.Tools.Run/project.json
+++ b/src/Microsoft.DotNet.Tools.Run/project.json
@@ -14,7 +14,9 @@
         "Microsoft.DotNet.Cli.Utils": "1.0.0-*"
     },
     "frameworks": {
-        "dnxcore50": { }
+        "dnxcore50": { 
+            "imports": "portable-net451+win8"
+        }
     },
     "scripts": {
     }

--- a/src/Microsoft.DotNet.Tools.Test/project.json
+++ b/src/Microsoft.DotNet.Tools.Test/project.json
@@ -11,6 +11,9 @@
     "emitEntryPoint": true
   },
   "dependencies": {
+    "NETStandard.Library": "1.0.0-rc2-23704",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23704",
+    "System.Diagnostics.TraceSource": "4.0.0-rc2-23704",
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23616",
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-23616",
     "Microsoft.Extensions.Compilation.Abstractions": "1.0.0-*",
@@ -36,13 +39,6 @@
   },
   "frameworks": {
     "dnxcore50": {
-      "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23704",
-        "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23616",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-23616",
-        "System.Dynamic.Runtime": "4.0.11-rc2-23616",
-        "System.Threading.Thread": "4.0.0-rc2-23616"
-      }
     }
   },
   "scripts": {

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -15,6 +15,7 @@
   "frameworks": {
     "net451": { },
     "dotnet5.4": {
+      "imports": "portable-net451+win8",
       "dependencies": {
         "System.IO.FileSystem": "4.0.1-rc2-23616",
         "System.Linq": "4.0.1-rc2-23616",

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -13,14 +13,12 @@
     "Newtonsoft.Json": "7.0.1",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0-*",
-    "System.Runtime.Serialization.Primitives": "4.0.11-rc2-23616"
+    "NETStandard.Library": "1.0.0-rc2-23704",
+    "System.Resources.ResourceManager": "4.0.1-rc2-23704",
+    "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23704"
   },
   "frameworks": {
     "dnxcore50": {
-      "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23704",
-        "System.Resources.ResourceManager": "4.0.1-rc2-23616"
-      }
     }
   },
   "scripts": {

--- a/test/Microsoft.DotNet.ProjectModel.Server.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Server.Tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Dynamic.Runtime": "4.0.11-*",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23704",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.DotNet.ProjectModel.Server": "1.0.0-*",
     "Newtonsoft.Json": "7.0.1",


### PR DESCRIPTION
- Fixed a bunch of dependencies that was causing dotnet restore to fail on the CLI
- Added imports to `project.json` so that `dotnet-restore` works
- Fixed a bunch of dependency issues in different projects
- Ironically, running `dotnet restore` on the dotnet-restore project still fails (will fix in another commit). Looks like it might be a nuget issue