### PR TITLE
* Don't throw if Assembly.GetEntryAssembly is null

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/CompilationOptions.cs
+++ b/src/Microsoft.Extensions.DependencyModel/CompilationOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Extensions.DependencyModel
 {
@@ -28,6 +29,19 @@ namespace Microsoft.Extensions.DependencyModel
         public bool? EmitEntryPoint { get; }
 
         public bool? GenerateXmlDocumentation { get; }
+
+        public static CompilationOptions Default { get; } = new CompilationOptions(
+            defines: Enumerable.Empty<string>(),
+            languageVersion: null,
+            platform: null,
+            allowUnsafe: null,
+            warningsAsErrors: null,
+            optimize: null,
+            keyFile: null,
+            delaySign: null,
+            publicSign: null,
+            emitEntryPoint: null,
+            generateXmlDocumentation: null);
 
         public CompilationOptions(IEnumerable<string> defines,
             string languageVersion,

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContext.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContext.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyModel
     {
         private const string DepsResourceSufix = ".deps.json";
 
-        private static Lazy<DependencyContext> _defaultContext = new Lazy<DependencyContext>(LoadDefault);
+        private static readonly Lazy<DependencyContext> _defaultContext = new Lazy<DependencyContext>(LoadDefault);
 
         public DependencyContext(string target, string runtime, CompilationOptions compilationOptions, CompilationLibrary[] compileLibraries, RuntimeLibrary[] runtimeLibraries)
         {
@@ -37,8 +37,8 @@ namespace Microsoft.Extensions.DependencyModel
 
         private static DependencyContext LoadDefault()
         {
-            var entryAssembly = (Assembly)typeof(Assembly).GetTypeInfo().GetDeclaredMethod("GetEntryAssembly").Invoke(null, null);
-            var stream = entryAssembly.GetManifestResourceStream(entryAssembly.GetName().Name + DepsResourceSufix);
+            var entryAssembly = Assembly.GetEntryAssembly();
+            var stream = entryAssembly?.GetManifestResourceStream(entryAssembly.GetName().Name + DepsResourceSufix);
 
             if (stream == null)
             {


### PR DESCRIPTION
* Add a CompilationOptions.Default for convenient use when DependencyContext.Default is null.