### PR TITLE
Compare `AssemblyName`s correctly.

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel.Loader/LoaderProjectContextExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/LoaderProjectContextExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -12,7 +13,7 @@ namespace Microsoft.DotNet.ProjectModel.Loader
         public static AssemblyLoadContext CreateLoadContext(this ProjectContext context, string configuration = "Debug")
         {
             var exporter = context.CreateExporter(configuration);
-            var assemblies = new Dictionary<AssemblyName, string>();
+            var assemblies = new Dictionary<AssemblyName, string>(AssemblyNameComparer.OrdinalIgnoreCase);
             var dllImports = new Dictionary<string, string>();
 
             foreach (var export in exporter.GetAllExports())
@@ -38,6 +39,34 @@ namespace Microsoft.DotNet.ProjectModel.Loader
 
                 // Add the project's output directory path to ensure project-to-project references get located
                 new[] { context.GetOutputPathCalculator().GetOutputDirectoryPath(configuration) });
+        }
+
+        private class AssemblyNameComparer : IEqualityComparer<AssemblyName>
+        {
+            public static readonly IEqualityComparer<AssemblyName> OrdinalIgnoreCase = new AssemblyNameComparer();
+
+            private AssemblyNameComparer()
+            {
+            }
+
+            public bool Equals(AssemblyName x, AssemblyName y)
+            {
+                // Ignore case because that's what Assembly.Load does.
+                return string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(x.CultureName ?? string.Empty, y.CultureName ?? string.Empty, StringComparison.Ordinal);
+            }
+
+            public int GetHashCode(AssemblyName obj)
+            {
+                var hashCode = 0;
+                if (obj.Name != null)
+                {
+                    hashCode ^= obj.Name.GetHashCode();
+                }
+
+                hashCode ^= (obj.CultureName ?? string.Empty).GetHashCode();
+                return hashCode;
+            }
         }
     }
 }


### PR DESCRIPTION
- Calling `AssemblyLoadContext.LoadFromAssemblyName(new AssemblyName("foo"))` would not work prior to this because the assembly path lookup was a dictionary where the key was `AssemblyName` without a proper `AssemblyName` comparer.

#1084