### PR TITLE
Clean up symlinks and fix conflict with mono-runtime-common

### DIFF
--- a/packaging/debian/dotnet-debian_config.json
+++ b/packaging/debian/dotnet-debian_config.json
@@ -39,18 +39,6 @@
 
     "symlinks": {
         "bin/dotnet" : "usr/bin/dotnet",
-        "bin/dotnet-build" : "usr/bin/dotnet-build",
-        "bin/dotnet-compile" : "usr/bin/dotnet-compile",
-        "bin/dotnet-compile-csc" : "usr/bin/dotnet-compile-csc",
-        "bin/dotnet-compile-fsc" : "usr/bin/dotnet-compile-fsc",
-        "bin/dotnet-compile-native" : "/usr/bin/dotnet-compile-native",
-        "bin/dotnet-new": "usr/bin/dotnet-new",
-        "bin/dotnet-publish" : "usr/bin/dotnet-publish",
-        "bin/dotnet-repl" : "usr/bin/dotnet-repl",
-        "bin/dotnet-repl-csi" : "usr/bin/dotnet-repl-csi",
-        "bin/dotnet-restore" : "usr/bin/dotnet-restore",
-        "bin/dotnet-dnx" : "usr/bin/dotnet-dnx",
-        "bin/dotnet-test" : "usr/bin/dotnet-test",
-        "bin/dotnet-resgen" : "usr/bin/dotnet-resgen"
+        "bin/dotnet-compile-native" : "/usr/bin/dotnet-compile-native"
     }
 }

--- a/packaging/debian/dotnet-nightly-debian_config.json
+++ b/packaging/debian/dotnet-nightly-debian_config.json
@@ -38,20 +38,7 @@
     ],
 
     "symlinks": {
-        "/usr/share/dotnet-nightly" : "/usr/share/dotnet",
         "bin/dotnet" : "usr/bin/dotnet",
-        "bin/dotnet-build" : "usr/bin/dotnet-build",
-        "bin/dotnet-compile" : "usr/bin/dotnet-compile",
-        "bin/dotnet-compile-csc" : "usr/bin/dotnet-compile-csc",
-        "bin/dotnet-compile-fsc" : "usr/bin/dotnet-compile-fsc",
-        "bin/dotnet-compile-native" : "/usr/bin/dotnet-compile-native",
-        "bin/dotnet-new": "usr/bin/dotnet-new",
-        "bin/dotnet-publish" : "usr/bin/dotnet-publish",
-        "bin/dotnet-repl" : "usr/bin/dotnet-repl",
-        "bin/dotnet-repl-csi" : "usr/bin/dotnet-repl-csi",
-        "bin/dotnet-restore" : "usr/bin/dotnet-restore",
-        "bin/dotnet-dnx" : "usr/bin/dotnet-dnx",
-        "bin/dotnet-test" : "usr/bin/dotnet-test",
-        "bin/dotnet-resgen" : "usr/bin/dotnet-resgen"
+        "bin/dotnet-compile-native" : "/usr/bin/dotnet-compile-native"
     }
 }


### PR DESCRIPTION
We should wait for Ubuntu builds to be back up before merging this.

This cleans up the symlinks in the debian package with the recent changes to move all commands to a single assembly.

It should also fix #1162 but this is difficult to test with Ubuntu builds down.