### PR TITLE
Fix the dotent help screen

### DIFF
--- a/src/Microsoft.DotNet.Cli/Program.cs
+++ b/src/Microsoft.DotNet.Cli/Program.cs
@@ -27,7 +27,7 @@ Common Options (passed before the command):
 Common Commands:
   new           Initialize a basic .NET project
   restore       Restore dependencies specified in the .NET project
-  compile       Compiles a .NET project
+  build         Builds a .NET project
   publish       Publishes a .NET project for deployment (including the runtime)
   run           Compiles and immediately executes a .NET project
   repl          Launch an interactive session (read, eval, print, loop)


### PR DESCRIPTION
Replace the compile verb with build.

Fix #1007 

/cc @brthor @davidfowl 