### PR TITLE
Cache NuGet packages on our CI server between builds.

### DIFF
--- a/scripts/build/restore-packages.sh
+++ b/scripts/build/restore-packages.sh
@@ -16,6 +16,26 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 source "$DIR/../common/_common.sh"
 
+if [ ! -z "$CI_BUILD" ]; then
+	# periodically clear out the package cache on the CI server
+	PackageCacheFile="$NUGET_PACKAGES/packageCacheTime.txt"
+	if [ ! -f $PackageCacheFile ]; then
+		date > $PackageCacheFile
+	else
+		#$NUGET_PACKAGES_CACHE_TIME_LIMIT is in hours
+		CacheTimeLimitInSeconds=$(($NUGET_PACKAGES_CACHE_TIME_LIMIT * 3600))
+		CacheExpireTime=$(($(date +%s) - $CacheTimeLimitInSeconds))
+
+		if [ $(date +%s -r $PackageCacheFile) -lt $CacheExpireTime ]; then
+			header "Clearing package cache"
+
+			rm -Rf $NUGET_PACKAGES
+			mkdir -p $NUGET_PACKAGES
+			date > $PackageCacheFile
+		fi
+	fi
+fi
+
 header "Restoring packages"
 
 dotnet restore "$REPOROOT/src" --runtime "$RID" $DISABLE_PARALLEL

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -6,6 +6,8 @@
 
 set -e
 
+export CI_BUILD=1
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"

--- a/scripts/common/_nuget.ps1
+++ b/scripts/common/_nuget.ps1
@@ -3,14 +3,12 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-if ($env:CI_BUILD -eq "1") {
-    $env:NUGET_PACKAGES = (Join-Path $RepoRoot "artifacts\home\.nuget\packages")
-} else {
-    $env:NUGET_PACKAGES = (Join-Path $env:USERPROFILE ".nuget\packages")
-}
-
+$env:NUGET_PACKAGES = (Join-Path $env:USERPROFILE ".nuget\packages")
 $env:DOTNET_PACKAGES = $env:NUGET_PACKAGES
 $env:DNX_PACKAGES = $env:NUGET_PACKAGES
 if(!(Test-Path $env:NUGET_PACKAGES)) {
     mkdir $env:NUGET_PACKAGES | Out-Null
 }
+
+# default the package cache expiration to 1 week, in hours
+setEnvIfDefault "NUGET_PACKAGES_CACHE_TIME_LIMIT" (7 * 24)

--- a/scripts/common/_nuget.sh
+++ b/scripts/common/_nuget.sh
@@ -4,7 +4,15 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-## Temporarily redirect to the NuGet package installation location
 export NUGET_PACKAGES=~/.nuget/packages
 export DOTNET_PACKAGES=$NUGET_PACKAGES
 export DNX_PACKAGES=$NUGET_PACKAGES
+
+if [ ! -d $NUGET_PACKAGES ]; then
+	mkdir -p $NUGET_PACKAGES
+fi
+
+if [ -z "$NUGET_PACKAGES_CACHE_TIME_LIMIT" ]; then
+	# default the package cache expiration to 1 week, in hours
+	export NUGET_PACKAGES_CACHE_TIME_LIMIT=$(( 7 * 24 ))
+fi


### PR DESCRIPTION
Currently on our CI builds, we point our NuGet cache under the repo. In between builds the repo gets deleted, thus the cache is lost.

This change moves the cache to %userprofile%\.nuget\packages on CI and dev boxes.  On CI, we expire the cache after a day by default.

@davidfowl @piotrpMSFT @anurse 