### PR TITLE
Updating NuGet.config to no longer point to myget.org.

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,17 +2,9 @@
 <configuration>
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />    
-    <add key="dotnet-core-rel" value="https://www.myget.org/F/dotnet-core-rel/api/v3/index.json" />
-    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
-    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
-    <add key="roslyn-nightly" value="https://www.myget.org/F/roslyn-nightly/api/v3/index.json" />
+    <clear />
+    <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
-    <add key="corefxlab" value="https://www.myget.org/F/netcore-package-prototyping/api/v3/index.json" />
-    <add key="corert" value="https://www.myget.org/F/dotnet/api/v3/index.json" />
-    <add key="dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/api/v3/index.json" />
-    <add key="fsharp-daily" value="https://www.myget.org/F/fsharp-daily/api/v3/index.json" />
   </packageSources>
   <activePackageSource>
     <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />


### PR DESCRIPTION
We are using our own cli-deps feed in an enterprise myget account in order to ensure we depend on stable nuget repositories.

@piotrpMSFT @anurse 