### PR TITLE
Make Portable PDB the default on Windows

### DIFF
--- a/src/Microsoft.DotNet.Compiler.Common/CommonCompilerOptionsExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/CommonCompilerOptionsExtensions.cs
@@ -32,6 +32,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
         internal static readonly OptionTemplate s_publicSignTemplate = new OptionTemplate("public-sign");
 
+        internal static readonly OptionTemplate s_debugTypeTemplate = new OptionTemplate("debug-type");
+
         internal static readonly OptionTemplate s_emitEntryPointTemplate = new OptionTemplate("emit-entry-point");
 
         internal static readonly OptionTemplate s_generateXmlDocumentation = new OptionTemplate("generate-xml-documentation");
@@ -44,6 +46,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             IReadOnlyList<string> suppressWarnings = null;
             string languageVersion = null;
             string platform = null;
+            string debugType = null;
             bool? allowUnsafe = null;
             bool? warningsAsErrors = null;
             bool? optimize = null;
@@ -61,6 +64,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             syntax.DefineOptionList(s_suppressWarningTemplate.LongName, ref suppressWarnings, "Suppresses the specified warning");
 
             syntax.DefineOptionList(s_additionalArgumentsTemplate.LongName, ref additionalArguments, "Pass the additional argument directly to the compiler");
+
+            syntax.DefineOption(s_debugTypeTemplate, ref debugType, "The type of PDB to emit: portable or full");
 
             syntax.DefineOption(s_languageVersionTemplate.LongName, ref languageVersion,
                     "The version of the language used to compile");
@@ -104,6 +109,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 KeyFile = keyFile,
                 DelaySign = delaySign,
                 PublicSign = publicSign,
+                DebugType = debugType,
                 EmitEntryPoint = emitEntryPoint,
                 GenerateXmlDocumentation = generateXmlDocumentation,
                 AdditionalArguments = additionalArguments
@@ -115,6 +121,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             var defines = options.Defines;
             var suppressWarnings = options.SuppressWarnings;
             var languageVersion = options.LanguageVersion;
+            var debugType = options.DebugType;
             var platform = options.Platform;
             var allowUnsafe = options.AllowUnsafe;
             var warningsAsErrors = options.WarningsAsErrors;
@@ -181,6 +188,11 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             if (publicSign != null)
             {
                 args.Add(s_publicSignTemplate.ToLongArg(publicSign));
+            }
+
+            if (debugType != null)
+            {
+                args.Add(s_debugTypeTemplate.ToLongArg(debugType));
             }
 
             if (emitEntryPoint != null)

--- a/src/Microsoft.DotNet.Compiler.Common/CommonCompilerOptionsExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/CommonCompilerOptionsExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
             syntax.DefineOptionList(s_additionalArgumentsTemplate.LongName, ref additionalArguments, "Pass the additional argument directly to the compiler");
 
-            syntax.DefineOption(s_debugTypeTemplate, ref debugType, "The type of PDB to emit: portable or full");
+            syntax.DefineOption(s_debugTypeTemplate.LongName, ref debugType, "The type of PDB to emit: portable or full");
 
             syntax.DefineOption(s_languageVersionTemplate.LongName, ref languageVersion,
                     "The version of the language used to compile");

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Cli.Compiler.Common;
@@ -195,9 +196,14 @@ namespace Microsoft.DotNet.ProjectModel.Workspaces
                 platform = Platform.AnyCpu;
             }
 
+            var debugType = StringComparer.OrdinalIgnoreCase.Equals(compilerOptions.DebugType, "full")
+                ? DebugInformationFormat.pdb
+                :DebugInformationFormat.Portable;
+
             options = options
                         .WithAllowUnsafe(allowUnsafe)
                         .WithPlatform(platform)
+                        .WithDebugInformationFormat(debugType)
                         .WithGeneralDiagnosticOption(warningsAsErrors ? ReportDiagnostic.Error : ReportDiagnostic.Default)
                         .WithOptimizationLevel(optimize ? OptimizationLevel.Release : OptimizationLevel.Debug);
 

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/ProjectJsonWorkspace.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.DotNet.Cli.Compiler.Common;
@@ -196,14 +195,9 @@ namespace Microsoft.DotNet.ProjectModel.Workspaces
                 platform = Platform.AnyCpu;
             }
 
-            var debugType = StringComparer.OrdinalIgnoreCase.Equals(compilerOptions.DebugType, "full")
-                ? DebugInformationFormat.pdb
-                :DebugInformationFormat.Portable;
-
             options = options
                         .WithAllowUnsafe(allowUnsafe)
                         .WithPlatform(platform)
-                        .WithDebugInformationFormat(debugType)
                         .WithGeneralDiagnosticOption(warningsAsErrors ? ReportDiagnostic.Error : ReportDiagnostic.Default)
                         .WithOptimizationLevel(optimize ? OptimizationLevel.Release : OptimizationLevel.Debug);
 

--- a/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
@@ -27,6 +27,8 @@ namespace Microsoft.DotNet.ProjectModel
 
         public bool? PublicSign { get; set; }
 
+        public string DebugType { get; set; }
+
         public bool? EmitEntryPoint { get; set; }
 
         public bool? PreserveCompilationContext { get; set; }
@@ -49,6 +51,7 @@ namespace Microsoft.DotNet.ProjectModel
                    KeyFile == other.KeyFile &&
                    DelaySign == other.DelaySign &&
                    PublicSign == other.PublicSign &&
+                   DebugType == other.DebugType &&
                    EmitEntryPoint == other.EmitEntryPoint &&
                    GenerateXmlDocumentation == other.GenerateXmlDocumentation &&
                    PreserveCompilationContext == other.PreserveCompilationContext &&
@@ -129,6 +132,11 @@ namespace Microsoft.DotNet.ProjectModel
                 if (option.PublicSign != null)
                 {
                     result.PublicSign = option.PublicSign;
+                }
+
+                if (option.DebugType != null)
+                {
+                    result.DebugType = option.DebugType;
                 }
 
                 if (option.EmitEntryPoint != null)

--- a/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Extensions.DependencyModel
                 compilerOptions.KeyFile,
                 compilerOptions.DelaySign,
                 compilerOptions.PublicSign,
+                compilerOptions.DebugType,
                 compilerOptions.EmitEntryPoint,
                 compilerOptions.GenerateXmlDocumentation);
         }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
@@ -569,6 +569,7 @@ namespace Microsoft.DotNet.ProjectModel
                 KeyFile = rawOptions.ValueAsString("keyFile"),
                 DelaySign = rawOptions.ValueAsNullableBoolean("delaySign"),
                 PublicSign = rawOptions.ValueAsNullableBoolean("publicSign"),
+                DebugType = rawOptions.ValueAsString("debugType"),
                 EmitEntryPoint = rawOptions.ValueAsNullableBoolean("emitEntryPoint"),
                 GenerateXmlDocumentation = rawOptions.ValueAsNullableBoolean("xmlDoc"),
                 PreserveCompilationContext = rawOptions.ValueAsNullableBoolean("preserveCompilationContext")

--- a/src/Microsoft.Extensions.DependencyModel/CompilationOptions.cs
+++ b/src/Microsoft.Extensions.DependencyModel/CompilationOptions.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Extensions.DependencyModel
 
         public bool? PublicSign { get; }
 
+        public string DebugType { get; }    
+
         public bool? EmitEntryPoint { get; }
 
         public bool? GenerateXmlDocumentation { get; }
@@ -40,6 +42,7 @@ namespace Microsoft.Extensions.DependencyModel
             keyFile: null,
             delaySign: null,
             publicSign: null,
+            debugType: null,
             emitEntryPoint: null,
             generateXmlDocumentation: null);
 
@@ -52,6 +55,7 @@ namespace Microsoft.Extensions.DependencyModel
             string keyFile,
             bool? delaySign,
             bool? publicSign,
+            string debugType,
             bool? emitEntryPoint,
             bool? generateXmlDocumentation)
         {
@@ -64,6 +68,7 @@ namespace Microsoft.Extensions.DependencyModel
             KeyFile = keyFile;
             DelaySign = delaySign;
             PublicSign = publicSign;
+            DebugType = debugType;
             EmitEntryPoint = emitEntryPoint;
             GenerateXmlDocumentation = generateXmlDocumentation;
         }

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Extensions.DependencyModel
                 compilationOptionsObject[DependencyContextStrings.KeyFilePropertyName]?.Value<string>(),
                 compilationOptionsObject[DependencyContextStrings.DelaySignPropertyName]?.Value<bool>(),
                 compilationOptionsObject[DependencyContextStrings.PublicSignPropertyName]?.Value<bool>(),
+                compilationOptionsObject[DependencyContextStrings.DebugTypePropertyName]?.Value<string>(),
                 compilationOptionsObject[DependencyContextStrings.EmitEntryPointPropertyName]?.Value<bool>(),
                 compilationOptionsObject[DependencyContextStrings.GenerateXmlDocumentationPropertyName]?.Value<bool>()
                 );

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextStrings.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextStrings.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Extensions.DependencyModel
 
         internal const string PublicSignPropertyName = "publicSign";
 
+        internal const string DebugTypePropertyName = "debugType";
+
         internal const string EmitEntryPointPropertyName = "emitEntryPoint";
 
         internal const string GenerateXmlDocumentationPropertyName = "xmlDoc";

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextWriter.cs
@@ -71,6 +71,10 @@ namespace Microsoft.Extensions.DependencyModel
             {
                 o[DependencyContextStrings.PublicSignPropertyName] = compilationOptions.PublicSign;
             }
+            if (compilationOptions.DebugType != null)
+            {
+                o[DependencyContextStrings.DebugTypePropertyName] = compilationOptions.DebugType;
+            }
             if (compilationOptions.EmitEntryPoint != null)
             {
                 o[DependencyContextStrings.EmitEntryPointPropertyName] = compilationOptions.EmitEntryPoint;

--- a/src/dotnet/commands/dotnet-compile-csc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-csc/Program.cs
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
 
             // Generate assembly info
             var assemblyInfo = Path.Combine(tempOutDir, $"dotnet-compile.assemblyinfo.cs");
-            
+
             File.WriteAllText(assemblyInfo, AssemblyInfoFileGenerator.GenerateCSharp(assemblyInfoOptions, sources));
 
             allArgs.Add($"\"{assemblyInfo}\"");
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             // Only the first should be quoted. This is handled
             // in dotnet-compile where the information is present.
             allArgs.AddRange(resources.Select(resource => $"-resource:{resource}"));
-            
+
             allArgs.AddRange(sources.Select(s => $"\"{s}\""));
 
             var rsp = Path.Combine(tempOutDir, "dotnet-compile-csc.rsp");
@@ -129,7 +129,6 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             {
                 "-nostdlib",
                 "-nologo",
-                "-debug:portable"
             };
 
             return args;
@@ -213,6 +212,10 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             {
                 commonArgs.Add("-t:library");
             }
+
+            commonArgs.Add((string.IsNullOrEmpty(options.DebugType) || options.DebugType == "portable")
+                ? "-debug:portable"
+                : "-debug:full");
 
             return commonArgs;
         }

--- a/src/dotnet/commands/dotnet-compile-csc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-csc/Program.cs
@@ -128,12 +128,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             var args = new List<string>()
             {
                 "-nostdlib",
-                "-nologo"
+                "-nologo",
+                "-debug:portable"
             };
-
-            args.Add(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? "-debug:full"
-                : "-debug:portable");
 
             return args;
         }


### PR DESCRIPTION
VS 2015 Update 2 CTP has been released which has support for debugging portable PDBs.  Now is a good time to make the transition so a) we can root out any remaining issues with portable PDBs and b) have larger dogfooding of the VS debugging experience here.

closes #704