### PR TITLE
Add set -e to package.sh

### DIFF
--- a/scripts/package/package.sh
+++ b/scripts/package/package.sh
@@ -14,6 +14,8 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 export REPOROOT="$(cd -P "$DIR/../.." && pwd)"
 
+set -e
+
 source "$DIR/../common/_common.sh"
 
 if [ -z "$DOTNET_CLI_VERSION" ]; then


### PR DESCRIPTION
So we'll start seeing build failures when things are breaking in packaging.