### PR TITLE
adjust lock file check to handle NuGet-style lock file

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
@@ -60,7 +60,9 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                 // If the framework name is empty, the associated dependencies are shared by all frameworks
                 if (group.FrameworkName == null)
                 {
-                    actualDependencies = project.Dependencies.Select(RenderDependency).OrderBy(x => x);
+                    actualDependencies = project.Dependencies
+                        .Select(RenderDependency)
+                        .OrderBy(x => x, StringComparer.OrdinalIgnoreCase);
                 }
                 else
                 {
@@ -71,7 +73,9 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                         return false;
                     }
 
-                    actualDependencies = framework.Dependencies.Select(RenderDependency).OrderBy(x => x);
+                    actualDependencies = framework.Dependencies
+                        .Select(RenderDependency)
+                        .OrderBy(x => x, StringComparer.OrdinalIgnoreCase);
                 }
 
                 if (!actualDependencies.SequenceEqual(expectedDependencies))
@@ -84,16 +88,6 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             return true;
         }
 
-        private string RenderDependency(LibraryRange arg)
-        {
-            var name = arg.Name;
-
-            if (arg.Target == LibraryType.ReferenceAssembly)
-            {
-                name = $"fx/{name}";
-            }
-
-            return $"{name} {VersionUtility.RenderVersion(arg.VersionRange)}";
-        }
+        private string RenderDependency(LibraryRange arg) => $"{arg.Name} {VersionUtility.RenderVersion(arg.VersionRange)}";
     }
 }


### PR DESCRIPTION
fixes #970

This should probably be taken for Beta since it gives a really poor user experience without it (spurious "restore required" warnings on all builds). I will be waiting until AFTER #963 is done before actually merging this and will rebase on that once it is in. But the change is simple and I wanted to start a review for it.

/cc @piotrpMSFT @davidfowl 