### PR TITLE
Updating the Compiler and Interactive toolsets to v1.2.0-beta1-20160202-02

### DIFF
--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -18,9 +18,9 @@
     "dependencies": {
         "Newtonsoft.Json": "7.0.1",
         
-        "Microsoft.Net.Compilers.netcore": "1.2.0-beta1-20160108-01",
+        "Microsoft.Net.Compilers.netcore": "1.2.0-beta1-20160202-02",
         "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-151218",
-        "Microsoft.Net.CSharp.Interactive.netcore": "1.2.0-beta1-20160108-01",
+        "Microsoft.Net.CSharp.Interactive.netcore": "1.2.0-beta1-20160202-02",
         "Microsoft.CodeAnalysis.CSharp":  "1.2.0-beta1-20160108-01",
         "NuGet.CommandLine.XPlat": "3.4.0-beta-569",
         "System.CommandLine" : "0.1.0-e160119-1",


### PR DESCRIPTION
This is the per sprint update.

FYI. @agocke, @ManishJayaswal, @dotnet/roslyn-infrastructure 