### PR TITLE
Fix diffs in generated nuspec with nuget.core

### DIFF
--- a/src/dotnet/commands/dotnet-pack/NuGet/ManifestContentFiles.cs
+++ b/src/dotnet/commands/dotnet-pack/NuGet/ManifestContentFiles.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Xml.Serialization;
-
 namespace NuGet
 {
     public class ManifestContentFiles

--- a/src/dotnet/commands/dotnet-pack/NuGet/PackageMetadataXmlExtensions.cs
+++ b/src/dotnet/commands/dotnet-pack/NuGet/PackageMetadataXmlExtensions.cs
@@ -35,13 +35,16 @@ namespace NuGet
             elem.Add(new XElement(ns + "id", metadata.Id));
             elem.Add(new XElement(ns + "version", metadata.Version.ToString()));
             AddElementIfNotNull(elem, ns, "title", metadata.Title);
-            elem.Add(new XElement(ns + "requireLicenseAcceptance", metadata.RequireLicenseAcceptance));
-            elem.Add(new XElement(ns + "developmentDependency", metadata.DevelopmentDependency));
             AddElementIfNotNull(elem, ns, "authors", metadata.Authors, authors => string.Join(",", authors));
             AddElementIfNotNull(elem, ns, "owners", metadata.Owners, owners => string.Join(",", owners));
             AddElementIfNotNull(elem, ns, "licenseUrl", metadata.LicenseUrl);
             AddElementIfNotNull(elem, ns, "projectUrl", metadata.ProjectUrl);
             AddElementIfNotNull(elem, ns, "iconUrl", metadata.IconUrl);
+            elem.Add(new XElement(ns + "requireLicenseAcceptance", metadata.RequireLicenseAcceptance));
+            if (metadata.DevelopmentDependency == true)
+            {
+                elem.Add(new XElement(ns + "developmentDependency", metadata.DevelopmentDependency));
+            }
             AddElementIfNotNull(elem, ns, "description", metadata.Description);
             AddElementIfNotNull(elem, ns, "summary", metadata.Summary);
             AddElementIfNotNull(elem, ns, "releaseNotes", metadata.ReleaseNotes);
@@ -218,7 +221,7 @@ namespace NuGet
                 files.Select(file =>
                 new XElement(ns + File,
                     new XAttribute("src", file.Source),
-                    new XAttribute("target", file.Source),
+                    new XAttribute("target", file.Target),
                     new XAttribute("exclude", file.Exclude)
                 )));
         }


### PR DESCRIPTION
There was a typo in file list that used Source
value for target attribute.

The ordering of metadata was different than
nuget.core and nuget.core never added
DevelopmentDependency if it was set to
false.

There are still some differences between a
nuspec generated through Manifest.Save
in Nuget.Core and this, but all of those
make it more consistent with the nuspec
that is put in the actual package so I'm
leaving them.

The primary difference is that NuGet.Core
used string types to represent the TFM in
groupable items so it would just pass through
whatever you gave the API to the nuspec.
The downside of this is that you might have
an invalid string and you wouldn't know that
until you packed (and cracked open the nuspec).
The new implementation parses the TFM
and writes a normalized version to the nuspec.
This is more wysiwyg so I'm leaving it.

replacement PR for https://github.com/dotnet/cli/pull/867
/cc @piotrpMSFT