### PR TITLE
Fix the way we pass the deps file to the host

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
@@ -181,8 +181,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
                 if (depsPath != null)
                 {
-                    additionalArgs.Add("--depsfile");
-                    additionalArgs.Add(depsPath);
+                    additionalArgs.Add($"--depsfile:{depsPath}");
                 }
 
                 args = additionalArgs.Concat(args);


### PR DESCRIPTION
When doing the argument escaping work, we changed the way we pass the depsfile to the host, this broke the dotnet test command. Moving the parameter back to its original and expected format.