### PR TITLE
Cleanup command options for Windows CppCompileStep and LinkStep

### DIFF
--- a/src/dotnet-compile-native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
+++ b/src/dotnet-compile-native/IntermediateCompilation/Windows/WindowsCppCompileStep.cs
@@ -19,11 +19,14 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         private readonly string InputExtension = ".cpp";
         
         private readonly string CompilerOutputExtension = ".obj";
-        
+
+        // TODO: Remove /DWIN32
+        private static readonly string[] DefaultCompilerOptions = { "/nologo", "/W3", "/GS", "/DCPPCODEGEN", "/DWIN32", "/EHs", "/MT", "/Zi" };
+
         private static readonly Dictionary<BuildConfiguration, string[]> ConfigurationCompilerOptionsMap = new Dictionary<BuildConfiguration, string[]>
         {
-            { BuildConfiguration.debug, new string[] {"/ZI", "/nologo", "/W3", "/WX-", "/sdl", "/Od", "/D", "CPPCODEGEN", "/D", "WIN32", "/D", "_CONSOLE", "/D", "_LIB", "/D", "_UNICODE", "/D", "UNICODE", "/Gm", "/EHsc", "/RTC1", "/MT", "/GS", "/fp:precise", "/Zc:wchar_t", "/Zc:forScope", "/Zc:inline", "/Gd", "/TP", "/wd4477", "/errorReport:prompt"} },
-            { BuildConfiguration.release, new string[] {"/Zi", "/nologo", "/W3", "/WX-", "/sdl", "/O2", "/Oi", "/GL", "/D", "CPPCODEGEN", "/D", "WIN32", "/D", "NDEBUG", "/D", "_CONSOLE", "/D", "_LIB", "/D", "_UNICODE", "/D", "UNICODE", "/Gm-", "/EHsc", "/MT", "/GS", "/Gy", "/fp:precise", "/Zc:wchar_t", "/Zc:forScope", "/Zc:inline", "/Gd", "/TP", "/wd4477", "/errorReport:prompt"} }
+            { BuildConfiguration.debug, new string[] { "/Od" } },
+            { BuildConfiguration.release, new string[] { "/O2" } }
         };
         
         private IEnumerable<string> CompilerArgs { get; set; }
@@ -71,6 +74,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var ilcSdkIncPath = Path.Combine(config.IlcSdkPath, "inc");
             argsList.Add("/I");
             argsList.Add($"{ilcSdkIncPath}");
+            
+            argsList.AddRange(DefaultCompilerOptions);
             
             // Configuration Based Compiler Options 
             argsList.AddRange(ConfigurationCompilerOptionsMap[config.BuildType]);

--- a/src/dotnet-compile-native/IntermediateCompilation/Windows/WindowsLinkStep.cs
+++ b/src/dotnet-compile-native/IntermediateCompilation/Windows/WindowsLinkStep.cs
@@ -18,10 +18,12 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         private readonly string InputExtension = ".obj";
 
-        private static readonly Dictionary<BuildConfiguration, string> ConfigurationLinkerOptionsMap = new Dictionary<BuildConfiguration, string>
+        private static readonly string[] DefaultLinkerOptions = new string[] { "/NOLOGO", "/DEBUG", "/MANIFEST:NO", "/IGNORE:4099" };
+
+        private static readonly Dictionary<BuildConfiguration, string[]> ConfigurationLinkerOptionsMap = new Dictionary<BuildConfiguration, string[]>
         {
-            { BuildConfiguration.debug, "/NOLOGO /ERRORREPORT:PROMPT /MANIFEST /MANIFESTUAC:\"level='asInvoker' uiAccess='false'\" /manifest:embed /Debug /TLBID:1 /DYNAMICBASE /NXCOMPAT" },
-            { BuildConfiguration.release, "/NOLOGO /ERRORREPORT:PROMPT /INCREMENTAL:NO /OPT:REF /OPT:ICF /LTCG:incremental /MANIFEST /MANIFESTUAC:\"level='asInvoker' uiAccess='false'\" /manifest:embed /Debug /TLBID:1 /DYNAMICBASE /NXCOMPAT" }
+            { BuildConfiguration.debug, new string[] { } },
+            { BuildConfiguration.release, new string[] { "/INCREMENTAL:NO", "/OPT:REF", "/OPT:ICF" } }
         };
 
         private static readonly Dictionary<NativeIntermediateMode, string[]> IlcSdkLibMap = new Dictionary<NativeIntermediateMode, string[]>
@@ -81,9 +83,11 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         private void InitializeArgs(NativeCompileSettings config)
         {
             var argsList = new List<string>();
-            
+
+            argsList.AddRange(DefaultLinkerOptions);
+
             // Configuration Based Linker Options 
-            argsList.Add(ConfigurationLinkerOptionsMap[config.BuildType]);
+            argsList.AddRange(ConfigurationLinkerOptionsMap[config.BuildType]);
             
             //Output
             var outFile = DetermineOutputFile(config);


### PR DESCRIPTION
- Pass command line options correctly to the linker (all options were passed as one giant quoted string and thus they had no effect)
- Remove unnecessary command line options
- Factored out command line options that are shared by debug and release configurations