### PR TITLE
Print RID

### DIFF
--- a/Documentation/manpages/dotnet.1
+++ b/Documentation/manpages/dotnet.1
@@ -7,7 +7,8 @@
 dotnet \-\- general driver for running the command\-line commands
 .SH SYNOPSIS
 .PP
-dotnet [\-\-version] [\-\-help] [\-\-verbose] < command > [< args >]
+dotnet [\-\-version] [\-\-rid] [\-\-help] [\-\-verbose] < command > [<
+args >]
 .SH DESCRIPTION
 .PP
 dotnet is a generic driver for the CLI toolchain.
@@ -33,6 +34,14 @@ Enable\ verbose\ output.
 .nf
 \f[C]
 Print\ out\ the\ version\ of\ the\ CLI\ tooling
+\f[]
+.fi
+.PP
+\f[C]\-\-rid\f[]
+.IP
+.nf
+\f[C]
+Print\ out\ the\ default\ runtime\ identifier\ of\ the\ CLI\ tooling
 \f[]
 .fi
 .PP

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -36,6 +36,7 @@ Arguments:
 Common Options (passed before the command):
   -v|--verbose  Enable verbose output
   --version     Display .NET CLI Version Info
+  --rid         Display the default runtime identifier
 
 Common Commands:
   new           Initialize a basic .NET project
@@ -87,6 +88,11 @@ Common Commands:
                 else if (IsArg(args[lastArg], "version"))
                 {
                     PrintVersionInfo();
+                    return 0;
+                }
+                else if (IsArg(args[lastArg], "rid"))
+                {
+                    PrintRuntimeIdentifier();
                     return 0;
                 }
                 else if (IsArg(args[lastArg], "h", "help"))
@@ -196,6 +202,11 @@ Common Commands:
             Reporter.Output.WriteLine($" OS Version:  {runtimeEnvironment.OperatingSystemVersion}");
             Reporter.Output.WriteLine($" OS Platform: {runtimeEnvironment.OperatingSystemPlatform}");
             Reporter.Output.WriteLine($" Runtime Id:  {runtimeEnvironment.GetRuntimeIdentifier()}");
+        }
+
+        private static void PrintRuntimeIdentifier()
+        {
+            Reporter.Output.WriteLine(PlatformServices.Default.Runtime.GetRuntimeIdentifier());
         }
 
         private static bool IsArg(string candidate, string longName)

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -8,7 +8,7 @@ dotnet -- general driver for running the command-line commands
 
 # SYNOPSIS
 
-dotnet [--version] [--help] [--verbose] < command > [< args >]
+dotnet [--version] [--rid] [--help] [--verbose] < command > [< args >]
 
 # DESCRIPTION
 dotnet is a generic driver for the CLI toolchain. Invoked on its own, it will give out brief usage instructions. 
@@ -24,6 +24,10 @@ Each specific feature is implemented as a command. In order to use the feature, 
 `--version`
 
     Print out the version of the CLI tooling
+
+`--rid`
+
+    Print out the default runtime identifier of the CLI tooling
 
 `-h, --help`
 


### PR DESCRIPTION
`dotnet --rid` prints the default RID.

Why? For general use with other scripting tools/languages. e.g. save users the hassle of figuring out the magic combitation of `dotnet --version`, `grep`, and `awk` to get RID when writing x-plat friendly scripts.