### PR TITLE
Argument Forwarding Changes

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
+    <clear />    
     <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
     <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />

--- a/scripts/build/build_appdeps.cmd
+++ b/scripts/build/build_appdeps.cmd
@@ -5,17 +5,18 @@ REM This file encapsulates the temporary steps to build the dotnet-compile-nativ
 REM The AppDepSDK package is a temporary artifact until we have CoreRT assemblies published to Nuget
 
 set __ScriptDir=%~dp0
-set __RepoRoot=%__ScriptDir%\..\..
+set __RepoRoot=%__ScriptDir%..\..
 set __AppDepsProjectDir=%__RepoRoot%\src\Microsoft.DotNet.Tools.Compiler.Native\appdep
 
 REM Get absolute path
 pushd %1
-set __OutputPath=%CD%\bin
+set __OutputPath=%__RepoRoot%\artifacts\win7-x64\stage2\bin
 popd
 
 
 pushd %__AppDepsProjectDir%
 rmdir /S /Q packages
+mkdir packages
 dotnet restore --packages %__AppDepsProjectDir%\packages
 set __AppDepSDK=%__AppDepsProjectDir%\packages\toolchain*\
 popd

--- a/scripts/test/argument-forwarding-tests.ps1
+++ b/scripts/test/argument-forwarding-tests.ps1
@@ -1,0 +1,37 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+. "$PSScriptRoot\..\common\_common.ps1"
+
+$TestPackagesPath = "$RepoRoot\tests\packages"
+
+$ArgTestRoot = "$RepoRoot\test\ArgumentForwardingTests"
+$ArgTestBinRoot = "$RepoRoot\artifacts\tests\arg-forwarding"
+
+dotnet publish --framework "dnxcore50" --runtime "$Rid" --output "$ArgTestBinRoot" --configuration "$Configuration" "$ArgTestRoot\Reflector"
+if (!$?) {
+    Write-Host Command failed: dotnet publish --framework "dnxcore50" --runtime "$Rid" --output "$ArgTestBinRoot" --configuration "$Configuration" "$ArgTestRoot\Reflector"
+    Exit 1
+}
+
+dotnet publish --framework "dnxcore50" --runtime "$Rid" --output "$ArgTestBinRoot" --configuration "$Configuration" "$ArgTestRoot\ArgumentForwardingTests"
+if (!$?) {
+    Write-Host Command failed: dotnet publish --framework "dnxcore50" --runtime "$Rid" --output "$ArgTestBinRoot" --configuration "$Configuration" "$ArgTestRoot\ArgumentForwardingTests"
+    Exit 1
+}
+
+cp "$ArgTestRoot\Reflector\reflector_cmd.cmd" "$ArgTestBinRoot"
+
+pushd $ArgTestBinRoot
+
+& ".\corerun" "xunit.console.netcore.exe" "ArgumentForwardingTests.dll" -xml "$_-testResults.xml" -notrait category=failing
+$exitCode = $LastExitCode
+
+popd
+
+# No need to output here, we'll get test results
+if ($exitCode -ne 0) {
+    Exit 1
+}

--- a/scripts/test/argument-forwarding-tests.sh
+++ b/scripts/test/argument-forwarding-tests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+source "$DIR/../common/_common.sh"
+
+ArgTestRoot = "$REPOROOT/test/ArgumentForwardingTests"
+ArgTestBinRoot="$REPOROOT/artifacts/tests/arg-forwarding"
+
+dotnet publish --framework "dnxcore50" --runtime "$RID" --output "$ArgTestBinRoot" --configuration "$CONFIGURATION" "$ArgTestRoot/Reflector"
+dotnet publish --framework "dnxcore50" --runtime "$RID" --output "$ArgTestBinRoot" --configuration "$CONFIGURATION" "$ArgTestRoot/ArgumentForwardingTests"
+
+cp "$ArgTestRoot/Reflector/reflector_cmd.cmd" "$ArgTestBinRoot"
+
+pushd $TestBinRoot
+./corerun "xunit.console.netcore.exe" "ArgumentForwardingTests.dll" -xml "ArgumentForwardingTests-testResults.xml" -notrait category=failing
+popd

--- a/scripts/test/runtests.ps1
+++ b/scripts/test/runtests.ps1
@@ -17,6 +17,11 @@ $TestProjects = @(
     "Microsoft.DotNet.Tools.Builder.Tests"
 )
 
+$TestScripts = @(
+    "package-command-test.ps1",
+    "argument-forwarding-tests.ps1"
+)
+
 # Publish each test project
 $TestProjects | ForEach-Object {
     dotnet publish --framework "dnxcore50" --runtime "$Rid" --output "$TestBinRoot" --configuration "$Configuration" "$RepoRoot\test\$_"
@@ -60,11 +65,14 @@ $TestProjects | ForEach-Object {
 
 popd
 
-& $RepoRoot\scripts\test\package-command-test.ps1
-$exitCode = $LastExitCode
-if ($exitCode -ne 0) {
+$TestScripts | ForEach-Object {
+    & "$RepoRoot\scripts\test\$_"
+    $exitCode = $LastExitCode
+    if ($exitCode -ne 0) {
+        $failingTests += "$_"
+    }
+
     $failCount += 1
-    $failingTests += "package-command-test"
 }
 
 if ($failCount -ne 0) {

--- a/scripts/test/runtests.sh
+++ b/scripts/test/runtests.sh
@@ -27,6 +27,11 @@ TestProjects=( \
     Microsoft.DotNet.Tools.Builder.Tests \
 )
 
+TestScripts=( \
+    "package-command-test.sh" \
+    "argument-forwarding-tests.sh" \
+)
+
 for project in ${TestProjects[@]}
 do
     dotnet publish --framework "dnxcore50" --output "$TestBinRoot" --configuration "$CONFIGURATION" "$REPOROOT/test/$project"
@@ -53,11 +58,15 @@ do
     fi
 done
 
-"$REPOROOT/scripts/test/package-command-test.sh"
-if [ $? -ne 0 ]; then
+for script in ${TestScripts[@]}
+do
+    "$REPOROOT/scripts/test/$script"
+    exitCode=$?
     failCount+=1
-    failedTests+=("package-command-test.sh")
-fi
+    if [ $exitCode -ne 0 ]; then
+        failedTests+=($script)
+    fi
+done
 
 for test in ${failedTests[@]}
 do

--- a/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
-        public static IEnumerable<string> EscapeArgArray(IEnumerable<string> args)
+        private static IEnumerable<string> EscapeArgArray(IEnumerable<string> args)
         {
             var escapedArgs = new List<string>();
 
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
-        public static IEnumerable<string> EscapeArgArrayForCmd(IEnumerable<string> arguments)
+        private static IEnumerable<string> EscapeArgArrayForCmd(IEnumerable<string> arguments)
         {
             var escapedArgs = new List<string>();
 

--- a/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public static class ArgumentEscaper
+    {
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main,
+        /// so that the next process will receive the same string[] args
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static string EscapeAndConcatenateArgArray(IEnumerable<string> args, bool cmd=false)
+        { 
+            var sb = new StringBuilder();
+            var first = false;
+
+            foreach (var arg in args)
+            {
+                if (first)
+                {
+                    first = false;
+                }
+                else
+                {
+                    sb.Append(' ');
+                }
+                sb.Append(EscapeArg(arg, cmd));
+            }
+
+            return sb.ToString();
+        }
+
+        public static string EscapeAndConcatenateArgArrayForBash(IEnumerable<string> args)
+        {
+            return EscapeAndConcatenateArgArray(EscapeArgArrayForBash(args));
+        }
+
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main,
+        /// so that the next process will receive the same string[] args
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static string EscapeAndConcatenateArgArrayForCmd(IEnumerable<string> args)
+        {
+            return EscapeAndConcatenateArgArray(EscapeArgArrayForCmd(args), true);
+        }
+
+        /// <summary>
+        /// Undo the processing which took place to create string[] args in Main,
+        /// so that the next process will receive the same string[] args
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static IEnumerable<string> EscapeArgArray(IEnumerable<string> args)
+        {
+            var escapedArgs = new List<string>();
+
+            foreach (var arg in args)
+            {
+                escapedArgs.Add(EscapeArg(arg));
+            }
+
+            return escapedArgs;
+        }
+
+        public static IEnumerable<string> EscapeArgArrayForBash(IEnumerable<string> arguments)
+        {
+            var escapedArgs = new List<string>();
+
+            foreach (var arg in arguments)
+            {
+                escapedArgs.Add(EscapeArgForBash(arg));
+            }
+
+            return escapedArgs;
+        }
+
+        /// <summary>
+        /// This prefixes every character with the '^' character to force cmd to
+        /// interpret the argument string literally. An alternative option would 
+        /// be to do this only for cmd metacharacters.
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public static IEnumerable<string> EscapeArgArrayForCmd(IEnumerable<string> arguments)
+        {
+            var escapedArgs = new List<string>();
+
+            foreach (var arg in arguments)
+            {
+                escapedArgs.Add(EscapeArgForCmd(arg));
+            }
+
+            return escapedArgs;
+        }
+
+        private static string EscapeArg(string arg, bool cmd=false)
+        {
+            var sb = new StringBuilder();
+
+            // Always quote beginning and end to account for possible spaces
+            if (cmd) sb.Append('^');
+            sb.Append('"');
+
+            if (!cmd)
+            {
+                for (int i = 0; i < arg.Length; ++i)
+                {
+                    var backslashCount = 0;
+
+                    // Consume All Backslashes
+                    while (i < arg.Length && arg[i] == '\\')
+                    {
+                        backslashCount++;
+                        i++;
+                    }
+
+                    // Escape any backslashes at the end of the arg
+                    // This ensures the outside quote is interpreted as
+                    // an argument delimiter
+                    if (i == arg.Length)
+                    {
+                        sb.Append('\\', 2 * backslashCount);
+                    }
+
+                    // Escape any preceding backslashes and the quote
+                    else if (arg[i] == '"')
+                    {
+                        sb.Append('\\', (2 * backslashCount) + 1);
+                        sb.Append('"');
+                    }
+
+                    // Output any consumed backslashes and the character
+                    else
+                    {
+                        sb.Append('\\', backslashCount);
+                        sb.Append(arg[i]);
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < arg.Length; ++i)
+                {
+                    if (arg[i] == '"')
+                    {
+                        sb.Append('"');
+                        sb.Append('^');
+                        sb.Append(arg[i]);
+                    }
+                    else
+                    {
+                        sb.Append(arg[i]);
+                    }
+                }
+            }
+            
+            if (cmd) sb.Append('^');
+            sb.Append('"');
+
+            return sb.ToString();
+        }
+
+        private static string EscapeArgForBash(string arguments)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Prepare as single argument to 
+        /// roundtrip properly through cmd.
+        /// 
+        /// This prefixes every character with the '^' character to force cmd to
+        /// interpret the argument string literally. An alternative option would 
+        /// be to do this only for cmd metacharacters.
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        private static string EscapeArgForCmd(string arguments)
+        {
+            var sb = new StringBuilder();
+
+            foreach (var character in arguments)
+            {
+                sb.Append('^');
+                sb.Append(character);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
-        public static string EscapeAndConcatenateArgArray(IEnumerable<string> args)
+        public static string EscapeAndConcatenateArgArrayForProcessStart(IEnumerable<string> args)
         { 
             return string.Join(" ", EscapeArgArray(args));
         }

--- a/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
@@ -20,30 +20,9 @@ namespace Microsoft.DotNet.Cli.Utils
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
-        public static string EscapeAndConcatenateArgArray(IEnumerable<string> args, bool cmd=false)
+        public static string EscapeAndConcatenateArgArray(IEnumerable<string> args)
         { 
-            var sb = new StringBuilder();
-            var first = false;
-
-            foreach (var arg in args)
-            {
-                if (first)
-                {
-                    first = false;
-                }
-                else
-                {
-                    sb.Append(' ');
-                }
-                sb.Append(EscapeArg(arg, cmd));
-            }
-
-            return sb.ToString();
-        }
-
-        public static string EscapeAndConcatenateArgArrayForBash(IEnumerable<string> args)
-        {
-            return EscapeAndConcatenateArgArray(EscapeArgArrayForBash(args));
+            return string.Join(" ", EscapeArgArray(args));
         }
 
         /// <summary>
@@ -57,7 +36,7 @@ namespace Microsoft.DotNet.Cli.Utils
         /// <returns></returns>
         public static string EscapeAndConcatenateArgArrayForCmd(IEnumerable<string> args)
         {
-            return EscapeAndConcatenateArgArray(EscapeArgArrayForCmd(args), true);
+            return string.Join(" ", EscapeArgArrayForCmd(args));
         }
 
         /// <summary>
@@ -76,18 +55,6 @@ namespace Microsoft.DotNet.Cli.Utils
             foreach (var arg in args)
             {
                 escapedArgs.Add(EscapeArg(arg));
-            }
-
-            return escapedArgs;
-        }
-
-        public static IEnumerable<string> EscapeArgArrayForBash(IEnumerable<string> arguments)
-        {
-            var escapedArgs = new List<string>();
-
-            foreach (var arg in arguments)
-            {
-                escapedArgs.Add(EscapeArgForBash(arg));
             }
 
             return escapedArgs;
@@ -115,76 +82,50 @@ namespace Microsoft.DotNet.Cli.Utils
             return escapedArgs;
         }
 
-        private static string EscapeArg(string arg, bool cmd=false)
+        private static string EscapeArg(string arg)
         {
             var sb = new StringBuilder();
 
-            // Always quote beginning and end to account for possible spaces
-            if (cmd) sb.Append('^');
-            sb.Append('"');
+            var quoted = ShouldSurroundWithQuotes(arg);
+            if (quoted) sb.Append("\"");
 
-            if (!cmd)
+            for (int i = 0; i < arg.Length; ++i)
             {
-                for (int i = 0; i < arg.Length; ++i)
+                var backslashCount = 0;
+
+                // Consume All Backslashes
+                while (i < arg.Length && arg[i] == '\\')
                 {
-                    var backslashCount = 0;
-
-                    // Consume All Backslashes
-                    while (i < arg.Length && arg[i] == '\\')
-                    {
-                        backslashCount++;
-                        i++;
-                    }
-
-                    // Escape any backslashes at the end of the arg
-                    // This ensures the outside quote is interpreted as
-                    // an argument delimiter
-                    if (i == arg.Length)
-                    {
-                        sb.Append('\\', 2 * backslashCount);
-                    }
-
-                    // Escape any preceding backslashes and the quote
-                    else if (arg[i] == '"')
-                    {
-                        sb.Append('\\', (2 * backslashCount) + 1);
-                        sb.Append('"');
-                    }
-
-                    // Output any consumed backslashes and the character
-                    else
-                    {
-                        sb.Append('\\', backslashCount);
-                        sb.Append(arg[i]);
-                    }
+                    backslashCount++;
+                    i++;
                 }
-            }
-            else
-            {
-                for (int i = 0; i < arg.Length; ++i)
+
+                // Escape any backslashes at the end of the arg
+                // This ensures the outside quote is interpreted as
+                // an argument delimiter
+                if (i == arg.Length)
                 {
-                    if (arg[i] == '"')
-                    {
-                        sb.Append('"');
-                        sb.Append('^');
-                        sb.Append(arg[i]);
-                    }
-                    else
-                    {
-                        sb.Append(arg[i]);
-                    }
+                    sb.Append('\\', 2 * backslashCount);
+                }
+
+                // Escape any preceding backslashes and the quote
+                else if (arg[i] == '"')
+                {
+                    sb.Append('\\', (2 * backslashCount) + 1);
+                    sb.Append('"');
+                }
+
+                // Output any consumed backslashes and the character
+                else
+                {
+                    sb.Append('\\', backslashCount);
+                    sb.Append(arg[i]);
                 }
             }
             
-            if (cmd) sb.Append('^');
-            sb.Append('"');
+            if (quoted) sb.Append("\"");
 
             return sb.ToString();
-        }
-
-        private static string EscapeArgForBash(string arguments)
-        {
-            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -200,17 +141,66 @@ namespace Microsoft.DotNet.Cli.Utils
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
-        private static string EscapeArgForCmd(string arguments)
+        private static string EscapeArgForCmd(string argument)
         {
             var sb = new StringBuilder();
 
-            foreach (var character in arguments)
+            var quoted = ShouldSurroundWithQuotes(argument);
+
+            if (quoted) sb.Append("^\"");
+
+            foreach (var character in argument)
             {
-                sb.Append('^');
-                sb.Append(character);
+
+                if (character == '"')
+                {
+
+                    sb.Append('^');
+                    sb.Append('"');
+                    sb.Append('^');
+                    sb.Append(character);
+                }
+                else
+                {
+                    sb.Append("^");
+                    sb.Append(character);
+                }
             }
 
+            if (quoted) sb.Append("^\"");
+
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Prepare as single argument to 
+        /// roundtrip properly through cmd.
+        /// 
+        /// This prefixes every character with the '^' character to force cmd to
+        /// interpret the argument string literally. An alternative option would 
+        /// be to do this only for cmd metacharacters.
+        /// 
+        /// See here for more info:
+        /// http://blogs.msdn.com/b/twistylittlepassagesallalike/archive/2011/04/23/everyone-quotes-arguments-the-wrong-way.aspx
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        internal static bool ShouldSurroundWithQuotes(string argument)
+        {
+            // Don't quote already quoted strings
+            if (argument.StartsWith("\"", StringComparison.Ordinal) &&
+                    argument.EndsWith("\"", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            // Only quote if whitespace exists in the string
+            if (argument.Contains(" ") || argument.Contains("\t") || argument.Contains("\n"))
+            {
+                return true;
+            }
+
+            return true;
         }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -39,20 +39,25 @@ namespace Microsoft.DotNet.Cli.Utils
             ResolutionStrategy = commandSpec.ResolutionStrategy;
         }
 
-        public static Command Create(string commandName, IEnumerable<string> args, NuGetFramework framework = null)
+        /// <summary>
+        /// Create a command with the specified arg array. Args will be 
+        /// escaped properly to ensure that exactly the strings in this
+        /// array will be present in the corresponding argument array
+        /// in the command's process.
+        /// </summary>
+        /// <param name="commandName"></param>
+        /// <param name="args"></param>
+        /// <param name="framework"></param>
+        /// <returns></returns>
+        public static Command Create(string commandName, IEnumerable<string> args, NuGetFramework framework = null, bool useComSpec = false)
         {
-            return Create(commandName, string.Join(" ", args), framework);
-        }
-
-        public static Command Create(string commandName, string args, NuGetFramework framework = null)
-        {
-            var commandSpec = CommandResolver.TryResolveCommandSpec(commandName, args, framework);
+            var commandSpec = CommandResolver.TryResolveCommandSpec(commandName, args, framework, useComSpec=useComSpec);
 
             if (commandSpec == null)
             {
                 throw new CommandUnknownException(commandName);
             }
-            
+
             var command = new Command(commandSpec);
 
             return command;
@@ -60,6 +65,7 @@ namespace Microsoft.DotNet.Cli.Utils
         
         public CommandResult Execute()
         {
+
             Reporter.Verbose.WriteLine($"Running {_process.StartInfo.FileName} {_process.StartInfo.Arguments}");
 
             ThrowIfRunning();

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
@@ -24,7 +24,6 @@ namespace Microsoft.DotNet.Cli.Utils
         private static CommandSpec ResolveFromPath(string commandName, IEnumerable<string> args, bool useComSpec = false)
         {
             var commandPath = Env.GetCommandPath(commandName);
-            if (commandPath != null) Console.WriteLine("path?");
             return commandPath == null 
                 ? null 
                 : CreateCommandSpecPreferringExe(commandName, args, commandPath, CommandResolutionStrategy.Path, useComSpec);
@@ -33,7 +32,6 @@ namespace Microsoft.DotNet.Cli.Utils
         private static CommandSpec ResolveFromAppBase(string commandName, IEnumerable<string> args, bool useComSpec = false)
         {
             var commandPath = Env.GetCommandPathFromAppBase(AppContext.BaseDirectory, commandName);
-            if (commandPath != null) Console.WriteLine("appbase?");
             return commandPath == null 
                 ? null 
                 : CreateCommandSpecPreferringExe(commandName, args, commandPath, CommandResolutionStrategy.BaseDirectory, useComSpec);
@@ -43,8 +41,6 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             if (Path.IsPathRooted(commandName))
             {
-                Console.WriteLine("rooted?");
-
                 if (useComSpec)
                 {
                     return CreateComSpecCommandSpec(commandName, args, CommandResolutionStrategy.Path);
@@ -196,8 +192,6 @@ namespace Microsoft.DotNet.Cli.Utils
                 fileName = Path.Combine(packageDir, commandPath);
             }
 
-            
-
             if (useComSpec)
             {
                 return CreateComSpecCommandSpec(fileName, args, CommandResolutionStrategy.NugetPackage);
@@ -256,7 +250,6 @@ namespace Microsoft.DotNet.Cli.Utils
             IEnumerable<string> args, 
             CommandResolutionStrategy resolutionStrategy)
         {
-
             // To prevent Command Not Found, comspec gets passed in as
             // the command already in some cases
             var comSpec = Environment.GetEnvironmentVariable("ComSpec");
@@ -266,7 +259,13 @@ namespace Microsoft.DotNet.Cli.Utils
                 args = args.Skip(1);
             }
             var cmdEscapedArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForCmd(args);
-            var escapedArgString = $"/s /c \"\"{command}\" {cmdEscapedArgs}\"";
+
+            if (ArgumentEscaper.ShouldSurroundWithQuotes(command))
+            {
+                command = $"\"{command}\"";
+            }
+
+            var escapedArgString = $"/s /c \"{command} {cmdEscapedArgs}\"";
 
             return new CommandSpec(comSpec, escapedArgString, resolutionStrategy);
         }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
@@ -258,7 +258,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 command = args.FirstOrDefault();
                 args = args.Skip(1);
             }
-            var cmdEscapedArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForCmd(args);
+            var cmdEscapedArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForCmdProcessStart(args);
 
             if (ArgumentEscaper.ShouldSurroundWithQuotes(command))
             {

--- a/src/Microsoft.DotNet.Cli.Utils/ScriptExecutor.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ScriptExecutor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli.Utils
             var scriptArguments = CommandGrammar.Process(
                 scriptCommandLine,
                 GetScriptVariable(project, getVariable),
-                preserveSurroundingQuotes: true);
+                preserveSurroundingQuotes: false);
 
             // Ensure the array won't be empty and the elements won't be null or empty strings.
             scriptArguments = scriptArguments.Where(argument => !string.IsNullOrEmpty(argument)).ToArray();
@@ -30,6 +30,8 @@ namespace Microsoft.DotNet.Cli.Utils
             {
                 return null;
             }
+
+            var useComSpec = false;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -45,24 +47,24 @@ namespace Microsoft.DotNet.Cli.Utils
                 var comSpec = Environment.GetEnvironmentVariable("ComSpec");
                 if (!string.IsNullOrEmpty(comSpec))
                 {
-                    scriptArguments =
-                        new[] { comSpec, "/S", "/C", "\"" }
-                        .Concat(scriptArguments)
-                        .Concat(new[] { "\"" })
-                        .ToArray();
+                    useComSpec=true;
+
+                    List<string> concatenatedArgs = new List<string>();
+                    concatenatedArgs.Add(comSpec);
+                    concatenatedArgs.AddRange(scriptArguments);
+
+                    scriptArguments = concatenatedArgs.ToArray();
                 }
             }
             else
             {
                 // Special-case a script name that, perhaps with added .sh, matches an existing file.
-                var surroundWithQuotes = false;
                 var scriptCandidate = scriptArguments[0];
                 if (scriptCandidate.StartsWith("\"", StringComparison.Ordinal) &&
                     scriptCandidate.EndsWith("\"", StringComparison.Ordinal))
                 {
                     // Strip surrounding quotes; they were required in project.json to keep the script name
                     // together but confuse File.Exists() e.g. "My Script", lacking ./ prefix and .sh suffix.
-                    surroundWithQuotes = true;
                     scriptCandidate = scriptCandidate.Substring(1, scriptCandidate.Length - 2);
                 }
 
@@ -76,19 +78,25 @@ namespace Microsoft.DotNet.Cli.Utils
                     // scriptCandidate may be a path relative to the project root. If so, likely will not be found
                     // in the $PATH; add ./ to let bash know where to look.
                     var prefix = Path.IsPathRooted(scriptCandidate) ? string.Empty : "./";
-                    var quote = surroundWithQuotes ? "\"" : string.Empty;
-                    scriptArguments[0] = $"{ quote }{ prefix }{ scriptCandidate }{ quote }";
+                    scriptArguments[0] = $"{prefix}{scriptCandidate}";
                 }
 
                 // Always use /usr/bin/env bash -c in order to support redirection and so on; similar to Windows case.
                 // Unlike Windows, must escape quotation marks within the newly-quoted string.
-                scriptArguments = new[] { "/usr/bin/env", "bash", "-c", "\"" }
-                    .Concat(scriptArguments.Select(argument => argument.Replace("\"", "\\\"")))
-                    .Concat(new[] { "\"" })
-                    .ToArray();
+                
+                // TODO change this back to original, not doing anything special for bash
+                var bashArgs = ArgumentEscaper.EscapeArgArrayForBash(scriptArguments);
+
+                List<string> concatenatedArgs = new List<string>();
+                concatenatedArgs.Add("/usr/bin/env");
+                concatenatedArgs.Add("bash");
+                concatenatedArgs.Add("-c");
+                concatenatedArgs.AddRange(bashArgs);
+                    
+                scriptArguments = concatenatedArgs.ToArray();
             }
 
-            return Command.Create(scriptArguments.FirstOrDefault(), string.Join(" ", scriptArguments.Skip(1)))
+            return Command.Create(scriptArguments.FirstOrDefault(), scriptArguments.Skip(1), useComSpec: useComSpec)
                 .WorkingDirectory(project.ProjectDirectory);
         }
         private static Func<string, string> WrapVariableDictionary(IDictionary<string, string> contextVariables)

--- a/src/Microsoft.DotNet.Cli.Utils/ScriptExecutor.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ScriptExecutor.cs
@@ -49,11 +49,9 @@ namespace Microsoft.DotNet.Cli.Utils
                 {
                     useComSpec=true;
 
-                    List<string> concatenatedArgs = new List<string>();
-                    concatenatedArgs.Add(comSpec);
-                    concatenatedArgs.AddRange(scriptArguments);
-
-                    scriptArguments = concatenatedArgs.ToArray();
+                    scriptArguments = new string[] { comSpec }
+                        .Concat(scriptArguments)
+                        .ToArray();
                 }
             }
             else

--- a/src/Microsoft.DotNet.Cli/Program.cs
+++ b/src/Microsoft.DotNet.Cli/Program.cs
@@ -119,7 +119,7 @@ Common Commands:
         {
             if (appArgs.Any())
             {
-                return Command.Create("dotnet-" + appArgs.First(), "--help")
+                return Command.Create("dotnet-" + appArgs.First(), new string[] { "--help" })
                     .ForwardStdErr()
                     .ForwardStdOut()
                     .Execute()

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             var existingAttributes = new List<Type>();
             foreach (var sourceFile in sourceFiles)
             {
-                var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFile));
+                var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFile.Trim('"')));
                 var root = tree.GetRoot();
 
                 // assembly attributes can be only on first level

--- a/src/Microsoft.DotNet.ProjectModel.Server/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Server/project.json
@@ -6,16 +6,16 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.0.0-rc2-23704",
-    "System.Threading.ThreadPool": "4.0.10-beta-23704",
+    "System.Threading.ThreadPool": "4.0.10-rc2-23704",
     "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23704",
-    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
+    "Microsoft.DotNet.ProjectModel": {"target":"project"},
+    "Microsoft.DotNet.Compiler.Common": {"target":"project"},
     "Microsoft.Extensions.CommandLineUtils.Sources": {
       "type": "build",
       "version": "1.0.0-*"
     },
-    "Microsoft.Extensions.Logging": "1.0.0-rc2-15935",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-15935",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-16011",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-16011",
     "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.ProjectModel.Server/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Server/project.json
@@ -8,8 +8,8 @@
     "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Threading.ThreadPool": "4.0.10-rc2-23704",
     "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23704",
-    "Microsoft.DotNet.ProjectModel": {"target":"project"},
-    "Microsoft.DotNet.Compiler.Common": {"target":"project"},
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils.Sources": {
       "type": "build",
       "version": "1.0.0-*"

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -13,7 +13,7 @@
         "System.Xml.XDocument": "4.0.11-rc2-23704",
         "NuGet.Packaging": "3.4.0-beta-*",
 
-        "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15964",
+        "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15975",
         "Microsoft.Extensions.JsonParser.Sources": {
             "type": "build",
             "version": "1.0.0-*"

--- a/src/Microsoft.DotNet.Tools.Builder/CompileContext.cs
+++ b/src/Microsoft.DotNet.Tools.Builder/CompileContext.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Tools.Build
 
             if (!newInputs.Any())
             {
-                Reporter.Output.WriteLine($"\nProject {project.ProjectName()} was previoulsy compiled. Skipping compilation.");
+                Reporter.Output.WriteLine($"\nProject {project.ProjectName()} was previously compiled. Skipping compilation.");
                 return false;
             }
 

--- a/src/Microsoft.DotNet.Tools.Builder/CompileContext.cs
+++ b/src/Microsoft.DotNet.Tools.Builder/CompileContext.cs
@@ -218,7 +218,7 @@ namespace Microsoft.DotNet.Tools.Build
         private void CollectCheckPathProbingPreconditions(ProjectContext project, IncrementalPreconditions preconditions)
         {
             var pathCommands = CompilerUtil.GetCommandsInvokedByCompile(project)
-                .Select(commandName => Command.Create(commandName, new string[] { }, project.TargetFramework))
+                .Select(commandName => Command.Create(commandName, Enumerable.Empty<string>(), project.TargetFramework))
                 .Where(c => c.ResolutionStrategy.Equals(CommandResolutionStrategy.Path));
 
             foreach (var pathCommand in pathCommands)
@@ -255,37 +255,21 @@ namespace Microsoft.DotNet.Tools.Build
 
         private bool InvokeCompileOnDependency(ProjectDescription projectDependency)
         {
-            string[] args;
+            var args = new List<string>();
+
+            args.Add("--framework");
+            args.Add($"{projectDependency.Framework}");
+            args.Add("--configuration");
+            args.Add($"{_args.ConfigValue}");
+            args.Add("--output");
+            args.Add($"{_args.OutputValue}");
+            args.Add("--temp-output");
+            args.Add($"{_args.IntermediateValue}");
+            args.Add($"{projectDependency.Project.ProjectDirectory}");
+
             if (_args.NoHostValue)
             {
-                args = new string[]
-                {
-                    $"--framework",
-                    $"{projectDependency.Framework}",
-                    $"--configuration",
-                    $"{_args.ConfigValue}",
-                    $"--output",
-                    $"{_args.OutputValue}",
-                    $"--temp-output",
-                    $"{_args.IntermediateValue}",
-                    "--no-host",
-                    $"{projectDependency.Project.ProjectDirectory}"
-                };
-            }
-            else
-            {
-                args = new string[]
-               {
-                    $"--framework",
-                    $"{projectDependency.Framework}",
-                    $"--configuration",
-                    $"{_args.ConfigValue}",
-                    $"--output",
-                    $"{_args.OutputValue}",
-                    $"--temp-output",
-                    $"{_args.IntermediateValue}",
-                    $"{projectDependency.Project.ProjectDirectory}"
-               };
+                args.Add("--no-host");
             }
 
             var compileResult = Command.Create("dotnet-compile", args)
@@ -299,7 +283,7 @@ namespace Microsoft.DotNet.Tools.Build
         private bool InvokeCompileOnRootProject()
         {
             // todo: add methods to CompilerCommandApp to generate the arg string?
-            List<string> args = new List<string>();
+            var args = new List<string>();
             args.Add("--framework");
             args.Add(_rootProject.TargetFramework.ToString());
             args.Add("--configuration");
@@ -309,26 +293,40 @@ namespace Microsoft.DotNet.Tools.Build
             args.Add("--temp-output");
             args.Add(_args.IntermediateValue);
 
-            if (_args.NoHostValue) args.Add("--no-host");
+            if (_args.NoHostValue) 
+            { 
+                args.Add("--no-host"); 
+            }
 
             //native args
-            if (_args.IsNativeValue) args.Add("--native");
-            if (_args.IsCppModeValue) args.Add("--cpp");
+            if (_args.IsNativeValue) 
+            { 
+                args.Add("--native"); 
+            }
+
+            if (_args.IsCppModeValue) 
+            { 
+                args.Add("--cpp"); 
+            }
+
             if (!string.IsNullOrWhiteSpace(_args.ArchValue))
             {
                 args.Add("--arch");
                 args.Add(_args.ArchValue);
             }
+
             if (!string.IsNullOrWhiteSpace(_args.IlcArgsValue))
             {
                 args.Add("--ilcargs");
                 args.Add(_args.IlcArgsValue);
             }
+
             if (!string.IsNullOrWhiteSpace(_args.IlcPathValue))
             {
                 args.Add("--ilcpath");
                 args.Add(_args.IlcPathValue);
             }
+
             if (!string.IsNullOrWhiteSpace(_args.IlcSdkPathValue))
             {
                 args.Add("--ilcsdkpath");
@@ -337,7 +335,7 @@ namespace Microsoft.DotNet.Tools.Build
 
             args.Add(_rootProject.ProjectDirectory);
 
-            var compileResult = Command.Create("dotnet-compile",args.ToArray())
+            var compileResult = Command.Create("dotnet-compile",args)
                 .ForwardStdOut()
                 .ForwardStdErr()
                 .Execute();

--- a/src/Microsoft.DotNet.Tools.Builder/CompileContext.cs
+++ b/src/Microsoft.DotNet.Tools.Builder/CompileContext.cs
@@ -218,7 +218,7 @@ namespace Microsoft.DotNet.Tools.Build
         private void CollectCheckPathProbingPreconditions(ProjectContext project, IncrementalPreconditions preconditions)
         {
             var pathCommands = CompilerUtil.GetCommandsInvokedByCompile(project)
-                .Select(commandName => Command.Create(commandName, "", project.TargetFramework))
+                .Select(commandName => Command.Create(commandName, new string[] { }, project.TargetFramework))
                 .Where(c => c.ResolutionStrategy.Equals(CommandResolutionStrategy.Path));
 
             foreach (var pathCommand in pathCommands)
@@ -255,13 +255,40 @@ namespace Microsoft.DotNet.Tools.Build
 
         private bool InvokeCompileOnDependency(ProjectDescription projectDependency)
         {
-            var compileResult = Command.Create("dotnet-compile",
-                $"--framework {projectDependency.Framework} " +
-                $"--configuration {_args.ConfigValue} " +
-                $"--output \"{_args.OutputValue}\" " +
-                $"--temp-output \"{_args.IntermediateValue}\" " +
-                (_args.NoHostValue ? "--no-host " : string.Empty) +
-                $"\"{projectDependency.Project.ProjectDirectory}\"")
+            string[] args;
+            if (_args.NoHostValue)
+            {
+                args = new string[]
+                {
+                    $"--framework",
+                    $"{projectDependency.Framework}",
+                    $"--configuration",
+                    $"{_args.ConfigValue}",
+                    $"--output",
+                    $"{_args.OutputValue}",
+                    $"--temp-output",
+                    $"{_args.IntermediateValue}",
+                    "--no-host",
+                    $"{projectDependency.Project.ProjectDirectory}"
+                };
+            }
+            else
+            {
+                args = new string[]
+               {
+                    $"--framework",
+                    $"{projectDependency.Framework}",
+                    $"--configuration",
+                    $"{_args.ConfigValue}",
+                    $"--output",
+                    $"{_args.OutputValue}",
+                    $"--temp-output",
+                    $"{_args.IntermediateValue}",
+                    $"{projectDependency.Project.ProjectDirectory}"
+               };
+            }
+
+            var compileResult = Command.Create("dotnet-compile", args)
                 .ForwardStdOut()
                 .ForwardStdErr()
                 .Execute();
@@ -272,20 +299,45 @@ namespace Microsoft.DotNet.Tools.Build
         private bool InvokeCompileOnRootProject()
         {
             // todo: add methods to CompilerCommandApp to generate the arg string?
-            var compileResult = Command.Create("dotnet-compile",
-                $"--framework {_rootProject.TargetFramework} " +
-                $"--configuration {_args.ConfigValue} " +
-                $"--output \"{_args.OutputValue}\" " +
-                $"--temp-output \"{_args.IntermediateValue}\" " +
-                (_args.NoHostValue ? "--no-host " : string.Empty) +
-                //nativeArgs
-                (_args.IsNativeValue ? "--native " : string.Empty) +
-                (_args.IsCppModeValue ? "--cpp " : string.Empty) +
-                (!string.IsNullOrWhiteSpace(_args.ArchValue) ? $"--arch {_args.ArchValue} " : string.Empty) +
-                (!string.IsNullOrWhiteSpace(_args.IlcArgsValue) ? $"--ilcargs \"{_args.IlcArgsValue}\" " : string.Empty) +
-                (!string.IsNullOrWhiteSpace(_args.IlcPathValue) ? $"--ilcpath \"{_args.IlcPathValue}\" " : string.Empty) +
-                (!string.IsNullOrWhiteSpace(_args.IlcSdkPathValue) ? $"--ilcsdkpath \"{_args.IlcSdkPathValue}\" " : string.Empty) +
-                $"\"{_rootProject.ProjectDirectory}\"")
+            List<string> args = new List<string>();
+            args.Add("--framework");
+            args.Add(_rootProject.TargetFramework.ToString());
+            args.Add("--configuration");
+            args.Add(_args.ConfigValue);
+            args.Add("--output");
+            args.Add(_args.OutputValue);
+            args.Add("--temp-output");
+            args.Add(_args.IntermediateValue);
+
+            if (_args.NoHostValue) args.Add("--no-host");
+
+            //native args
+            if (_args.IsNativeValue) args.Add("--native");
+            if (_args.IsCppModeValue) args.Add("--cpp");
+            if (!string.IsNullOrWhiteSpace(_args.ArchValue))
+            {
+                args.Add("--arch");
+                args.Add(_args.ArchValue);
+            }
+            if (!string.IsNullOrWhiteSpace(_args.IlcArgsValue))
+            {
+                args.Add("--ilcargs");
+                args.Add(_args.IlcArgsValue);
+            }
+            if (!string.IsNullOrWhiteSpace(_args.IlcPathValue))
+            {
+                args.Add("--ilcpath");
+                args.Add(_args.IlcPathValue);
+            }
+            if (!string.IsNullOrWhiteSpace(_args.IlcSdkPathValue))
+            {
+                args.Add("--ilcsdkpath");
+                args.Add(_args.IlcSdkPathValue);
+            }
+
+            args.Add(_rootProject.ProjectDirectory);
+
+            var compileResult = Command.Create("dotnet-compile",args.ToArray())
                 .ForwardStdOut()
                 .ForwardStdErr()
                 .Execute();

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
@@ -79,26 +79,28 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 return returnCode;
             }
 
-            var translated = TranslateCommonOptions(commonOptions, outputName);
+            var translated = TranslateCommonOptions(commonOptions, outputName.Trim('"'));
 
             var allArgs = new List<string>(translated);
             allArgs.AddRange(GetDefaultOptions());
 
             // Generate assembly info
-            var assemblyInfo = Path.Combine(tempOutDir, $"dotnet-compile.assemblyinfo.cs");
+            var tempOutputStrippedSpaces = tempOutDir.Trim('"');
+            var assemblyInfo = Path.Combine(tempOutputStrippedSpaces, $"dotnet-compile.assemblyinfo.cs");
+            
             File.WriteAllText(assemblyInfo, AssemblyInfoFileGenerator.Generate(assemblyInfoOptions, sources));
             allArgs.Add($"\"{assemblyInfo}\"");
 
             if (outputName != null)
             {
-                allArgs.Add($"-out:\"{outputName}\"");
+                allArgs.Add($"-out:\"{outputName.Trim('"')}\"");
             }
 
             allArgs.AddRange(references.Select(r => $"-r:\"{r.Trim('"')}\""));
             allArgs.AddRange(resources.Select(resource => $"-resource:{resource.Trim('"')}"));
             allArgs.AddRange(sources.Select(s => $"\"{s.Trim('"')}\""));
 
-            var rsp = Path.Combine(tempOutDir, "dotnet-compile-csc.rsp");
+            var rsp = Path.Combine(tempOutputStrippedSpaces, "dotnet-compile-csc.rsp");
 
             File.WriteAllLines(rsp, allArgs, Encoding.UTF8);
 
@@ -192,7 +194,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
 
             if (options.GenerateXmlDocumentation == true)
             {
-                commonArgs.Add($"-doc:{Path.ChangeExtension(outputName, "xml")}");
+                commonArgs.Add($"-doc:\"{Path.ChangeExtension(outputName.Trim('"'), "xml")}\"");
             }
 
             if (options.EmitEntryPoint != true)

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
@@ -79,8 +79,6 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 return returnCode;
             }
 
-            sources = sources.Select(s => s.Trim('"')).ToList();
-
             var translated = TranslateCommonOptions(commonOptions, outputName);
 
             var allArgs = new List<string>(translated);
@@ -96,9 +94,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 allArgs.Add($"-out:\"{outputName}\"");
             }
 
-            allArgs.AddRange(references.Select(r => $"-r:\"{r}\""));
-            allArgs.AddRange(resources.Select(resource => $"-resource:{resource}"));
-            allArgs.AddRange(sources.Select(s => $"\"{s}\""));
+            allArgs.AddRange(references.Select(r => $"-r:\"{r.Trim('"')}\""));
+            allArgs.AddRange(resources.Select(resource => $"-resource:{resource.Trim('"')}"));
+            allArgs.AddRange(sources.Select(s => $"\"{s.Trim('"')}\""));
 
             var rsp = Path.Combine(tempOutDir, "dotnet-compile-csc.rsp");
 

--- a/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Csc/Program.cs
@@ -79,6 +79,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 return returnCode;
             }
 
+            sources = sources.Select(s => s.Trim('"')).ToList();
+
             var translated = TranslateCommonOptions(commonOptions, outputName);
 
             var allArgs = new List<string>(translated);
@@ -103,7 +105,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             File.WriteAllLines(rsp, allArgs, Encoding.UTF8);
 
             // Execute CSC!
-            var result = RunCsc($"-noconfig @\"{rsp}\"")
+            var result = RunCsc(new string[] { $"-noconfig", "@" + $"{rsp}" })
                 .ForwardStdErr()
                 .ForwardStdOut()
                 .Execute();
@@ -214,7 +216,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             return languageVersion;
         }
 
-        private static Command RunCsc(string cscArgs)
+        private static Command RunCsc(string[] cscArgs)
         {
             // Locate CoreRun
             return Command.Create("csc", cscArgs);

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
@@ -1,44 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-
-using Microsoft.Dnx.Runtime.Common.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools.Common;
+using System.Linq;
 
 namespace Microsoft.DotNet.Tools.Compiler.Native
 {
     public class MacRyuJitCompileStep : IPlatformNativeStep
     {
-        private readonly string CompilerName = "clang";
-        private readonly string InputExtension = ".obj";
+        private const string CompilerName = "clang";
+        private const string InputExtension = ".obj";
 
-        private readonly string CompilerOutputExtension = "";
+        private const string CompilerOutputExtension = "";
+
+        private IEnumerable<string> CompilerArgs;
 
         // TODO: debug/release support
-        private readonly string cflags = "-g -lstdc++ -Wno-invalid-offsetof -pthread -ldl -lm -liconv";
+        private readonly string [] _cflags = { "-g", "-lstdc++", "-Wno-invalid-offsetof", "-pthread", "-ldl", "-lm", "-liconv" };
 
-        private readonly string[] IlcSdkLibs = new string[]
-        {
-            "libbootstrapper.a",
-            "libRuntime.a",
-            "libSystem.Private.CoreLib.Native.a"
-        };
+        private readonly string[] _ilcSdkLibs = 
+            {
+                "libbootstrapper.a",
+                "libRuntime.a",
+                "libSystem.Private.CoreLib.Native.a"
+            };
 
-        private readonly string[] appdeplibs = new string[]
-        {
-            "libSystem.Native.a"
-        };
-
-
-        private string CompilerArgStr { get; set; }
-        private NativeCompileSettings config;
+        private readonly string[] appdeplibs = 
+            {
+                "libSystem.Native.a"
+            };
 
         public MacRyuJitCompileStep(NativeCompileSettings config)
         {
-            this.config = config;
             InitializeArgs(config);
         }
 
@@ -64,7 +56,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var argsList = new List<string>();
 
             // Flags
-            argsList.Add(cflags);
+            argsList.AddRange(_cflags);
             
             // Pass the optional native compiler flags if specified
             if (!string.IsNullOrWhiteSpace(config.CppCompilerFlags))
@@ -77,31 +69,24 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             argsList.Add("-Xlinker "+inLibFile);
 
             // ILC SDK Libs
-            var IlcSdkLibPath = Path.Combine(config.IlcSdkPath, "sdk");
-            foreach (var lib in IlcSdkLibs)
-            {
-                var libPath = Path.Combine(IlcSdkLibPath, lib);
-                argsList.Add("-Xlinker "+libPath);
-            }
+            var ilcSdkLibPath = Path.Combine(config.IlcSdkPath, "sdk");
+            argsList.AddRange(_ilcSdkLibs.Select(lib => Path.Combine(ilcSdkLibPath, lib)).Select(libPath => "-Xlinker " + libPath));
 
             // AppDep Libs
             var baseAppDepLibPath = Path.Combine(config.AppDepSDKPath, "CPPSdk/osx.10.10", config.Architecture.ToString());
-            foreach (var lib in appdeplibs)
-            {
-                var appDepLibPath = Path.Combine(baseAppDepLibPath, lib);
-                argsList.Add("-Xlinker "+appDepLibPath);
-            }
+            argsList.AddRange(appdeplibs.Select(lib => Path.Combine(baseAppDepLibPath, lib)).Select(appDepLibPath => "-Xlinker " + appDepLibPath));
 
             // Output
             var libOut = DetermineOutputFile(config);
-            argsList.Add($"-o \"{libOut}\"");
+            argsList.Add($"-o");
+            argsList.Add($"{libOut}");
 
-            this.CompilerArgStr = string.Join(" ", argsList);
+            this.CompilerArgs = argsList;
         }
 
         private int InvokeCompiler()
         {
-            var result = Command.Create(CompilerName, CompilerArgStr)
+            var result = Command.Create(CompilerName, CompilerArgs)
                 .ForwardStdErr()
                 .ForwardStdOut()
                 .Execute();

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
@@ -83,8 +83,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
             // Output
             var objOut = DetermineOutputFile(config);
-            argsList.Add($"/Fo");
-            argsList.Add($"{objOut}");
+            argsList.Add($"/Fo{objOut}");
             
             // Input File
             var inCppFile = DetermineInFile(config);

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
@@ -20,13 +20,13 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         
         private readonly string CompilerOutputExtension = ".obj";
         
-        private static readonly Dictionary<BuildConfiguration, string> ConfigurationCompilerOptionsMap = new Dictionary<BuildConfiguration, string>
+        private static readonly Dictionary<BuildConfiguration, string[]> ConfigurationCompilerOptionsMap = new Dictionary<BuildConfiguration, string[]>
         {
-            { BuildConfiguration.debug, "/ZI /nologo /W3 /WX- /sdl /Od /D CPPCODEGEN /D WIN32 /D _CONSOLE /D _LIB /D _UNICODE /D UNICODE /Gm /EHsc /RTC1 /MD /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Gd /TP /wd4477 /errorReport:prompt" },
-            { BuildConfiguration.release, "/Zi /nologo /W3 /WX- /sdl /O2 /Oi /GL /D CPPCODEGEN /D WIN32 /D NDEBUG /D _CONSOLE /D _LIB /D _UNICODE /D UNICODE /Gm- /EHsc /MD /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /Gd /TP /wd4477 /errorReport:prompt" }
+            { BuildConfiguration.debug, new string[] {"/ZI", "/nologo", "/W3", "/WX-", "/sdl", "/Od", "/D", "CPPCODEGEN", "/D", "WIN32", "/D", "_CONSOLE", "/D", "_LIB", "/D", "_UNICODE", "/D", "UNICODE", "/Gm", "/EHsc", "/RTC1", "/MD", "/GS", "/fp:precise", "/Zc:wchar_t", "/Zc:forScope", "/Zc:inline", "/Gd", "/TP", "/wd4477", "/errorReport:prompt"} },
+            { BuildConfiguration.release, new string[] {"/Zi", "/nologo", "/W3", "/WX-", "/sdl", "/O2", "/Oi", "/GL", "/D", "CPPCODEGEN", "/D", "WIN32", "/D", "NDEBUG", "/D", "_CONSOLE", "/D", "_LIB", "/D", "_UNICODE", "/D", "UNICODE", "/Gm-", "/EHsc", "/MD", "/GS", "/Gy", "/fp:precise", "/Zc:wchar_t", "/Zc:forScope", "/Zc:inline", "/Gd", "/TP", "/wd4477", "/errorReport:prompt"} }
         };
         
-        private string CompilerArgStr { get; set; }
+        private IEnumerable<string> CompilerArgs { get; set; }
 
         private NativeCompileSettings config;
         
@@ -70,10 +70,10 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             // Add Includes
             var ilcSdkIncPath = Path.Combine(config.IlcSdkPath, "inc");
             argsList.Add("/I");
-            argsList.Add($"\"{ilcSdkIncPath}\"");
+            argsList.Add($"{ilcSdkIncPath}");
             
             // Configuration Based Compiler Options 
-            argsList.Add(ConfigurationCompilerOptionsMap[config.BuildType]);
+            argsList.AddRange(ConfigurationCompilerOptionsMap[config.BuildType]);
             
             // Pass the optional native compiler flags if specified
             if (!string.IsNullOrWhiteSpace(config.CppCompilerFlags))
@@ -83,13 +83,14 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
             // Output
             var objOut = DetermineOutputFile(config);
-            argsList.Add($"/Fo\"{objOut}\"");
+            argsList.Add($"/Fo");
+            argsList.Add($"{objOut}");
             
             // Input File
             var inCppFile = DetermineInFile(config);
-            argsList.Add($"\"{inCppFile}\"");
-            
-            this.CompilerArgStr = string.Join(" ", argsList);
+            argsList.Add($"{inCppFile}");
+
+            this.CompilerArgs = argsList;
         }
         
         private int InvokeCompiler()
@@ -97,7 +98,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var vcInstallDir = Environment.GetEnvironmentVariable("VS140COMNTOOLS");
             var compilerPath = Path.Combine(vcInstallDir, VSBin, CompilerName);
             
-            var result = Command.Create(compilerPath, CompilerArgStr)
+            var result = Command.Create(compilerPath, CompilerArgs.ToArray())
                 .ForwardStdErr()
                 .ForwardStdOut()
                 .Execute();

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
@@ -95,8 +95,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             
             //Output
             var outFile = DetermineOutputFile(config);
-            argsList.Add($"/out");
-            argsList.Add($"{outFile}");
+            argsList.Add($"/out:{outFile}");
             
             // Constant Libs
             foreach (var lib in ConstantLinkLibs)

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/IntermediateCompilation/Windows/WindowsLinkStep.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             { BuildConfiguration.release , new string[] { "msvcrt.lib" } }
         };
         
-        private string ArgStr { get; set; }
+        private IEnumerable<string> Args { get; set; }
         private NativeCompileSettings config;
         
         public WindowsLinkStep(NativeCompileSettings config)
@@ -95,10 +95,14 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             
             //Output
             var outFile = DetermineOutputFile(config);
-            argsList.Add($"/out:\"{outFile}\"");
+            argsList.Add($"/out");
+            argsList.Add($"{outFile}");
             
             // Constant Libs
-            argsList.Add(string.Join(" ", ConstantLinkLibs));
+            foreach (var lib in ConstantLinkLibs)
+            {
+                argsList.Add(lib);
+            }
 
             // ILC SDK Libs
             var SDKLibs = IlcSdkLibMap[config.NativeMode];
@@ -106,19 +110,19 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             foreach (var lib in SDKLibs)
             {
                 var sdkLibPath = Path.Combine(IlcSdkLibPath, lib);
-                argsList.Add($"\"{sdkLibPath}\"");
+                argsList.Add($"{sdkLibPath}");
             }
 
             // Configuration Based Libs
             var configLibs = ConfigurationLinkLibMap[config.BuildType];
             foreach (var lib in configLibs)
             {
-                argsList.Add($"\"{lib}\"");
+                argsList.Add($"{lib}");
             }
 
             // Link Libs
             foreach(var path in config.LinkLibPaths){
-                argsList.Add($"\"{path}\"");
+                argsList.Add($"{path}");
             }
             
             //arch
@@ -126,9 +130,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
             //Input Obj file
             var inputFile = DetermineInputFile(config);
-            argsList.Add($"\"{inputFile}\"");
-            
-            this.ArgStr = string.Join(" ", argsList);
+            argsList.Add($"{inputFile}");
+
+            this.Args = argsList;
         }
         
         private int InvokeLinker()
@@ -136,7 +140,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var vcInstallDir = Environment.GetEnvironmentVariable("VS140COMNTOOLS");
             var linkerPath = Path.Combine(vcInstallDir, VSBin, LinkerName);
             
-            var result = Command.Create(linkerPath, ArgStr)
+            var result = Command.Create(linkerPath, Args.ToArray())
                 .ForwardStdErr()
                 .ForwardStdOut()
                 .Execute();

--- a/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
+++ b/src/Microsoft.DotNet.Tools.Compiler.Native/appdep/project.json
@@ -5,7 +5,7 @@
         "emitEntryPoint": true
     },
     "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1-*",
+        "Microsoft.NETCore.Platforms": "1.0.1-rc2-23704",
         "Microsoft.DotNet.AppDep":"1.0.4-*"
     },
     "frameworks": {

--- a/src/Microsoft.DotNet.Tools.Compiler/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/Program.cs
@@ -149,7 +149,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             //     Need CoreRT Framework published to nuget
 
             // Do Native Compilation
-            var result = Command.Create("dotnet-compile-native", $"--rsp \"{rsp}\"")
+            var result = Command.Create("dotnet-compile-native", new string[] { "--rsp", $"{rsp}" })
                                 .ForwardStdErr()
                                 .ForwardStdOut()
                                 .Execute();
@@ -235,10 +235,10 @@ namespace Microsoft.DotNet.Tools.Compiler
                     references.AddRange(dependency.CompilationAssemblies.Select(r => r.ResolvedPath));
                 }
 
-                compilerArgs.AddRange(dependency.SourceReferences);
+                compilerArgs.AddRange(dependency.SourceReferences.Select(s => $"\"{s}\""));
             }
 
-            compilerArgs.AddRange(references.Select(r => $"--reference:{r}"));
+            compilerArgs.AddRange(references.Select(r => $"--reference:\"{r}\""));
 
             if (compilationOptions.PreserveCompilationContext == true)
             {
@@ -295,7 +295,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             };
             RunScripts(context, ScriptNames.PreCompile, contextVariables);
 
-            var result = Command.Create($"dotnet-compile-{compilerName}", $"@\"{rsp}\"")
+            var result = Command.Create($"dotnet-compile-{compilerName}", new string[] {"@" + $"{rsp}" })
                 .OnErrorLine(line =>
                 {
                     var diagnostic = ParseDiagnostic(context.ProjectDirectory, line);
@@ -420,7 +420,14 @@ namespace Microsoft.DotNet.Tools.Compiler
                 {
                     var result =
                         Command.Create("dotnet-resgen",
-                            $"\"{resgenFile.InputFile}\" -o \"{resgenFile.OutputFile}\" -v \"{project.Version.Version}\"")
+                            new string[]
+                            {
+                                $"{resgenFile.InputFile}",
+                                "-o",
+                                $"{resgenFile.OutputFile}",
+                                "-v",
+                                $"{project.Version.Version}"
+                            })
                             .ForwardStdErr()
                             .ForwardStdOut()
                             .Execute();

--- a/src/Microsoft.DotNet.Tools.Compiler/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/Program.cs
@@ -204,8 +204,8 @@ namespace Microsoft.DotNet.Tools.Compiler
             // Assemble args
             var compilerArgs = new List<string>()
             {
-                $"--temp-output:{intermediateOutputPath}",
-                $"--out:{outputName}"
+                $"--temp-output:\"{intermediateOutputPath}\"",
+                $"--out:\"{outputName}\""
             };
 
             var compilationOptions = CompilerUtil.ResolveCompilationOptions(context, args.ConfigValue);
@@ -255,7 +255,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                     writer.Write(dependencyContext, fileStream);
                 }
 
-                compilerArgs.Add($"--resource:\"{depsJsonFile}\",{context.ProjectFile.Name}.deps.json");
+                compilerArgs.Add($"--resource:\"{depsJsonFile},{context.ProjectFile.Name}.deps.json\"");
 
                 var refsFolder = Path.Combine(outputPath, "refs");
                 if (Directory.Exists(refsFolder))
@@ -437,11 +437,11 @@ namespace Microsoft.DotNet.Tools.Compiler
                         return false;
                     }
 
-                    compilerArgs.Add($"--resource:\"{resgenFile.OutputFile}\",{Path.GetFileName(resgenFile.MetadataName)}");
+                    compilerArgs.Add($"--resource:\"{resgenFile.OutputFile},{Path.GetFileName(resgenFile.MetadataName)}\"");
                 }
                 else
                 {
-                    compilerArgs.Add($"--resource:\"{resgenFile.InputFile}\",{Path.GetFileName(resgenFile.MetadataName)}");
+                    compilerArgs.Add($"--resource:\"{resgenFile.InputFile},{Path.GetFileName(resgenFile.MetadataName)}\"");
                 }
             }
 

--- a/src/Microsoft.DotNet.Tools.Pack/BuildProjectCommand.cs
+++ b/src/Microsoft.DotNet.Tools.Pack/BuildProjectCommand.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Tools.Pack
 {
@@ -39,22 +40,25 @@ namespace Microsoft.DotNet.Tools.Pack
 
             if (_project.Files.SourceFiles.Any())
             {
-                var argsBuilder = new StringBuilder();
-                argsBuilder.Append($"--configuration {_configuration}");
+                var argsBuilder = new List<string>();
+                argsBuilder.Add("--configuration");
+                argsBuilder.Add($"{_configuration}");
 
                 if (!string.IsNullOrEmpty(_artifactPathsCalculator.PackageArtifactsPathParameter))
                 {
-                    argsBuilder.Append($" --output \"{_artifactPathsCalculator.PackageArtifactsPathParameter}\"");
+                    argsBuilder.Add("--output");
+                    argsBuilder.Add($"{_artifactPathsCalculator.PackageArtifactsPathParameter}");
                 }
 
                 if (!string.IsNullOrEmpty(_intermediateOutputPath))
                 {
-                    argsBuilder.Append($" --temp-output \"{_intermediateOutputPath}\"");
+                    argsBuilder.Add("--temp-output");
+                    argsBuilder.Add($"{_intermediateOutputPath}");
                 }
 
-                argsBuilder.Append($" \"{_project.ProjectFilePath}\"");
+                argsBuilder.Add($"{_project.ProjectFilePath}");
 
-                var result = Command.Create("dotnet-build", argsBuilder.ToString())
+                var result = Command.Create("dotnet-build", argsBuilder)
                        .ForwardStdOut()
                        .ForwardStdErr()
                        .Execute();

--- a/src/Microsoft.DotNet.Tools.Publish/PublishCommand.cs
+++ b/src/Microsoft.DotNet.Tools.Publish/PublishCommand.cs
@@ -110,12 +110,17 @@ namespace Microsoft.DotNet.Tools.Publish
             }
 
             // Compile the project (and transitively, all it's dependencies)
-            var result = Command.Create("dotnet-build",
-                $"--framework \"{context.TargetFramework.DotNetFrameworkName}\" " +
-                $"--output \"{outputPath}\" " +
-                $"--configuration \"{configuration}\" " +
-                "--no-host " +
-                $"\"{context.ProjectFile.ProjectDirectory}\"")
+            var result = Command.Create("dotnet-build", 
+                new string[] {
+                    "--framework", 
+                    $"{context.TargetFramework.DotNetFrameworkName}",
+                    "--output", 
+                    $"{outputPath}",
+                    "--configuration", 
+                    $"{configuration}",
+                    "--no-host",
+                    $"{context.ProjectFile.ProjectDirectory}"
+                })
                 .ForwardStdErr()
                 .ForwardStdOut()
                 .Execute();

--- a/src/Microsoft.DotNet.Tools.Repl.Csi/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Repl.Csi/Program.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
-using System.Text;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
@@ -60,10 +59,21 @@ namespace Microsoft.DotNet.Tools.Repl.Csi
             Reporter.Output.WriteLine($"Compiling {projectContext.RootProject.Identity.Name.Yellow()} for {projectContext.TargetFramework.DotNetFrameworkName.Yellow()} to use with the {"C# REPL".Yellow()} environment.");
 
             // --temp-output is actually the intermediate output folder and can be the same as --output for our temporary compilation (`dotnet run` can be seen doing the same)
-            return Command.Create($"dotnet-build", $"--output \"{tempOutputDir}\" --temp-output \"{tempOutputDir}\" --framework \"{projectContext.TargetFramework}\" --configuration \"{configuration}\" \"{projectContext.ProjectDirectory}\"")
-                                .ForwardStdOut(onlyIfVerbose: true)
-                                .ForwardStdErr()
-                                .Execute();
+            return Command.Create($"dotnet-build", new [] 
+                {
+                    $"--output",
+                    $"{tempOutputDir}",
+                    $"--temp-output",
+                    $"{tempOutputDir}",
+                    $"--framework",
+                    $"{projectContext.TargetFramework}",
+                    $"--configuration",
+                    $"{configuration}",
+                    $"{projectContext.ProjectDirectory}"
+                })
+                .ForwardStdOut(onlyIfVerbose: true)
+                .ForwardStdErr()
+                .Execute();
         }
 
         private static IEnumerable<string> GetRuntimeDependencies(ProjectContext projectContext, string buildConfiguration)
@@ -148,7 +158,7 @@ namespace Microsoft.DotNet.Tools.Repl.Csi
                     }
 
                     string responseFile = CreateResponseFile(projectContext, buildConfiguration, tempOutputDir);
-                    csiArgs.Add($"@\"{responseFile}\"");
+                    csiArgs.Add($"@{responseFile}");
                 }
 
                 if (string.IsNullOrEmpty(script) && !remainingArguments.Any())

--- a/src/Microsoft.DotNet.Tools.Run/RunCommand.cs
+++ b/src/Microsoft.DotNet.Tools.Run/RunCommand.cs
@@ -90,7 +90,18 @@ namespace Microsoft.DotNet.Tools.Run
             var tempDir = Path.Combine(_context.ProjectDirectory, "bin", ".dotnetrun", Guid.NewGuid().ToString("N"));
 
             // Compile to that directory
-            var result = Command.Create($"dotnet-build", $"--output \"{tempDir}\" --temp-output \"{tempDir}\" --framework \"{_context.TargetFramework}\" --configuration \"{Configuration}\" {_context.ProjectFile.ProjectDirectory}")
+            var result = Command.Create($"dotnet-build", new []
+                {
+                    $"--output",
+                    $"{tempDir}",
+                    $"--temp-output",
+                    $"{tempDir}",
+                    $"--framework",
+                    $"{_context.TargetFramework}",
+                    $"--configuration",
+                    $"{Configuration}",
+                    $"{_context.ProjectFile.ProjectDirectory}"
+                })
                 .ForwardStdOut(onlyIfVerbose: true)
                 .ForwardStdErr()
                 .Execute();
@@ -132,7 +143,7 @@ namespace Microsoft.DotNet.Tools.Run
                 }
             }
 
-            result = Command.Create(outputName, string.Join(" ", _args))
+            result = Command.Create(outputName, _args)
                 .ForwardStdOut()
                 .ForwardStdErr()
                 .EnvironmentVariable("DOTNET_HOME", runtime)
@@ -149,7 +160,7 @@ namespace Microsoft.DotNet.Tools.Run
 
         private static int RunInteractive(string scriptName)
         {
-            var command = Command.Create($"dotnet-repl-csi", scriptName)
+            var command = Command.Create($"dotnet-repl-csi", new [] {scriptName})
                 .ForwardStdOut()
                 .ForwardStdErr();
             var result = command.Execute();

--- a/src/Microsoft.DotNet.Tools.Test/project.json
+++ b/src/Microsoft.DotNet.Tools.Test/project.json
@@ -14,9 +14,12 @@
     "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23704",
     "System.Diagnostics.TraceSource": "4.0.0-rc2-23704",
+
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23616",
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-23616",
+    
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
+    "Microsoft.Extensions.Testing.Abstractions": "1.0.0-*",
     "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
       "version": "1.0.0-*",
       "type": "build"
@@ -25,21 +28,14 @@
       "version": "1.0.0-*",
       "type": "build"
     },
-    "Microsoft.Extensions.Testing.Abstractions": {
-      "version": "1.0.0-*",
-      "type": "build"
-    },
     "Microsoft.Extensions.CommandLineUtils.Sources": {
       "version": "1.0.0-*",
       "type": "build"
     },
-    "Microsoft.Extensions.Logging": "1.0.0-rc2-15935",
-    "Newtonsoft.Json": "7.0.1"
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-16023"
   },
   "frameworks": {
     "dnxcore50": {
     }
-  },
-  "scripts": {
   }
 }

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
-    "Microsoft.DotNet.ProjectModel": {"target":"project"},
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-15935",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-16023",
     "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Resources.ResourceManager": "4.0.1-rc2-23704",
     "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23704"
@@ -20,7 +20,5 @@
   "frameworks": {
     "dnxcore50": {
     }
-  },
-  "scripts": {
   }
 }

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-16023",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-16011",
     "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Resources.ResourceManager": "4.0.1-rc2-23704",
     "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23704"

--- a/src/dotnet-restore/Program.cs
+++ b/src/dotnet-restore/Program.cs
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Tools.Restore
             Console.WriteLine($"Restoring Tool '{tooldep.Name}' for '{projectPath}' in '{tempPath}'");
 
             File.WriteAllText(projectPath, GenerateProjectJsonContents(new[] {"dnxcore50"}, tooldep));
-            NuGet3.Restore(new [] { $"\"{projectPath}\"", "--runtime", $"{DefaultRid}"}.Concat(args), quiet);
+            NuGet3.Restore(new [] { $"{projectPath}", "--runtime", $"{DefaultRid}"}.Concat(args), quiet);
         }
 
         private static string GenerateProjectJsonContents(IEnumerable<string> frameworks, LibraryRange tooldep)

--- a/src/dotnet-restore/project.json
+++ b/src/dotnet-restore/project.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "NuGet.CommandLine.XPlat": "3.4.0-beta-517",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23704",
-    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23704",
     "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Linq.Expressions": "4.0.11-rc2-23704",
     "Microsoft.DotNet.Cli.Utils": {"target":"project"},
@@ -26,7 +25,7 @@
       "version": "1.0.0-*",
       "type": "build"
     },
-    "Microsoft.Extensions.Logging": "1.0.0-rc2-15935",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-16010",
     "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {

--- a/src/dotnet-restore/project.json
+++ b/src/dotnet-restore/project.json
@@ -16,8 +16,8 @@
     "Microsoft.NETCore.TestHost": "1.0.0-rc2-23704",
     "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Linq.Expressions": "4.0.11-rc2-23704",
-    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
+    "Microsoft.DotNet.Cli.Utils": {"target":"project"},
+    "Microsoft.DotNet.Compiler.Common": {"target":"project"},
     "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
       "version": "1.0.0-*",
       "type": "build"

--- a/src/dotnet-restore/project.json
+++ b/src/dotnet-restore/project.json
@@ -13,10 +13,11 @@
   "dependencies": {
     "NuGet.CommandLine.XPlat": "3.4.0-beta-517",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23704",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23704",
     "NETStandard.Library": "1.0.0-rc2-23704",
     "System.Linq.Expressions": "4.0.11-rc2-23704",
-    "Microsoft.DotNet.Cli.Utils": {"target":"project"},
-    "Microsoft.DotNet.Compiler.Common": {"target":"project"},
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
+    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
       "version": "1.0.0-*",
       "type": "build"

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests/ArgumentForwardingTests.cs
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests/ArgumentForwardingTests.cs
@@ -106,6 +106,11 @@ namespace Microsoft.DotNet.Tests.ArgumentForwarding
         [InlineData(@"a\""b \\ cd ""\e f\"" \\""\\\")]
         public void TestArgumentForwardingCmd(string testUserArgument)
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
             // Get Baseline Argument Evaluation via Reflector
             // This does not need to be different for cmd because
             // it only establishes what the string[] args should be

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests/ArgumentForwardingTests.cs
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests/ArgumentForwardingTests.cs
@@ -1,0 +1,257 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.Extensions.PlatformAbstractions;
+using System.Diagnostics;
+using FluentAssertions;
+
+namespace Microsoft.DotNet.Tests.ArgumentForwarding
+{
+    public class ArgumentForwardingTests : TestBase
+    {
+        private static readonly string s_reflectorExeName = "reflector" + Constants.ExeSuffix;
+        private static readonly string s_reflectorCmdName = "reflector_cmd";
+
+        private string ReflectorPath { get; set; }
+        private string ReflectorCmdPath { get; set; }
+
+        public static void Main()
+        {
+            Console.WriteLine("Dummy Entrypoint.");
+        }
+       
+        public ArgumentForwardingTests()
+        {
+            // This test has a dependency on an argument reflector
+            // Make sure it's been binplaced properly
+            FindAndEnsureReflectorPresent();
+        }
+
+        private void FindAndEnsureReflectorPresent()
+        {
+            ReflectorPath = Path.Combine(AppContext.BaseDirectory, s_reflectorExeName);
+            ReflectorCmdPath = Path.Combine(AppContext.BaseDirectory, s_reflectorCmdName);
+            File.Exists(ReflectorPath).Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Tests argument forwarding in Command.Create
+        /// This is a critical scenario for the driver.
+        /// </summary>
+        /// <param name="testUserArgument"></param>
+        [Theory]
+        [InlineData(@"""abc"" d e")]
+        [InlineData(@"""abc""      d e")]
+        [InlineData("\"abc\"\t\td\te")]
+        [InlineData(@"a\\b d""e f""g h")]
+        [InlineData(@"\ \\ \\\")]
+        [InlineData(@"a\""b c d")]
+        [InlineData(@"a\\""b c d")]
+        [InlineData(@"a\\\""b c d")]
+        [InlineData(@"a\\\\""b c d")]
+        [InlineData(@"a\\\\""b c d")]
+        [InlineData(@"a\\\\""b c"" d e")]
+        [InlineData(@"a""b c""d e""f g""h i""j k""l")]
+        [InlineData(@"a b c""def")]
+        [InlineData(@"""\a\"" \\""\\\ b c")]
+        [InlineData(@"a\""b \\ cd ""\e f\"" \\""\\\")]
+        public void TestArgumentForwarding(string testUserArgument)
+        {
+            // Get Baseline Argument Evaluation via Reflector
+            var rawEvaluatedArgument = RawEvaluateArgumentString(testUserArgument);
+
+            // Escape and Re-Evaluate the rawEvaluatedArgument
+            var escapedEvaluatedRawArgument = EscapeAndEvaluateArgumentString(rawEvaluatedArgument);
+
+            rawEvaluatedArgument.Length.Should().Be(escapedEvaluatedRawArgument.Length);
+
+            for (int i=0; i<rawEvaluatedArgument.Length; ++i)
+            {
+                var rawArg = rawEvaluatedArgument[i];
+                var escapedArg = escapedEvaluatedRawArgument[i];
+
+                rawArg.Should().Be(escapedArg);
+            }
+        }
+
+        /// <summary>
+        /// Tests argument forwarding in Command.Create to a cmd file
+        /// This is a critical scenario for the driver.
+        /// </summary>
+        /// <param name="testUserArgument"></param>
+        [Theory]
+        [InlineData(@"""abc"" d e")]
+        [InlineData(@"""abc""      d e")]
+        [InlineData("\"abc\"\t\td\te")]
+        [InlineData(@"a\\b d""e f""g h")]
+        [InlineData(@"\ \\ \\\")]
+        [InlineData(@"a\""b c d")]
+        [InlineData(@"a\\""b c d")]
+        [InlineData(@"a\\\""b c d")]
+        [InlineData(@"a\\\\""b c d")]
+        [InlineData(@"a\\\\""b c d")]
+        [InlineData(@"a\\\\""b c"" d e")]
+        [InlineData(@"a""b c""d e""f g""h i""j k""l")]
+        [InlineData(@"a b c""def")]
+        [InlineData(@"""\a\"" \\""\\\ b c")]
+        [InlineData(@"a\""b \\ cd ""\e f\"" \\""\\\")]
+        public void TestArgumentForwardingCmd(string testUserArgument)
+        {
+            // Get Baseline Argument Evaluation via Reflector
+            // This does not need to be different for cmd because
+            // it only establishes what the string[] args should be
+            var rawEvaluatedArgument = RawEvaluateArgumentString(testUserArgument);
+
+            // Escape and Re-Evaluate the rawEvaluatedArgument
+            var escapedEvaluatedRawArgument = EscapeAndEvaluateArgumentStringCmd(rawEvaluatedArgument);
+
+            try
+            {
+                rawEvaluatedArgument.Length.Should().Be(escapedEvaluatedRawArgument.Length);
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine("Argument Lists differ in length.");
+
+                var expected = string.Join(",", rawEvaluatedArgument);
+                var actual = string.Join(",", escapedEvaluatedRawArgument);
+                Console.WriteLine($"Expected: {expected}");
+                Console.WriteLine($"Actual: {actual}");
+
+                throw e;
+            }
+
+            for (int i = 0; i < rawEvaluatedArgument.Length; ++i)
+            {
+                var rawArg = rawEvaluatedArgument[i];
+                var escapedArg = escapedEvaluatedRawArgument[i];
+                
+                try
+                {
+                    rawArg.Should().Be(escapedArg);
+                }
+                catch(Exception e)
+                {
+                    Console.WriteLine($"Expected: {rawArg}");
+                    Console.WriteLine($"Actual: {escapedArg}");
+                    throw e;
+                }
+            }
+        }
+
+        /// <summary>
+        /// EscapeAndEvaluateArgumentString returns a representation of string[] args
+        /// when rawEvaluatedArgument is passed as an argument to a process using
+        /// Command.Create(). Ideally this should escape the argument such that 
+        /// the output is == rawEvaluatedArgument.
+        /// </summary>
+        /// <param name="rawEvaluatedArgument">A string[] representing string[] args as already evaluated by a process</param>
+        /// <returns></returns>
+        private string[] EscapeAndEvaluateArgumentString(string[] rawEvaluatedArgument)
+        {
+            var commandResult = Command.Create(ReflectorPath, rawEvaluatedArgument)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute();
+
+            commandResult.ExitCode.Should().Be(0);
+
+            return ParseReflectorOutput(commandResult.StdOut);
+        }
+
+        /// <summary>
+        /// EscapeAndEvaluateArgumentString returns a representation of string[] args
+        /// when rawEvaluatedArgument is passed as an argument to a process using
+        /// Command.Create(). Ideally this should escape the argument such that 
+        /// the output is == rawEvaluatedArgument.
+        /// </summary>
+        /// <param name="rawEvaluatedArgument">A string[] representing string[] args as already evaluated by a process</param>
+        /// <returns></returns>
+        private string[] EscapeAndEvaluateArgumentStringCmd(string[] rawEvaluatedArgument)
+        {
+            var cmd = Command.Create(s_reflectorCmdName, rawEvaluatedArgument);
+            var commandResult = cmd
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute();
+
+            Console.WriteLine(commandResult.StdOut);
+            Console.WriteLine(commandResult.StdErr);
+
+            commandResult.ExitCode.Should().Be(0);
+
+            return ParseReflectorCmdOutput(commandResult.StdOut);
+        }
+
+        /// <summary>
+        /// Parse the output of the reflector into a string array.
+        /// Reflector output is simply string[] args written to 
+        /// one string separated by commas.
+        /// </summary>
+        /// <param name="reflectorOutput"></param>
+        /// <returns></returns>
+        private string[] ParseReflectorOutput(string reflectorOutput)
+        {
+            return reflectorOutput.Split(',');
+        }
+
+        /// <summary>
+        /// Parse the output of the reflector into a string array.
+        /// Reflector output is simply string[] args written to 
+        /// one string separated by commas.
+        /// </summary>
+        /// <param name="reflectorOutput"></param>
+        /// <returns></returns>
+        private string[] ParseReflectorCmdOutput(string reflectorOutput)
+        {
+            var args = reflectorOutput.Split(new string[] { "," }, StringSplitOptions.None);
+            args[args.Length-1] = args[args.Length-1].TrimEnd('\r', '\n');
+
+            // To properly pass args to cmd, quotes inside a parameter are doubled
+            // Count them as a single quote for our comparison.
+            for (int i=0; i < args.Length; ++i)
+            {
+                args[i] = args[i].Replace(@"""""", @"""");
+            }
+            return args;
+        }
+
+        /// <summary>
+        /// RawEvaluateArgumentString returns a representation of string[] args
+        /// when testUserArgument is provided (unmodified) as arguments to a c#
+        /// process.
+        /// </summary>
+        /// <param name="testUserArgument">A test argument representing what a "user" would provide to a process</param>
+        /// <returns>A string[] representing string[] args with the provided testUserArgument</returns>
+        private string[] RawEvaluateArgumentString(string testUserArgument)
+        {
+            var proc = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = s_reflectorExeName,
+                    Arguments = testUserArgument,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    CreateNoWindow = true
+                }
+            };
+
+            proc.Start();
+            var stdOut = proc.StandardOutput.ReadToEnd();
+
+            Assert.Equal(0, proc.ExitCode);
+
+            return ParseReflectorOutput(stdOut);
+        }
+    }
+}

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests/ArgumentForwardingTests.xproj
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests/ArgumentForwardingTests.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.24720" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>6973e08d-11ec-49dc-82ef-d5effec7c6e9</ProjectGuid>
+    <RootNamespace>Microsoft.DotNet.Tests.ArgumentForwarding</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests/project.json
@@ -10,7 +10,7 @@
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",
-        "xunit.netcore.extensions": "1.0.0-prerelease-*",
+        "xunit.netcore.extensions": "1.0.0-prerelease-00153",
         "xunit.runner.utility": "2.1.0",
 
         "Microsoft.DotNet.ProjectModel": { "target": "project" },

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests/project.json
@@ -1,0 +1,24 @@
+﻿{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "NETStandard.Library" : "1.0.0-rc2-23706",
+        "Microsoft.NETCore.TestHost": "1.0.0-rc2-23706",
+
+        "xunit": "2.1.0",
+        "xunit.console.netcore": "1.0.2-prerelease-00101",
+        "xunit.netcore.extensions": "1.0.0-prerelease-*",
+        "xunit.runner.utility": "2.1.0",
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" },
+        "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" }
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests/project.json
@@ -5,8 +5,8 @@
     },
 
     "dependencies": {
-        "NETStandard.Library" : "1.0.0-rc2-23706",
-        "Microsoft.NETCore.TestHost": "1.0.0-rc2-23706",
+        "NETStandard.Library" : "1.0.0-rc2-23714",
+        "Microsoft.NETCore.TestHost": "1.0.0-rc2-23714",
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",

--- a/test/ArgumentForwardingTests/Reflector/Reflector.cs
+++ b/test/ArgumentForwardingTests/Reflector/Reflector.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.Extensions.PlatformAbstractions;
+using System.Diagnostics;
+using FluentAssertions;
+
+namespace Microsoft.DotNet.Tests.ArgumentForwarding
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            bool first=true;
+            foreach (var arg in args)
+            {
+                if (first)
+                {
+                    first=false;
+                }
+                else
+                {
+                    Console.Write(",");
+                }
+                Console.Write(arg);
+            }
+        }
+    }
+}

--- a/test/ArgumentForwardingTests/Reflector/Reflector.xproj
+++ b/test/ArgumentForwardingTests/Reflector/Reflector.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.24720" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>6f2e6f25-b43b-495d-9ca5-7f207d1dd604</ProjectGuid>
+    <RootNamespace>Microsoft.DotNet.Tests.ArgumentForwarding</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/ArgumentForwardingTests/Reflector/project.json
+++ b/test/ArgumentForwardingTests/Reflector/project.json
@@ -10,7 +10,7 @@
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",
-        "xunit.netcore.extensions": "1.0.0-prerelease-*",
+        "xunit.netcore.extensions": "1.0.0-prerelease-00153",
         "xunit.runner.utility": "2.1.0",
 
         "Microsoft.DotNet.ProjectModel": { "target": "project" },

--- a/test/ArgumentForwardingTests/Reflector/project.json
+++ b/test/ArgumentForwardingTests/Reflector/project.json
@@ -1,0 +1,24 @@
+﻿{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "NETStandard.Library" : "1.0.0-rc2-23706",
+        "Microsoft.NETCore.TestHost": "1.0.0-rc2-23706",
+
+        "xunit": "2.1.0",
+        "xunit.console.netcore": "1.0.2-prerelease-00101",
+        "xunit.netcore.extensions": "1.0.0-prerelease-*",
+        "xunit.runner.utility": "2.1.0",
+
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
+        "Microsoft.DotNet.Cli.Utils": { "target": "project" },
+        "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" }
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/test/ArgumentForwardingTests/Reflector/reflector_cmd.cmd
+++ b/test/ArgumentForwardingTests/Reflector/reflector_cmd.cmd
@@ -1,0 +1,19 @@
+@echo off
+set ALL_ARGS=
+set a=%1
+if not defined a goto :doneSetArgs
+
+set ALL_ARGS=%~1%
+shift
+
+:setArgs
+set a=%1
+if not defined a goto :doneSetArgs
+
+set ALL_ARGS=%ALL_ARGS%,%~1%
+shift
+goto setArgs
+
+:doneSetArgs
+echo %ALL_ARGS%
+goto :EOF

--- a/test/E2E/E2E.xproj
+++ b/test/E2E/E2E.xproj
@@ -7,7 +7,7 @@
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>65741cb1-8aee-4c66-8198-10a7ea0e4258</ProjectGuid>
-    <RootNamespace>E2E</RootNamespace>
+    <RootNamespace>Microsoft.DotNet.Tests.EndToEnd</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>

--- a/test/E2E/EndToEndTest.cs
+++ b/test/E2E/EndToEndTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
     {
         private static readonly string s_expectedOutput = "Hello World!" + Environment.NewLine;
         private static readonly string s_testdirName = "e2etestroot";
-        private static readonly string s_outputdirName = "testbin";
+        private static readonly string s_outputdirName = "test space/bin";
         
         private string Rid { get; set; }
         private string TestDirectory { get; set; }
@@ -51,8 +51,6 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         [Fact]
         public void TestDotnetIncrementalBuild()
         {
-            TestSetup();
-
             // first build
             var buildCommand = new BuildCommand(TestProject, output: OutputDirectory);
             buildCommand.Execute().Should().Pass();

--- a/test/E2E/project.json
+++ b/test/E2E/project.json
@@ -5,11 +5,12 @@
     },
 
     "dependencies": {
-        "NETStandard.Library" : "1.0.0-rc2-23714",
+        "NETStandard.Library" : "1.0.0-rc2-23704",
+        "Microsoft.NETCore.TestHost" : "1.0.0-rc2-23704",
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",
-        "xunit.netcore.extensions": "1.0.0-prerelease-*",
+        "xunit.netcore.extensions": "1.0.0-prerelease-00153",
         "xunit.runner.utility": "2.1.0",
 
         "Microsoft.DotNet.ProjectModel": {"target":"project"},

--- a/test/E2E/project.json
+++ b/test/E2E/project.json
@@ -5,13 +5,12 @@
     },
 
     "dependencies": {
-        "NETStandard.Library" : "1.0.0-rc2-23706",
+        "NETStandard.Library" : "1.0.0-rc2-23714",
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",
         "xunit.netcore.extensions": "1.0.0-prerelease-*",
         "xunit.runner.utility": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-*",
 
         "Microsoft.DotNet.ProjectModel": {"target":"project"},
         "Microsoft.DotNet.Cli.Utils": {"target":"project"},

--- a/test/E2E/project.json
+++ b/test/E2E/project.json
@@ -5,19 +5,21 @@
     },
 
     "dependencies": {
-        "NETStandard.Library" : "1.0.0-rc2-23704",
+        "NETStandard.Library" : "1.0.0-rc2-23706",
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",
         "xunit.netcore.extensions": "1.0.0-prerelease-*",
         "xunit.runner.utility": "2.1.0",
+        "dotnet-test-xunit": "1.0.0-dev-*",
 
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-        "Microsoft.DotNet.Tools.Tests.Utilities": "1.0.0-*"
+        "Microsoft.DotNet.ProjectModel": {"target":"project"},
+        "Microsoft.DotNet.Cli.Utils": {"target":"project"},
+        "Microsoft.DotNet.Tools.Tests.Utilities": {"target":"project"}
     },
 
     "frameworks": {
         "dnxcore50": { }
-    }
+    }, 
+    "testRunner":"xunit"
 }

--- a/test/FSharpTestProjects/CompileFail/project.json
+++ b/test/FSharpTestProjects/CompileFail/project.json
@@ -9,9 +9,9 @@
     ],
     "dependencies": {
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "Microsoft.NETCore.ConsoleHost": "1.0.0-23428",
-        "Microsoft.NETCore.Runtime": "1.0.1-23428",
-        "System.Console": "4.0.0-beta-23109"
+        "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23704",
+        "Microsoft.NETCore.Runtime": "1.0.1-rc2-23704",
+        "System.Console": "4.0.0-rc2-23704"
     },
 
     "frameworks": {

--- a/test/LoadContextTest/project.json
+++ b/test/LoadContextTest/project.json
@@ -15,7 +15,7 @@
 
         "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16530",
 
-        "Microsoft.DotNet.ProjectModel.Loader": "1.0.0-*"
+        "Microsoft.DotNet.ProjectModel.Loader": {"target":"project"}
     },
 
     "frameworks": {

--- a/test/Microsoft.DotNet.ProjectModel.Server.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Server.Tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23704",
+    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23706",
     "Microsoft.DotNet.ProjectModel": {"target":"project"},
     "Microsoft.DotNet.ProjectModel.Server": {"target":"project"},
     "Newtonsoft.Json": "7.0.1",

--- a/test/Microsoft.DotNet.Tools.Builder.Tests/IncrementalTestBase.cs
+++ b/test/Microsoft.DotNet.Tools.Builder.Tests/IncrementalTestBase.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
         protected static void AssertProjectSkipped(string skippedProject, CommandResult buildResult)
         {
-            Assert.Contains($"Project {skippedProject} was previoulsy compiled. Skipping compilation.", buildResult.StdOut);
+            Assert.Contains($"Project {skippedProject} was previously compiled. Skipping compilation.", buildResult.StdOut);
         }
 
         protected static void AssertProjectCompiled(string rebuiltProject, CommandResult buildResult)

--- a/test/Microsoft.DotNet.Tools.Builder.Tests/project.json
+++ b/test/Microsoft.DotNet.Tools.Builder.Tests/project.json
@@ -3,11 +3,11 @@
   
   "dependencies": {
     "NETStandard.Library": "1.0.0-rc2-23704",
-    "Microsoft.NETCore.TestHost" : "1.0.0-*",
+    "Microsoft.NETCore.TestHost" : "1.0.0-rc2-23704",
 
     "xunit": "2.1.0",
     "xunit.console.netcore": "1.0.2-prerelease-00101",
-    "xunit.netcore.extensions": "1.0.0-prerelease-*",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00153",
     "xunit.runner.utility": "2.1.0",
 
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },

--- a/test/Microsoft.DotNet.Tools.Compiler.Tests/project.json
+++ b/test/Microsoft.DotNet.Tools.Compiler.Tests/project.json
@@ -5,9 +5,12 @@
     "NETStandard.Library": "1.0.0-rc2-23704",
     "Microsoft.NETCore.TestHost" : "1.0.0-*",
 
+    "NETStandard.Library": "1.0.0-rc2-23704",
+    "Microsoft.NETCore.TestHost" : "1.0.0-rc2-23704",
+
     "xunit": "2.1.0",
     "xunit.console.netcore": "1.0.2-prerelease-00101",
-    "xunit.netcore.extensions": "1.0.0-prerelease-*",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00153",
     "xunit.runner.utility": "2.1.0",
 
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },

--- a/test/Microsoft.DotNet.Tools.Publish.Tests/Microsoft.DotNet.Tools.Publish.Tests.cs
+++ b/test/Microsoft.DotNet.Tools.Publish.Tests/Microsoft.DotNet.Tools.Publish.Tests.cs
@@ -175,6 +175,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
         }
 
         [Fact]
+        [ActiveIssue(982)]
         public void PublishScriptsRun()
         {
             // create unique directories in the 'temp' folder

--- a/test/Microsoft.DotNet.Tools.Publish.Tests/Microsoft.DotNet.Tools.Publish.Tests.cs
+++ b/test/Microsoft.DotNet.Tools.Publish.Tests/Microsoft.DotNet.Tools.Publish.Tests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
                     new object[] { "", PlatformServices.Default.Runtime.GetLegacyRestoreRuntimeIdentifier(), "", "" },
                     new object[] { "", "", "Release", "" },
                     new object[] { "", "", "", "some/dir"},
-                    //new object[] { "", "", "", "\"some/dir/with spaces\"" }, // issue - https://github.com/dotnet/cli/issues/525
+                    new object[] { "", "", "", "some/dir/with spaces" }, 
                     new object[] { "dnxcore50", PlatformServices.Default.Runtime.GetLegacyRestoreRuntimeIdentifier(), "Debug", "some/dir" },
                 };
             }

--- a/test/Microsoft.DotNet.Tools.Publish.Tests/project.json
+++ b/test/Microsoft.DotNet.Tools.Publish.Tests/project.json
@@ -2,9 +2,9 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23704",
-    "Microsoft.NETCore.TestHost": "1.0.0-rc2-*",
-    "System.Text.RegularExpressions": "4.0.11-*",
+    "NETStandard.Library": "1.0.0-rc2-23706",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23706",
+    "System.Text.RegularExpressions": "4.0.11-rc2-23706",
 
     "xunit": "2.1.0",
     "xunit.console.netcore": "1.0.2-prerelease-00101",

--- a/test/Microsoft.DotNet.Tools.Publish.Tests/project.json
+++ b/test/Microsoft.DotNet.Tools.Publish.Tests/project.json
@@ -8,7 +8,7 @@
 
     "xunit": "2.1.0",
     "xunit.console.netcore": "1.0.2-prerelease-00101",
-    "xunit.netcore.extensions": "1.0.0-prerelease-*",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00153",
     "xunit.runner.utility": "2.1.0",
 
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             {
                 return _outputDirectory == string.Empty ?
                                            "" :
-                                           $"-o {_outputDirectory}";
+                                           $"-o \"{_outputDirectory}\"";
             }
         }
 
@@ -214,7 +214,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         private string BuildArgs()
         {
-            return $"{BuildProfile} {ForceIncrementalUnsafe} {_projectPath} {OutputOption} {TempOutputOption} {ConfigurationOption} {NoHostOption} {NativeOption} {ArchitectureOption} {IlcArgsOption} {IlcPathOption} {AppDepSDKPathOption} {NativeCppModeOption} {CppCompilerFlagsOption}";
+            return $"{BuildProfile} {ForceIncrementalUnsafe} \"{_projectPath}\" {OutputOption} {TempOutputOption} {ConfigurationOption} {NoHostOption} {NativeOption} {ArchitectureOption} {IlcArgsOption} {IlcPathOption} {AppDepSDKPathOption} {NativeCppModeOption} {CppCompilerFlagsOption}";
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PackCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PackCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             {
                 return _outputDirectory == string.Empty ?
                                            "" :
-                                           $"-o {_outputDirectory}";
+                                           $"-o \"{_outputDirectory}\"";
             }
         }
 

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         private string GetOutputOption()
         {
-            return string.IsNullOrEmpty(_output) ? "" : $"-o {_output}";
+            return string.IsNullOrEmpty(_output) ? "" : $"-o \"{_output}\"";
         }
 
         private string GetConfigOption()

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RunCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RunCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             {
                 return _projectPath == string.Empty ?
                                        "" :
-                                       $"-p {_projectPath}";
+                                       $"-p \"{_projectPath}\"";
             }
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             get
             {
                 return _preserveTemporary ?
-                                       $"-t {_projectPath}" :
+                                       $"-t \"{_projectPath}\"" :
                                        "";
             }
         }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -4,6 +4,7 @@
 using Microsoft.DotNet.Cli.Utils;
 using System;
 using System.Diagnostics;
+using System.IO;
 
 
 namespace Microsoft.DotNet.Tools.Test.Utilities
@@ -19,10 +20,14 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         public virtual CommandResult Execute(string args = "")
         {
-            Console.WriteLine($"Executing - {_command} {args}");
+            var commandPath = _command;
+            if (!Path.IsPathRooted(_command))
+            {
+                _command = Env.GetCommandPath(_command) ??
+                           Env.GetCommandPathFromAppBase(AppContext.BaseDirectory, _command);
+            }
 
-            var commandPath = Env.GetCommandPath(_command) ??
-                Env.GetCommandPathFromAppBase(AppContext.BaseDirectory, _command);
+            Console.WriteLine($"Executing - {_command} {args}");
 
             var stdOut = new StreamForwarder();
             var stdErr = new StreamForwarder();

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -44,10 +44,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
             var commandPath = Env.GetCommandPath(_command, ".exe", ".cmd", "") ??
                 Env.GetCommandPathFromAppBase(AppContext.BaseDirectory, _command, ".exe", ".cmd", "");
-
-            Console.Write("command");
-            Console.WriteLine(commandPath);
-
+                
             var stdOut = new StreamForwarder();
             var stdErr = new StreamForwarder();
 

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Cli.Utils;
 using System;
+using System.Diagnostics;
 
 
 namespace Microsoft.DotNet.Tools.Test.Utilities
@@ -19,23 +20,69 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         public virtual CommandResult Execute(string args = "")
         {
             Console.WriteLine($"Executing - {_command} {args}");
-            var commandResult = Command.Create(_command, args)
-                .ForwardStdErr()
-                .ForwardStdOut()
-                .Execute();
 
-            return commandResult;
+            var commandPath = Env.GetCommandPath(_command) ??
+                Env.GetCommandPathFromAppBase(AppContext.BaseDirectory, _command);
+
+            var stdOut = new StreamForwarder();
+            var stdErr = new StreamForwarder();
+
+            stdOut.ForwardTo(write: Reporter.Output.Write, writeLine: Reporter.Output.WriteLine);
+            stdErr.ForwardTo(write: Reporter.Error.Write, writeLine: Reporter.Output.WriteLine);
+
+            return RunProcess(commandPath, args, stdOut, stdErr);
         }
 
         public virtual CommandResult ExecuteWithCapturedOutput(string args = "")
         {
             Console.WriteLine($"Executing (Captured Output) - {_command} {args}");
-            var commandResult = Command.Create(_command, args)
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute();
 
-            return commandResult;
+            var commandPath = Env.GetCommandPath(_command, ".exe", ".cmd", "") ??
+                Env.GetCommandPathFromAppBase(AppContext.BaseDirectory, _command, ".exe", ".cmd", "");
+
+            Console.Write("command");
+            Console.WriteLine(commandPath);
+
+            var stdOut = new StreamForwarder();
+            var stdErr = new StreamForwarder();
+
+            stdOut.Capture();
+            stdErr.Capture();
+
+            return RunProcess(commandPath, args, stdOut, stdErr);
+        }
+
+        private CommandResult RunProcess(string executable, string args, StreamForwarder stdOut, StreamForwarder stdErr)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = executable,
+                Arguments = args,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true
+            };
+
+            var process = new Process
+            {
+                StartInfo = psi
+            };
+
+            process.EnableRaisingEvents = true;
+            process.Start();
+
+            var threadOut = stdOut.BeginRead(process.StandardOutput);
+            var threadErr = stdErr.BeginRead(process.StandardError);
+
+            process.WaitForExit();
+            threadOut.Join();
+            threadErr.Join();
+
+            var result = new CommandResult(
+                process.ExitCode, 
+                stdOut.GetCapturedOutput(), 
+                stdErr.GetCapturedOutput());
+
+            return result;
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -3,18 +3,18 @@
   "description": "Microsoft.DotNet.Tools.Tests.Utilities Class Library",
 
   "dependencies": {
-    "System.Collections": "4.0.11-*",
-    "System.Collections.Immutable": "1.1.38-*",
-    "System.Linq": "4.0.1-*",
-    "System.Threading": "4.0.11-*",
-    "System.IO.FileSystem": "4.0.1-*",
-    "System.IO": "4.0.11-*",
-    "System.Runtime.InteropServices": "4.0.21-*",
-    "System.Text.RegularExpressions": "4.0.11-*",
+    "System.Collections": "4.0.11-rc2-*",
+    "System.Collections.Immutable": "1.1.38-rc2-*",
+    "System.Linq": "4.0.1-rc2-*",
+    "System.Threading": "4.0.11-rc2-*",
+    "System.IO.FileSystem": "4.0.1-rc2-*",
+    "System.IO": "4.0.11-rc2-*",
+    "System.Runtime.InteropServices": "4.0.21-rc2-*",
+    "System.Text.RegularExpressions": "4.0.11-rc2-*",
     "FluentAssertions": "4.0.0",
     "xunit": "2.1.0",
 
-    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
+    "Microsoft.DotNet.Cli.Utils": {"target":"project"},
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16530"
   },
 
@@ -23,3 +23,4 @@
     "dnxcore50": { }
   }
 }
+

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -3,14 +3,14 @@
   "description": "Microsoft.DotNet.Tools.Tests.Utilities Class Library",
 
   "dependencies": {
-    "System.Collections": "4.0.11-rc2-*",
-    "System.Collections.Immutable": "1.1.38-rc2-*",
-    "System.Linq": "4.0.1-rc2-*",
-    "System.Threading": "4.0.11-rc2-*",
-    "System.IO.FileSystem": "4.0.1-rc2-*",
-    "System.IO": "4.0.11-rc2-*",
-    "System.Runtime.InteropServices": "4.0.21-rc2-*",
-    "System.Text.RegularExpressions": "4.0.11-rc2-*",
+    "System.Collections": "4.0.11-rc2-23714",
+    "System.Collections.Immutable": "1.1.38-rc2-23714",
+    "System.Linq": "4.0.1-rc2-23714",
+    "System.Threading": "4.0.11-rc2-23714",
+    "System.IO.FileSystem": "4.0.1-rc2-23714",
+    "System.IO": "4.0.11-rc2-23714",
+    "System.Runtime.InteropServices": "4.0.21-rc2-23714",
+    "System.Text.RegularExpressions": "4.0.11-rc2-23714",
     "FluentAssertions": "4.0.0",
     "xunit": "2.1.0",
 

--- a/test/PackagedCommands/Consumers/AppWithDirectAndToolDependency/project.json.template
+++ b/test/PackagedCommands/Consumers/AppWithDirectAndToolDependency/project.json.template
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23714",
         "dotnet-hello": { "version": "1.0.0", "target": "package" }
     },
 

--- a/test/PackagedCommands/Consumers/AppWithDirectAndToolDependency/project.json.template
+++ b/test/PackagedCommands/Consumers/AppWithDirectAndToolDependency/project.json.template
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23714",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "dotnet-hello": { "version": "1.0.0", "target": "package" }
     },
 

--- a/test/PackagedCommands/Consumers/AppWithDirectDependency/project.json.template
+++ b/test/PackagedCommands/Consumers/AppWithDirectDependency/project.json.template
@@ -7,7 +7,7 @@
     "testRunner": "must-be-specified-to-generate-deps",
     
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616",
+        "NETStandard.Library": "1.0.0-rc2-23714",
         "dotnet-hello": {"version": "1.0.0", "target": "package"}
     },
 

--- a/test/PackagedCommands/Consumers/AppWithDirectDependency/project.json.template
+++ b/test/PackagedCommands/Consumers/AppWithDirectDependency/project.json.template
@@ -7,7 +7,7 @@
     "testRunner": "must-be-specified-to-generate-deps",
     
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23714",
+        "NETStandard.Library": "1.0.0-rc2-23704",
         "dotnet-hello": {"version": "1.0.0", "target": "package"}
     },
 

--- a/test/PackagedCommands/Consumers/AppWithToolDependency/project.json.template
+++ b/test/PackagedCommands/Consumers/AppWithToolDependency/project.json.template
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23616"
+        "NETStandard.Library": "1.0.0-rc2-23714"
     },
 
     "frameworks": {

--- a/test/StreamForwarderTests/project.json
+++ b/test/StreamForwarderTests/project.json
@@ -9,7 +9,7 @@
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",
-        "xunit.netcore.extensions": "1.0.0-prerelease-*",
+        "xunit.netcore.extensions": "1.0.0-prerelease-00153",
         "xunit.runner.utility": "2.1.0",
 
         "Microsoft.DotNet.ProjectModel": { "target": "project" },

--- a/test/StreamForwarderTests/project.json
+++ b/test/StreamForwarderTests/project.json
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "NETStandard.Library" : "1.0.0-rc2-23704",
+        "NETStandard.Library" : "1.0.0-rc2-23706",
 
         "xunit": "2.1.0",
         "xunit.console.netcore": "1.0.2-prerelease-00101",

--- a/test/TestProjects/TestApp/project.json
+++ b/test/TestProjects/TestApp/project.json
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "TestLibrary": "1.0.0-*",
+        "TestLibrary": { "target":"project"},
 
         "NETStandard.Library": "1.0.0-rc2-23704",
         "Microsoft.NETCore.Platforms": "1.0.1-rc2-23704"

--- a/test/TestProjects/TestAppWithArgs/project.json
+++ b/test/TestProjects/TestAppWithArgs/project.json
@@ -5,10 +5,10 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
-        "System.IO": "4.0.10-beta-*",
-        "System.Console": "4.0.0-beta-*",
-        "System.Runtime": "4.0.21-beta-*"
+        "Microsoft.NETCore.Runtime": "1.0.1-rc2-23714",
+        "System.IO": "4.0.10-rc2-23714",
+        "System.Console": "4.0.0-rc2-23714",
+        "System.Runtime": "4.0.21-rc2-23714"
     },
 
     "frameworks": {

--- a/test/TestProjects/TestAppWithContents/project.json
+++ b/test/TestProjects/TestAppWithContents/project.json
@@ -5,10 +5,10 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.Runtime": "1.0.1-beta-*",
-    "System.IO": "4.0.10-beta-*",
-    "System.Console": "4.0.0-beta-*",
-    "System.Runtime": "4.0.21-beta-*"
+    "Microsoft.NETCore.Runtime": "1.0.1-rc2-23714",
+    "System.IO": "4.0.10-rc2-23714",
+    "System.Console": "4.0.0-rc2-23714",
+    "System.Runtime": "4.0.21-rc2-23714"
   }, 
   
 


### PR DESCRIPTION
Fixes #525

These changes ended up being pretty big. 
It properly escapes arguments before passing them off to Process.Start, and special cases when using CMD.

Thanks @piotrpMSFT for the help getting in all the changes throughout the product
and thanks @krwq for helping out with the initial product changes

cc @anurse @piotrpMSFT @livarcocc @krwq @davidfowl 