### PR TITLE
Fix "unable to locate deps file" for dotnet-test on release configuration

### DIFF
--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -149,10 +149,13 @@ namespace Microsoft.DotNet.Cli.Build
         public static BuildTargetResult BuildTests(BuildTargetContext c)
         {
             var dotnet = DotNetCli.Stage2;
+
+            var configuration = c.BuildContext.Get<string>("Configuration");
+
             foreach (var testProject in TestProjects)
             {
                 c.Info($"Building tests: {testProject}");
-                dotnet.Build()
+                dotnet.Build("--configuration", configuration)
                     .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "test", testProject))
                     .Execute()
                     .EnsureSuccessful();
@@ -170,6 +173,8 @@ namespace Microsoft.DotNet.Cli.Build
             var dotnet = DotNetCli.Stage2;
             var vsvars = LoadVsVars(c);
 
+            var configuration = c.BuildContext.Get<string>("Configuration");
+
             // Copy the test projects
             var testProjectsDir = Path.Combine(Dirs.TestOutput, "TestProjects");
             Rmdir(testProjectsDir);
@@ -181,7 +186,7 @@ namespace Microsoft.DotNet.Cli.Build
             foreach (var project in TestProjects)
             {
                 c.Info($"Running tests in: {project}");
-                var result = dotnet.Test("-xml", $"{project}-testResults.xml", "-notrait", "category=failing")
+                var result = dotnet.Test("--configuration", configuration, "-xml", $"{project}-testResults.xml", "-notrait", "category=failing")
                     .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "test", project))
                     .Environment(vsvars)
                     .EnvironmentVariable("PATH", $"{DotNetCli.Stage2.BinPath}{Path.PathSeparator}{Environment.GetEnvironmentVariable("PATH")}")

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -41,9 +41,16 @@ namespace Microsoft.DotNet.Cli.Utils
             ResolutionStrategy = commandSpec.ResolutionStrategy;
         }
 
-        public static Command CreateDotNet(string commandName, IEnumerable<string> args, NuGetFramework framework = null)
+        public static Command CreateDotNet(
+            string commandName, 
+            IEnumerable<string> args, 
+            NuGetFramework framework = null,  
+            string configuration = Constants.DefaultConfiguration)
         {
-            return Create("dotnet", new[] { commandName }.Concat(args), framework);
+            return Create("dotnet", 
+                new[] { commandName }.Concat(args), 
+                framework, 
+                configuration: configuration);
         }
 
         /// <summary>
@@ -56,9 +63,16 @@ namespace Microsoft.DotNet.Cli.Utils
         /// <param name="args"></param>
         /// <param name="framework"></param>
         /// <returns></returns>
-        public static Command Create(string commandName, IEnumerable<string> args, NuGetFramework framework = null)
+        public static Command Create(
+            string commandName, 
+            IEnumerable<string> args, 
+            NuGetFramework framework = null, 
+            string configuration = Constants.DefaultConfiguration)
         {
-            var commandSpec = CommandResolver.TryResolveCommandSpec(commandName, args, framework);
+            var commandSpec = CommandResolver.TryResolveCommandSpec(commandName, 
+                args, 
+                framework, 
+                configuration: configuration);
 
             if (commandSpec == null)
             {
@@ -70,9 +84,16 @@ namespace Microsoft.DotNet.Cli.Utils
             return command;
         }
         
-        public static Command CreateForScript(string commandName, IEnumerable<string> args, Project project, string[] inferredExtensionList)
+        public static Command CreateForScript(
+            string commandName, 
+            IEnumerable<string> args, 
+            Project project, 
+            string[] inferredExtensionList)
         {
-            var commandSpec = CommandResolver.TryResolveScriptCommandSpec(commandName, args, project, inferredExtensionList);
+            var commandSpec = CommandResolver.TryResolveScriptCommandSpec(commandName, 
+                args, 
+                project, 
+                inferredExtensionList);
 
             if (commandSpec == null)
             {

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
@@ -13,10 +13,10 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     internal static class CommandResolver
     {
-        public static CommandSpec TryResolveCommandSpec(string commandName, IEnumerable<string> args, NuGetFramework framework = null)
+        public static CommandSpec TryResolveCommandSpec(string commandName, IEnumerable<string> args, NuGetFramework framework = null, string configuration=Constants.DefaultConfiguration)
         {
             return ResolveFromRootedCommand(commandName, args) ??
-                   ResolveFromProjectDependencies(commandName, args, framework) ??
+                   ResolveFromProjectDependencies(commandName, args, framework, configuration) ??
                    ResolveFromProjectTools(commandName, args) ??
                    ResolveFromAppBase(commandName, args) ??
                    ResolveFromPath(commandName, args);
@@ -29,6 +29,7 @@ namespace Microsoft.DotNet.Cli.Utils
                    ResolveFromAppBase(commandName, args) ??
                    ResolveFromPath(commandName, args);
         }
+        
 
         private static CommandSpec ResolveFromPath(string commandName, IEnumerable<string> args)
         {
@@ -65,8 +66,11 @@ namespace Microsoft.DotNet.Cli.Utils
             return null;
         }
 
-        public static CommandSpec ResolveFromProjectDependencies(string commandName, IEnumerable<string> args,
-            NuGetFramework framework)
+        public static CommandSpec ResolveFromProjectDependencies(
+            string commandName, 
+            IEnumerable<string> args, 
+            NuGetFramework framework, 
+            string configuration)
         {
             if (framework == null) return null;
 
@@ -78,7 +82,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
             if (commandPackage == null) return null;
 
-            var depsPath = projectContext.GetOutputPaths(Constants.DefaultConfiguration).RuntimeFiles.Deps;
+            var depsPath = projectContext.GetOutputPaths(configuration).RuntimeFiles.Deps;
 
             return ConfigureCommandFromPackage(commandName, args, commandPackage, projectContext, depsPath);
         }

--- a/src/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -8,6 +8,7 @@ namespace Microsoft.DotNet.Cli.Utils
     public static class Constants
     {
         private static Platform CurrentPlatform => PlatformServices.Default.Runtime.OperatingSystemPlatform;
+        public const string DefaultConfiguration = "Debug";
 
         public static readonly string ProjectFileName = "project.json";
         public static readonly string ExeSuffix = CurrentPlatform == Platform.Windows ? ".exe" : string.Empty;
@@ -17,7 +18,6 @@ namespace Microsoft.DotNet.Cli.Utils
                                                          ? new string[] { ".exe", ".cmd", ".bat" }
                                                          : new string[] { string.Empty };
 
-        public static readonly string DefaultConfiguration = "Debug";
         public static readonly string BinDirectoryName = "bin";
         public static readonly string ObjDirectoryName = "obj";
 

--- a/src/Microsoft.DotNet.Cli.Utils/DotNetCommandFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/DotNetCommandFactory.cs
@@ -8,9 +8,13 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class DotNetCommandFactory : ICommandFactory
     {
-        public ICommand Create(string commandName, IEnumerable<string> args, NuGetFramework framework = null)
+        public ICommand Create(
+        	string commandName, 
+        	IEnumerable<string> args, 
+        	NuGetFramework framework = null, 
+        	string configuration = Constants.DefaultConfiguration)
         {
-            return Command.CreateDotNet(commandName, args, framework);
+            return Command.CreateDotNet(commandName, args, framework, configuration);
         }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/ICommandFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ICommandFactory.cs
@@ -9,6 +9,6 @@ namespace Microsoft.DotNet.Cli.Utils
     public interface ICommandFactory
     {
         ICommand Create(
-            string commandName, IEnumerable<string> args, NuGetFramework framework = null);
+            string commandName, IEnumerable<string> args, NuGetFramework framework = null, string configuration = null);
     }
 }

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Tools.Test
             var commandArgs = new List<string> { projectContext.GetOutputPaths(configuration).CompilationFiles.Assembly };
             commandArgs.AddRange(app.RemainingArguments);
 
-            return Command.CreateDotNet($"{GetCommandName(testRunner)}", commandArgs, projectContext.TargetFramework)
+            return Command.Create($"dotnet-{GetCommandName(testRunner)}", commandArgs, projectContext.TargetFramework, configuration: configuration)
                 .ForwardStdErr()
                 .ForwardStdOut()
                 .Execute()

--- a/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
+++ b/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
@@ -183,7 +183,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
                 .Create(
                     It.IsAny<string>(),
                     It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<NuGetFramework>()))
+                    It.IsAny<NuGetFramework>(),
+                    It.IsAny<string>()))
                 .Returns(command.Object);
 
             var _args = new CompilerCommandApp("dotnet compile", ".NET Compiler", "Compiler for the .NET Platform");


### PR DESCRIPTION
Part 2 of #1253

Now that we have configuration piped through dotnet-test we just need to pipe it through the command resolver so it's used when resolving commands from project dependencies.

Fixes #1268 

cc @livarcocc @piotrpMSFT 