### PR TITLE
Make use of mcg package and update mcg references

### DIFF
--- a/src/Microsoft.DotNet.Tools.Mcg/Program.cs
+++ b/src/Microsoft.DotNet.Tools.Mcg/Program.cs
@@ -13,11 +13,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Mcg
     public class Program
     {        
         private readonly static string HostExecutableName = "corerun" + Constants.ExeSuffix;
-        private readonly static string McgBinaryName = "mcg.exe";        
-        private static IReadOnlyList<string> references = Array.Empty<string>();
-        private static string inputAssembly;
-        private static string targetArch;
-        private static string outputPath;
+        private readonly static string McgBinaryName = "mcg.exe"; 
 
         private static string[] ParseResponseFile(string rspPath)
         {
@@ -40,73 +36,18 @@ namespace Microsoft.DotNet.Tools.Compiler.Mcg
 
             var nArgs = content.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
             return nArgs;
-        }
-
-        private static IEnumerable<string> TransformCommandLine(string[] args)
-        {
-            var mcgArgs = new List<string>();
-
-            //TODO : Mcg argument need to be consistent with ilc.exe , also expose all mcg arguments         
-            ArgumentSyntax.Parse(args, syntax =>
-            {
-                syntax.HandleHelp = false;
-                syntax.HandleErrors = false;
-                syntax.DefineOption("p", ref targetArch, "Target architecture.");
-                syntax.DefineOptionList("reference", ref references, "Use to specify Managed DLL references of the app.");
-                syntax.DefineOption("outputpath", ref outputPath, "Mcg output path");
-                syntax.DefineParameter("INPUT_ASSEMBLY", ref inputAssembly, "The managed input assembly.");
-                string helpText = syntax.GetHelpText();
-                if (string.IsNullOrWhiteSpace(inputAssembly))
-                {
-                    syntax.ReportError("Input Assembly is a required parameter.");
-                }
-            });
-
-            // TODO : References necessary to resolve types and compile mcg generated code.This should 
-            // come from nuget.
-            string referencepath = Path.Combine(AppContext.BaseDirectory, "mcg", "ref");
-
-            mcgArgs.Add($"{inputAssembly}");
-
-            mcgArgs.Add("-p");
-            mcgArgs.Add($"{targetArch}");
-
-            mcgArgs.Add("-referencepath");
-            mcgArgs.Add($"{referencepath}");
-
-            mcgArgs.Add("-outputpath");
-            mcgArgs.Add($"{outputPath}");
-
-            return mcgArgs;
-        }
+        }      
 
         public static int Main(string[] args)
         {
             DebugHelper.HandleDebugSwitch(ref args);
-
-            // Support Response File
-            foreach (var arg in args)
-            {
-                if (arg.Contains(".rsp"))
-                {
-                    args = ParseResponseFile(arg);
-
-                    if (args == null)
-                    {
-                        return 1;
-                    }
-                }
-            }
-            var mcgArguments = TransformCommandLine(args);
-            return ExecuteMcg(mcgArguments);
+            return ExecuteMcg(args);
         }
 
         private static int ExecuteMcg(IEnumerable<string> arguments)
-        {
-            // TODO : Mcg is assumed to be present under the current path.This will change once 
-            // we have mcg working on coreclr and is available as a nuget package.                                 
-            var executablePath = Path.Combine(@"mcg", McgBinaryName);
-            Console.WriteLine(arguments);
+        {            
+            var executablePath = Path.Combine(AppContext.BaseDirectory, McgBinaryName);
+            
             var result = Command.Create(executablePath, arguments)
                 .ForwardStdErr()
                 .ForwardStdOut()

--- a/src/Microsoft.DotNet.Tools.Mcg/project.json
+++ b/src/Microsoft.DotNet.Tools.Mcg/project.json
@@ -14,9 +14,9 @@
         "Microsoft.Extensions.CommandLineUtils.Sources": {
             "type": "build",
             "version": "1.0.0-*"
-        },        
-        "Microsoft.DotNet.ILCompiler.SDK": "1.0.4-*",
-        "Microsoft.DotNet.Compiler.Common": "1.0.0-*"
+        },                
+        "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
+        "Microsoft.DotNet.Mcg": "1.0.0-prerelease-0003"
     },
     "frameworks": {
         "dnxcore50": {


### PR DESCRIPTION
Mcg now available as a package , use it in dotnet-mcg command.
Use System.CommandLine for command parsing.
Pass in AppDep and ILSDK as mcg references.