### PR TITLE
Disable crossgen, and provide centralized ability to do so.

### DIFF
--- a/scripts/common/_common.ps1
+++ b/scripts/common/_common.ps1
@@ -5,6 +5,7 @@
 
 . $PSScriptRoot\_utility.ps1
 
+$Skip_Crossgen = $true
 $Rid = "win7-x64"
 $Tfm = "dnxcore50"
 $RepoRoot = Resolve-Path "$PSScriptRoot\..\.."
@@ -27,6 +28,7 @@ $env:Channel = "$env:ReleaseSuffix"
 # Set reasonable defaults for unset variables
 setEnvIfDefault "DOTNET_INSTALL_DIR"  "$(Convert-Path "$PSScriptRoot\..")\.dotnet_stage0\win7-x64"
 setEnvIfDefault "DOTNET_CLI_VERSION" "0.1.0.0"
+setEnvIfDefault "SKIP_CROSSGEN" "$Skip_Crossgen"
 setPathAndHomeIfDefault "$Stage2Dir"
 setVarIfDefault "Configuration" "Debug"
 

--- a/scripts/common/_common.sh
+++ b/scripts/common/_common.sh
@@ -15,6 +15,7 @@ source "$COMMONDIR/_prettyprint.sh"
 source "$COMMONDIR/_rid.sh"
 
 # TODO: Replace this with a dotnet generation
+export SKIP_CROSSGEN=true
 export TFM=dnxcore50
 export REPOROOT=$(cd $COMMONDIR/../.. && pwd)
 export OUTPUT_ROOT=$REPOROOT/artifacts/$RID

--- a/scripts/crossgen/crossgen_roslyn.cmd
+++ b/scripts/crossgen/crossgen_roslyn.cmd
@@ -3,6 +3,8 @@
 REM Copyright (c) .NET Foundation and contributors. All rights reserved.
 REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+if %SKIP_CROSSGEN% EQU 0 goto skip
+
 REM Get absolute path
 pushd %1
 set BIN_DIR=%CD%\bin
@@ -49,5 +51,9 @@ goto end
 popd
 echo Crossgen failed...
 exit /B 1
+
+:skip
+echo Skipping Crossgen
+goto end
 
 :end

--- a/scripts/crossgen/crossgen_roslyn.sh
+++ b/scripts/crossgen/crossgen_roslyn.sh
@@ -4,6 +4,22 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+source "$DIR/../common/_common.sh"
+
+if $SKIP_CROSSGEN ; then
+    echo "Skipping Crossgen"
+    exit 0
+fi
+
 set -e
 
 BIN_DIR="$( cd $1 && pwd )"
@@ -22,6 +38,8 @@ else
     exit 1
 fi
 
+READYTORUN="-ReadyToRun"
+
 # Replace with a robust method for finding the right crossgen.exe
 CROSSGEN_UTIL=$NUGET_PACKAGES/runtime.$RID.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23805/tools/crossgen
 
@@ -31,20 +49,20 @@ cd $BIN_DIR
 cp $CROSSGEN_UTIL $BIN_DIR
 chmod +x crossgen
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR mscorlib.dll
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR mscorlib.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR System.Collections.Immutable.dll
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR System.Collections.Immutable.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR System.Reflection.Metadata.dll
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR System.Reflection.Metadata.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.dll
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.CSharp.dll
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.CSharp.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.VisualBasic.dll
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.VisualBasic.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR csc.dll
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR csc.dll
 [ -e csc.ni.exe ] && [ ! -e csc.ni.dll ] && mv csc.ni.exe csc.ni.dll
 
-./crossgen -nologo -platform_assemblies_paths $BIN_DIR vbc.dll
+./crossgen -nologo $READYTORUN -platform_assemblies_paths $BIN_DIR vbc.dll
 [ -e vbc.ni.exe ] && [ ! -e vbc.ni.dll ] && mv vbc.ni.exe vbc.ni.dll


### PR DESCRIPTION
CrossGen'd images are still causing CLI commands to fail. This change disables crossgen and provides a single flag for controlling crossgen.