### PR TITLE
prep for nuget bootstrapping

### DIFF
--- a/src/dotnet-restore/project.json
+++ b/src/dotnet-restore/project.json
@@ -19,11 +19,10 @@
     "NuGet.Packaging.Core": "3.4.0-beta-*",
     "NuGet.Packaging.Core.Types": "3.4.0-beta-*",
     "NuGet.Versioning": "3.4.0-beta-*",
-    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23608",
-    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23608",
-    "NETStandard.Library": "1.0.0-rc2-23608",
-    "System.Linq": "4.0.1-beta-23504",
-    "System.Collections": "4.0.11-beta-23504",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23704",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23704",
+    "NETStandard.Library": "1.0.0-rc2-23704",
+    "System.Linq.Expressions": "4.0.11-rc2-23704",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
@@ -38,7 +37,9 @@
     "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   },
   "scripts": {
   }


### PR DESCRIPTION
I need to 

a) Make some workaround changes to `dotnet-restore`'s project.json because of a runtime.json issue in System.Linq.Expressions `4.0.10` (working on an isolated repro but don't want to block beta on this /cc @ericstj )

b) Trigger a new build so we pick up the latest (fixed) NuGet3 build in our next stage 0 build. Since we use commit count as a version number, I have to make a change to trigger it :)

Please review ASAP. Once this is in I can switch to using `dotnet restore` in the CLI build scripts!

/cc @piotrpMSFT @davidfowl @Sridhar-MS @brthor @pakrym 