### PR TITLE
Run tests using debug build for the tests.

### DIFF
--- a/scripts/test/build-tests.sh
+++ b/scripts/test/build-tests.sh
@@ -22,6 +22,6 @@ PROJECTS=$(loadTestProjectList)
 for project in $PROJECTS
 do
     #we should use publish to an output path, we will once issue #1183 has been fixed and we can point dotnet test do a dll.
-    dotnet build --framework "dnxcore50" --runtime "$RID" --configuration "$CONFIGURATION" "$REPOROOT/test/$project"
+    dotnet build "$REPOROOT/test/$project"
 done
 

--- a/scripts/test/run-tests.ps1
+++ b/scripts/test/run-tests.ps1
@@ -33,7 +33,7 @@ cp -rec -Force "$RepoRoot\test\TestProjects\*" "$TestBinRoot\TestProjects"
 $TestProjects | foreach {
     # This is a workaroudn for issue #1184, where dotnet test needs to be executed from the folder containing the project.json.
     pushd "$RepoRoot\test\$($_.ProjectName)"
-    dotnet test -c "$Configuration" -xml "$TestBinRoot\$($_.ProjectName)-testResults.xml" -notrait category=failing
+    dotnet test -xml "$TestBinRoot\$($_.ProjectName)-testResults.xml" -notrait category=failing
     popd
 
     $exitCode = $LastExitCode

--- a/scripts/test/run-tests.sh
+++ b/scripts/test/run-tests.sh
@@ -33,7 +33,7 @@ for project in $TestProjects
 do
     # This is a workaroudn for issue #1184, where dotnet test needs to be executed from the folder containing the project.json.
     pushd "$REPOROOT/test/$project"
-    dotnet test -c "$CONFIGURATION" -xml "$TEST_BIN_ROOT/${project}-testResults.xml" -notrait category=failing
+    dotnet test -xml "$TEST_BIN_ROOT/${project}-testResults.xml" -notrait category=failing
     popd
 
     exitCode=$?


### PR DESCRIPTION
We still having issues when passing configuration to dotnet tests. This change makes dotnet build of tests and dotnet test commands always use debug build. We have issues #1267 and #1268 tracking fixes for this problem