### PR TITLE
Fix the help command to work with intrinsic commands.

### DIFF
--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.Help
+{
+    public class HelpCommand
+    {
+        private const string ProductLongName = ".NET Command Line Tools";
+        private const string UsageText = @"Usage: dotnet [common-options] [command] [arguments]
+
+Arguments:
+  [command]     The command to execute
+  [arguments]   Arguments to pass to the command
+
+Common Options (passed before the command):
+  -v|--verbose  Enable verbose output
+  --version     Display .NET CLI Version Info
+
+Common Commands:
+  new           Initialize a basic .NET project
+  restore       Restore dependencies specified in the .NET project
+  build         Builds a .NET project
+  publish       Publishes a .NET project for deployment (including the runtime)
+  run           Compiles and immediately executes a .NET project
+  repl          Launch an interactive session (read, eval, print, loop)
+  pack          Creates a NuGet package";
+        private static readonly string ProductVersion = GetProductVersion();
+
+        private static string GetProductVersion()
+        {
+            var attr = typeof(HelpCommand).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return attr?.InformationalVersion;
+        }
+
+        public static int Run(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                PrintHelp();
+                return 0;
+            }
+            else
+            {
+                return Cli.Program.Main(new[] { args[0], "--help" });
+            }
+        }
+
+        public static void PrintHelp()
+        {
+            PrintVersionHeader();
+            Reporter.Output.WriteLine(UsageText);
+        }
+
+        public static void PrintVersionHeader()
+        {
+            var versionString = string.IsNullOrEmpty(ProductVersion) ?
+                string.Empty :
+                $" ({ProductVersion})";
+            Reporter.Output.WriteLine(ProductLongName + versionString);
+        }
+    }
+}

--- a/test/EndToEnd/EndToEndTest.cs
+++ b/test/EndToEnd/EndToEndTest.cs
@@ -169,6 +169,20 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             TestExecutable(OutputDirectory, publishCommand.GetOutputExecutable(), s_expectedOutput);    
         }
 
+        [Fact]
+        public void TestDotnetHelp()
+        {
+            var helpCommand = new HelpCommand();
+            helpCommand.Execute().Should().Pass();
+        }
+
+        [Fact]
+        public void TestDotnetHelpBuild()
+        {
+            var helpCommand = new HelpCommand();
+            helpCommand.Execute("build").Should().Pass();
+        }
+
         private void TestInstanceSetup()
         {
             var root = Temp.CreateDirectory();

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/HelpCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/HelpCommand.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public sealed class HelpCommand : TestCommand
+    {
+        public HelpCommand()
+            : base("dotnet")
+        {
+        }
+
+        public override CommandResult Execute(string args = "")
+        {
+            args = $"help {args}";
+            return base.Execute(args);
+        }
+    }
+}


### PR DESCRIPTION
The old "dotnet help" code assumed every command is defined by a "dotnet-command" executable. However this is no longer true for intrinsic commands.

I tried this change out with both intrinsic and extrinsic commands and they now print help as expected.

I also added some tests to make sure the "dotnet help" command executes successfully.