### PR TITLE
Fix dotnet-compile-fsc

### DIFF
--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -80,6 +80,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 return returnCode;
             }
 
+            outputName = outputName.Trim('"');
+            tempOutDir = tempOutDir.Trim('"');
+
             var translated = TranslateCommonOptions(commonOptions, outputName);
 
             var allArgs = new List<string>(translated);
@@ -101,8 +104,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                     outputName = Path.ChangeExtension(outputName, ".exe");
                 }
 
-                allArgs.Add($"--out:");
-                allArgs.Add($"{outputName}");
+                allArgs.Add($"--out:{outputName}");
             }
 
             //set target framework
@@ -112,22 +114,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 allArgs.Add("--targetprofile:netcore");
             }
 
-            foreach (var reference in references)
-            {
-                allArgs.Add("-r");
-                allArgs.Add($"{reference}");
-            }
-
-            foreach (var resource in resources)
-            {
-                allArgs.Add("--resource");
-                allArgs.Add($"{resource}");
-            }
-
-            foreach (var source in sources)
-            {
-                allArgs.Add($"{source}");
-            }
+            allArgs.AddRange(references.Select(r => $"-r:{r.Trim('"')}"));
+            allArgs.AddRange(resources.Select(resource => $"--resource:{resource.Trim('"')}"));
+            allArgs.AddRange(sources.Select(s => $"{s.Trim('"')}"));
 
             var rsp = Path.Combine(tempOutDir, "dotnet-compile-fsc.rsp");
             File.WriteAllLines(rsp, allArgs, Encoding.UTF8);
@@ -175,9 +164,21 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 commonArgs.AddRange(options.Defines.Select(def => $"-d:{def}"));
             }
 
+            if (options.SuppressWarnings != null)
+            {
+            }
+
+            if (options.LanguageVersion != null)
+            {
+            }
+
             if (options.Platform != null)
             {
                 commonArgs.Add($"--platform:{options.Platform}");
+            }
+
+            if (options.AllowUnsafe == true)
+            {
             }
 
             if (options.WarningsAsErrors == true)
@@ -190,7 +191,19 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 commonArgs.Add("--optimize");
             }
 
-            if(options.GenerateXmlDocumentation == true)
+            if (options.KeyFile != null)
+            {
+            }
+
+            if (options.DelaySign == true)
+            {
+            }
+
+            if (options.PublicSign == true)
+            {
+            }
+
+            if (options.GenerateXmlDocumentation == true)
             {
                 commonArgs.Add($"--doc:{Path.ChangeExtension(outputName, "xml")}");
             }
@@ -207,7 +220,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     var win32manifestPath = Path.Combine(AppContext.BaseDirectory, "default.win32manifest");
-                    commonArgs.Add($"--win32manifest:\"{win32manifestPath}\"");
+                    commonArgs.Add($"--win32manifest:{win32manifestPath}");
                 }
             }
 

--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Microsoft.DotNet.Cli.Compiler.Common;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
+using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Tools.Compiler.Fsc
 {
@@ -102,6 +103,13 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
 
                 allArgs.Add($"--out:");
                 allArgs.Add($"{outputName}");
+            }
+
+            //set target framework
+            var framework = new NuGetFramework(assemblyInfoOptions.TargetFramework);
+            if (!framework.IsDesktop())
+            {
+                allArgs.Add("--targetprofile:netcore");
             }
 
             foreach (var reference in references)

--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -175,6 +175,12 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
             {
             }
 
+            // Additional arguments are added verbatim
+            if (options.AdditionalArguments != null)
+            {
+                commonArgs.AddRange(options.AdditionalArguments);
+            }
+
             if (options.LanguageVersion != null)
             {
             }

--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -134,6 +134,13 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 File.Move(outputName, originalOutputName);
             }
 
+            //HACK dotnet build require a pdb (crash without), fsc atm cant generate a portable pdb, so an empty pdb is created
+            string pdbPath = Path.ChangeExtension(outputName, ".pdb");
+            if (!File.Exists(pdbPath))
+            {
+                File.WriteAllBytes(pdbPath, Array.Empty<byte>());
+            }
+
             return result.ExitCode;
         }
 

--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -108,8 +108,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
             }
 
             //set target framework
-            var framework = new NuGetFramework(assemblyInfoOptions.TargetFramework);
-            if (!framework.IsDesktop())
+            if (commonOptions.Defines.Contains("DNXCORE50"))
             {
                 allArgs.Add("--targetprofile:netcore");
             }


### PR DESCRIPTION
rebased fix for `dotnet-compile-fsc`.

Only `src/dotnet/commands/dotnet-compile-fsc/Program.cs` is changed to fix bugs

fix #1199 #692 and probably #1279
