### PR TITLE
Dotnet new dir lang/type

### DIFF
--- a/src/dotnet/commands/dotnet-new/Program.cs
+++ b/src/dotnet/commands/dotnet-new/Program.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Tools.New
             return parts[parts.Length - 2] + "." + parts[parts.Length - 1];
         }
 
-        public int CreateEmptyProject(string languageName, string templateDir)
+        public int CreateEmptyProject(string languageName, string templateName, string templateDir)
         {
             var thisAssembly = typeof(NewCommand).GetTypeInfo().Assembly;
             var resources = from resourceName in thisAssembly.GetManifestResourceNames()
@@ -45,14 +45,14 @@ namespace Microsoft.DotNet.Tools.New
                 resourceNameToFileName.Add(resourceName, fileName);
                 if (File.Exists(fileName))
                 {
-                    Reporter.Error.WriteLine($"Creating new {languageName} project would override file {fileName}.");
+                    Reporter.Error.WriteLine($"Creating new {languageName} {templateName} project would override file {fileName}.");
                     hasFilesToOverride = true;
                 }
             }
 
             if (hasFilesToOverride)
             {
-                Reporter.Error.WriteLine($"Creating new {languageName} project failed.");
+                Reporter.Error.WriteLine($"Creating new {languageName} {templateName} project failed.");
                 return 1;
             }
 
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Tools.New
                 }
             }
 
-            Reporter.Output.WriteLine($"Created new {languageName} project in {Directory.GetCurrentDirectory()}.");
+            Reporter.Output.WriteLine($"Created new {languageName} {templateName} project in {Directory.GetCurrentDirectory()}.");
 
             return 0;
         }
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.Tools.New
 
                 string templateDir = $"{language.TemplatePrefix}_{templateName}";
 
-                return dotnetNew.CreateEmptyProject(language.Name, templateDir);
+                return dotnetNew.CreateEmptyProject(language.Name, templateName, templateDir);
             });
 
             try


### PR DESCRIPTION
ref #655 

add `dir` and `lang/type` arguments, full is `dotnet new dir lang/type`. 
the `--type` and `--lang` works too.

Default are:

- `dir` empty => `.`
- `lang/type` empty => `csharp/console`


so `dotnet new` = `dotnet new . csharp/console` like current behaviour

If `dir` exists => error

Some examples:

```
PS D:\github\cli\prova> dotnet new hello_world
Created new C# Console project in D:\github\cli\prova\hello_world.

PS D:\github\cli\prova> dotnet new hello2 console
Created new C# Console project in D:\github\cli\prova\hello2.

PS D:\github\cli\prova> dotnet new hello2 fsharp/console
Directory hello2 already exists

PS D:\github\cli\prova> dotnet new hello3 fsharp/console
Created new F# Console project in D:\github\cli\prova\hello3.

PS D:\github\cli\prova> dotnet new hello5 --type console
Created new C# Console project in D:\github\cli\prova\hello5.

PS D:\github\cli\prova> dotnet new . console
Created new C# Console project in D:\github\cli\prova.

PS D:\github\cli\prova> dotnet new --lang f# hello7 console
Created new F# Console project in D:\github\cli\prova\hello7.

PS D:\github\cli\prova> dotnet new --lang f# hello7 suave
Unrecognized type: suave
Avaiable types for F# :
- Console
```

ready for review /cc @blackdwarf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/1124)
<!-- Reviewable:end -->