### PR TITLE
Invoke intrinsic commands directly instead of creating a process.

### DIFF
--- a/src/dotnet/commands/dotnet-build/CompileContext.cs
+++ b/src/dotnet/commands/dotnet-build/CompileContext.cs
@@ -280,13 +280,10 @@ namespace Microsoft.DotNet.Tools.Build
             args.Add("--configuration");
             args.Add(_args.ConfigValue);
             args.Add(projectDependency.Project.ProjectDirectory);
-            
-            var compileResult = Command.CreateDotNet("compile", args)
-                .ForwardStdOut()
-                .ForwardStdErr()
-                .Execute();
 
-            return compileResult.ExitCode == 0;
+            var compileResult = CommpileCommand.Run(args.ToArray());
+
+            return compileResult == 0;
         }
 
         private bool InvokeCompileOnRootProject()
@@ -339,12 +336,9 @@ namespace Microsoft.DotNet.Tools.Build
 
             args.Add(_rootProject.ProjectDirectory);
 
-            var compileResult = Command.CreateDotNet("compile", args)
-                .ForwardStdOut()
-                .ForwardStdErr()
-                .Execute();
+            var compileResult = CommpileCommand.Run(args.ToArray());
 
-            var succeeded = compileResult.ExitCode == 0;
+            var succeeded = compileResult == 0;
 
             if (succeeded)
             {

--- a/src/dotnet/commands/dotnet-compile/Program.cs
+++ b/src/dotnet/commands/dotnet-compile/Program.cs
@@ -147,12 +147,9 @@ namespace Microsoft.DotNet.Tools.Compiler
             //     Need CoreRT Framework published to nuget
 
             // Do Native Compilation
-            var result = Command.CreateDotNet("compile-native", new string[] { "--rsp", $"{rsp}" })
-                                .ForwardStdErr()
-                                .ForwardStdOut()
-                                .Execute();
+            var result = Native.CompileNativeCommand.Run(new string[] { "--rsp", $"{rsp}" });
 
-            return result.ExitCode == 0;
+            return result == 0;
         }
 
         private static bool CompileProject(ProjectContext context, CompilerCommandApp args)
@@ -378,13 +375,9 @@ namespace Microsoft.DotNet.Tools.Compiler
                     var rsp = Path.Combine(intermediateOutputPath, $"dotnet-resgen-resx.rsp");
                     File.WriteAllLines(rsp, arguments);
 
-                    var result =
-                        Command.CreateDotNet("resgen", new[] { $"@{rsp}" })
-                            .ForwardStdErr()
-                            .ForwardStdOut()
-                            .Execute();
+                    var result = Resgen.ResgenCommand.Run(new[] { $"@{rsp}" });
 
-                    if (result.ExitCode != 0)
+                    if (result != 0)
                     {
                         return false;
                     }
@@ -429,11 +422,8 @@ namespace Microsoft.DotNet.Tools.Compiler
                 var rsp = Path.Combine(intermediateOutputPath, $"dotnet-resgen.rsp");
                 File.WriteAllLines(rsp, arguments);
 
-                var result = Command.CreateDotNet("resgen", new[] { $"@{rsp}" })
-                    .ForwardStdErr()
-                    .ForwardStdOut()
-                    .Execute();
-                if (result.ExitCode != 0)
+                var result = Resgen.ResgenCommand.Run(new[] { $"@{rsp}" });
+                if (result != 0)
                 {
                     return false;
                 }

--- a/src/dotnet/commands/dotnet-pack/BuildProjectCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/BuildProjectCommand.cs
@@ -58,12 +58,9 @@ namespace Microsoft.DotNet.Tools.Pack
 
                 argsBuilder.Add($"{_project.ProjectFilePath}");
 
-                var result = Command.CreateDotNet("build", argsBuilder)
-                       .ForwardStdOut()
-                       .ForwardStdErr()
-                       .Execute();
+                var result = Build.BuildCommand.Run(argsBuilder.ToArray());
 
-                return result.ExitCode;
+                return result;
             }
 
             return 0;

--- a/src/dotnet/commands/dotnet-publish/PublishCommand.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommand.cs
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Tools.Publish
             }
 
             // Compile the project (and transitively, all it's dependencies)
-            var result = Command.CreateDotNet("build",
+            var result = Build.BuildCommand.Run(
                 new string[] {
                     "--framework",
                     $"{context.TargetFramework.DotNetFrameworkName}",
@@ -115,12 +115,9 @@ namespace Microsoft.DotNet.Tools.Publish
                     "--configuration",
                     configuration,
                     context.ProjectFile.ProjectDirectory
-                })
-                .ForwardStdErr()
-                .ForwardStdOut()
-                .Execute();
+                });
 
-            if (result.ExitCode != 0)
+            if (result != 0)
             {
                 return false;
             }

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Tools.Run
             var tempDir = Path.Combine(_context.ProjectDirectory, "bin", ".dotnetrun", Guid.NewGuid().ToString("N"));
 
             // Compile to that directory
-            var result = Command.CreateDotNet($"build", new []
+            var result = Build.BuildCommand.Run(new[]
                 {
                     $"--output",
                     $"{tempDir}",
@@ -101,14 +101,11 @@ namespace Microsoft.DotNet.Tools.Run
                     $"--configuration",
                     $"{Configuration}",
                     $"{_context.ProjectFile.ProjectDirectory}"
-                })
-                .ForwardStdOut(onlyIfVerbose: true)
-                .ForwardStdErr()
-                .Execute();
+                });
 
-            if (result.ExitCode != 0)
+            if (result != 0)
             {
-                return result.ExitCode;
+                return result;
             }
 
             // Now launch the output and give it the results
@@ -149,7 +146,8 @@ namespace Microsoft.DotNet.Tools.Run
                 .ForwardStdOut()
                 .ForwardStdErr()
                 .EnvironmentVariable("DOTNET_HOME", dotnetHome)
-                .Execute();
+                .Execute()
+                .ExitCode;
 
             // Clean up
             if (!PreserveTemporary)
@@ -157,7 +155,7 @@ namespace Microsoft.DotNet.Tools.Run
                 Directory.Delete(tempDir, recursive: true);
             }
 
-            return result.ExitCode;
+            return result;
         }
 
         private static int RunInteractive(string scriptName)


### PR DESCRIPTION
This is a second try of pull request #1197.

Since issue #1149 intrinsic commands are now invoked directly from the dotnet.exe program rather than creating a new a new dotnet-intrinsic.exe process. Now that all the commands live inside the same assembly, intrinsic commands that invoke other commands could potentially do so without creating a new process. As creating a process, loading the CLR, resolving dependencies, and JIT-ing code all take a bit of time, this change could speed things up a bit.

I believe the principal change in behavior this change causes is for the DOTNET_CLI_CONTEXT_ environmental variables to be inherit by intrinsic commands created by other intrinsic commands. Currently Microsoft.DotNet.Cli.Program.ProcessArgs() seems to overwrite this environmental variable every time based on command line flags.

There are probably nicer ways of doing this, but I wanted to try the simplest thing possible to see if it would work and if y'all are interested in doing something like this.