### PR TITLE
Fix vesion badge looks & upload issue

### DIFF
--- a/resources/images/version_badge.svg
+++ b/resources/images/version_badge.svg
@@ -1,20 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="102" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
         <stop offset="1" stop-opacity=".1" />
     </linearGradient>
     <mask id="a">
-        <rect width="102" height="20" rx="3" fill="#fff" />
+        <rect width="150" height="20" rx="3" fill="#fff" />
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h52v20H0z" />
-        <path fill="#007ec6" d="M52 0h50v20H52z" />
-        <path fill="url(#b)" d="M0 0h102v20H0z" />
+        <path fill="#007ec6" d="M52 0h100v20H52z" />
+        <path fill="url(#b)" d="M0 0h150v20H0z" />
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="26" y="15" fill="#010101" fill-opacity=".3">version</text>
         <text x="26" y="14">version</text>
-        <text x="76" y="15" fill="#010101" fill-opacity=".3">ver_number</text>
-        <text x="76" y="14">ver_number</text>
+        <text x="100" y="15" fill="#010101" fill-opacity=".3">ver_number</text>
+        <text x="100" y="14">ver_number</text>
     </g>
 </svg>

--- a/scripts/publish/publish.ps1
+++ b/scripts/publish/publish.ps1
@@ -140,10 +140,10 @@ function UploadVersionBadge($badgeFile)
     $fileName = "windows_$Configuration_$([System.IO.Path]::GetFileName($badgeFile))"
     
     Write-Host "Uploading the version badge to Latest"
-    UploadFile "dev/Binaries/Latest/$filename" $badgeFile
+    UploadFile "$env:CHANNEL/Binaries/Latest/$filename" $badgeFile
     
     Write-Host "Uploading the version badge to $env:DOTNET_CLI_VERSION"
-    UploadFile "dev/Binaries/$env:DOTNET_CLI_VERSION/$filename" $badgeFile
+    UploadFile "$env:CHANNEL/Binaries/$env:DOTNET_CLI_VERSION/$filename" $badgeFile
 
     return 0
 }

--- a/scripts/publish/publish.sh
+++ b/scripts/publish/publish.sh
@@ -194,10 +194,10 @@ upload_version_badge(){
     local badgefile=$1
     local filename="$OSNAME_$CONFIGURATION_$(basename $badgefile)"
     echo "Uploading the version badge to Latest"
-    upload_file_to_blob_storage_azure_cli "dev/Binaries/Latest/$filename" $badgefile
+    upload_file_to_blob_storage_azure_cli "$CHANNEL/Binaries/Latest/$filename" $badgefile
     
     echo "Uploading the version badge to $DOTNET_CLI_VERSION"
-    upload_file_to_blob_storage_azure_cli "dev/Binaries/$DOTNET_CLI_VERSION/$filename" $badgefile
+    upload_file_to_blob_storage_azure_cli "$CHANNEL/Binaries/$DOTNET_CLI_VERSION/$filename" $badgefile
 
     return 0
 }


### PR DESCRIPTION
The uploads didn't take into consideration the $CHANNEL variable and
badges were ending up in the dev channel. Also, the badge was too short
for the version number so fixing the SVG as well.

/cc @Sridhar-MS @piotrpMSFT 