### PR TITLE
Publishing a single project to avoid recompiling

### DIFF
--- a/scripts/compile/compile-stage.ps1
+++ b/scripts/compile/compile-stage.ps1
@@ -15,26 +15,7 @@ param(
 . $REPOROOT\scripts\package\projectsToPack.ps1
 
 $Projects = @(
-    "dotnet",
-    "dotnet-build",
-    "dotnet-compile",
-    "dotnet-compile-csc",
-    "dotnet-compile-fsc",
-    "dotnet-compile-native",
-    "dotnet-new",
-    "dotnet-pack",
-    "dotnet-projectmodel-server",
-    "dotnet-publish",
-    "dotnet-restore",
-    "dotnet-repl",
-    "dotnet-repl-csi",
-    "dotnet-resgen",
-    "dotnet-run",
-    "dotnet-test",
-    "Microsoft.DotNet.Cli.Utils",
-    "Microsoft.DotNet.ProjectModel.Loader",
-    "Microsoft.DotNet.ProjectModel.Workspaces",
-    "Microsoft.Extensions.Testing.Abstractions"
+    "bundler"
 )
 
 $BinariesForCoreHost = @(
@@ -49,6 +30,10 @@ $FilesToClean = @(
     "Microsoft.DotNet.Runtime.dll"
     "Microsoft.DotNet.Runtime.deps"
     "Microsoft.DotNet.Runtime.pdb"
+    "bundler.exe"
+    "bundler.dll"
+    "bundler.deps"
+    "bundler.pdb"
 )
 
 $RuntimeOutputDir = "$OutputDir\runtime\coreclr"

--- a/scripts/compile/compile-stage.sh
+++ b/scripts/compile/compile-stage.sh
@@ -24,22 +24,7 @@ source "$DIR/../common/_common.sh"
 [ ! -z "$COMPILATION_OUTPUT_DIR" ] || die "Missing required environment variable COMPILATION_OUTPUT_DIR"
 
 PROJECTS=( \
-    dotnet \
-    dotnet-build \
-    dotnet-compile \
-    dotnet-compile-csc \
-    dotnet-compile-fsc \
-    dotnet-compile-native \
-    dotnet-new \
-    dotnet-pack \
-    dotnet-projectmodel-server \
-    dotnet-publish \
-    dotnet-repl \
-    dotnet-repl-csi \
-    dotnet-restore \
-    dotnet-resgen \
-    dotnet-run \
-    dotnet-test \
+    bundler \
 )
 
 BINARIES_FOR_COREHOST=( \
@@ -54,6 +39,10 @@ FILES_TO_CLEAN=( \
     Microsoft.DotNet.Runtime.dll \
     Microsoft.DotNet.Runtime.deps \
     Microsoft.DotNet.Runtime.pdb \
+    bundler \
+    bundler.dll \
+    bundler.deps \
+    bundler.pdb \
 )
 
 RUNTIME_OUTPUT_DIR="$OUTPUT_DIR/runtime/coreclr"

--- a/scripts/crossgen/crossgen_roslyn.cmd
+++ b/scripts/crossgen/crossgen_roslyn.cmd
@@ -9,7 +9,7 @@ set BIN_DIR=%CD%\bin
 popd
 
 REM Replace with a robust method for finding the right crossgen.exe
-set CROSSGEN_UTIL=%NUGET_PACKAGES%\runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR\1.0.1-rc2-23720\tools\crossgen.exe
+set CROSSGEN_UTIL=%NUGET_PACKAGES%\runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR\1.0.1-rc3-23727\tools\crossgen.exe
 
 REM Crossgen currently requires itself to be next to mscorlib
 copy %CROSSGEN_UTIL% /Y %BIN_DIR% > nul

--- a/scripts/crossgen/crossgen_roslyn.sh
+++ b/scripts/crossgen/crossgen_roslyn.sh
@@ -23,7 +23,7 @@ else
 fi
 
 # Replace with a robust method for finding the right crossgen.exe
-CROSSGEN_UTIL=$NUGET_PACKAGES/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23720/tools/crossgen
+CROSSGEN_UTIL=$NUGET_PACKAGES/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc3-23727/tools/crossgen
 
 cd $BIN_DIR
 

--- a/src/bundler/Program.cs
+++ b/src/bundler/Program.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+namespace bundler
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Temporary and bogus. Just needed so we can publish this
+            return 1;
+        }
+    }
+}

--- a/src/bundler/project.json
+++ b/src/bundler/project.json
@@ -1,0 +1,28 @@
+{
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+    "dependencies": {
+        "dotnet": "1.0.0-*",
+        "dotnet-build": "1.0.0-*",
+        "dotnet-compile": "1.0.0-*",
+        "dotnet-compile-csc": "1.0.0-*",
+        "dotnet-compile-fsc": "1.0.0-*",
+        "dotnet-compile-native": "1.0.0-*",
+        "dotnet-new": "1.0.0-*",
+        "dotnet-pack": "1.0.0-*",
+        "dotnet-projectmodel-server": "1.0.0-*",
+        "dotnet-publish": "1.0.0-*",
+        "dotnet-repl": "1.0.0-*",
+        "dotnet-repl-csi": "1.0.0-*",
+        "dotnet-resgen": "1.0.0-*",
+        "dotnet-restore": "1.0.0-*",
+        "dotnet-run": "1.0.0-*",
+        "dotnet-test": "1.0.0-*"
+    },
+    "frameworks": {
+        "dnxcore50": {
+            "imports": "portable-net45+win8"
+        }
+    }
+}


### PR DESCRIPTION
- Let nuget deal with unifying versions across differnet projects.