### PR TITLE
Add "additionalArguments" compilation option

### DIFF
--- a/scripts/configuration/testProjects.csv
+++ b/scripts/configuration/testProjects.csv
@@ -3,3 +3,4 @@ StreamForwarderTests
 dotnet-publish.Tests
 dotnet-compile.Tests
 dotnet-build.Tests
+Compiler.Common.Tests

--- a/src/Microsoft.DotNet.Compiler.Common/CommonCompilerOptionsExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/CommonCompilerOptionsExtensions.cs
@@ -36,6 +36,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
         internal static readonly OptionTemplate s_generateXmlDocumentation = new OptionTemplate("generate-xml-documentation");
 
+        internal static readonly OptionTemplate s_additionalArgumentsTemplate = new OptionTemplate("additional-argument");
+
         public static CommonCompilerOptions Parse(ArgumentSyntax syntax)
         {
             IReadOnlyList<string> defines = null;
@@ -50,12 +52,15 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             bool? publicSign = null;
             bool? emitEntryPoint = null;
             bool? generateXmlDocumentation = null;
+            IReadOnlyList<string> additionalArguments = null;
 
             Func<string, bool?> nullableBoolConverter = v => bool.Parse(v);
 
             syntax.DefineOptionList(s_definesTemplate.LongName, ref defines, "Preprocessor definitions");
 
             syntax.DefineOptionList(s_suppressWarningTemplate.LongName, ref suppressWarnings, "Suppresses the specified warning");
+
+            syntax.DefineOptionList(s_additionalArgumentsTemplate.LongName, ref additionalArguments, "Pass the additional argument directly to the compiler");
 
             syntax.DefineOption(s_languageVersionTemplate.LongName, ref languageVersion,
                     "The version of the language used to compile");
@@ -100,7 +105,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 DelaySign = delaySign,
                 PublicSign = publicSign,
                 EmitEntryPoint = emitEntryPoint,
-                GenerateXmlDocumentation = generateXmlDocumentation
+                GenerateXmlDocumentation = generateXmlDocumentation,
+                AdditionalArguments = additionalArguments
             };
         }
 
@@ -118,6 +124,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             var publicSign = options.PublicSign;
             var emitEntryPoint = options.EmitEntryPoint;
             var generateXmlDocumentation = options.GenerateXmlDocumentation;
+            var additionalArguments = options.AdditionalArguments;
 
             var args = new List<string>();
 
@@ -129,6 +136,11 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             if (suppressWarnings != null)
             {
                 args.AddRange(suppressWarnings.Select(def => s_suppressWarningTemplate.ToLongArg(def)));
+            }
+
+            if (additionalArguments != null)
+            {
+                args.AddRange(additionalArguments.Select(arg => s_additionalArgumentsTemplate.ToLongArg(arg)));
             }
 
             if (languageVersion != null)

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
@@ -560,6 +560,7 @@ namespace Microsoft.DotNet.ProjectModel
             {
                 Defines = rawOptions.ValueAsStringArray("define"),
                 SuppressWarnings = rawOptions.ValueAsStringArray("nowarn"),
+                AdditionalArguments = rawOptions.ValueAsStringArray("additionalArguments"),
                 LanguageVersion = rawOptions.ValueAsString("languageVersion"),
                 AllowUnsafe = rawOptions.ValueAsNullableBoolean("allowUnsafe"),
                 Platform = rawOptions.ValueAsString("platform"),

--- a/src/dotnet/commands/dotnet-compile-csc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-csc/Program.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                     syntax.DefineOption("out", ref outputName, "Name of the output assembly");
 
                     syntax.DefineOptionList("reference", ref references, "Path to a compiler metadata reference");
-                    
+
                     syntax.DefineOptionList("analyzer", ref analyzers, "Path to an analyzer assembly");
 
                     syntax.DefineOptionList("resource", ref resources, "Resources to embed");
@@ -145,6 +145,12 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             if (options.SuppressWarnings != null)
             {
                 commonArgs.AddRange(options.SuppressWarnings.Select(w => $"-nowarn:{w}"));
+            }
+
+            // Additional arguments are added verbatim
+            if (options.AdditionalArguments != null)
+            {
+                commonArgs.AddRange(options.AdditionalArguments);
             }
 
             if (options.LanguageVersion != null)

--- a/test/Compiler.Common.Tests/Tests.cs
+++ b/test/Compiler.Common.Tests/Tests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.CommandLine;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Compiler.Common
+{
+    public class Tests : TestBase
+    {
+        private static void EqualAfterDeserialize(IEnumerable<string> args, CommonCompilerOptions original)
+        {
+            CommonCompilerOptions newOptions = null;
+
+            ArgumentSyntax.Parse(args, syntax =>
+            {
+                newOptions = CommonCompilerOptionsExtensions.Parse(syntax);
+            });
+
+            Assert.Equal(original, newOptions);
+
+        }
+
+        [Fact]
+        public void SimpleSerialize()
+        {
+            var options = new CommonCompilerOptions();
+            options.AdditionalArguments = new[] { "-highentropyva+" };
+
+            var args = options.SerializeToArgs();
+            Assert.Equal(new [] { "--additional-argument:-highentropyva+" }, args);
+
+            EqualAfterDeserialize(args, options);
+        }
+
+        [Fact]
+        public void WithSpaces()
+        {
+            var options = new CommonCompilerOptions();
+            options.AdditionalArguments = new[] { "-highentropyva+", "-addmodule:\"path with spaces\";\"after semicolon\"" };
+
+            var args = options.SerializeToArgs();
+            Assert.Equal(new [] {
+                "--additional-argument:-highentropyva+",
+                "--additional-argument:-addmodule:\"path with spaces\";\"after semicolon\""
+                }, args);
+
+            EqualAfterDeserialize(args, options);
+        }
+    }
+}

--- a/test/Compiler.Common.Tests/project.json
+++ b/test/Compiler.Common.Tests/project.json
@@ -1,0 +1,23 @@
+{
+    "version": "1.0.0-*",
+
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23727",
+        "Microsoft.NETCore.TestHost" : "1.0.0-*",
+
+        "xunit": "2.1.0",
+        "xunit.console.netcore": "1.0.2-prerelease-00101",
+        "xunit.netcore.extensions": "1.0.0-prerelease-*",
+        "xunit.runner.utility": "2.1.0",
+
+        "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+        "Microsoft.DotNet.ProjectModel": { "target": "project" },
+        "Microsoft.DotNet.Compiler.Common": { "target": "project" }
+    },
+
+    "frameworks": {
+        "dnxcore50": {
+            "imports": "portable-net45+win8"
+        }
+    }
+}

--- a/test/TestProjects/TestLibrary/project.json
+++ b/test/TestProjects/TestLibrary/project.json
@@ -2,7 +2,8 @@
     "version": "1.0.0-*",
     "compilationOptions": {
         "nowarn": [ "CS1591" ],
-        "xmlDoc": true
+        "xmlDoc": true,
+        "additionalArguments": [ "-highentropyva+" ]
     },
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23727"


### PR DESCRIPTION
The `compilationOptions` section of the project.json provides support for a lot of commonly used compilation options but it will not, and should not, provide the full set of options available to all possible compilers. However, there should still be a way to pass specific options down to those compilers, ignoring the layers and filtering in between.

The `additionalArguments` section of the `compilationOptions` provides this by allowing for an arbitrary list of strings to be added to the compilation options which will be directly appended to the options eventually given to the language-specific compiler.

/cc @anurse @brthor @davidfowl 