### PR TITLE
Updating build scripts to publish to stage\bin flat folder again

### DIFF
--- a/packaging/nuget/package.ps1
+++ b/packaging/nuget/package.ps1
@@ -24,7 +24,7 @@ New-Item -ItemType Directory -Force -Path $IntermediatePackagesDir
 foreach ($ProjectName in $ProjectsToPack) {
     $ProjectFile = "$RepoRoot\src\$ProjectName\project.json"
 
-    & $toolsDir\dotnet pack "$ProjectFile" --basepath "$Stage2CompilationDir\bin" --output "$IntermediatePackagesDir" --configuration "$Configuration" $versionArg $versionSuffix
+    & $toolsDir\dotnet pack "$ProjectFile" --basepath "$Stage2CompilationDir\forPackaging" --output "$IntermediatePackagesDir" --configuration "$Configuration" $versionArg $versionSuffix
     if (!$?) {
         Write-Host "$toolsDir\dotnet pack failed for: $ProjectFile"
         Exit 1

--- a/scripts/compile/compile-stage-1.sh
+++ b/scripts/compile/compile-stage-1.sh
@@ -21,6 +21,6 @@ export PATH=$DOTNET_INSTALL_DIR/bin:$PATH
 
 # Build Stage 1
 header "Building stage1 dotnet using downloaded stage0 ..."
-COMPILATION_OUTPUT_DIR=$STAGE1_COMPILATION_DIR OUTPUT_DIR=$STAGE1_DIR $REPOROOT/scripts/compile/compile-stage.sh
+OUTPUT_DIR=$STAGE1_DIR $REPOROOT/scripts/compile/compile-stage.sh
 
 export PATH=$StartPath

--- a/scripts/compile/compile-stage-2.sh
+++ b/scripts/compile/compile-stage-2.sh
@@ -23,7 +23,7 @@ export PATH=$STAGE1_DIR/bin:$PATH
 
 # Compile Stage 2
 header "Compiling stage2 dotnet using just-built stage1 ..."
-COMPILATION_OUTPUT_DIR=$STAGE2_COMPILATION_DIR OUTPUT_DIR=$STAGE2_DIR $REPOROOT/scripts/compile/compile-stage.sh
+OUTPUT_DIR=$STAGE2_DIR $REPOROOT/scripts/compile/compile-stage.sh
 
 export DOTNET_HOME=$STAGE2_DIR 
 export DOTNET_TOOLS=$STAGE2_DIR 

--- a/scripts/compile/compile-stage.ps1
+++ b/scripts/compile/compile-stage.ps1
@@ -52,52 +52,28 @@ $FilesToClean = @(
 )
 
 $RuntimeOutputDir = "$OutputDir\runtime\coreclr"
-$binariesOutputDir = "$CompilationOutputDir\bin\$Configuration\$Tfm"
-$runtimeBinariesOutputDir = "$CompilationOutputDir\runtime\coreclr\$Configuration\$Tfm"
-
-if(!(Test-Path $OutputDir\bin))
-{
-    mkdir $OutputDir\bin | Out-Null
-}
-
-if(!(Test-Path $RuntimeOutputDir))
-{
-    mkdir $RuntimeOutputDir | Out-Null
-}
 
 # Publish each project
 $Projects | ForEach-Object {
-    dotnet publish --native-subdirectory --framework "$Tfm" --runtime "$Rid" --output "$CompilationOutputDir\bin" --configuration "$Configuration" "$RepoRoot\src\$_"
+    dotnet publish --native-subdirectory --framework "$Tfm" --runtime "$Rid" --output "$OutputDir\bin" --configuration "$Configuration" "$RepoRoot\src\$_"
     if (!$?) {
-        Write-Host Command failed: dotnet publish --native-subdirectory --framework "$Tfm" --runtime "$Rid" --output "$CompilationOutputDir\bin" --configuration "$Configuration" "$RepoRoot\src\$_"
+        Write-Host Command failed: dotnet publish --native-subdirectory --framework "$Tfm" --runtime "$Rid" --output "$OutputDir\bin" --configuration "$Configuration" "$RepoRoot\src\$_"
         exit 1
     }
 }
 
-if (! (Test-Path $binariesOutputDir)) {
-    $binariesOutputDir = "$CompilationOutputDir\bin"
-}
-
-cp $binariesOutputDir\* $OutputDir\bin -force -recurse
-
 # Publish the runtime
-dotnet publish --framework "$Tfm" --runtime "$Rid" --output "$CompilationOutputDir\runtime\coreclr" --configuration "$Configuration" "$RepoRoot\src\Microsoft.DotNet.Runtime"
+dotnet publish --framework "$Tfm" --runtime "$Rid" --output "$RuntimeOutputDir" --configuration "$Configuration" "$RepoRoot\src\Microsoft.DotNet.Runtime"
 if (!$?) {
-    Write-Host Command failed: dotnet publish --framework "$Tfm" --runtime "$Rid" --output "$CompilationOutputDir\runtime\coreclr" --configuration "$Configuration" "$RepoRoot\src\Microsoft.DotNet.Runtime"
+    Write-Host Command failed: dotnet publish --framework "$Tfm" --runtime "$Rid" --output "$RuntimeOutputDir" --configuration "$Configuration" "$RepoRoot\src\Microsoft.DotNet.Runtime"
     Exit 1
 }
 
-if (! (Test-Path $runtimeBinariesOutputDir)) {
-    $runtimeBinariesOutputDir = "$CompilationOutputDir\runtime\coreclr"
-}
-
-cp $runtimeBinariesOutputDir\* $RuntimeOutputDir -force -recurse
-
 # Build the projects that we are going to ship as nuget packages
 $ProjectsToPack | ForEach-Object {
-    dotnet build --output "$CompilationOutputDir\bin" --configuration "$Configuration" "$RepoRoot\src\$_"
+    dotnet build --output "$CompilationOutputDir\forPackaging" --configuration "$Configuration" "$RepoRoot\src\$_"
     if (!$?) {
-        Write-Host Command failed: dotnet build --native-subdirectory --output "$CompilationOutputDir\bin" --configuration "$Configuration" "$RepoRoot\src\$_"
+        Write-Host Command failed: dotnet build --native-subdirectory --output "$CompilationOutputDir\forPackaging" --configuration "$Configuration" "$RepoRoot\src\$_"
         exit 1
     }
 }

--- a/scripts/compile/compile-stage.sh
+++ b/scripts/compile/compile-stage.sh
@@ -21,7 +21,6 @@ source "$DIR/../common/_common.sh"
 [ ! -z "$CONFIGURATION" ] || die "Missing required environment variable CONFIGURATION"
 [ ! -z "$OUTPUT_DIR" ] || die "Missing required environment variable OUTPUT_DIR"
 [ ! -z "$HOST_DIR" ] || die "Missing required environment variable HOST_DIR"
-[ ! -z "$COMPILATION_OUTPUT_DIR" ] || die "Missing required environment variable COMPILATION_OUTPUT_DIR"
 
 PROJECTS=( \
     Microsoft.DotNet.Cli \
@@ -57,32 +56,15 @@ FILES_TO_CLEAN=( \
 )
 
 RUNTIME_OUTPUT_DIR="$OUTPUT_DIR/runtime/coreclr"
-BINARIES_OUTPUT_DIR="$COMPILATION_OUTPUT_DIR/bin/$CONFIGURATION/$TFM"
-RUNTIME_BINARIES_OUTPUT_DIR="$COMPILATION_OUTPUT_DIR/runtime/coreclr/$CONFIGURATION/$TFM"
-
-mkdir -p "$OUTPUT_DIR/bin"
-mkdir -p "$RUNTIME_OUTPUT_DIR"
 
 for project in ${PROJECTS[@]}
 do
-    echo dotnet publish --native-subdirectory --framework "$TFM" --output "$COMPILATION_OUTPUT_DIR/bin" --configuration "$CONFIGURATION" "$REPOROOT/src/$project"
-    dotnet publish --native-subdirectory --framework "$TFM" --output "$COMPILATION_OUTPUT_DIR/bin" --configuration "$CONFIGURATION" "$REPOROOT/src/$project"
+    echo dotnet publish --native-subdirectory --framework "$TFM" --output "$OUTPUT_DIR/bin" --configuration "$CONFIGURATION" "$REPOROOT/src/$project"
+    dotnet publish --native-subdirectory --framework "$TFM" --output "$OUTPUT_DIR/bin" --configuration "$CONFIGURATION" "$REPOROOT/src/$project"
 done
 
-if [ ! -d "$BINARIES_OUTPUT_DIR" ]
-then
-    BINARIES_OUTPUT_DIR="$COMPILATION_OUTPUT_DIR/bin"
-fi
-cp -R -f $BINARIES_OUTPUT_DIR/* $OUTPUT_DIR/bin
-
 # Bring in the runtime
-dotnet publish --output "$COMPILATION_OUTPUT_DIR/runtime/coreclr" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Runtime"
-
-if [ ! -d "$RUNTIME_BINARIES_OUTPUT_DIR" ]
-then
-    RUNTIME_BINARIES_OUTPUT_DIR="$COMPILATION_OUTPUT_DIR/runtime/coreclr"
-fi
-cp -R -f $RUNTIME_BINARIES_OUTPUT_DIR/* $RUNTIME_OUTPUT_DIR
+dotnet publish --output "$RUNTIME_OUTPUT_DIR" --configuration "$CONFIGURATION" "$REPOROOT/src/Microsoft.DotNet.Runtime"
 
 # Clean up bogus additional files
 for file in ${FILES_TO_CLEAN[@]}


### PR DESCRIPTION
Updating build scripts to publish to stage\bin flat folder again, we don't need it anymore after allowing publish to publish to flat output folders again. This simplifies the scripts. I kept packaging happening in a separate compilation folder because for that we need the tfm folder structure. This also fixes a bug where binaries were only being copied for the first time we built, because we checked that compilationfolder/bin/config/tfm was there. After fowler changes, this was not true for the published CLI, but the packaged folders were still creating this structure, which cause in subsequent build to only the binaries under compilationfolder/bin/debug/dnxcore50 to be copied to stage2dir/bin, instead of everything.