### PR TITLE
fix slash in run_tests

### DIFF
--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -33,7 +33,7 @@ for project in $TestProjects
 do
     # This is a workaroudn for issue #1184, where dotnet test needs to be executed from the folder containing the project.json.
     pushd "$REPOROOT/test/$project"
-    dotnet test -c "$CONFIGURATION" -xml "$TEST_BIN_ROOT\$project-testResults.xml" -notrait category=failing
+    dotnet test -c "$CONFIGURATION" -xml "$TEST_BIN_ROOT/${project}-testResults.xml" -notrait category=failing
     popd
 
     exitCode=$?


### PR DESCRIPTION
This is probably why we're not seeing test results on unix systems
