### PR TITLE
Switch config to build the targeted branch

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -6,18 +6,13 @@
 import jobs.generation.Utilities;
 
 def project = GithubProject
+def branch = GithubBranchName
 
 def osList = ['Ubuntu', 'OSX', 'Windows_NT', 'CentOS7.1']
-
-def machineLabelMap = ['Ubuntu':'ubuntu-doc',
-                       'OSX':'mac',
-                       'Windows_NT':'windows',
-                       'CentOS7.1' : 'centos-71']
 
 def static getBuildJobName(def configuration, def os) {
     return configuration.toLowerCase() + '_' + os.toLowerCase()
 }
-
 
 [true, false].each { isPR ->
     ['Debug', 'Release'].each { configuration ->
@@ -28,7 +23,6 @@ def static getBuildJobName(def configuration, def os) {
             // Calculate job name
             def jobName = getBuildJobName(configuration, os)
             def buildCommand = '';
-            def postBuildCommand = '';
 
             // Calculate the build command
             if (os == 'Windows_NT') {
@@ -48,26 +42,15 @@ def static getBuildJobName(def configuration, def os) {
                     else {
                         // Shell
                         shell(buildCommand)
-
-                        // Post Build Cleanup
-                        publishers {
-                            postBuildScripts {
-                                steps {
-                                    shell(postBuildCommand)
-                                }
-                                onlyIfBuildSucceeds(false)
-                            }
-                        }
-
                     }
                 }
             }
 
             Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
-            Utilities.standardJobSetup(newJob, project, isPR)
+            Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
             Utilities.addXUnitDotNETResults(newJob, '**/*-testResults.xml')
             if (isPR) {
-                Utilities.addGithubPRTrigger(newJob, "${os} ${configuration} Build")
+                Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${configuration} Build")
             }
             else {
                 Utilities.addGithubPushTrigger(newJob)


### PR DESCRIPTION
This configuration switches CLI to the new branch model.  The branch is specified primarily in the repo list on dotnet-ci, then passed along to various utility functions.  The configuration itself is read from the specified branch in the repo, and any PR's generated are branch specific.

This means that changing the configuration in rel/1.0.0 will only affect the jobs that run against that branch