### PR TITLE
Stream Forwarding Changes.

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -65,3 +65,6 @@ Each command's project root should contain a manpage-style Readme.md that descri
 #### Add command to packages
 - Update the `symlinks` property of `packaging/debian/debian_config.json` to include the new command
 - Update the `$Projects` property in `packaging/osx/scripts/postinstall`
+
+#### Things to Know
+- Any added commands are usually invoked through `dotnet {command}`. As a result of this, stdout and stderr are redirected through the driver (`dotnet`) and buffered by line. As a result of this, child commands should use Console.WriteLine in any cases where they expect output to be written immediately. Any uses of Console.Write should be followed by Console.WriteLine to ensure the output is written.

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -111,8 +111,8 @@ namespace Microsoft.DotNet.Cli.Utils
             return new CommandResult(
                 this._process.StartInfo,
                 exitCode,
-                _stdOut.GetCapturedOutput(),
-                _stdErr.GetCapturedOutput());
+                _stdOut.CapturedOutput,
+                _stdErr.CapturedOutput);
         }
 
         public Command WorkingDirectory(string projectDirectory)
@@ -148,11 +148,11 @@ namespace Microsoft.DotNet.Cli.Utils
             {
                 if (to == null)
                 {
-                    _stdOut.ForwardTo(write: Reporter.Output.Write, writeLine: Reporter.Output.WriteLine);
+                    _stdOut.ForwardTo(writeLine: Reporter.Output.WriteLine);
                 }
                 else
                 {
-                    _stdOut.ForwardTo(write: to.Write, writeLine: to.WriteLine);
+                    _stdOut.ForwardTo(writeLine: to.WriteLine);
                 }
             }
             return this;
@@ -165,11 +165,11 @@ namespace Microsoft.DotNet.Cli.Utils
             {
                 if (to == null)
                 {
-                    _stdErr.ForwardTo(write: Reporter.Error.Write, writeLine: Reporter.Error.WriteLine);
+                    _stdErr.ForwardTo(writeLine: Reporter.Error.WriteLine);
                 }
                 else
                 {
-                    _stdErr.ForwardTo(write: to.Write, writeLine: to.WriteLine);
+                    _stdErr.ForwardTo(writeLine: to.WriteLine);
                 }
             }
             return this;
@@ -178,14 +178,14 @@ namespace Microsoft.DotNet.Cli.Utils
         public Command OnOutputLine(Action<string> handler)
         {
             ThrowIfRunning();
-            _stdOut.ForwardTo(write: null, writeLine: handler);
+            _stdOut.ForwardTo(writeLine: handler);
             return this;
         }
 
         public Command OnErrorLine(Action<string> handler)
         {
             ThrowIfRunning();
-            _stdErr.ForwardTo(write: null, writeLine: handler);
+            _stdErr.ForwardTo(writeLine: handler);
             return this;
         }
 

--- a/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli.Utils
     // Stupid-simple console manager
     public class Reporter
     {
-        private static readonly Reporter Null = new Reporter(console: null);
+        private static readonly Reporter NullReporter = new Reporter(console: null);
         private static object _lock = new object();
 
         private readonly AnsiConsole _console;
@@ -20,8 +20,8 @@ namespace Microsoft.DotNet.Cli.Utils
         }
 
         public static Reporter Output { get; } = Create(AnsiConsole.GetOutput);
-        public static Reporter Error { get; } = Create(AnsiConsole.GetOutput);
-        public static Reporter Verbose { get; } = CommandContext.IsVerbose() ? Create(AnsiConsole.GetOutput) : Null;
+        public static Reporter Error { get; } = Create(AnsiConsole.GetError);
+        public static Reporter Verbose { get; } = CommandContext.IsVerbose() ? Create(AnsiConsole.GetOutput) : NullReporter;
 
         public static Reporter Create(Func<bool, AnsiConsole> getter)
         {

--- a/src/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
@@ -7,45 +7,45 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public sealed class StreamForwarder
     {
-        private const int DefaultBufferSize = 256;
-
-        private readonly int _bufferSize;
         private StringBuilder _builder;
         private StringWriter _capture;
         private Action<string> _write;
         private Action<string> _writeLine;
 
-        public StreamForwarder(int bufferSize = DefaultBufferSize)
+        public string CapturedOutput
         {
-            _bufferSize = bufferSize;
+            get 
+            {
+                return _capture?.GetStringBuilder()?.ToString();
+            }
         }
 
-        public void Capture()
+        public StreamForwarder Capture()
         {
             if (_capture != null)
             {
                 throw new InvalidOperationException("Already capturing stream!");
             }
             _capture = new StringWriter();
+
+            return this;
         }
 
-        public string GetCapturedOutput()
-        {
-            return _capture?.GetStringBuilder()?.ToString();
-        }
-
-        public void ForwardTo(Action<string> write, Action<string> writeLine)
+        public StreamForwarder ForwardTo(Action<string> writeLine)
         {
             if (writeLine == null)
             {
                 throw new ArgumentNullException(nameof(writeLine));
             }
+
             if (_writeLine != null)
             {
-                throw new InvalidOperationException("Already handling stream!");
+                throw new InvalidOperationException("WriteLine forwarder set previously");
             }
-            _write = write;
+
             _writeLine = writeLine;
+
+            return this;
         }
 
         public Thread BeginRead(TextReader reader)
@@ -57,91 +57,59 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public void Read(TextReader reader)
         {
+            var bufferSize = 1;
+
+            int readCharacterCount; 
+            char currentCharacter;
+
+            var buffer = new char[bufferSize];
             _builder = new StringBuilder();
-            var buffer = new char[_bufferSize];
-            int n;
-            while ((n = reader.Read(buffer, 0, _bufferSize)) > 0)
-            {
-                _builder.Append(buffer, 0, n);
-                WriteBlocks();
-            }
-            WriteRemainder();
-        }
 
-        private void WriteBlocks()
-        {
-            int n = _builder.Length;
-            if (n == 0)
+            // Using Read with buffer size 1 to prevent looping endlessly
+            // like we would when using Read() with no buffer
+            while ((readCharacterCount = reader.Read(buffer, 0, bufferSize)) > 0)
             {
-                return;
-            }
+                currentCharacter = buffer[0];
 
-            int offset = 0;
-            bool sawReturn = false;
-            for (int i = 0; i < n; i++)
-            {
-                char c = _builder[i];
-                switch (c)
+                // Flush per line
+                if (currentCharacter == '\n')
                 {
-                    case '\r':
-                        sawReturn = true;
-                        continue;
-                    case '\n':
-                        WriteLine(_builder.ToString(offset, i - offset - (sawReturn ? 1 : 0)));
-                        offset = i + 1;
-                        break;
+                    WriteBuilder();
                 }
-                sawReturn = false;
+                else
+                {
+                    // Ignore \r
+                    if (currentCharacter != '\r')
+                    {
+                        _builder.Append(currentCharacter);
+                    }
+                }
             }
 
-            // If the buffer contains no line breaks and _write is
-            // supported, send the buffer content.
-            if (!sawReturn &&
-                (offset == 0) &&
-                ((_write != null) || (_writeLine == null)))
-            {
-                WriteRemainder();
-            }
-            else
-            {
-                _builder.Remove(0, offset);
-            }
+            // Flush anything else when the stream is closed
+            // Which should only happen if someone used console.Write
+            WriteBuilder();
         }
 
-        private void WriteRemainder()
+        private void WriteBuilder()
         {
             if (_builder.Length == 0)
             {
                 return;
             }
-            Write(_builder.ToString());
+
+            WriteLine(_builder.ToString());
             _builder.Clear();
         }
 
         private void WriteLine(string str)
-        {
+        { 
             if (_capture != null)
             {
                 _capture.WriteLine(str);
             }
-            // If _write is supported, so is _writeLine.
-            if (_writeLine != null)
-            {
-                _writeLine(str);
-            }
-        }
 
-        private void Write(string str)
-        {
-            if (_capture != null)
-            {
-                _capture.Write(str);
-            }
-            if (_write != null)
-            {
-                _write(str);
-            }
-            else if (_writeLine != null)
+            if (_writeLine != null)
             {
                 _writeLine(str);
             }

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -21,7 +21,6 @@ namespace Microsoft.DotNet.Tools.Restore
     {
         private static readonly string DefaultRid = PlatformServices.Default.Runtime.GetLegacyRestoreRuntimeIdentifier();
 
-
         public static int Run(string[] args)
         {
             DebugHelper.HandleDebugSwitch(ref args);

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests/ArgumentForwardingTests.cs
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests/ArgumentForwardingTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Tests.ArgumentForwarding
         /// <returns></returns>
         private string[] ParseReflectorOutput(string reflectorOutput)
         {
-            return reflectorOutput.Split(',');
+            return reflectorOutput.TrimEnd('\r', '\n').Split(',');
         }
 
         /// <summary>

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -32,8 +32,8 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             var stdOut = new StreamForwarder();
             var stdErr = new StreamForwarder();
 
-            stdOut.ForwardTo(write: Reporter.Output.Write, writeLine: Reporter.Output.WriteLine);
-            stdErr.ForwardTo(write: Reporter.Error.Write, writeLine: Reporter.Output.WriteLine);
+            stdOut.ForwardTo(writeLine: Reporter.Output.WriteLine);
+            stdErr.ForwardTo(writeLine: Reporter.Output.WriteLine);
 
             return RunProcess(commandPath, args, stdOut, stdErr);
         }
@@ -82,8 +82,8 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             var result = new CommandResult(
                 process.StartInfo,
                 process.ExitCode, 
-                stdOut.GetCapturedOutput(), 
-                stdErr.GetCapturedOutput());
+                stdOut.CapturedOutput, 
+                stdErr.CapturedOutput);
 
             return result;
         }

--- a/test/StreamForwarderTests/StreamForwarderTests.cs
+++ b/test/StreamForwarderTests/StreamForwarderTests.cs
@@ -129,36 +129,6 @@ namespace StreamForwarderTests
             Assert.Equal(expectedCaptured, captured);
         }
 
-        [Fact]
-        public void TestAsyncOrdering()
-        {
-            var expectedOutputLines = new string[] 
-            {
-                "** Standard Out 1 **",
-                "** Standard Error 1 **",
-                "** Standard Out 2 **",
-                "** Standard Error 2 **"
-            };
-
-            var expectedOutput = string.Join(Environment.NewLine, expectedOutputLines) + Environment.NewLine;
-
-            var testProjectDllPath = SetupTestProject();
-
-            var testReporter = new TestReporter();
-
-            var testCommand = Command.Create(testProjectDllPath, new string[0])
-                .OnOutputLine(testReporter.WriteLine)
-                .OnErrorLine(testReporter.WriteLine);
-
-            testCommand.Execute();
-
-            var resultString = testReporter.InternalStringWriter.GetStringBuilder().ToString();
-            Console.WriteLine(expectedOutput);
-            Console.WriteLine(resultString);
-
-            Assert.Equal(expectedOutput, resultString);
-        }
-
         private string SetupTestProject()
         {
             var sourceTestProjectPath = Path.Combine(s_testProjectRoot, "OutputStandardOutputAndError");
@@ -172,30 +142,6 @@ namespace StreamForwarderTests
             var buildOutputPath = Path.Combine(binTestProjectPath, "bin/Debug/dnxcore50", buildOutputExe);
 
             return buildOutputPath;
-        } 
-
-        private class TestReporter
-        {   
-            private static object _lock = new object();
-            private StringWriter _stringWriter;
-
-            public StringWriter InternalStringWriter 
-            { 
-                get { return _stringWriter; } 
-            }
-
-            public TestReporter()
-            {
-                _stringWriter = new StringWriter();
-            }
-
-            public void WriteLine(string message)
-            {
-                lock(_lock)
-                {
-                    _stringWriter.WriteLine(message);
-                }
-            }
         }
     }
 }

--- a/test/StreamForwarderTests/project.json
+++ b/test/StreamForwarderTests/project.json
@@ -22,5 +22,9 @@
         }
     },
 
+    "content": [
+        "../TestProjects/OutputStandardOutputAndError/*"
+    ],
+
     "testRunner": "xunit"
 }

--- a/test/TestProjects/OutputStandardOutputAndError/OutputStandardOutputAndError.xproj
+++ b/test/TestProjects/OutputStandardOutputAndError/OutputStandardOutputAndError.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>58808bbc-371e-47d6-a3d0-4902145eda4e</ProjectGuid>
+    <RootNamespace>OutputStandardOutputAndError</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/TestProjects/OutputStandardOutputAndError/Program.cs
+++ b/test/TestProjects/OutputStandardOutputAndError/Program.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace TestApp
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.Out.WriteLine("** Standard Out 1 **");
+            Console.Error.WriteLine("** Standard Error 1 **");
+            Console.Out.WriteLine("** Standard Out 2 **");
+            Console.Error.WriteLine("** Standard Error 2 **");
+        }
+    }
+}

--- a/test/TestProjects/OutputStandardOutputAndError/project.json
+++ b/test/TestProjects/OutputStandardOutputAndError/project.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23728"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/test/dotnet-build.Tests/IncrementalTests.cs
+++ b/test/dotnet-build.Tests/IncrementalTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             Assert.False(File.Exists(lockFile));
 
             buildResult = BuildProject(expectBuildFailure : true);
-            Assert.Contains("does not have a lock file", buildResult.StdOut);
+            Assert.Contains("does not have a lock file", buildResult.StdErr);
         }
 
         [Fact]

--- a/test/dotnet-compile.Tests/CompilerTests.cs
+++ b/test/dotnet-compile.Tests/CompilerTests.cs
@@ -58,7 +58,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
             var buildCmd = new BuildCommand(testProject, output: outputDir);
             var result = buildCmd.ExecuteWithCapturedOutput();
             result.Should().Pass();
-            Assert.Contains("CA1018", result.StdOut);
+            
+            Assert.Contains("CA1018", result.StdErr);
         }
 
         private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)


### PR DESCRIPTION
Stream Forwarding changes to not wait on buffer full before writing. Instead child process input streams will be read character by character as they Console.Write or Console.WriteLine. Upon finding a newline character, the line will be printed to the parent process's console.

On child process exit, any remaining characters will be flushed.

This will partially fix #925 with the caveat that a newline must be written to the child process stream before any output will be written. When the newline is written, order of writes is now preserved though.

Previously, any write which did not fill the Streamforwarder's internal buffer would be held until the buffer was full or the process exited.

PTAL @anurse @piotrpMSFT @Sridhar-MS @davidfowl @livarcocc 