### PR TITLE
Include project.json dependencies and use response files

### DIFF
--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.Build
     public class CompileTargets
     {
         public static readonly string CoreCLRVersion = "1.0.1-rc2-23811";
-        public static readonly string AppDepSdkVersion = "1.0.5-prerelease-00001";
+        public static readonly string AppDepSdkVersion = "1.0.6-prerelease-00001";
 
         public static readonly List<string> AssembliesToCrossGen = GetAssembliesToCrossGen();
 

--- a/src/dotnet/commands/dotnet-build/CompileContext.cs
+++ b/src/dotnet/commands/dotnet-build/CompileContext.cs
@@ -339,10 +339,10 @@ namespace Microsoft.DotNet.Tools.Build
                 args.Add(_args.ArchValue);
             }
 
-            if (!string.IsNullOrWhiteSpace(_args.IlcArgsValue))
+            foreach (var ilcArg in _args.IlcArgsValue)
             {
-                args.Add("--ilcargs");
-                args.Add(_args.IlcArgsValue);
+                args.Add("--ilcarg");
+                args.Add(ilcArg);
             }
 
             if (!string.IsNullOrWhiteSpace(_args.IlcPathValue))

--- a/src/dotnet/commands/dotnet-compile-native/ArgValues.cs
+++ b/src/dotnet/commands/dotnet-compile-native/ArgValues.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         public ArchitectureMode Architecture { get; set; }
         public NativeIntermediateMode? NativeMode { get; set; }
         public IEnumerable<string> ReferencePaths { get; set; }
-        public string IlcArgs { get; set; }
+        public IEnumerable<string> IlcArgs { get; set; }
         public IEnumerable<string> LinkLibPaths { get; set; }
         public string AppDepSDKPath { get; set; }
         public string IlcPath { get; set; }
@@ -88,7 +88,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
                 config.LogPath = LogPath;
             }
 
-            if (!string.IsNullOrEmpty(IlcArgs))
+            if (IlcArgs != null)
             {
                 config.IlcArgs = IlcArgs;
             }

--- a/src/dotnet/commands/dotnet-compile-native/ArgumentsParser.cs
+++ b/src/dotnet/commands/dotnet-compile-native/ArgumentsParser.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.Linq;
 
 namespace Microsoft.DotNet.Tools.Compiler.Native
 {
@@ -15,7 +16,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             BuildConfiguration? buildConfiguration = null;
             string mode = null;
             NativeIntermediateMode? nativeMode = null;
-            string ilcArgs = null;
+            IReadOnlyList<string> ilcArgs = Array.Empty<string>();
+            IEnumerable<string> unquotIlcArgs = Array.Empty<string>();
             string ilcPath = null;
             string ilcSdkPath = null;
             string appDepSdk = null;
@@ -26,7 +28,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             string cppCompilerFlags = null;
 
             IReadOnlyList<string> references = Array.Empty<string>();
-            IReadOnlyList<string> linklib = Array.Empty<string>();            
+            IReadOnlyList<string> linklib = Array.Empty<string>();
 
             try
             {
@@ -46,7 +48,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
                         "Use to specify Managed DLL references of the app.");
 
                     // Custom Extensibility Points to support CoreRT workflow TODO better descriptions
-                    syntax.DefineOption("ilcargs", ref ilcArgs, "Use to specify custom arguments for the IL Compiler.");
+                    syntax.DefineOptionList("ilcarg", ref ilcArgs, "Use to specify custom arguments for the IL Compiler.");
                     syntax.DefineOption("ilcpath", ref ilcPath, "Use to specify a custom build of IL Compiler.");
                     syntax.DefineOption("ilcsdkpath", ref ilcSdkPath, "Use to specify a custom build of IL Compiler SDK");
 
@@ -67,7 +69,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
                         "The managed input assembly to compile to native.");
 
                     helpText = syntax.GetHelpText();
-                    
+
                     if (string.IsNullOrWhiteSpace(inputAssembly))
                     {
                         syntax.ReportError("Input Assembly is a required parameter.");
@@ -99,6 +101,15 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
                             help = true;
                         }
                     }
+
+                    unquotIlcArgs = ilcArgs.Select(s =>
+                    {
+                        if (!s.StartsWith("\"") || !s.EndsWith("\""))
+                        {
+                            throw new ArgumentSyntaxException("--ilcarg must be specified in double quotes");
+                        }
+                        return s.Substring(1, s.Length - 2);
+                    });
                 });
             }
             catch (ArgumentSyntaxException exception)
@@ -130,7 +141,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
                 BuildConfiguration = buildConfiguration,
                 NativeMode = nativeMode,
                 ReferencePaths = references,
-                IlcArgs = ilcArgs,
+                IlcArgs = unquotIlcArgs,
                 IlcPath = ilcPath,
                 IlcSdkPath = ilcSdkPath,
                 LinkLibPaths = linklib,

--- a/src/dotnet/commands/dotnet-compile-native/ILCompilerInvoker.cs
+++ b/src/dotnet/commands/dotnet-compile-native/ILCompilerInvoker.cs
@@ -1,13 +1,15 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.Compiler.Native
 {
     public class ILCompilerInvoker
     {
-        private readonly string ExecutableName = "corerun" + Constants.ExeSuffix;
-        private readonly string ILCompiler = "ilc.exe";
+        private static readonly string HostExeName = "corerun" + Constants.ExeSuffix;
+        private static readonly string ILCompiler = "ilc.exe";
+
         private IEnumerable<string> Args;
         private NativeCompileSettings config;
 
@@ -27,14 +29,6 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         {
             var argsList = new List<string>();
 
-            var managedPath = Path.Combine(config.IlcPath, ILCompiler);
-            if (!File.Exists(managedPath))
-            {
-                throw new FileNotFoundException("Unable to find ILCompiler at " + managedPath);
-            }
-
-            argsList.Add($"{managedPath}");
-            
             // Input File 
             var inputFilePath = config.InputManagedAssemblyPath;
             argsList.Add($"{inputFilePath}");
@@ -43,32 +37,29 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var coreLibsPath = Path.Combine(config.IlcSdkPath, "sdk");
             foreach (var reference in Directory.EnumerateFiles(coreLibsPath, "*.dll"))
             {
-                argsList.Add($"-r");
-                argsList.Add($"{reference}");
+                argsList.Add($"-r:{reference}");
             }
             
             // AppDep References
             foreach (var reference in config.ReferencePaths)
             {
-                argsList.Add($"-r");
-                argsList.Add($"{reference}");
+                argsList.Add($"-r:{reference}");
             }
             
             // Set Output DetermineOutFile
             var outFile = DetermineOutputFile(config);
-            argsList.Add($"-out");
-            argsList.Add($"{outFile}");
+            argsList.Add($"-o:{outFile}");
             
             // Add Mode Flag TODO
             if (config.NativeMode == NativeIntermediateMode.cpp)
             {
-                argsList.Add("-cpp");
+                argsList.Add("--cpp");
             }
             
             // Custom Ilc Args support
-            if (! string.IsNullOrEmpty(config.IlcArgs))
+            foreach (var ilcArg in config.IlcArgs)
             {
-                argsList.Add(config.IlcArgs);
+                argsList.Add(ilcArg);
             }
                         
             Args = argsList;
@@ -76,9 +67,20 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         public int Invoke()
         {
-            var executablePath = Path.Combine(config.IlcPath, ExecutableName);
-            
-            var result = Command.Create(executablePath, Args)
+            // Check if ILCompiler is present
+            var ilcExePath = Path.Combine(config.IlcPath, ILCompiler);
+            if (!File.Exists(ilcExePath))
+            {
+                throw new FileNotFoundException("Unable to find ILCompiler at " + ilcExePath);
+            }
+
+            // Write the response file
+            var intermediateDirectory = config.IntermediateDirectory;
+            var rsp = Path.Combine(intermediateDirectory, "dotnet-compile-native-ilc.rsp");
+            File.WriteAllLines(rsp, Args, Encoding.UTF8);
+
+            var hostPath = Path.Combine(config.IlcPath, HostExeName);
+            var result = Command.Create(hostPath, new string[] { ilcExePath, "@" + $"{rsp}" })
                 .ForwardStdErr()
                 .ForwardStdOut()
                 .Execute();

--- a/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
+++ b/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         private readonly string[] _appdeplibs = 
             {
-                "libSystem.Native.a"
+                "System.Native.a"
             };
 
         public LinuxCppCompileStep(NativeCompileSettings config)

--- a/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
+++ b/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         private readonly string[] _appdeplibs = 
             {
-                "libSystem.Native.a"
+                "System.Native.a"
             };
 
         public LinuxRyuJitCompileStep(NativeCompileSettings config)

--- a/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacCppCompileStep.cs
+++ b/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacCppCompileStep.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         private readonly string[] _appdeplibs = 
             {
-                "libSystem.Native.a"
+                "System.Native.a"
             };
 
         

--- a/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
+++ b/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         private readonly string[] appdeplibs = 
             {
-                "libSystem.Native.a"
+                "System.Native.a"
             };
 
         public MacRyuJitCompileStep(NativeCompileSettings config)

--- a/src/dotnet/commands/dotnet-compile-native/appdep/project.json
+++ b/src/dotnet/commands/dotnet-compile-native/appdep/project.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23811",
-        "Microsoft.DotNet.AppDep":"1.0.5-prerelease-00001"
+        "Microsoft.DotNet.AppDep":"1.0.6-prerelease-00001"
     },
     "frameworks": {
         "dnxcore50": { }

--- a/src/dotnet/commands/dotnet-compile/CompilerCommandApp.cs
+++ b/src/dotnet/commands/dotnet-compile/CompilerCommandApp.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Tools.Compiler
         public string ConfigValue { get; set; }
         public bool IsNativeValue { get; set; }
         public string ArchValue { get; set; }
-        public string IlcArgsValue { get; set; }
+        public IEnumerable<string> IlcArgsValue { get; set; }
         public string IlcPathValue { get; set; }
         public string IlcSdkPathValue { get; set; }
         public bool IsCppModeValue { get; set; }
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             // Native Args
             _nativeOption = _app.Option("-n|--native", "Compiles source to native machine code.", CommandOptionType.NoValue);
             _archOption = _app.Option("-a|--arch <ARCH>", "The architecture for which to compile. x64 only currently supported.", CommandOptionType.SingleValue);
-            _ilcArgsOption = _app.Option("--ilcargs <ARGS>", "Command line arguments to be passed directly to ILCompiler.", CommandOptionType.SingleValue);
+            _ilcArgsOption = _app.Option("--ilcarg <ARG>", "Command line option to be passed directly to ILCompiler.", CommandOptionType.MultipleValue);
             _ilcPathOption = _app.Option("--ilcpath <PATH>", "Path to the folder containing custom built ILCompiler.", CommandOptionType.SingleValue);
             _ilcSdkPathOption = _app.Option("--ilcsdkpath <PATH>", "Path to the folder containing ILCompiler application dependencies.", CommandOptionType.SingleValue);
             _appDepSdkPathOption = _app.Option("--appdepsdkpath <PATH>", "Path to the folder containing ILCompiler application dependencies.", CommandOptionType.SingleValue);
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Tools.Compiler
 
                 IsNativeValue = _nativeOption.HasValue();
                 ArchValue = _archOption.Value();
-                IlcArgsValue = _ilcArgsOption.Value();
+                IlcArgsValue = _ilcArgsOption.HasValue() ? _ilcArgsOption.Values : Enumerable.Empty<string>();
                 IlcPathValue = _ilcPathOption.Value();
                 IlcSdkPathValue = _ilcSdkPathOption.Value();
                 AppDepSdkPathValue = _appDepSdkPathOption.Value();

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -30,7 +30,7 @@
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
         "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
         "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-        "Microsoft.DotNet.ILCompiler.SDK": "1.0.5-prerelease-00002",
+        "Microsoft.DotNet.ILCompiler.SDK": "1.0.6-prerelease-00003",
 
         "Microsoft.Extensions.Logging": "1.0.0-rc2-16040",
         "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-16040",

--- a/test/EndToEnd/EndToEndTest.cs
+++ b/test/EndToEnd/EndToEndTest.cs
@@ -81,7 +81,6 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         }
 
         [Fact]
-        [ActiveIssue(712, PlatformID.Windows | PlatformID.OSX | PlatformID.Linux)]
         public void TestDotnetBuildNativeRyuJit()
         {
             if(IsCentOS())


### PR DESCRIPTION
WIP because I am still debugging why I am not able to pass: `--ilcarg --verbose` or `--ilcarg -r:c:\foo.dll` to the ILC.

@gkhanna79 @brthor PTAL.

* Depends on new ILC (corresponding changes, mainly using `System.CommandLine` will be sent for PR shortly)
* Instead of a single gigantic `ilcargs`, we will be able to chain multiple single `--ilcarg` and add them to the response file.

Cc @tijoytom @piotrpMSFT 

Spent a bunch of time debugging why EndToEnd failed but apparently because `DOTNET_HOME` was set to some old CLI install.