### PR TITLE
Add default suppress to compiler options message

### DIFF
--- a/src/Microsoft.DotNet.Compiler.Common/DefaultCompilerWarningSuppresses.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/DefaultCompilerWarningSuppresses.cs
@@ -7,11 +7,9 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 {
     public class DefaultCompilerWarningSuppresses
     {
-        private static IReadOnlyDictionary<string, IReadOnlyList<string>> _suppresses = new Dictionary<string, IReadOnlyList<string>>
+        public static IReadOnlyDictionary<string, IReadOnlyList<string>> Map { get; } = new Dictionary<string, IReadOnlyList<string>>
         {
             { "csc", new string[] {"CS1701", "CS1702", "CS1705" } }
         };
-
-        public static IReadOnlyDictionary<string, IReadOnlyList<string>> Instance => _suppresses;
     }
 }

--- a/src/Microsoft.DotNet.Compiler.Common/DefaultCompilerWarningSuppresses.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/DefaultCompilerWarningSuppresses.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Cli.Compiler.Common
+{
+    public class DefaultCompilerWarningSuppresses
+    {
+        private static IReadOnlyDictionary<string, IReadOnlyList<string>> _suppresses = new Dictionary<string, IReadOnlyList<string>>
+        {
+            { "csc", new string[] {"CS1701", "CS1702", "CS1705" } }
+        };
+
+        public static IReadOnlyDictionary<string, IReadOnlyList<string>> Instance => _suppresses;
+    }
+}

--- a/src/Microsoft.DotNet.Compiler.Common/ProjectContextExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/ProjectContextExtensions.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
             return rootOutputPath;
         }
-        
+
         public static void MakeCompilationOutputRunnable(this ProjectContext context, string outputPath, string configuration)
         {
             context
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             targetDirectory = EnsureTrailingSlash(targetDirectory);
 
             var pathMap = sourceFiles
-                .ToDictionary(s => s, 
+                .ToDictionary(s => s,
                     s => Path.Combine(targetDirectory,
                         PathUtility.GetRelativePath(sourceDirectory, s)));
 
@@ -198,6 +198,15 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             {
                 appConfig.Save(stream);
             }
+        }
+
+        public static CommonCompilerOptions GetLanguageSpecificCompilerOption(this ProjectContext context, NuGetFramework framework, string configurationName)
+        {
+            var baseOption = context.ProjectFile.GetCompilerOptions(framework, configurationName);
+            baseOption.SuppressWarnings = baseOption.SuppressWarnings.Concat(
+                DefaultCompilerWarningSuppresses.Map[context.ProjectFile.CompilerName ?? "csc"]).Distinct();
+
+            return baseOption;
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel.Server/InternalModels/ProjectContextSnapshot.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Server/InternalModels/ProjectContextSnapshot.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.ProjectModel.Server
     internal class ProjectContextSnapshot
     {
         public string RootDependency { get; set; }
+        public string CompilerName { get; set; }
         public NuGetFramework TargetFramework { get; set; }
         public IReadOnlyList<string> SourceFiles { get; set; }
         public CommonCompilerOptions CompilerOptions { get; set; }
@@ -59,6 +60,7 @@ namespace Microsoft.DotNet.ProjectModel.Server
                 }
             }
 
+            snapshot.CompilerName = context.ProjectFile.CompilerName ?? "csc";
             snapshot.RootDependency = context.ProjectFile.Name;
             snapshot.TargetFramework = context.TargetFramework;
             snapshot.SourceFiles = allSourceFiles.Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(path => path).ToList();

--- a/src/Microsoft.DotNet.ProjectModel.Server/InternalModels/ProjectContextSnapshot.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Server/InternalModels/ProjectContextSnapshot.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.ProjectModel.Server.Helpers;
 using Microsoft.DotNet.ProjectModel.Server.Models;
+using Microsoft.DotNet.Cli.Compiler.Common;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.ProjectModel.Server
@@ -13,7 +14,6 @@ namespace Microsoft.DotNet.ProjectModel.Server
     internal class ProjectContextSnapshot
     {
         public string RootDependency { get; set; }
-        public string CompilerName { get; set; }
         public NuGetFramework TargetFramework { get; set; }
         public IReadOnlyList<string> SourceFiles { get; set; }
         public CommonCompilerOptions CompilerOptions { get; set; }
@@ -60,11 +60,10 @@ namespace Microsoft.DotNet.ProjectModel.Server
                 }
             }
 
-            snapshot.CompilerName = context.ProjectFile.CompilerName ?? "csc";
             snapshot.RootDependency = context.ProjectFile.Name;
             snapshot.TargetFramework = context.TargetFramework;
             snapshot.SourceFiles = allSourceFiles.Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(path => path).ToList();
-            snapshot.CompilerOptions = context.ProjectFile.GetCompilerOptions(context.TargetFramework, configuration);
+            snapshot.CompilerOptions = context.GetLanguageSpecificCompilerOption(context.TargetFramework, configuration);
             snapshot.ProjectReferences = allProjectReferences.OrderBy(reference => reference.Name).ToList();
             snapshot.FileReferences = allFileReferences.Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(path => path).ToList();
             snapshot.DependencyDiagnostics = allDependencyDiagnostics;

--- a/src/Microsoft.DotNet.ProjectModel.Server/Messengers/CompilerOptionsMessenger.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Server/Messengers/CompilerOptionsMessenger.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.ProjectModel.Server.Models;
 
 namespace Microsoft.DotNet.ProjectModel.Server.Messengers
@@ -15,15 +17,21 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
         protected override bool CheckDifference(ProjectContextSnapshot local, ProjectContextSnapshot remote)
         {
             return remote.CompilerOptions != null &&
+                   Equals(local.CompilerName, remote.CompilerName) &&
                    Equals(local.CompilerOptions, remote.CompilerOptions);
         }
 
         protected override object CreatePayload(ProjectContextSnapshot local)
         {
+            var option = CommonCompilerOptions.Combine(local.CompilerOptions, new CommonCompilerOptions
+            {
+                SuppressWarnings = DefaultCompilerWarningSuppresses.Instance[local.CompilerName]
+            });
+
             return new CompilationOptionsMessage
             {
                 Framework = local.TargetFramework.ToPayload(),
-                Options = local.CompilerOptions
+                Options = option
             };
         }
 

--- a/src/Microsoft.DotNet.ProjectModel.Server/Messengers/CompilerOptionsMessenger.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Server/Messengers/CompilerOptionsMessenger.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.ProjectModel.Server.Models;
 
 namespace Microsoft.DotNet.ProjectModel.Server.Messengers
@@ -17,21 +15,15 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
         protected override bool CheckDifference(ProjectContextSnapshot local, ProjectContextSnapshot remote)
         {
             return remote.CompilerOptions != null &&
-                   Equals(local.CompilerName, remote.CompilerName) &&
                    Equals(local.CompilerOptions, remote.CompilerOptions);
         }
 
         protected override object CreatePayload(ProjectContextSnapshot local)
         {
-            var option = CommonCompilerOptions.Combine(local.CompilerOptions, new CommonCompilerOptions
-            {
-                SuppressWarnings = DefaultCompilerWarningSuppresses.Instance[local.CompilerName]
-            });
-
             return new CompilationOptionsMessage
             {
                 Framework = local.TargetFramework.ToPayload(),
-                Options = option
+                Options = local.CompilerOptions
             };
         }
 

--- a/src/Microsoft.DotNet.ProjectModel.Server/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Server/project.json
@@ -9,6 +9,7 @@
     "System.Threading.ThreadPool": "4.0.10-beta-23704",
     "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23704",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils.Sources": {
       "type": "build",
       "version": "1.0.0-*"

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.ProjectModel.Workspaces
             // TODO: ctor argument?
             var configuration = "Debug";
 
-            var compilationOptions = project.ProjectFile.GetCompilerOptions(project.TargetFramework, configuration);
+            var compilationOptions = project.GetLanguageSpecificCompilerOption(project.TargetFramework, configuration);
 
             var compilationSettings = ToCompilationSettings(compilationOptions, project.TargetFramework, project.ProjectFile.ProjectDirectory);
 
@@ -146,10 +146,7 @@ namespace Microsoft.DotNet.ProjectModel.Workspaces
         {
             var options = GetCompilationOptions(compilerOptions, projectDirectory);
 
-            // Disable 1702 until roslyn turns this off by default
-            var defaultCSharpSuppresses = DefaultCompilerWarningSuppresses.Instance["csc"];
-
-            options = options.WithSpecificDiagnosticOptions(defaultCSharpSuppresses.ToDictionary(
+            options = options.WithSpecificDiagnosticOptions(compilerOptions.SuppressWarnings.ToDictionary(
                 suppress => suppress, _ => ReportDiagnostic.Suppress));
 
             AssemblyIdentityComparer assemblyIdentityComparer =

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Cli.Compiler.Common;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.ProjectModel.Workspaces
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.ProjectModel.Workspaces
                     _cache[path] = assemblyMetadata;
                 }
             }
-            
+
             return assemblyMetadata.GetReference();
         }
 
@@ -147,12 +147,10 @@ namespace Microsoft.DotNet.ProjectModel.Workspaces
             var options = GetCompilationOptions(compilerOptions, projectDirectory);
 
             // Disable 1702 until roslyn turns this off by default
-            options = options.WithSpecificDiagnosticOptions(new Dictionary<string, ReportDiagnostic>
-            {
-                { "CS1701", ReportDiagnostic.Suppress }, // Binding redirects
-                { "CS1702", ReportDiagnostic.Suppress },
-                { "CS1705", ReportDiagnostic.Suppress }
-            });
+            var defaultCSharpSuppresses = DefaultCompilerWarningSuppresses.Instance["csc"];
+
+            options = options.WithSpecificDiagnosticOptions(defaultCSharpSuppresses.ToDictionary(
+                suppress => suppress, _ => ReportDiagnostic.Suppress));
 
             AssemblyIdentityComparer assemblyIdentityComparer =
                 targetFramework.IsDesktop() ?

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -1,16 +1,17 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "keyFile": "../../tools/Key.snk"
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23704",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.2.0-beta1-20160108-01"
-    },
-    "frameworks": {
-        "dnxcore50": {
-            "imports": "portable-net45+win8"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk"
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.0.0-rc2-23704",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
+    "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.2.0-beta1-20160108-01"
+  },
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
     }
+  }
 }

--- a/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Cli.Compiler.Common;
 
 namespace Microsoft.DotNet.Tools.Compiler.Csc
 {
@@ -124,9 +125,10 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 ? "-debug:full"
                 : "-debug:portable");
 
-            args.Add("-nowarn:CS1701");
-            args.Add("-nowarn:CS1702");
-            args.Add("-nowarn:CS1705");
+            foreach (var suppress in DefaultCompilerWarningSuppresses.Instance["csc"])
+            {
+                args.Add($"-nowarn:{suppress}");
+            }
 
             return args;
         }

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 ? "-debug:full"
                 : "-debug:portable");
 
-            foreach (var suppress in DefaultCompilerWarningSuppresses.Instance["csc"])
+            foreach (var suppress in DefaultCompilerWarningSuppresses.Map["csc"])
             {
                 args.Add($"-nowarn:{suppress}");
             }


### PR DESCRIPTION
We need to send back the default suppress warning setting to tooling client through project model server. This change centralized the default settings.

https://github.com/dotnet/cli/issues/848