### PR TITLE
Fix fsharp targetfw rel1.0.0

### DIFF
--- a/src/Microsoft.DotNet.Tools.Compiler.Fsc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Fsc/Program.cs
@@ -80,6 +80,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 return returnCode;
             }
 
+            outputName = outputName.Trim('"');
+            tempOutDir = tempOutDir.Trim('"');
+
             var translated = TranslateCommonOptions(commonOptions, outputName);
 
             var allArgs = new List<string>(translated);
@@ -101,8 +104,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                     outputName = Path.ChangeExtension(outputName, ".exe");
                 }
 
-                allArgs.Add($"--out:");
-                allArgs.Add($"{outputName}");
+                allArgs.Add($"--out:{outputName}");
             }
 
             //set target framework
@@ -112,22 +114,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 allArgs.Add("--targetprofile:netcore");
             }
 
-            foreach (var reference in references)
-            {
-                allArgs.Add("-r");
-                allArgs.Add($"{reference}");
-            }
-
-            foreach (var resource in resources)
-            {
-                allArgs.Add("--resource");
-                allArgs.Add($"{resource}");
-            }
-
-            foreach (var source in sources)
-            {
-                allArgs.Add($"{source}");
-            }
+            allArgs.AddRange(references.Select(r => $"-r:{r.Trim('"')}"));
+            allArgs.AddRange(resources.Select(resource => $"--resource:{resource.Trim('"')}"));
+            allArgs.AddRange(sources.Select(s => $"{s.Trim('"')}"));
 
             var rsp = Path.Combine(tempOutDir, "dotnet-compile-fsc.rsp");
             File.WriteAllLines(rsp, allArgs, Encoding.UTF8);
@@ -175,9 +164,21 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 commonArgs.AddRange(options.Defines.Select(def => $"-d:{def}"));
             }
 
+            if (options.SuppressWarnings != null)
+            {
+            }
+
+            if (options.LanguageVersion != null)
+            {
+            }
+
             if (options.Platform != null)
             {
                 commonArgs.Add($"--platform:{options.Platform}");
+            }
+
+            if (options.AllowUnsafe == true)
+            {
             }
 
             if (options.WarningsAsErrors == true)
@@ -190,7 +191,19 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 commonArgs.Add("--optimize");
             }
 
-            if(options.GenerateXmlDocumentation == true)
+            if (options.KeyFile != null)
+            {
+            }
+
+            if (options.DelaySign == true)
+            {
+            }
+
+            if (options.PublicSign == true)
+            {
+            }
+
+            if (options.GenerateXmlDocumentation == true)
             {
                 commonArgs.Add($"--doc:{Path.ChangeExtension(outputName, "xml")}");
             }
@@ -207,7 +220,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     var win32manifestPath = Path.Combine(AppContext.BaseDirectory, "default.win32manifest");
-                    commonArgs.Add($"--win32manifest:\"{win32manifestPath}\"");
+                    commonArgs.Add($"--win32manifest:{win32manifestPath}");
                 }
             }
 

--- a/src/Microsoft.DotNet.Tools.Compiler.Fsc/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler.Fsc/Program.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
+using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Tools.Compiler.Fsc
 {
@@ -102,6 +103,13 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
 
                 allArgs.Add($"--out:");
                 allArgs.Add($"{outputName}");
+            }
+
+            //set target framework
+            var framework = new NuGetFramework(assemblyInfoOptions.TargetFramework);
+            if (!framework.IsDesktop())
+            {
+                allArgs.Add("--targetprofile:netcore");
             }
 
             foreach (var reference in references)

--- a/test/FSharpTestProjects/CompileFail/NuGet.Config
+++ b/test/FSharpTestProjects/CompileFail/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>

--- a/test/FSharpTestProjects/TestApp/NuGet.Config
+++ b/test/FSharpTestProjects/TestApp/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>

--- a/test/FSharpTestProjects/TestApp/project.json
+++ b/test/FSharpTestProjects/TestApp/project.json
@@ -8,7 +8,7 @@
         "Program.fs"
     ],
     "dependencies": {
-        "TestLibrary": "1.0.0-*",
+        "TestLibrary": { "target":"project"},
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
         "NETStandard.Library": "1.0.0-rc3-23722"
     },

--- a/test/FSharpTestProjects/TestApp/project.json
+++ b/test/FSharpTestProjects/TestApp/project.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "TestLibrary": { "target":"project"},
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "NETStandard.Library": "1.0.0-rc3-23722"
+        "NETStandard.Library": "1.0.0-rc3-23727"
     },
 
     "frameworks": {

--- a/test/FSharpTestProjects/TestAppWithArgs/NuGet.Config
+++ b/test/FSharpTestProjects/TestAppWithArgs/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>

--- a/test/FSharpTestProjects/TestAppWithArgs/project.json
+++ b/test/FSharpTestProjects/TestAppWithArgs/project.json
@@ -9,7 +9,7 @@
     ],
     "dependencies": {
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "NETStandard.Library": "1.0.0-rc3-23722"
+        "NETStandard.Library": "1.0.0-rc3-23727"
     },
 
     "frameworks": {

--- a/test/FSharpTestProjects/TestAppWithInteger/NuGet.Config
+++ b/test/FSharpTestProjects/TestAppWithInteger/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>

--- a/test/FSharpTestProjects/TestAppWithInteger/Program.fs
+++ b/test/FSharpTestProjects/TestAppWithInteger/Program.fs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace TestAppWithInteger
+
+open System
+
+module Program =
+
+    [<EntryPoint>]
+    let Main args =
+        if 1 < 2 then 0 else 1

--- a/test/FSharpTestProjects/TestAppWithInteger/project.json
+++ b/test/FSharpTestProjects/TestAppWithInteger/project.json
@@ -9,7 +9,7 @@
     ],
     "dependencies": {
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "NETStandard.Library": "1.0.0-rc3-23722"
+        "NETStandard.Library": "1.0.0-rc3-23727"
     },
 
     "frameworks": {

--- a/test/FSharpTestProjects/TestAppWithInteger/project.json
+++ b/test/FSharpTestProjects/TestAppWithInteger/project.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "version": "1.0.0-*",
     "compilationOptions": {
         "emitEntryPoint": true
@@ -8,7 +8,6 @@
         "Program.fs"
     ],
     "dependencies": {
-        "TestLibrary": "1.0.0-*",
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
         "NETStandard.Library": "1.0.0-rc3-23722"
     },

--- a/test/FSharpTestProjects/TestLibrary/NuGet.Config
+++ b/test/FSharpTestProjects/TestLibrary/NuGet.Config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
+    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
+    <add key="corert" value="https://www.myget.org/F/dotnet/api/v2" />
+    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
+    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
+  </packageSources>
+  <activePackageSource>
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+  </activePackageSource>
+</configuration>

--- a/test/FSharpTestProjects/TestLibrary/project.json
+++ b/test/FSharpTestProjects/TestLibrary/project.json
@@ -2,7 +2,7 @@
     "version": "1.0.0-*",
     "dependencies": {
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "NETStandard.Library": "1.0.0-rc3-23722"
+        "NETStandard.Library": "1.0.0-rc3-23727"
     },
     "compilerName": "fsc",
     "compileFiles": [


### PR DESCRIPTION
fix #692 

- use `--targetprofile:netcore` if target framework is coreclr
- add nuget.conf to make restore safe
- use rc2 because it's requried by fsharp.core

same as #894 , but target `rel/1.0.0` branch (also fix arguments quote issues in rel/1.0.0).

ready to review/merge

