### PR TITLE
Making the tests build without tfm, rid or configuration

### DIFF
--- a/scripts/test/build-tests.ps1
+++ b/scripts/test/build-tests.ps1
@@ -8,9 +8,10 @@
 # Publish each test project
 loadTestProjectList | foreach {
     #we should use publish to an output path, we will once issue #1183 has been fixed and we can point dotnet test do a dll.
-    dotnet build --framework "dnxcore50" --runtime "$Rid" --configuration "$Configuration" "$RepoRoot\test\$($_.ProjectName)"
+    #we need to add back tfm, rid and configuration, but dotnet test need to be made aware of those as well. Tracked at issue #1237.
+    dotnet build "$RepoRoot\test\$($_.ProjectName)"
     if (!$?) {
-        Write-Host Command failed: dotnet publish --framework "dnxcore50" --runtime "$Rid" --configuration "$Configuration" "$RepoRoot\test\$($_.ProjectName)"
+        Write-Host Command failed: dotnet build "$RepoRoot\test\$($_.ProjectName)"
         exit 1
     }
 }


### PR DESCRIPTION
Making the tests build without tfm, rid or configuration, because dotnet test does not understand those. that means that if we build for release and then do a dotnet test, the test will fail because dotnet test will look for binaries under debug/tfm.