### PR TITLE
Auto reference facades in the common cases

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -212,21 +212,11 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         {
             foreach (var assemblyPath in section)
             {
-                if (IsPlaceholderFile(assemblyPath))
-                {
-                    continue;
-                }
-
                 assets.Add(new LibraryAsset(
                     Path.GetFileNameWithoutExtension(assemblyPath),
                     assemblyPath,
                     Path.Combine(package.Path, assemblyPath)));
             }
-        }
-
-        private static bool IsPlaceholderFile(string path)
-        {
-            return string.Equals(Path.GetFileName(path), "_._", StringComparison.Ordinal);
         }
 
         private static bool LibraryIsOfType(LibraryType type, LibraryDescription library)

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LibraryDependencyType.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LibraryDependencyType.cs
@@ -7,13 +7,15 @@ namespace Microsoft.DotNet.ProjectModel.Graph
 {
     public struct LibraryDependencyType
     {
-        private readonly LibraryDependencyTypeFlag _flags;
-
         public static LibraryDependencyType Default = LibraryDependencyType.Parse("default");
+
+        public static LibraryDependencyType Build = LibraryDependencyType.Parse("build");
+
+        public LibraryDependencyTypeFlag Flags { get; private set; }
 
         private LibraryDependencyType(LibraryDependencyTypeFlag flags)
         {
-            _flags = flags;
+            Flags = flags;
         }
 
         public static LibraryDependencyType Parse(string keyword)
@@ -41,7 +43,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
 
         public bool HasFlag(LibraryDependencyTypeFlag flag)
         {
-            return (_flags & flag) != 0;
+            return (Flags & flag) != 0;
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/LibraryDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/LibraryDescription.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.ProjectModel
 
         public override string ToString()
         {
-            return $"{Identity} = {Path}";
+            return $"{Identity} ({Identity.Type}) = {Path}";
         }
 
         // For diagnostics, we don't want to duplicate requested dependencies so we 

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
@@ -109,8 +109,6 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
             {
                 var metadataReader = peReader.GetMetadataReader();
 
-                var references = new List<string>(metadataReader.AssemblyReferences.Count);
-
                 foreach (var assemblyReferenceHandle in metadataReader.AssemblyReferences)
                 {
                     var assemblyReference = metadataReader.GetAssemblyReference(assemblyReferenceHandle);

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
@@ -5,7 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using Microsoft.DotNet.ProjectModel.Graph;
+using NuGet.Frameworks;
 using NuGet.Packaging;
 
 namespace Microsoft.DotNet.ProjectModel.Resolution
@@ -13,13 +16,15 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
     public class PackageDependencyProvider
     {
         private readonly VersionFolderPathResolver _packagePathResolver;
+        private readonly FrameworkReferenceResolver _frameworkReferenceResolver;
 
-        public PackageDependencyProvider(string packagesPath)
+        public PackageDependencyProvider(string packagesPath, FrameworkReferenceResolver frameworkReferenceResolver)
         {
             _packagePathResolver = new VersionFolderPathResolver(packagesPath);
+            _frameworkReferenceResolver = frameworkReferenceResolver;
         }
 
-        public PackageDescription GetDescription(LockFilePackageLibrary package, LockFileTargetLibrary targetLibrary)
+        public PackageDescription GetDescription(NuGetFramework targetFramework, LockFilePackageLibrary package, LockFileTargetLibrary targetLibrary)
         {
             // If a NuGet dependency is supposed to provide assemblies but there is no assembly compatible with
             // current target framework, we should mark this dependency as unresolved
@@ -37,6 +42,14 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
 
             var path = _packagePathResolver.GetInstallPath(package.Name, package.Version);
 
+            // Remove place holders
+            targetLibrary.CompileTimeAssemblies = targetLibrary.CompileTimeAssemblies.Where(item => !IsPlaceholderFile(item.Path)).ToList();
+            targetLibrary.RuntimeAssemblies = targetLibrary.RuntimeAssemblies.Where(item => !IsPlaceholderFile(item.Path)).ToList();
+
+            // If the package's compile time assemblies is for a portable profile then, read the assembly metadata
+            // and turn System.* references into reference assembly dependencies
+            PopulateLegacyPortableDependencies(targetFramework, dependencies, path, targetLibrary);
+
             var packageDescription = new PackageDescription(
                 path,
                 package,
@@ -45,6 +58,66 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
                 compatible);
 
             return packageDescription;
+        }
+
+        private void PopulateLegacyPortableDependencies(NuGetFramework targetFramework, List<LibraryRange> dependencies, string packagePath, LockFileTargetLibrary targetLibrary)
+        {
+            var seen = new HashSet<string>();
+            
+            foreach (var assembly in targetLibrary.CompileTimeAssemblies)
+            {
+                // (ref/lib)/{tfm}/{assembly}
+                var pathParts = assembly.Path.Split('/');
+
+                if (pathParts.Length != 3)
+                {
+                    continue;
+                }
+
+                var assemblyTargetFramework = NuGetFramework.Parse(pathParts[1]);
+                
+                if (!assemblyTargetFramework.IsPCL)
+                {
+                    continue;
+                }
+
+                var assemblyPath = Path.Combine(packagePath, assembly.Path);
+                
+                foreach (var dependency in GetDependencies(assemblyPath))
+                {
+                    if (seen.Add(dependency))
+                    {
+                        string path;
+                        Version version;
+                        
+                        // If there exists a reference assembly on the requested framework with the same name then turn this into a
+                        // framework assembly dependency
+                        if (_frameworkReferenceResolver.TryGetAssembly(dependency, targetFramework, out path, out version))
+                        {
+                            dependencies.Add(new LibraryRange(dependency, 
+                                LibraryType.ReferenceAssembly, 
+                                LibraryDependencyType.Build));
+                        }
+                    }
+                }
+            }
+        }
+        
+        private static IEnumerable<string> GetDependencies(string path)
+        {
+            using (var peReader = new PEReader(File.OpenRead(path)))
+            {
+                var metadataReader = peReader.GetMetadataReader();
+
+                var references = new List<string>(metadataReader.AssemblyReferences.Count);
+
+                foreach (var assemblyReferenceHandle in metadataReader.AssemblyReferences)
+                {
+                    var assemblyReference = metadataReader.GetAssemblyReference(assemblyReferenceHandle);
+
+                    yield return metadataReader.GetString(assemblyReference.Name);
+                }
+            }
         }
 
         private void PopulateDependencies(List<LibraryRange> dependencies, LockFileTargetLibrary targetLibrary)
@@ -65,6 +138,11 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
                     LibraryType.ReferenceAssembly, 
                     LibraryDependencyType.Default));
             }
+        }
+
+        public static bool IsPlaceholderFile(string path)
+        {
+            return string.Equals(Path.GetFileName(path), "_._", StringComparison.Ordinal);
         }
 
         public static string ResolvePackagesPath(string rootDirectory, GlobalSettings settings)

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/ProjectDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/ProjectDependencyProvider.cs
@@ -48,17 +48,17 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
 
             if (targetFramework != null && targetFramework.IsDesktop())
             {
-                targetFrameworkDependencies.Add(new LibraryRange("mscorlib", LibraryType.ReferenceAssembly));
+                targetFrameworkDependencies.Add(new LibraryRange("mscorlib", LibraryType.ReferenceAssembly, LibraryDependencyType.Build));
 
-                targetFrameworkDependencies.Add(new LibraryRange("System", LibraryType.ReferenceAssembly));
+                targetFrameworkDependencies.Add(new LibraryRange("System", LibraryType.ReferenceAssembly, LibraryDependencyType.Build));
 
                 if (targetFramework.Version >= new Version(3, 5))
                 {
-                    targetFrameworkDependencies.Add(new LibraryRange("System.Core", LibraryType.ReferenceAssembly));
+                    targetFrameworkDependencies.Add(new LibraryRange("System.Core", LibraryType.ReferenceAssembly, LibraryDependencyType.Build));
 
                     if (targetFramework.Version >= new Version(4, 0))
                     {
-                        targetFrameworkDependencies.Add(new LibraryRange("Microsoft.CSharp", LibraryType.ReferenceAssembly));
+                        targetFrameworkDependencies.Add(new LibraryRange("Microsoft.CSharp", LibraryType.ReferenceAssembly, LibraryDependencyType.Build));
                     }
                 }
             }

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -6,6 +6,7 @@
     "description": "Types to model a .NET Project",
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23704",
+        "System.Reflection.Metadata": "1.2.0-rc2-23608",
         "System.Runtime.Loader": "4.0.0-rc2-23704",
         "System.Dynamic.Runtime": "4.0.11-rc2-23704",
         "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23704",


### PR DESCRIPTION
- There are 2 major cases to auto reference facades:
1. When using a netstandard/dotnet* based package on a platform where the System.* packages don't provide any compilation assemblies.
2. When referencing a PCL where no dependencies were specified in the nuspec.
- For 1, we handle it by replacing package references with reference assemblies if possible. For 2. We turn assembly references of PCL assemblies into package dependencies.
This should cover the 90% case where people had to manually reference facades anytime they wanted to use a PCL on Net4.x.

Other references:
http://stackoverflow.com/questions/34136228/unable-to-resolve-assembly-reference-issue-without-frameworkassemblies

TODO: P2P PCL references, Figure out how to add tests :smile: 

#164

/cc @bricelam @ericstj 