### PR TITLE
Fix testmsi.ps1

### DIFF
--- a/packaging/windows/testmsi.ps1
+++ b/packaging/windows/testmsi.ps1
@@ -56,7 +56,7 @@ try {
         Exit 0
     }
     
-    & $xunitRunner $testBin\Dotnet.Cli.Msi.Tests.exe | Out-Host
+    & $xunitRunner $testBin\Debug\net46\Dotnet.Cli.Msi.Tests.exe | Out-Host
 
     if($LastExitCode -ne 0)
     {


### PR DESCRIPTION
It appears `dotnet publish` now adds the configuration and framework to
the output folder. The commented out part of testmsi.ps1 needs to adapt
to that since it is expected to pass occasionally.

Please close this pull request if I misunderstood the root cause of the issue.