### PR TITLE
Add support in dotnet run for pid files

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private bool _running = false;
 
+        private string _pidFile;
+
         private Command(CommandSpec commandSpec)
         {
             var psi = new ProcessStartInfo
@@ -101,6 +103,11 @@ namespace Microsoft.DotNet.Cli.Utils
             _process.Start();
 
             Reporter.Verbose.WriteLine($"Process ID: {_process.Id}");
+            if (!string.IsNullOrEmpty(_pidFile))
+            {
+                Reporter.Verbose.WriteLine($"Process ID (PID) file: {_pidFile}");
+                File.WriteAllText(_pidFile, _process.Id.ToString());
+            }
 
             var threadOut = _stdOut.BeginRead(_process.StandardOutput);
             var threadErr = _stdErr.BeginRead(_process.StandardError);
@@ -133,6 +140,12 @@ namespace Microsoft.DotNet.Cli.Utils
         public ICommand WorkingDirectory(string projectDirectory)
         {
             _process.StartInfo.WorkingDirectory = projectDirectory;
+            return this;
+        }
+
+        public ICommand PidFile(string file)
+        {
+            _pidFile = file;
             return this;
         }
 

--- a/src/Microsoft.DotNet.Cli.Utils/ICommand.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ICommand.cs
@@ -12,6 +12,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
         ICommand WorkingDirectory(string projectDirectory);
 
+        ICommand PidFile(string file);
+
         ICommand EnvironmentVariable(string name, string value);
 
         ICommand CaptureStdOut();

--- a/src/dotnet/commands/dotnet-run/Program.cs
+++ b/src/dotnet/commands/dotnet-run/Program.cs
@@ -29,6 +29,7 @@ namespace Microsoft.DotNet.Tools.Run
                     syntax.DefineOption("f|framework", ref runCmd.Framework, "Compile a specific framework");
                     syntax.DefineOption("c|configuration", ref runCmd.Configuration, "Configuration under which to build");
                     syntax.DefineOption("p|project", ref runCmd.Project, "The path to the project to run (defaults to the current directory). Can be a path to a project.json or a project directory");
+                    syntax.DefineOption("pf|pid-file", ref runCmd.PidFile, "A file that contains the process id of the executed application");
 
                     syntax.DefineOption("h|help", ref help, "Help for compile native.");
 

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Tools.Run
         public string Framework = null;
         public string Configuration = null;
         public string Project = null;
+        public string PidFile = null;
         public IReadOnlyList<string> Args = null;
 
         ProjectContext _context;
@@ -150,6 +151,7 @@ namespace Microsoft.DotNet.Tools.Run
                 .ForwardStdOut()
                 .ForwardStdErr()
                 .EnvironmentVariable("DOTNET_HOME", dotnetHome)
+                .PidFile(PidFile)
                 .Execute()
                 .ExitCode;
 


### PR DESCRIPTION
Add support for dropping a pid file. The watcher needs it because otherwise it cannot kill the process started by `dotnet run`

cc @piotrpMSFT @anurse 