### PR TITLE
Updating the Compiler and Interactive toolsets to v1.2.0-beta1-20160202-02

### DIFF
--- a/scripts/crossgen/crossgen_roslyn.cmd
+++ b/scripts/crossgen/crossgen_roslyn.cmd
@@ -29,16 +29,24 @@ if exist mscorlib.ni.dll (
 
 set READYTORUN=
 
+echo Crossgenning System.Collections.Immutable
 crossgen /nologo %READYTORUN% /Platform_Assemblies_Paths %BIN_DIR% System.Collections.Immutable.dll >nul 2>nul
 if not %errorlevel% EQU 0 goto fail
 
+echo Crossgenning System.Reflection.Metadata
 crossgen /nologo %READYTORUN% /Platform_Assemblies_Paths %BIN_DIR% System.Reflection.Metadata.dll >nul 2>nul
 if not %errorlevel% EQU 0 goto fail
 
+echo Crossgenning Microsoft.CodeAnalysis
 crossgen /nologo %READYTORUN% /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.dll >nul 2>nul
 if not %errorlevel% EQU 0 goto fail
 
+echo Crossgenning Microsoft.CodeAnalysis.CSharp
 crossgen /nologo %READYTORUN% /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.CSharp.dll >nul 2>nul
+if not %errorlevel% EQU 0 goto fail
+
+echo Crossgenning Microsoft.CodeAnalysis.CSharp.Scripting
+crossgen /nologo %READYTORUN% /Platform_Assemblies_Paths %BIN_DIR% Microsoft.CodeAnalysis.CSharp.Scripting.dll >nul 2>nul
 if not %errorlevel% EQU 0 goto fail
 
 echo Crossgenning Microsoft.CodeAnalysis.VisualBasic
@@ -47,6 +55,10 @@ if not %errorlevel% EQU 0 goto fail
 
 echo Crossgenning csc
 crossgen /nologo %READYTORUN% /Platform_Assemblies_Paths %BIN_DIR% csc.dll >nul 2>nul
+if not %errorlevel% EQU 0 goto fail
+
+echo Crossgenning csi
+crossgen /nologo %READYTORUN% /Platform_Assemblies_Paths %BIN_DIR% csi.dll >nul 2>nul
 if not %errorlevel% EQU 0 goto fail
 
 echo Crossgenning vbc

--- a/scripts/crossgen/crossgen_roslyn.sh
+++ b/scripts/crossgen/crossgen_roslyn.sh
@@ -54,19 +54,33 @@ chmod +x crossgen
 
 ./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR mscorlib.dll
 
+info "Crossgenning System.Collections.Immutable"
 ./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR System.Collections.Immutable.dll
 
+info "Crossgenning System.Reflection.Metadata"
 ./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR System.Reflection.Metadata.dll
 
+info "Crossgenning Microsoft.CodeAnalysis"
 ./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.dll
 
+info "Crossgenning Microsoft.CodeAnalysis.CSharp"
 ./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.CSharp.dll
 
+info "Crossgenning Microsoft.CodeAnalysis.CSharp.Scripting"
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.CSharp.Scripting.dll
+
+info "Crossgenning Microsoft.CodeAnalysis.VisualBasic"
 ./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.VisualBasic.dll
 
+info "Crossgenning csc"
 ./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR csc.dll
 [ -e csc.ni.exe ] && [ ! -e csc.ni.dll ] && mv csc.ni.exe csc.ni.dll
 
+info "Crossgenning csi"
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR csi.dll
+[ -e csi.ni.exe ] && [ ! -e csi.ni.dll ] && mv csi.ni.exe csi.ni.dll
+
+info "Crossgenning vbc"
 ./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR vbc.dll
 [ -e vbc.ni.exe ] && [ ! -e vbc.ni.dll ] && mv vbc.ni.exe vbc.ni.dll
 

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -7,6 +7,7 @@
 
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23811",
+        "System.Reflection.Metadata": "1.2.0-rc3-23811",
         "System.CommandLine": "0.1.0-e160119-1",
         "Microsoft.CodeAnalysis.CSharp":  "1.2.0-beta1-20160202-02",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -8,7 +8,7 @@
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23811",
         "System.CommandLine": "0.1.0-e160119-1",
-        "Microsoft.CodeAnalysis.CSharp":  "1.2.0-beta1-20160108-01",
+        "Microsoft.CodeAnalysis.CSharp":  "1.2.0-beta1-20160202-02",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
         "Microsoft.DotNet.Files": {"version": "1.0.0-*", "target": "project"}

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -7,7 +7,7 @@
         "NETStandard.Library": "1.0.0-rc2-23811",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
-        "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.2.0-beta1-20160108-01"
+        "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.2.0-beta1-20160202-02"
     },
     "frameworks": {
         "dnxcore50": {

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -5,6 +5,7 @@
     },
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23811",
+        "System.Reflection.Metadata": "1.2.0-rc3-23811",
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
         "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.2.0-beta1-20160202-02"

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -18,10 +18,12 @@
     "dependencies": {
         "Newtonsoft.Json": "7.0.1",
 
-        "Microsoft.Net.Compilers.netcore": "1.2.0-beta1-20160108-01",
+        "Microsoft.Net.Compilers.netcore": "1.2.0-beta1-20160202-02",
         "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-151218",
-        "Microsoft.Net.CSharp.Interactive.netcore": "1.2.0-beta1-20160108-01",
-        "Microsoft.CodeAnalysis.CSharp": "1.2.0-beta1-20160108-01",
+        "Microsoft.Net.CSharp.Interactive.netcore": "1.2.0-beta1-20160202-02",
+        "Microsoft.CodeAnalysis.CSharp":  "1.2.0-beta1-20160202-02",
+        "Microsoft.DiaSymReader.Native": "1.3.3",
+
         "NuGet.CommandLine.XPlat": "3.4.0-beta-583",
         "System.CommandLine": "0.1.0-e160119-1",
 

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -54,6 +54,7 @@
         "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23811",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23811",
         "NETStandard.Library": "1.0.0-rc2-23811",
+        "System.Reflection.Metadata": "1.2.0-rc3-23811",
         "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23811",
         "System.Diagnostics.TraceSource": "4.0.0-rc2-23811",
         "System.Linq.Expressions": "4.0.11-rc2-23811",


### PR DESCRIPTION
**Contained in this Pull Request**
* Updates `Microsoft.Net.Compilers.netcore` to v1.2.0-beta1-20160202-02
* Updates `Microsoft.Net.CSharp.Interactive.netcore` to v1.2.0-beta1-20160202-02
* Adds the `csi` and `Microsoft.CodeAnalysis.CSharp.Scripting` to the list of assemblies to crossgen
* Adds a direct dependency to `Microsoft.DiaSymReader.Native`, v1.3.3
* Removes the `/ReadyToRun` switch from the crossgen arguments for Windows crossgen