### PR TITLE
Strong naming Microsoft.Dotnet.Cli.Utils

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -1,5 +1,9 @@
 ﻿{
     "version": "1.0.0-*",
+    
+    "compilationOptions": {
+        "keyFile": "../../tools/Key.snk"
+    },
 
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23704",


### PR DESCRIPTION
Because Microsoft.Dotnet.Cli.Utils is not signed any utils using this assembly cannot be signed. 