### PR TITLE
This change mimics the nuget lock file generation logic

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/Graph/LibraryRange.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LibraryRange.cs
@@ -104,6 +104,48 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             return sb.ToString();
         }
 
+        public string ToLockFileDependencyGroupString()
+        {
+            var sb = new StringBuilder();
+            sb.Append(Name);
+
+            if (VersionRange != null)
+            {
+                if (VersionRange.HasLowerBound)
+                {
+                    sb.Append(" ");
+
+                    if (VersionRange.IsMinInclusive)
+                    {
+                        sb.Append(">= ");
+                    }
+                    else
+                    {
+                        sb.Append("> ");
+                    }
+
+                    if (VersionRange.IsFloating)
+                    {
+                        sb.Append(VersionRange.Float.ToString());
+                    }
+                    else
+                    {
+                        sb.Append(VersionRange.MinVersion.ToNormalizedString());
+                    }
+                }
+
+                if (VersionRange.HasUpperBound)
+                {
+                    sb.Append(" ");
+
+                    sb.Append(VersionRange.IsMaxInclusive ? "<= " : "< ");
+                    sb.Append(VersionRange.MaxVersion.ToNormalizedString());
+                }
+            }
+
+            return sb.ToString();
+        }
+
         public bool HasFlag(LibraryDependencyTypeFlag flag)
         {
             return Type.HasFlag(flag);

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                 if (group.FrameworkName == null)
                 {
                     actualDependencies = project.Dependencies
-                        .Select(RenderDependency)
+                        .Select(d => d.ToLockFileDependencyGroupString())
                         .OrderBy(x => x, StringComparer.OrdinalIgnoreCase);
                 }
                 else
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                     }
 
                     actualDependencies = framework.Dependencies
-                        .Select(RenderDependency)
+                        .Select(d => d.ToLockFileDependencyGroupString())
                         .OrderBy(x => x, StringComparer.OrdinalIgnoreCase);
                 }
 
@@ -86,15 +86,6 @@ namespace Microsoft.DotNet.ProjectModel.Graph
 
             message = null;
             return true;
-        }
-
-        private string RenderDependency(LibraryRange arg)
-        {
-            if (arg.Target == LibraryType.Project && arg.VersionRange == null)
-            {
-                return arg.Name;
-            }
-            return $"{arg.Name} {VersionUtility.RenderVersion(arg.VersionRange)}";
         }
     }
 }


### PR DESCRIPTION
We should eventually move all of these intrinsics to NuGet and just use them as is.

/cc @emgarten 