### PR TITLE
The dotnet MSI doesn't properly set ALLUSERS property.

### DIFF
--- a/packaging/windows/dotnet.wxs
+++ b/packaging/windows/dotnet.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <?include "Variables.wxi" ?>
     <Product Id="*" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
-        <Package Compressed="yes" InstallerVersion="200" />
+        <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
 
         <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
 


### PR DESCRIPTION
The dotnet installer writes content under %ProgramFiles% which is
machine-wide and requires elevation. The Package@InstallScope attribute
must be set to perMachine in this case and will ensure that the Burn
bootstrapper prompts for elevation during install.