### PR TITLE
Updated to a newer version of NuGet

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
@@ -88,6 +88,13 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             return true;
         }
 
-        private string RenderDependency(LibraryRange arg) => $"{arg.Name} {VersionUtility.RenderVersion(arg.VersionRange)}";
+        private string RenderDependency(LibraryRange arg)
+        {
+            if (arg.Target == LibraryType.Project && arg.VersionRange == null)
+            {
+                return arg.Name;
+            }
+            return $"{arg.Name} {VersionUtility.RenderVersion(arg.VersionRange)}";
+        }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
@@ -175,7 +175,7 @@ namespace Microsoft.DotNet.ProjectModel
             var libraries = new Dictionary<LibraryKey, LibraryDescription>();
             var projectResolver = new ProjectDependencyProvider(ProjectResolver);
 
-            var mainProject = projectResolver.GetDescription(TargetFramework, Project);
+            var mainProject = projectResolver.GetDescription(TargetFramework, Project, targetLibrary: null);
 
             // Add the main project
             libraries.Add(new LibraryKey(mainProject.Identity.Name), mainProject);

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -6,7 +6,7 @@
     "description": "Types to model a .NET Project",
     "dependencies": {
         "System.Reflection.Metadata": "1.2.0-rc3-23811",
-        "NuGet.Packaging": "3.4.0-beta-583",
+        "NuGet.Packaging": "3.4.0-beta-625",
         "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15996",
         "Microsoft.Extensions.JsonParser.Sources": {
             "type": "build",

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -24,7 +24,7 @@
         "Microsoft.CodeAnalysis.CSharp":  "1.2.0-beta1-20160202-02",
         "Microsoft.DiaSymReader.Native": "1.3.3",
 
-        "NuGet.CommandLine.XPlat": "3.4.0-beta-583",
+        "NuGet.CommandLine.XPlat": "3.4.0-beta-625",
         "System.CommandLine": "0.1.0-e160119-1",
 
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",
@@ -47,10 +47,7 @@
             "version": "1.0.0-rc2-16453",
             "type": "build"
         },
-        "Microsoft.Extensions.Testing.Abstractions": {
-            "version": "1.0.0-*",
-            "type": "build"
-        },
+        "Microsoft.Extensions.Testing.Abstractions": "1.0.0-*",
         "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23811",
         "Microsoft.NETCore.TestHost": "1.0.0-rc2-23811",
         "NETStandard.Library": "1.0.0-rc2-23811",

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -6,8 +6,7 @@
 
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": {
-      "target": "project",
-      "type": "build"
+      "target": "project"
     },
 
     "xunit": "2.1.0",

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -6,8 +6,7 @@
     
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": {
-      "target": "project",
-      "type": "build"
+      "target": "project"
     },
 
     "xunit": "2.1.0",

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -5,8 +5,7 @@
     "NETStandard.Library": "1.0.0-rc2-23811",
 
     "Microsoft.DotNet.Cli.Utils": {
-      "target": "project",
-      "type": "build"
+      "target": "project"
     },
 
     "dotnet": { "target": "project" },

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -6,8 +6,7 @@
 
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": {
-      "target": "project",
-      "type": "build"
+      "target": "project"
     },
 
     "xunit": "2.1.0",


### PR DESCRIPTION
- Update the newest nuget
- Filter out build dependencies from the project resolver based on hte lock file
- Fix more erroneous build dependencies

/cc @emgarten @piotrpMSFT 