### PR TITLE
remove unnecessary dependency (that isn't present anymore)

### DIFF
--- a/src/Microsoft.DotNet.Tools.Test/project.json
+++ b/src/Microsoft.DotNet.Tools.Test/project.json
@@ -16,7 +16,6 @@
     "System.Diagnostics.TraceSource": "4.0.0-rc2-23704",
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23616",
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-23616",
-    "Microsoft.Extensions.Compilation.Abstractions": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
       "version": "1.0.0-*",


### PR DESCRIPTION
It wasn't in use, and it was actually incorrect. The package name is `Microsoft.Extensions.CompilationAbstractions` (no third `.`), but `Microsoft.Extensions.Compilation.Abstractions` did exist on our feed (from an older version). Our restore process didn't put it back because it's not a current package.