### PR TITLE
Fix release builds in docker.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,48 +24,32 @@ if [ -z "$HOME" ]; then
     mkdir -p $HOME
 fi
 
+args=( "$@" )
+
 while [[ $# > 0 ]]; do
     lowerI="$(echo $1 | awk '{print tolower($0)}')"
     case $lowerI in
-        -c|--configuration)
-            export CONFIGURATION=$2
-            shift
-            ;;
-        --nopackage)
-            export DOTNET_BUILD_SKIP_PACKAGING=1
-            ;;
         --docker)
             export BUILD_IN_DOCKER=1
             export DOCKER_IMAGENAME=$2
+            # remove docker args
+            args=( "${args[@]/$1}" )
+            args=( "${args[@]/$2}" )
             shift
             ;;
-        --skip-prereqs)
-            # Allow CI to disable prereqs check since the CI has the pre-reqs but not ldconfig it seems
-            export DOTNET_INSTALL_SKIP_PREREQS=1
-            ;;
-        --help)
-            echo "Usage: $0 [--configuration <CONFIGURATION>] [--skip-prereqs] [--nopackage] [--docker <IMAGENAME>] [--help] <TARGETS...>"
-            echo ""
-            echo "Options:"
-            echo "  --configuration <CONFIGURATION>     Build the specified Configuration (Debug or Release, default: Debug)"
-            echo "  --nopackage                         Skip packaging targets"
-            echo "  --skip-prereqs                      Skip checks for pre-reqs in dotnet_install"
-            echo "  --docker <IMAGENAME>                Build in Docker using the Dockerfile located in scripts/docker/IMAGENAME"
-            echo "  --help                              Display this help message"
-            echo "  <TARGETS...>                        The build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
-            exit 0
-            ;;
         *)
-            break
-            ;;
     esac
-
     shift
 done
 
+# $args array may have empty elements in it.
+# The easiest way to remove them is to cast to string and back to array.
+temp="${args[@]}"
+args=($temp)
+
 # Check if we need to build in docker
 if [ ! -z "$BUILD_IN_DOCKER" ]; then
-    $DIR/scripts/dockerbuild.sh "$@"
+    $DIR/scripts/dockerbuild.sh "${args[@]}"
 else
-    $DIR/scripts/run-build.sh "$@"
+    $DIR/scripts/run-build.sh "${args[@]}"
 fi

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -14,6 +14,40 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
+while [[ $# > 0 ]]; do
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -c|--configuration)
+            export CONFIGURATION=$2
+            shift
+            ;;
+        --nopackage)
+            export DOTNET_BUILD_SKIP_PACKAGING=1
+            ;;
+        --skip-prereqs)
+            # Allow CI to disable prereqs check since the CI has the pre-reqs but not ldconfig it seems
+            export DOTNET_INSTALL_SKIP_PREREQS=1
+            ;;
+        --help)
+            echo "Usage: $0 [--configuration <CONFIGURATION>] [--skip-prereqs] [--nopackage] [--docker <IMAGENAME>] [--help] <TARGETS...>"
+            echo ""
+            echo "Options:"
+            echo "  --configuration <CONFIGURATION>     Build the specified Configuration (Debug or Release, default: Debug)"
+            echo "  --nopackage                         Skip packaging targets"
+            echo "  --skip-prereqs                      Skip checks for pre-reqs in dotnet_install"
+            echo "  --docker <IMAGENAME>                Build in Docker using the Dockerfile located in scripts/docker/IMAGENAME"
+            echo "  --help                              Display this help message"
+            echo "  <TARGETS...>                        The build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
+            exit 0
+            ;;
+        *)
+            break
+            ;;
+    esac
+
+    shift
+done
+
 # Set up the environment to be used for building with clang.
 if which "clang-3.5" > /dev/null 2>&1; then
     export CC="$(which clang-3.5)"


### PR DESCRIPTION
Move the args processing to run-build.sh. Earlier all the args were processed in build.sh and not passed on properly to a docker container.

cc @brthor @anurse @piotrpMSFT 