### PR TITLE
Remove the place binary script from MCG project

### DIFF
--- a/src/Microsoft.DotNet.Tools.Mcg/project.json
+++ b/src/Microsoft.DotNet.Tools.Mcg/project.json
@@ -22,9 +22,5 @@
         "dnxcore50": { }
     },
     "scripts": {
-        "postcompile": [
-            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.dll\"",
-            "../../scripts/build/place-binary \"%compile:OutputDir%/%project:Name%.pdb\""
-        ]
     }
 }


### PR DESCRIPTION
It is shutting off incremental compilation.

MCG PR was merged into master so I directed this PR into master as well.