### PR TITLE
Fix output paths (and some other stuff associated with it)

### DIFF
--- a/scripts/test/argument-forwarding-tests.ps1
+++ b/scripts/test/argument-forwarding-tests.ps1
@@ -9,7 +9,6 @@ $TestPackagesPath = "$RepoRoot\tests\packages"
 
 $ArgTestRoot = "$RepoRoot\test\ArgumentForwardingTests"
 $ArgTestOutputRoot = "$RepoRoot\artifacts\tests\arg-forwarding"
-$ArgTestBin = "$ArgTestOutputRoot\$Configuration\dnxcore50"
 
 dotnet publish --framework "dnxcore50" --runtime "$Rid" --output "$ArgTestOutputRoot" --configuration "$Configuration" "$ArgTestRoot\Reflector"
 if (!$?) {
@@ -23,9 +22,9 @@ if (!$?) {
     Exit 1
 }
 
-cp "$ArgTestRoot\Reflector\reflector_cmd.cmd" "$ArgTestBin"
+cp "$ArgTestRoot\Reflector\reflector_cmd.cmd" "$ArgTestOutputRoot"
 
-pushd "$ArgTestBin"
+pushd "$ArgTestOutputRoot"
 
 & ".\corerun" "xunit.console.netcore.exe" "ArgumentForwardingTests.dll" -xml "$_-testResults.xml" -notrait category=failing
 $exitCode = $LastExitCode

--- a/scripts/test/argument-forwarding-tests.sh
+++ b/scripts/test/argument-forwarding-tests.sh
@@ -19,13 +19,12 @@ source "$DIR/../common/_common.sh"
 
 ArgTestRoot="$REPOROOT/test/ArgumentForwardingTests"
 ArgTestOutputRoot="$REPOROOT/artifacts/tests/arg-forwarding"
-ArgTestBin="$ArgTestOutputRoot/$CONFIGURATION/dnxcore50"
 
 dotnet publish --framework "dnxcore50" --output "$ArgTestOutputRoot" --configuration "$CONFIGURATION" "$ArgTestRoot/Reflector"
 dotnet publish --framework "dnxcore50" --output "$ArgTestOutputRoot" --configuration "$CONFIGURATION" "$ArgTestRoot/ArgumentForwardingTests"
 
 
 
-pushd "$ArgTestBin"
+pushd "$ArgTestOutputRoot"
     ./corerun "xunit.console.netcore.exe" "ArgumentForwardingTests.dll" -xml "ArgumentForwardingTests-testResults.xml" -notrait category=failing
 popd

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
@@ -207,7 +207,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private static string GetDepsPath(ProjectContext context, string buildConfiguration)
         {
-            return Path.Combine(context.GetOutputDirectoryPath(buildConfiguration),
+            return Path.Combine(context.GetOutputPathCalculator().GetOutputDirectoryPath(buildConfiguration),
                 context.ProjectFile.Name + FileNameSuffixes.Deps);
         }
 

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
@@ -24,16 +24,16 @@ namespace Microsoft.DotNet.Cli.Utils
         private static CommandSpec ResolveFromPath(string commandName, IEnumerable<string> args, bool useComSpec = false)
         {
             var commandPath = Env.GetCommandPath(commandName);
-            return commandPath == null 
-                ? null 
+            return commandPath == null
+                ? null
                 : CreateCommandSpecPreferringExe(commandName, args, commandPath, CommandResolutionStrategy.Path, useComSpec);
         }
 
         private static CommandSpec ResolveFromAppBase(string commandName, IEnumerable<string> args, bool useComSpec = false)
         {
             var commandPath = Env.GetCommandPathFromAppBase(AppContext.BaseDirectory, commandName);
-            return commandPath == null 
-                ? null 
+            return commandPath == null
+                ? null
                 : CreateCommandSpecPreferringExe(commandName, args, commandPath, CommandResolutionStrategy.BaseDirectory, useComSpec);
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Cli.Utils
                     var escapedArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args);
                     return new CommandSpec(commandName, escapedArgs, CommandResolutionStrategy.Path);
                 }
-                
+
             }
 
             return null;
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
             if (commandPackage == null) return null;
 
-            var depsPath = GetDepsPath(projectContext, Constants.DefaultConfiguration);
+            var depsPath = projectContext.GetOutputPathCalculator().GetDepsPath(Constants.DefaultConfiguration);
 
             return ConfigureCommandFromPackage(commandName, args, commandPackage, projectContext, depsPath, useComSpec);
         }
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Cli.Utils
         private static PackageDescription GetCommandPackage(ProjectContext projectContext, string commandName)
         {
             return projectContext.LibraryManager.GetLibraries()
-                .Where(l => l.GetType() == typeof (PackageDescription))
+                .Where(l => l.GetType() == typeof(PackageDescription))
                 .Select(l => l as PackageDescription)
                 .FirstOrDefault(p => p.Library.Files
                     .Select(Path.GetFileName)
@@ -201,21 +201,13 @@ namespace Microsoft.DotNet.Cli.Utils
                 var escapedArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args);
                 return new CommandSpec(fileName, escapedArgs, CommandResolutionStrategy.NugetPackage);
             }
-
-            
-        }
-
-        private static string GetDepsPath(ProjectContext context, string buildConfiguration)
-        {
-            return Path.Combine(context.GetOutputPathCalculator().GetOutputDirectoryPath(buildConfiguration),
-                context.ProjectFile.Name + FileNameSuffixes.Deps);
         }
 
         private static CommandSpec CreateCommandSpecPreferringExe(
-            string commandName, 
-            IEnumerable<string> args, 
+            string commandName,
+            IEnumerable<string> args,
             string commandPath,
-            CommandResolutionStrategy resolutionStrategy, 
+            CommandResolutionStrategy resolutionStrategy,
             bool useComSpec = false)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
@@ -226,7 +218,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 // Use cmd if we can't find an exe
                 if (preferredCommandPath == null)
                 {
-                    useComSpec = true;   
+                    useComSpec = true;
                 }
                 else
                 {
@@ -246,8 +238,8 @@ namespace Microsoft.DotNet.Cli.Utils
         }
 
         private static CommandSpec CreateComSpecCommandSpec(
-            string command, 
-            IEnumerable<string> args, 
+            string command,
+            IEnumerable<string> args,
             CommandResolutionStrategy resolutionStrategy)
         {
             // To prevent Command Not Found, comspec gets passed in as

--- a/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
@@ -20,8 +20,8 @@ namespace Microsoft.DotNet.Cli.Utils
         }
 
         public static Reporter Output { get; } = Create(AnsiConsole.GetOutput);
-        public static Reporter Error { get; } = Create(AnsiConsole.GetError);
-        public static Reporter Verbose { get; } = CommandContext.IsVerbose() ? Create(AnsiConsole.GetError) : Null;
+        public static Reporter Error { get; } = Create(AnsiConsole.GetOutput);
+        public static Reporter Verbose { get; } = CommandContext.IsVerbose() ? Create(AnsiConsole.GetOutput) : Null;
 
         public static Reporter Create(Func<bool, AnsiConsole> getter)
         {

--- a/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
@@ -1,22 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.DotNet.ProjectModel;
 using Microsoft.DotNet.ProjectModel.Compilation;
 
 namespace Microsoft.DotNet.Cli.Compiler.Common
 {
     public static class LibraryExporterExtensions
     {
-        internal static void CopyProjectDependenciesTo(this LibraryExporter exporter, string path, params ProjectDescription[] except)
-        {
-            exporter.GetAllExports()
-                .Where(e => !except.Contains(e.Library))
-                .Where(e => e.Library is ProjectDescription)
-                .SelectMany(e => e.NativeLibraries.Union(e.RuntimeAssemblies))
-                .CopyTo(path);
-        }
-
         public static void WriteDepsTo(this IEnumerable<LibraryExport> exports, string path)
         {
             File.WriteAllLines(path, exports.SelectMany(GenerateLines));

--- a/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
@@ -32,16 +32,18 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             }));
         }
 
-        internal static IEnumerable<LibraryAsset> RuntimeAssets(this LibraryExport export)
+        internal static IEnumerable<string> RuntimeAssets(this LibraryExport export)
         {
-            return export.RuntimeAssemblies.Union(export.NativeLibraries);
+            return export.RuntimeAssemblies.Union(export.NativeLibraries)
+                .Select(e => e.ResolvedPath)
+                .Union(export.RuntimeAssets);
         }
 
-        internal static void CopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath)
+        internal static void CopyTo(this IEnumerable<string> assets, string destinationPath)
         {
             foreach (var asset in assets)
             {
-                File.Copy(asset.ResolvedPath, Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath)),
+                File.Copy(asset, Path.Combine(destinationPath, Path.GetFileName(asset)),
                     overwrite: true);
             }
         }

--- a/src/Microsoft.DotNet.Compiler.Common/ProjectContextExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/ProjectContextExtensions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
     public static class ProjectContextExtensions
     {
         public static string ProjectName(this ProjectContext context) => context.RootProject.Identity.Name;
+        public static string GetDisplayName(this ProjectContext context) => $"{context.RootProject.Identity.Name} ({context.TargetFramework})";
 
         public static void MakeCompilationOutputRunnable(this ProjectContext context, string outputPath, string configuration)
         {

--- a/src/Microsoft.DotNet.ProjectModel.Loader/LoaderProjectContextExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/LoaderProjectContextExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.ProjectModel.Loader
                 dllImports,
 
                 // Add the project's output directory path to ensure project-to-project references get located
-                new[] { context.GetOutputDirectoryPath(configuration) });
+                new[] { context.GetOutputPathCalculator().GetOutputDirectoryPath(configuration) });
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExport.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExport.cs
@@ -20,6 +20,11 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         public IEnumerable<LibraryAsset> RuntimeAssemblies { get; }
 
         /// <summary>
+        /// Non assembly runtime assets.
+        /// </summary>
+        public IEnumerable<string> RuntimeAssets { get; }
+
+        /// <summary>
         /// Gets a list of fully-qualified paths to native binaries required to run
         /// </summary>
         public IEnumerable<LibraryAsset> NativeLibraries { get; }
@@ -33,26 +38,28 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         /// Gets a list of fully-qualified paths to source code file references
         /// </summary>
         public IEnumerable<string> SourceReferences { get; }
-        
-       /// <summary>
-       /// Get a list of analyzers provided by this export.
-       /// </summary>
-       public IEnumerable<AnalyzerReference> AnalyzerReferences { get; }
 
-       public LibraryExport(LibraryDescription library,
-                            IEnumerable<LibraryAsset> compileAssemblies,
-                            IEnumerable<string> sourceReferences,
-                            IEnumerable<LibraryAsset> runtimeAssemblies,
-                            IEnumerable<LibraryAsset> nativeLibraries,
-                            IEnumerable<AnalyzerReference> analyzers)
-       {
-           Library = library;
-           CompilationAssemblies = compileAssemblies;
-           SourceReferences = sourceReferences;
-           RuntimeAssemblies = runtimeAssemblies;
-           NativeLibraries = nativeLibraries;
-           AnalyzerReferences = analyzers;
-       }
+        /// <summary>
+        /// Get a list of analyzers provided by this export.
+        /// </summary>
+        public IEnumerable<AnalyzerReference> AnalyzerReferences { get; }
+
+        public LibraryExport(LibraryDescription library,
+                             IEnumerable<LibraryAsset> compileAssemblies,
+                             IEnumerable<string> sourceReferences,
+                             IEnumerable<LibraryAsset> runtimeAssemblies,
+                             IEnumerable<string> runtimeAssets,
+                             IEnumerable<LibraryAsset> nativeLibraries,
+                             IEnumerable<AnalyzerReference> analyzers)
+        {
+            Library = library;
+            CompilationAssemblies = compileAssemblies;
+            SourceReferences = sourceReferences;
+            RuntimeAssemblies = runtimeAssemblies;
+            RuntimeAssets = runtimeAssets;
+            NativeLibraries = nativeLibraries;
+            AnalyzerReferences = analyzers;
+        }
 
         private string DebuggerDisplay => Library.Identity.ToString();
     }

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -163,6 +163,11 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                     assemblyPath,
                     Path.Combine(project.Project.ProjectDirectory, assemblyPath)));
             }
+            else
+            {
+                var assemblyPath = project.GetOutputPathCalculator().GetAssemblyPath(_configuration);
+                compileAssemblies.Add(new LibraryAsset(project.Identity.Name, null, assemblyPath));
+            }
 
             // Add shared sources
             foreach (var sharedFile in project.Project.Files.SharedFiles)

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -184,14 +184,14 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                 
                 foreach (var path in outputCalculator.GetBuildOutputs(_configuration))
                 {
-                    if (Path.GetFileNameWithoutExtension(path) == project.Identity.Name)
+                    var assetName = project.Identity.Name;
+                    if (Path.GetFileNameWithoutExtension(path) != project.Identity.Name)
                     {
-                        continue;
+                        assetName += "/" + Path.GetExtension(path).Substring(1);
                     }
 
                     // We're going to call this asset 
-                    var extension = Path.GetExtension(path).Substring(1);
-                    runtimeAssemblies.Add(new LibraryAsset(project.Identity.Name + "/" + extension, null, path));
+                    runtimeAssemblies.Add(new LibraryAsset(assetName, null, path));
                 }
             }
 

--- a/src/Microsoft.DotNet.ProjectModel/OutputPathCalculator.cs
+++ b/src/Microsoft.DotNet.ProjectModel/OutputPathCalculator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 using NuGet.Frameworks;
@@ -87,6 +88,21 @@ namespace Microsoft.DotNet.ProjectModel
             return Path.Combine(
                 GetOutputDirectoryPath(buildConfiguration),
                 _project.Name + outputExtension);
+        }
+        
+        public IEnumerable<string> GetBuildOutputs(string buildConfiguration)
+        {
+            var assemblyPath = GetAssemblyPath(buildConfiguration);
+            
+            yield return assemblyPath;
+            yield return Path.ChangeExtension(assemblyPath, "pdb");
+
+            var compilationOptions = _project.GetCompilerOptions(_framework, buildConfiguration);
+            
+            if (compilationOptions.GenerateXmlDocumentation == true)
+            {
+                yield return Path.ChangeExtension(assemblyPath, "xml");
+            }
         }
         
         public string GetExecutablePath(string buildConfiguration)

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -120,37 +120,9 @@ namespace Microsoft.DotNet.ProjectModel
                         .BuildAllTargets();
         }
 
-        public string GetAssemblyPath(string buildConfiguration)
+        public OutputPathCalculator GetOutputPathCalculator(string baseOutputPath = null)
         {
-            return Path.Combine(
-                GetOutputDirectoryPath(buildConfiguration),
-                ProjectFile.Name + FileNameSuffixes.DotNet.DynamicLib);
-        }
-
-        public string GetPdbPath(string buildConfiguration)
-        {
-            return Path.Combine(
-                GetOutputDirectoryPath(buildConfiguration),
-                ProjectFile.Name + FileNameSuffixes.DotNet.ProgramDatabase);
-        }
-
-        public string GetOutputDirectoryPath(string buildConfiguration)
-        {
-            var outDir = Path.Combine(
-                ProjectDirectory,
-                DirectoryNames.Bin,
-                buildConfiguration,
-                TargetFramework.GetShortFolderName());
-            if (!string.IsNullOrEmpty(RuntimeIdentifier))
-            {
-                outDir = Path.Combine(outDir, RuntimeIdentifier);
-            }
-            return outDir;
-        }
-
-        public OutputPathCalculator GetOutputPathCalculator(string rootOutputPath)
-        {
-            return new OutputPathCalculator(this, rootOutputPath);
+            return new OutputPathCalculator(ProjectFile, TargetFramework, RuntimeIdentifier, baseOutputPath);
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectDescription.cs
@@ -43,5 +43,10 @@ namespace Microsoft.DotNet.ProjectModel
         public Project Project { get; }
 
         public TargetFrameworkInformation TargetFrameworkInfo { get; }
+        
+        public OutputPathCalculator GetOutputPathCalculator()
+        {
+            return new OutputPathCalculator(Project, Framework, runtimeIdentifier: null, baseOutputPath: null);
+        }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
@@ -510,7 +510,6 @@ namespace Microsoft.DotNet.ProjectModel
             if (binNode != null)
             {
                 targetFrameworkInformation.AssemblyPath = binNode.ValueAsString("assembly");
-                targetFrameworkInformation.PdbPath = binNode.ValueAsString("pdb");
             }
 
             project._targetFrameworks[frameworkName] = targetFrameworkInformation;

--- a/src/Microsoft.DotNet.ProjectModel/TargetFrameworkInformation.cs
+++ b/src/Microsoft.DotNet.ProjectModel/TargetFrameworkInformation.cs
@@ -23,7 +23,5 @@ namespace Microsoft.DotNet.ProjectModel
         public string WrappedProject { get; set; }
 
         public string AssemblyPath { get; set; }
-
-        public string PdbPath { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.Tools.Builder/CompileContext.cs
+++ b/src/Microsoft.DotNet.Tools.Builder/CompileContext.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
@@ -20,7 +19,6 @@ namespace Microsoft.DotNet.Tools.Build
     // Collects icnremental safety checks and transitively compiles a project context
     internal class CompileContext
     {
-
         public static readonly string[] KnownCompilers = { "csc", "vbc", "fsc" };
 
         private readonly ProjectContext _rootProject;
@@ -36,13 +34,13 @@ namespace Microsoft.DotNet.Tools.Build
 
             // Cleaner to clone the args and mutate the clone than have separate CompileContext fields for mutated args 
             // and then reasoning which ones to get from args and which ones from fields.
-            _args = (BuilderCommandApp) args.ShallowCopy();
+            _args = (BuilderCommandApp)args.ShallowCopy();
 
             // Set up Output Paths. They are unique per each CompileContext
             var outputPathCalculator = _rootProject.GetOutputPathCalculator(_args.OutputValue);
             _args.OutputValue = outputPathCalculator.BaseCompilationOutputPath;
             _args.IntermediateValue =
-                outputPathCalculator.GetIntermediateOutputPath(_args.ConfigValue, _args.IntermediateValue);
+                outputPathCalculator.GetIntermediateOutputDirectoryPath(_args.ConfigValue, _args.IntermediateValue);
 
             // Set up dependencies
             _dependencies = new ProjectDependenciesFacade(_rootProject, _args.ConfigValue);
@@ -62,7 +60,7 @@ namespace Microsoft.DotNet.Tools.Build
                 {
                     var dependencyProjectContext = ProjectContext.Create(dependency.Path, dependency.Framework);
 
-                    if (!NeedsRebuilding(dependencyProjectContext, new ProjectDependenciesFacade(dependencyProjectContext, _args.ConfigValue)))
+                    if (!DependencyNeedsRebuilding(dependencyProjectContext, new ProjectDependenciesFacade(dependencyProjectContext, _args.ConfigValue)))
                     {
                         continue;
                     }
@@ -88,14 +86,24 @@ namespace Microsoft.DotNet.Tools.Build
             return success;
         }
 
+        private bool DependencyNeedsRebuilding(ProjectContext project, ProjectDependenciesFacade dependencies)
+        {
+            return NeedsRebuilding(project, dependencies, buildOutputPath: null, intermediateOutputPath: null);
+        }
+
         private bool NeedsRebuilding(ProjectContext project, ProjectDependenciesFacade dependencies)
         {
-            var compilerIO = GetCompileIO(project, _args.ConfigValue, _args.OutputValue, _args.IntermediateValue, dependencies);
+            return NeedsRebuilding(project, dependencies, _args.OutputValue, _args.IntermediateValue);
+        }
+
+        private bool NeedsRebuilding(ProjectContext project, ProjectDependenciesFacade dependencies, string buildOutputPath, string intermediateOutputPath)
+        {
+            var compilerIO = GetCompileIO(project, _args.ConfigValue, buildOutputPath, intermediateOutputPath, dependencies);
 
             // rebuild if empty inputs / outputs
             if (!(compilerIO.Outputs.Any() && compilerIO.Inputs.Any()))
             {
-                Reporter.Output.WriteLine($"\nProject {project.ProjectName()} will be compiled because it either has empty inputs or outputs");
+                Reporter.Output.WriteLine($"Project {project.GetDisplayName()} will be compiled because it either has empty inputs or outputs");
                 return true;
             }
 
@@ -125,18 +133,24 @@ namespace Microsoft.DotNet.Tools.Build
 
             if (!newInputs.Any())
             {
-                Reporter.Output.WriteLine($"\nProject {project.ProjectName()} was previously compiled. Skipping compilation.");
+                Reporter.Output.WriteLine($"Project {project.GetDisplayName()} was previously compiled. Skipping compilation.");
                 return false;
             }
 
-            Reporter.Output.WriteLine($"\nProject {project.ProjectName()} will be compiled because some of its inputs were newer than its oldest output.");
-            Reporter.Verbose.WriteLine($"Oldest output item was written at {minDate} : {minOutputPath}");
-            Reporter.Verbose.WriteLine($"Inputs newer than the oldest output item:");
+            Reporter.Output.WriteLine($"Project {project.GetDisplayName()} will be compiled because some of its inputs were newer than its oldest output.");
+            Reporter.Verbose.WriteLine();
+            Reporter.Verbose.WriteLine($" Oldest output item:");
+            Reporter.Verbose.WriteLine($"  {minDate}: {minOutputPath}");
+            Reporter.Verbose.WriteLine();
+
+            Reporter.Verbose.WriteLine($" Inputs newer than the oldest output item:");
 
             foreach (var newInput in newInputs)
             {
-                Reporter.Verbose.WriteLine($"\t{File.GetLastWriteTime(newInput)}\t:\t{newInput}");
+                Reporter.Verbose.WriteLine($"  {File.GetLastWriteTime(newInput)}: {newInput}");
             }
+
+            Reporter.Verbose.WriteLine();
 
             return true;
         }
@@ -150,14 +164,14 @@ namespace Microsoft.DotNet.Tools.Build
                 return false;
             }
 
-            Reporter.Output.WriteLine($"\nProject {project.ProjectName()} will be compiled because expected {itemsType} are missing. ");
+            Reporter.Verbose.WriteLine($"Project {project.GetDisplayName()} will be compiled because expected {itemsType} are missing.");
 
             foreach (var missing in missingItems)
             {
-                Reporter.Verbose.WriteLine($"\t {missing}");
+                Reporter.Verbose.WriteLine($" {missing}");
             }
 
-            Reporter.Output.WriteLine();
+            Reporter.Verbose.WriteLine(); ;
 
             return true;
         }
@@ -205,7 +219,7 @@ namespace Microsoft.DotNet.Tools.Build
         private List<ProjectContext> GetProjectsToCheck()
         {
             // include initial root project
-            var contextsToCheck = new List<ProjectContext>(1 + _dependencies.ProjectDependenciesWithSources.Count) {_rootProject};
+            var contextsToCheck = new List<ProjectContext>(1 + _dependencies.ProjectDependenciesWithSources.Count) { _rootProject };
 
             // convert ProjectDescription to ProjectContext
             var dependencyContexts = _dependencies.ProjectDependenciesWithSources.Select
@@ -262,12 +276,8 @@ namespace Microsoft.DotNet.Tools.Build
             args.Add("--framework");
             args.Add($"{projectDependency.Framework}");
             args.Add("--configuration");
-            args.Add($"{_args.ConfigValue}");
-            args.Add("--output");
-            args.Add($"{_args.OutputValue}");
-            args.Add("--temp-output");
-            args.Add($"{_args.IntermediateValue}");
-            args.Add($"{projectDependency.Project.ProjectDirectory}");
+            args.Add(_args.ConfigValue);
+            args.Add(projectDependency.Project.ProjectDirectory);
 
             if (_args.NoHostValue)
             {
@@ -295,20 +305,20 @@ namespace Microsoft.DotNet.Tools.Build
             args.Add("--temp-output");
             args.Add(_args.IntermediateValue);
 
-            if (_args.NoHostValue) 
-            { 
-                args.Add("--no-host"); 
+            if (_args.NoHostValue)
+            {
+                args.Add("--no-host");
             }
 
             //native args
-            if (_args.IsNativeValue) 
-            { 
-                args.Add("--native"); 
+            if (_args.IsNativeValue)
+            {
+                args.Add("--native");
             }
 
-            if (_args.IsCppModeValue) 
-            { 
-                args.Add("--cpp"); 
+            if (_args.IsCppModeValue)
+            {
+                args.Add("--cpp");
             }
 
             if (!string.IsNullOrWhiteSpace(_args.ArchValue))
@@ -337,7 +347,7 @@ namespace Microsoft.DotNet.Tools.Build
 
             args.Add(_rootProject.ProjectDirectory);
 
-            var compileResult = Command.Create("dotnet-compile",args)
+            var compileResult = Command.Create("dotnet-compile", args)
                 .ForwardStdOut()
                 .ForwardStdErr()
                 .Execute();
@@ -387,11 +397,17 @@ namespace Microsoft.DotNet.Tools.Build
         // computes all the inputs and outputs that would be used in the compilation of a project
         // ensures that all paths are files
         // ensures no missing inputs
-        public static CompilerIO GetCompileIO(ProjectContext project, string config, string outputPath, string intermediaryOutputPath, ProjectDependenciesFacade dependencies)
+        public static CompilerIO GetCompileIO(
+            ProjectContext project,
+            string buildConfiguration,
+            string outputPath,
+            string intermediaryOutputPath,
+            ProjectDependenciesFacade dependencies)
         {
             var compilerIO = new CompilerIO(new List<string>(), new List<string>());
-            var binariesOutputPath = project.GetOutputPathCalculator(outputPath).GetCompilationOutputPath(config);
-            var compilationOutput = CompilerUtil.GetCompilationOutput(project.ProjectFile, project.TargetFramework, config, binariesOutputPath);
+            var calculator = project.GetOutputPathCalculator(outputPath);
+            var binariesOutputPath = calculator.GetOutputDirectoryPath(buildConfiguration);
+            var compilationOutput = calculator.GetAssemblyPath(buildConfiguration);
 
             // input: project.json
             compilerIO.Inputs.Add(project.ProjectFile.ProjectFilePath);
@@ -410,7 +426,7 @@ namespace Microsoft.DotNet.Tools.Build
             compilerIO.Outputs.Add(compilationOutput);
 
             // input / output: compilation options files
-            AddFilesFromCompilationOptions(project, config, compilationOutput, compilerIO);
+            AddFilesFromCompilationOptions(project, buildConfiguration, compilationOutput, compilerIO);
 
             // input / output: resources without culture
             AddCultureResources(project, intermediaryOutputPath, compilerIO);
@@ -423,7 +439,7 @@ namespace Microsoft.DotNet.Tools.Build
 
         private static void AddLockFile(ProjectContext project, CompilerIO compilerIO)
         {
-            if(project.LockFile == null)
+            if (project.LockFile == null)
             {
                 var errorMessage = $"Project {project.ProjectName()} does not have a lock file.";
                 Reporter.Error.WriteLine(errorMessage);

--- a/src/Microsoft.DotNet.Tools.Compiler/CompilerUtil.cs
+++ b/src/Microsoft.DotNet.Tools.Compiler/CompilerUtil.cs
@@ -125,20 +125,6 @@ namespace Microsoft.DotNet.Tools.Compiler
         // used in incremental compilation
         public static IEnumerable<string> GetCompilationSources(ProjectContext project) => project.ProjectFile.Files.SourceFiles;
 
-        // used in incremental compilation
-        public static string GetCompilationOutput(Project project, NuGetFramework framework, string configuration, string outputPath)
-        {
-            var compilationOptions = project.GetCompilerOptions(framework, configuration);
-            var outputExtension = ".dll";
-
-            if (framework.IsDesktop() && compilationOptions.EmitEntryPoint.GetValueOrDefault())
-            {
-                outputExtension = ".exe";
-            }
-
-            return Path.Combine(outputPath, project.Name + outputExtension);
-        }
-
         // used in incremental compilation for the key file
         public static CommonCompilerOptions ResolveCompilationOptions(ProjectContext context, string configuration)
         {

--- a/src/Microsoft.DotNet.Tools.Publish/PublishCommand.cs
+++ b/src/Microsoft.DotNet.Tools.Publish/PublishCommand.cs
@@ -185,16 +185,8 @@ namespace Microsoft.DotNet.Tools.Publish
                 {
                     Directory.CreateDirectory(destinationDirectory);
                 }
-
-                File.Copy(file.ResolvedPath, Path.Combine(destinationDirectory, Path.GetFileName(file.ResolvedPath)), overwrite: true);
                 
-                // Copy pdbs
-                var pdbPath = Path.ChangeExtension(file.ResolvedPath, FileNameSuffixes.DotNet.ProgramDatabase);
-
-                if (File.Exists(pdbPath))
-                {
-                    File.Copy(pdbPath, Path.Combine(destinationDirectory, Path.GetFileName(pdbPath)), overwrite: true);
-                }
+                File.Copy(file.ResolvedPath, Path.Combine(destinationDirectory, Path.GetFileName(file.ResolvedPath)), overwrite: true);
             }
         }
 

--- a/src/Microsoft.DotNet.Tools.Publish/PublishCommand.cs
+++ b/src/Microsoft.DotNet.Tools.Publish/PublishCommand.cs
@@ -132,6 +132,7 @@ namespace Microsoft.DotNet.Tools.Publish
 
                 PublishFiles(export.RuntimeAssemblies, outputPath, nativeSubdirectories: false);
                 PublishFiles(export.NativeLibraries, outputPath, nativeSubdirectories);
+                PublishFiles(export.RuntimeAssets, outputPath);
             }
 
             CopyContents(context, outputPath);
@@ -173,6 +174,14 @@ namespace Microsoft.DotNet.Tools.Publish
             }
 
             return 0;
+        }
+        private static void PublishFiles(IEnumerable<string> files, string outputPath)
+        {
+            foreach (var file in files)
+            {
+                var targetPath = Path.Combine(outputPath, Path.GetFileName(file));
+                File.Copy(file, targetPath, overwrite: true);
+            }
         }
 
         private static void PublishFiles(IEnumerable<LibraryAsset> files, string outputPath, bool nativeSubdirectories)

--- a/src/Microsoft.DotNet.Tools.Run/RunCommand.cs
+++ b/src/Microsoft.DotNet.Tools.Run/RunCommand.cs
@@ -112,15 +112,14 @@ namespace Microsoft.DotNet.Tools.Run
             }
 
             // Now launch the output and give it the results
-            var outputName = Path.Combine(
-                _context.GetOutputPathCalculator(tempDir).GetCompilationOutputPath(Configuration),
-                _context.ProjectFile.Name + Constants.ExeSuffix);
+            var outputName = _context.GetOutputPathCalculator(tempDir).GetExecutablePath(Configuration);
+
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 if (_context.TargetFramework.IsDesktop())
                 {
                     // Run mono if we're running a desktop target on non windows
-                    _args.Insert(0, outputName + ".exe");
+                    _args.Insert(0, outputName);
 
                     if (string.Equals(Configuration, "Debug", StringComparison.OrdinalIgnoreCase))
                     {

--- a/src/Microsoft.DotNet.Tools.Test/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Test/Program.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Tools.Test
             var parentProcessIdOption = app.Option("--parentProcessId", "Used by IDEs to specify their process ID. Test will exit if the parent process does.", CommandOptionType.SingleValue);
             var portOption = app.Option("--port", "Used by IDEs to specify a port number to listen for a connection.", CommandOptionType.SingleValue);
             var projectPath = app.Argument("<PROJECT>", "The project to test, defaults to the current directory. Can be a path to a project.json or a project directory.");
-            
+
             app.OnExecute(() =>
             {
                 try
@@ -51,17 +51,17 @@ namespace Microsoft.DotNet.Tools.Test
 
                         RegisterForParentProcessExit(processId);
                     }
-                    
+
                     var projectContexts = CreateProjectContexts(projectPath.Value);
 
                     var projectContext = projectContexts.First();
 
                     var testRunner = projectContext.ProjectFile.TestRunner;
-                    
+
                     if (portOption.HasValue())
                     {
                         int port;
-                        
+
                         if (!Int32.TryParse(portOption.Value(), out port))
                         {
                             throw new InvalidOperationException($"{portOption.Value()} is not a valid port number.");
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Tools.Test
 
         private static int RunConsole(ProjectContext projectContext, CommandLineApplication app, string testRunner)
         {
-            var commandArgs = new List<string> {projectContext.GetAssemblyPath(Constants.DefaultConfiguration)};
+            var commandArgs = new List<string> { projectContext.GetOutputPathCalculator().GetAssemblyPath(Constants.DefaultConfiguration) };
             commandArgs.AddRange(app.RemainingArguments);
 
             return Command.Create($"{GetCommandName(testRunner)}", commandArgs, projectContext.TargetFramework)
@@ -171,7 +171,7 @@ namespace Microsoft.DotNet.Tools.Test
         {
             TestHostTracing.Source.TraceInformation("Starting Discovery");
 
-            var commandArgs = new List<string> { projectContext.GetAssemblyPath(Constants.DefaultConfiguration) };
+            var commandArgs = new List<string> { projectContext.GetOutputPathCalculator().GetAssemblyPath(Constants.DefaultConfiguration) };
 
             commandArgs.AddRange(new[]
             {
@@ -193,7 +193,7 @@ namespace Microsoft.DotNet.Tools.Test
         {
             TestHostTracing.Source.TraceInformation("Starting Execution");
 
-            var commandArgs = new List<string> { projectContext.GetAssemblyPath(Constants.DefaultConfiguration) };
+            var commandArgs = new List<string> { projectContext.GetOutputPathCalculator().GetAssemblyPath(Constants.DefaultConfiguration) };
 
             commandArgs.AddRange(new[]
             {
@@ -230,7 +230,7 @@ namespace Microsoft.DotNet.Tools.Test
 
             throw new InvalidOperationException(error);
         }
-        
+
         private static void ExecuteRunnerCommand(string testRunner, ReportingChannel channel, List<string> commandArgs)
         {
             var result = Command.Create(GetCommandName(testRunner), commandArgs, new NuGetFramework("DNXCore", Version.Parse("5.0")))

--- a/src/Microsoft.DotNet.Tools.Test/project.json
+++ b/src/Microsoft.DotNet.Tools.Test/project.json
@@ -37,7 +37,6 @@
         "Newtonsoft.Json": "7.0.1"
     },
     "frameworks": {
-        "dnxcore50": {
-        }
+        "dnxcore50": { }
     }
 }

--- a/test/E2E/EndToEndTest.cs
+++ b/test/E2E/EndToEndTest.cs
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             var publishCommand = new PublishCommand(TestProject, output: OutputDirectory);
             publishCommand.Execute().Should().Pass();
 
-            TestOutputExecutable(OutputDirectory, publishCommand.GetOutputExecutable(), s_expectedOutput);    
+            TestExecutable(OutputDirectory, publishCommand.GetOutputExecutable(), s_expectedOutput);    
         }
 
         private void TestSetup()

--- a/test/Microsoft.DotNet.Tools.Builder.Tests/IncrementalTestBase.cs
+++ b/test/Microsoft.DotNet.Tools.Builder.Tests/IncrementalTestBase.cs
@@ -75,12 +75,12 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
         protected static void AssertProjectSkipped(string skippedProject, CommandResult buildResult)
         {
-            Assert.Contains($"Project {skippedProject} was previously compiled. Skipping compilation.", buildResult.StdOut, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"Project {skippedProject} (DNXCore,Version=v5.0) was previously compiled. Skipping compilation.", buildResult.StdOut, StringComparison.OrdinalIgnoreCase);
         }
 
         protected static void AssertProjectCompiled(string rebuiltProject, CommandResult buildResult)
         {
-            Assert.Contains($"Project {rebuiltProject} will be compiled", buildResult.StdOut, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains($"Project {rebuiltProject} (DNXCore,Version=v5.0) will be compiled", buildResult.StdOut, StringComparison.OrdinalIgnoreCase);
         }
 
         protected string GetBinDirectory()

--- a/test/Microsoft.DotNet.Tools.Builder.Tests/IncrementalTests.cs
+++ b/test/Microsoft.DotNet.Tools.Builder.Tests/IncrementalTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             Assert.False(File.Exists(lockFile));
 
             buildResult = BuildProject(expectBuildFailure : true);
-            Assert.Contains("does not have a lock file", buildResult.StdErr);
+            Assert.Contains("does not have a lock file", buildResult.StdOut);
         }
 
         [Fact(Skip="https://github.com/dotnet/cli/issues/980")]

--- a/test/Microsoft.DotNet.Tools.Compiler.Tests/CompilerTests.cs
+++ b/test/Microsoft.DotNet.Tools.Compiler.Tests/CompilerTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             var buildCmd = new BuildCommand(testProject, output: outputDir);
             var result = buildCmd.ExecuteWithCapturedOutput();
             result.Should().Pass();
-            Assert.Contains("CA1018", result.StdErr);
+            Assert.Contains("CA1018", result.StdOut);
         }
 
         private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)

--- a/test/Microsoft.DotNet.Tools.Publish.Tests/Microsoft.DotNet.Tools.Publish.Tests.cs
+++ b/test/Microsoft.DotNet.Tools.Publish.Tests/Microsoft.DotNet.Tools.Publish.Tests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
 
             publishCommand.GetOutputDirectory().Should().HaveFile("TestLibraryWithRunner.dll");
             publishCommand.GetOutputDirectory().Should().HaveFile("TestLibraryWithRunner.pdb");
-            publishCommand.GetOutputDirectory().Should().HaveFile("TestLibraryWithRunner.deps");
+            publishCommand.GetOutputDirectory().Should().NotHaveFile("TestLibraryWithRunner.deps");
             publishCommand.GetOutputDirectory().Should().HaveFile("TestLibraryWithRunner.dll.config");
             // dependencies should also be copied
             publishCommand.GetOutputDirectory().Should().HaveFile("Newtonsoft.Json.dll");

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
@@ -61,8 +61,8 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             string framework = string.IsNullOrEmpty(_framework) ?
                 _project.GetTargetFrameworks().First().FrameworkName.GetShortFolderName() : _framework;
             string runtime = string.IsNullOrEmpty(_runtime) ? PlatformServices.Default.Runtime.GetLegacyRestoreRuntimeIdentifier() : _runtime;
-            //TODO: add runtime back as soon as it gets propagated through the various commands.
-            string output = Path.Combine(config, framework);
+            
+            string output = Path.Combine(config, framework, runtime);
 
             return output;
         }
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         {
             if (!string.IsNullOrEmpty(_output))
             {
-                return new DirectoryInfo(Path.Combine(_output, BuildRelativeOutputPath()));
+                return new DirectoryInfo(_output);
             }
 
             string output = Path.Combine(_project.ProjectDirectory, "bin", BuildRelativeOutputPath());

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/TestBase.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/TestBase.cs
@@ -58,13 +58,11 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 string.Equals("on", val, StringComparison.OrdinalIgnoreCase));
         }
 
-        protected void TestOutputExecutable(
-            string outputDir,
+        protected void TestExecutable(string outputDir,
             string executableName,
-            string expectedOutput,
-            bool native = false)
+            string expectedOutput)
         {
-            var executablePath = Path.Combine(GetCompilationOutputPath(outputDir, native), executableName);
+            var executablePath = Path.Combine(outputDir, executableName);
 
             var executableCommand = new TestCommand(executablePath);
 
@@ -72,7 +70,16 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
             result.Should().HaveStdOut(expectedOutput);
             result.Should().NotHaveStdErr();
-            result.Should().Pass();
+            result.Should().Pass();            
+        }
+        
+        protected void TestOutputExecutable(
+            string outputDir,
+            string executableName,
+            string expectedOutput,
+            bool native = false)
+        {
+            TestExecutable(GetCompilationOutputPath(outputDir, native), executableName, expectedOutput);
         }
 
         protected void TestNativeOutputExecutable(string outputDir, string executableName, string expectedOutput)


### PR DESCRIPTION
- Make all of the code looking for built assets use the OutputPathCalculator
- Project dependencies are always built into their specific folders and the main project is the only one that uses the output path and intermediate output path variable.
- Publish respects the output path for publish only, not compile as part of publish. This means that publishing multiple runtimes will stomp on each other. So don't do that. We can throw if you specify and output location and you haven't specified a specific combination of RID and framework. Alternatively it should probably just pick the first TFM/RID pair from the lock file. This is similar to how `dotnet run` works.
- Cleaned up the incremental build output formatting
- Use a single stream (output stream) since interleaving them was causing formatting issues (like losing random characters in the middle of outputting things).
- Didn't change how pack works, it still preserves the output structure when passing `--output`, this one is worth discussing. We could leave the build output inplace and only move the package to the output location. That's more consistent with how everything else works and can be a follow up PR.

#987 #1019

I'll squash after review.

/cc @cdmihai @livarcocc @victorhurdugaci 