### PR TITLE
Fix color printing and --verbose

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
@@ -51,12 +51,19 @@ namespace Microsoft.DotNet.Cli.Utils
     
             Console.ForegroundColor = (ConsoleColor)((int)Console.ForegroundColor ^ 0x08);
         }
-    
+
         public void WriteLine(string message)
+        {
+            Write(message);
+            Writer.WriteLine();
+        }
+
+
+        public void Write(string message)
         {
             if (!_useConsoleColor)
             {
-                Writer.WriteLine(message);
+                Writer.Write(message);
                 return;
             }
     
@@ -137,7 +144,6 @@ namespace Microsoft.DotNet.Cli.Utils
                     escapeScan = endIndex + 1;
                 }
             }
-            Writer.WriteLine();
         }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -168,7 +168,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 if (to == null)
                 {
                     _stdOut.ForwardTo(writeLine: Reporter.Output.WriteLine);
-                    _process.StartInfo.Environment[CommandContext.Variables.AnsiPassThru] = ansiPassThrough.ToString();
+                    EnvironmentVariable(CommandContext.Variables.AnsiPassThru, ansiPassThrough.ToString());
                 }
                 else
                 {
@@ -186,7 +186,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 if (to == null)
                 {
                     _stdErr.ForwardTo(writeLine: Reporter.Error.WriteLine);
-                    _process.StartInfo.Environment[CommandContext.Variables.AnsiPassThru] = ansiPassThrough.ToString();
+                    EnvironmentVariable(CommandContext.Variables.AnsiPassThru, ansiPassThrough.ToString());
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.Cli.Utils
             return this;
         }
 
-        public ICommand ForwardStdOut(TextWriter to = null, bool onlyIfVerbose = false)
+        public ICommand ForwardStdOut(TextWriter to = null, bool onlyIfVerbose = false, bool ansiPassThrough = true)
         {
             ThrowIfRunning();
             if (!onlyIfVerbose || CommandContext.IsVerbose())
@@ -168,6 +168,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 if (to == null)
                 {
                     _stdOut.ForwardTo(writeLine: Reporter.Output.WriteLine);
+                    _process.StartInfo.Environment[CommandContext.Variables.AnsiPassThru] = ansiPassThrough.ToString();
                 }
                 else
                 {
@@ -177,7 +178,7 @@ namespace Microsoft.DotNet.Cli.Utils
             return this;
         }
 
-        public ICommand ForwardStdErr(TextWriter to = null, bool onlyIfVerbose = false)
+        public ICommand ForwardStdErr(TextWriter to = null, bool onlyIfVerbose = false, bool ansiPassThrough = true)
         {
             ThrowIfRunning();
             if (!onlyIfVerbose || CommandContext.IsVerbose())
@@ -185,6 +186,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 if (to == null)
                 {
                     _stdErr.ForwardTo(writeLine: Reporter.Error.WriteLine);
+                    _process.StartInfo.Environment[CommandContext.Variables.AnsiPassThru] = ansiPassThrough.ToString();
                 }
                 else
                 {

--- a/src/Microsoft.DotNet.Cli.Utils/ICommand.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ICommand.cs
@@ -18,9 +18,9 @@ namespace Microsoft.DotNet.Cli.Utils
 
         ICommand CaptureStdErr();
 
-        ICommand ForwardStdOut(TextWriter to = null, bool onlyIfVerbose = false);
+        ICommand ForwardStdOut(TextWriter to = null, bool onlyIfVerbose = false, bool ansiPassThrough = true);
 
-        ICommand ForwardStdErr(TextWriter to = null, bool onlyIfVerbose = false);
+        ICommand ForwardStdErr(TextWriter to = null, bool onlyIfVerbose = false, bool ansiPassThrough = true);
 
         ICommand OnOutputLine(Action<string> handler);
 

--- a/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
@@ -55,7 +55,14 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             lock (_lock)
             {
-                _console?.Writer?.Write(message);
+                if (CommandContext.ShouldPassAnsiCodesThrough())
+                {
+                    _console?.Writer?.Write(message);
+                }
+                else
+                {
+                    _console?.Write(message);
+                }
             }
         }
     }


### PR DESCRIPTION
I noticed that the escape codes are being printed instead of colors on Windows. There were a couple problems:

* When running intrinsic commands, the AnsiPassThrough was being enabled. This caused the escape codes to never be processed for intrinsic commands.

* Reporter.Write did not transform escape codes into colors. The Command uses this method to forward some output.

Calling ShouldPassAnsiCodesThrough() for the side effect of reading the environmental variable seems a little lame. Perhaps instead Command.CreateDotNet should always set this variable? I'm not sure if Microsoft.DotNet.Cli.Utils is meant for consumption by externals tools as a means of invoking dotnet.exe, so I did not do it there.