### PR TITLE
Calculate the intermediate output path in CompileContext.NeedsRebuilding

### DIFF
--- a/src/dotnet/commands/dotnet-build/CompileContext.cs
+++ b/src/dotnet/commands/dotnet-build/CompileContext.cs
@@ -433,6 +433,8 @@ namespace Microsoft.DotNet.Tools.Build
             var compilerIO = new CompilerIO(new List<string>(), new List<string>());
             var calculator = project.GetOutputPathCalculator(outputPath);
             var binariesOutputPath = calculator.GetOutputDirectoryPath(buildConfiguration);
+            intermediaryOutputPath = calculator.GetIntermediateOutputDirectoryPath(buildConfiguration, intermediaryOutputPath);
+
 
             // input: project.json
             compilerIO.Inputs.Add(project.ProjectFile.ProjectFilePath);


### PR DESCRIPTION
Supersedes https://github.com/dotnet/cli/pull/1123