### PR TITLE
fix version number padding

### DIFF
--- a/scripts/dotnet-cli-build/Utils/BuildVersion.cs
+++ b/scripts/dotnet-cli-build/Utils/BuildVersion.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Microsoft.DotNet.Cli.Build
+﻿namespace Microsoft.DotNet.Cli.Build
 {
     public class BuildVersion
     {
@@ -14,8 +9,8 @@ namespace Microsoft.DotNet.Cli.Build
         public string CommitCountString => CommitCount.ToString("000000");
         public string ReleaseSuffix { get; set; }
 
-        public string SimpleVersion => $"{Major}.{Minor}.{Patch}.{CommitCount}";
-        public string VersionSuffix => $"{ReleaseSuffix}-{CommitCount}";
+        public string SimpleVersion => $"{Major}.{Minor}.{Patch}.{CommitCountString}";
+        public string VersionSuffix => $"{ReleaseSuffix}-{CommitCountString}";
         public string NuGetVersion => $"{Major}.{Minor}.{Patch}-{VersionSuffix}";
 
         public string GenerateMsiVersion()


### PR DESCRIPTION
Version numbers weren't padded properly.

Someone with the MyGet admin creds is going to have to purge the one or two versions that got published with the broken version strings.

/cc @piotrpMSFT @brthor @davidfowl 