### PR TITLE
Add initial stubs for NetBSD

### DIFF
--- a/scripts/common/_rid.sh
+++ b/scripts/common/_rid.sh
@@ -27,6 +27,13 @@ if [ -z "$RID" ]; then
         else
             error "unknown Linux Distro" 1>&2
         fi
+    elif [ "$UNAME" == "NetBSD" ]; then
+        export OSNAME=netbsd
+        version=$(uname -r)
+        machine=$(uname -m)
+        if [ "x$machine" = "xamd64" ]; then
+            export RID=${OSNAME}.${version}-x64
+        fi
     else
         error "unknown OS: $UNAME" 1>&2
     fi

--- a/scripts/obtain/install.sh
+++ b/scripts/obtain/install.sh
@@ -88,6 +88,8 @@ current_os()
     local uname=$(uname)
     if [ "$uname" = "Darwin" ]; then
         echo "osx"
+    elif [ "$uname" = "NetBSD" ]; then
+        echo "netbsd"
     else
         # Detect Distro
         if [ "$(cat /etc/*-release | grep -cim1 ubuntu)" -eq 1 ]; then


### PR DESCRIPTION
1. Is there need to normalize version of NetBSD from x.y.z to x? For example:

```
$ uname -a
NetBSD chieftec 7.99.25 NetBSD 7.99.25 (GENERIC) #0: Fri Dec 25 20:51:06 UTC 2015  root@chieftec:/tmp/netbsd-tmp/sys/arch/amd64/compile/GENERIC amd64
```

Should it be normalized to 7?

2. While there, I'm unsure how to continue:

```
 ./build.sh                                                                                                                                        
*** Building dotnet tools version 1.0.1.001187 - Debug ***
*** Checking Pre-Reqs ***
*** Adjusting file descriptors limit, if necessary ***
*** Restoring Tools and Packages ***
*** Installing dotnet stage 0 ***
dotnet_install: Preparing to install .NET Tools to /public/cli/.dotnet_stage0/netbsd.7.99.25-x64
local: d</Code><Message>The: bad variable name
dotnet_install: Latest Version: Time:2016-01-30T00:47:08.8957594Z</Message></Error>
dotnet_install: Local Version: <none>
dotnet_install: Downloading dotnet-netbsd-x64.latest.tar.gz from https://dotnetcli.blob.core.windows.net/dotnet/dev/Binaries/Latest
######################################################################## 100,0%
HTTP Error 404 fetching the dotnet cli from https://dotnetcli.blob.core.windows.net/dotnet/dev/Binaries/Latest 
/public/cli/scripts/obtain/install.sh: ="1.0": bad variable name
```