### PR TITLE
Add analyzer support

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/AnalyzerOptions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/AnalyzerOptions.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.ProjectModel
+{
+    public class AnalyzerOptions
+    {
+        /// <summary>
+        /// The identifier indicating the project language as defined by NuGet.
+        /// </summary>
+        /// <remarks>
+        /// See https://docs.nuget.org/create/analyzers-conventions for valid values
+        /// </remarks>
+        public string LanguageId { get; set; }
+
+        public static bool operator ==(AnalyzerOptions left, AnalyzerOptions right)
+        {
+            return left.LanguageId == right.LanguageId;
+        }
+
+        public static bool operator !=(AnalyzerOptions left, AnalyzerOptions right)
+        {
+            return !(left == right);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+
+            var options = obj as AnalyzerOptions;
+            return obj != null && (this == options);
+        }
+
+        public override int GetHashCode()
+        {
+            return LanguageId.GetHashCode();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/AnalyzerAssembly.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/AnalyzerAssembly.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.ProjectModel.Compilation
+{
+    public class AnalyzerReference
+    {
+        /// <summary>
+        /// The fully-qualified path to the analyzer assembly.
+        /// </summary>
+        public string AssemblyPath { get; }
+        
+        /// <summary>
+        /// The supported language of the analyzer assembly.
+        /// </summary>
+        public string AnalyzerLanguage { get; }
+        
+        /// <summary>
+        /// The required framework for hosting the analyzer assembly.
+        /// </summary>
+        public NuGetFramework RequiredFramework { get; }
+        
+        /// <summary>
+        /// The required runtime for hosting the analyzer assembly.
+        /// </summary>
+        public string RuntimeIdentifier { get; }
+        
+        public AnalyzerReference(
+            string assembly,
+            NuGetFramework framework,
+            string language,
+            string runtimeIdentifier)
+        {
+            AnalyzerLanguage = language;
+            AssemblyPath = assembly;
+            RequiredFramework = framework;
+            RuntimeIdentifier = runtimeIdentifier;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExport.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExport.cs
@@ -33,15 +33,26 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         /// Gets a list of fully-qualified paths to source code file references
         /// </summary>
         public IEnumerable<string> SourceReferences { get; }
+        
+       /// <summary>
+       /// Get a list of analyzers provided by this export.
+       /// </summary>
+       public IEnumerable<AnalyzerReference> AnalyzerReferences { get; }
 
-        public LibraryExport(LibraryDescription library, IEnumerable<LibraryAsset> compileAssemblies, IEnumerable<string> sourceReferences, IEnumerable<LibraryAsset> runtimeAssemblies, IEnumerable<LibraryAsset> nativeLibraries)
-        {
-            Library = library;
-            CompilationAssemblies = compileAssemblies;
-            SourceReferences = sourceReferences;
-            RuntimeAssemblies = runtimeAssemblies;
-            NativeLibraries = nativeLibraries;
-        }
+       public LibraryExport(LibraryDescription library,
+                            IEnumerable<LibraryAsset> compileAssemblies,
+                            IEnumerable<string> sourceReferences,
+                            IEnumerable<LibraryAsset> runtimeAssemblies,
+                            IEnumerable<LibraryAsset> nativeLibraries,
+                            IEnumerable<AnalyzerReference> analyzers)
+       {
+           Library = library;
+           CompilationAssemblies = compileAssemblies;
+           SourceReferences = sourceReferences;
+           RuntimeAssemblies = runtimeAssemblies;
+           NativeLibraries = nativeLibraries;
+           AnalyzerReferences = analyzers;
+       }
 
         private string DebuggerDisplay => Library.Identity.ToString();
     }

--- a/src/Microsoft.DotNet.ProjectModel/Project.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Project.cs
@@ -35,6 +35,8 @@ namespace Microsoft.DotNet.ProjectModel
                 return Path.GetDirectoryName(ProjectFilePath);
             }
         }
+        
+        public AnalyzerOptions AnalyzerOptions { get; set; }
 
         public string Name { get; set; }
 

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
@@ -29,6 +29,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             IReadOnlyList<string> references = Array.Empty<string>();
             IReadOnlyList<string> resources = Array.Empty<string>();
             IReadOnlyList<string> sources = Array.Empty<string>();
+            IReadOnlyList<string> analyzers = Array.Empty<string>();
             string outputName = null;
             var help = false;
             var returnCode = 0;
@@ -50,6 +51,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                     syntax.DefineOption("out", ref outputName, "Name of the output assembly");
 
                     syntax.DefineOptionList("reference", ref references, "Path to a compiler metadata reference");
+                    
+                    syntax.DefineOptionList("analyzer", ref analyzers, "Path to an analyzer assembly");
 
                     syntax.DefineOptionList("resource", ref resources, "Resources to embed");
 
@@ -96,6 +99,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 allArgs.Add($"-out:\"{outputName.Trim('"')}\"");
             }
 
+            allArgs.AddRange(analyzers.Select(a => $"-a:\"{a.Trim('"')}\""));
             allArgs.AddRange(references.Select(r => $"-r:\"{r.Trim('"')}\""));
             allArgs.AddRange(resources.Select(resource => $"-resource:{resource.Trim('"')}"));
             allArgs.AddRange(sources.Select(s => $"\"{s.Trim('"')}\""));

--- a/src/Microsoft.DotNet.Tools.Compiler/CompilerUtil.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/CompilerUtil.cs
@@ -27,6 +27,14 @@ namespace Microsoft.DotNet.Tools.Compiler
 
             return compilerName;
         }
+        
+        public static string ResolveLanguageId(ProjectContext context)
+        {
+            var languageId = context.ProjectFile.AnalyzerOptions?.LanguageId;
+            languageId = languageId ?? "cs";
+            
+            return languageId;
+        }
 
         public struct NonCultureResgenIO
         {

--- a/src/Microsoft.DotNet.Tools.Compiler/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/Program.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Microsoft.Dnx.Runtime.Common.CommandLine;
 using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
@@ -212,6 +211,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             };
 
             var compilationOptions = CompilerUtil.ResolveCompilationOptions(context, args.ConfigValue);
+            var languageId = CompilerUtil.ResolveLanguageId(context);
 
             var references = new List<string>();
 
@@ -239,6 +239,11 @@ namespace Microsoft.DotNet.Tools.Compiler
                 }
 
                 compilerArgs.AddRange(dependency.SourceReferences.Select(s => $"\"{s}\""));
+
+                // Add analyzer references
+                compilerArgs.AddRange(dependency.AnalyzerReferences
+                    .Where(a => a.AnalyzerLanguage == languageId)
+                    .Select(a => $"--analyzer:\"{a.AssemblyPath}\""));
             }
 
             compilerArgs.AddRange(references.Select(r => $"--reference:\"{r}\""));

--- a/test/Microsoft.DotNet.Tools.Compiler.Tests/CompilerTests.cs
+++ b/test/Microsoft.DotNet.Tools.Compiler.Tests/CompilerTests.cs
@@ -38,6 +38,24 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             Assert.True(File.Exists(outputXml));
             Assert.Contains("Gets the message from the helper", File.ReadAllText(outputXml));
         }
+        
+        [Fact]
+        public void LibraryWithAnalyzer()
+        {
+            var root = Temp.CreateDirectory();
+            var testLibDir = root.CreateDirectory("TestLibraryWithAnalyzer");
+            
+            CopyProjectToTempDir(Path.Combine(_testProjectsRoot, "TestLibraryWithAnalyzer"), testLibDir);
+            RunRestore(testLibDir.Path);
+            
+            // run compile
+            var outputDir = Path.Combine(testLibDir.Path, "bin");
+            var testProject = GetProjectPath(testLibDir);
+            var buildCmd = new BuildCommand(testProject, output: outputDir);
+            var result = buildCmd.ExecuteWithCapturedOutput();
+            result.Should().Pass();
+            Assert.Contains("CA1018", result.StdErr);
+        }
 
         private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)
         {

--- a/test/TestProjects/TestLibraryWithAnalyzer/NuGet.Config
+++ b/test/TestProjects/TestLibraryWithAnalyzer/NuGet.Config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/test/TestProjects/TestLibraryWithAnalyzer/Program.cs
+++ b/test/TestProjects/TestLibraryWithAnalyzer/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+
+    public class TT : Attribute
+    {}
+}

--- a/test/TestProjects/TestLibraryWithAnalyzer/project.json
+++ b/test/TestProjects/TestLibraryWithAnalyzer/project.json
@@ -1,0 +1,15 @@
+﻿{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23704",
+        "System.Runtime.Analyzers": { "version": "1.1.0", "type": "build" }
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
With this change, any referenced analyzer project will be parsed by the
project system and the assemblies will be passed down to the compiler.
By default, the analyzer language is considered to be "cs". If another
language is used, the "languageID" option should be specified inside the
"analyzerOptions" section of the project.json file.

Resolves #83