### PR TITLE
Improve MSI performance

### DIFF
--- a/packaging/windows/checkbuildtype.wxs
+++ b/packaging/windows/checkbuildtype.wxs
@@ -8,7 +8,7 @@
     </Property>
 
     <Condition Message="$(var.IncompatibleBuildTypeError)">
-        NOT INSTALLEDCLIBUILDTYPE OR INSTALLEDCLIBUILDTYPE ~= "$(var.BuildType)"
+        Installed OR NOT INSTALLEDCLIBUILDTYPE OR INSTALLEDCLIBUILDTYPE ~= "$(var.BuildType)"
     </Condition>
   </Fragment>
 </Wix>

--- a/packaging/windows/checkbuildtype.wxs
+++ b/packaging/windows/checkbuildtype.wxs
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <?include "Variables.wxi" ?>
   <Fragment>
     <Property Id="INSTALLEDCLIBUILDTYPE">
         <RegistrySearch Id="DotnetCLI_BuildType" Type="raw"
             Root="HKLM" Key="SOFTWARE\dotnet\Setup" Name="BuildType" Win64="$(var.Win64AttributeValue)"/>
     </Property>
-    <SetProperty Before="LaunchConditions" Id="EXPECTEDCLIBUILDTYPE" Value="$(var.BuildType)" />
+
+    <Condition Message="$(var.IncompatibleBuildTypeError)">
+        NOT INSTALLEDCLIBUILDTYPE OR INSTALLEDCLIBUILDTYPE ~= "$(var.BuildType)"
+    </Condition>
   </Fragment>
 </Wix>

--- a/packaging/windows/dotnet.wxs
+++ b/packaging/windows/dotnet.wxs
@@ -6,7 +6,8 @@
 
         <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
 
-        <MediaTemplate CompressionLevel="mszip" EmbedCab="yes"/>
+        <MediaTemplate CompressionLevel="high" EmbedCab="yes"/>
+
         <Feature Id="MainFeature" Title="Main Feature" Level="1">
             <ComponentGroupRef Id="InstallFiles" />
             <ComponentGroupRef Id="AuthoredRegistryKeys"/>

--- a/packaging/windows/dotnet.wxs
+++ b/packaging/windows/dotnet.wxs
@@ -27,9 +27,6 @@
         <CustomActionRef Id="WixBroadcastEnvironmentChange" />
 
         <PropertyRef Id="INSTALLEDCLIBUILDTYPE"/>
-        <Condition Message="$(var.IncompatibleBuildTypeError)">
-            <![CDATA[NOT INSTALLEDCLIBUILDTYPE OR INSTALLEDCLIBUILDTYPE ~= EXPECTEDCLIBUILDTYPE]]>
-        </Condition>
     </Product>
     <Fragment>
         <Directory Id="TARGETDIR" Name="SourceDir">

--- a/packaging/windows/dotnet.wxs
+++ b/packaging/windows/dotnet.wxs
@@ -20,6 +20,8 @@
         <Property Id="ProductCPU" Value="$(var.Platform)" />
         <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />
 
+        <Property Id="MSIFASTINSTALL" Value="7" />
+
         <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
 
         <Property Id="WIXUI_INSTALLDIR" Value="DOTNETHOME"/>

--- a/packaging/windows/dotnet.wxs
+++ b/packaging/windows/dotnet.wxs
@@ -33,7 +33,7 @@
     </Product>
     <Fragment>
         <Directory Id="TARGETDIR" Name="SourceDir">
-            <Directory Id="$(var.Program_Files)" Name="$(var.Program_Files)">
+            <Directory Id="$(var.Program_Files)">
                 <Directory Id="DOTNETHOME" Name="dotnet"/>
             </Directory>
         </Directory>

--- a/packaging/windows/provider.wxs
+++ b/packaging/windows/provider.wxs
@@ -2,10 +2,8 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
   <?include "Variables.wxi" ?>
   <Fragment>
-    <DirectoryRef Id="TARGETDIR">
-      <Component Id="Dotnet_CLI_$(var.Dotnet_DisplayVersion)" DiskId="1" Win64="no" Guid="3B7DF8C8-9BB9-3F4C-8CBF-E393E4D7FF43">
-        <dep:Provides Key="Dotnet.CLI_$(var.Dotnet_DisplayVersion)" />
-      </Component>
-    </DirectoryRef>
+    <Component Id="Dotnet_CLI_$(var.Dotnet_DisplayVersion)" Directory="TARGETDIR" Win64="no" Guid="3B7DF8C8-9BB9-3F4C-8CBF-E393E4D7FF43">
+      <dep:Provides Key="Dotnet.CLI_$(var.Dotnet_DisplayVersion)" />
+    </Component>
   </Fragment>
 </Wix>

--- a/packaging/windows/variables.wxi
+++ b/packaging/windows/variables.wxi
@@ -20,10 +20,10 @@
   <?define ProductEdition   =   "001dotnet" ?>
   <?define LCID  = "$(var.ProductLanguage)"?>
   <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
-  <?define IncompatibleBuildTypeError = "You have installed '[INSTALLEDCLIBUILDTYPE]' build of Dotnet CLI. It cannot be upgraded to a '[EXPECTEDCLIBUILDTYPE]' build of Dotnet CLI. Please uninstall it and re-run setup."?>
-  
+  <?define IncompatibleBuildTypeError = "You have installed '[INSTALLEDCLIBUILDTYPE]' build of Dotnet CLI. It cannot be upgraded to a '$(var.BuildType)' build of Dotnet CLI. Please uninstall it and re-run setup."?>
+
   <?define Platform   =   "$(sys.BUILDARCH)" ?>
-  <?if $(var.Platform)=x86?>  
+  <?if $(var.Platform)=x86?>
   <?define Program_Files="ProgramFilesFolder"?>
   <?define Win64AttributeValue=no?>
   <?define UpgradeCode="70A1576F-63B6-4659-9E39-25C7B769DDE5"?>


### PR DESCRIPTION
A few small changes for some pretty nice wins:

1. Package size reduced 17% (46.8 MB reduction to 38.8 MB)
2. Install time reduced 20% (2 seconds, on my machine)
3. Removed last custom action (except for WiX standard custom actions)
4. Repair/uninstall will always work now