### PR TITLE
Cleanup quoting in response files, and trims.

### DIFF
--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             var existingAttributes = new List<Type>();
             foreach (var sourceFile in sourceFiles)
             {
-                var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFile.Trim('"')));
+                var tree = CSharpSyntaxTree.ParseText(File.ReadAllText(sourceFile));
                 var root = tree.GetRoot();
 
                 // assembly attributes can be only on first level

--- a/src/dotnet/commands/dotnet-compile-csc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-csc/Program.cs
@@ -82,29 +82,33 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 return returnCode;
             }
 
-            var translated = TranslateCommonOptions(commonOptions, outputName.Trim('"'));
+            var translated = TranslateCommonOptions(commonOptions, outputName);
 
             var allArgs = new List<string>(translated);
             allArgs.AddRange(GetDefaultOptions());
 
             // Generate assembly info
-            var tempOutputStrippedSpaces = tempOutDir.Trim('"');
-            var assemblyInfo = Path.Combine(tempOutputStrippedSpaces, $"dotnet-compile.assemblyinfo.cs");
+            var assemblyInfo = Path.Combine(tempOutDir, $"dotnet-compile.assemblyinfo.cs");
             
             File.WriteAllText(assemblyInfo, AssemblyInfoFileGenerator.Generate(assemblyInfoOptions, sources));
             allArgs.Add($"\"{assemblyInfo}\"");
 
             if (outputName != null)
             {
-                allArgs.Add($"-out:\"{outputName.Trim('"')}\"");
+                allArgs.Add($"-out:\"{outputName}\"");
             }
 
-            allArgs.AddRange(analyzers.Select(a => $"-a:\"{a.Trim('"')}\""));
-            allArgs.AddRange(references.Select(r => $"-r:\"{r.Trim('"')}\""));
-            allArgs.AddRange(resources.Select(resource => $"-resource:{resource}"));
-            allArgs.AddRange(sources.Select(s => $"\"{s.Trim('"')}\""));
+            allArgs.AddRange(analyzers.Select(a => $"-a:\"{a}\""));
+            allArgs.AddRange(references.Select(r => $"-r:\"{r}\""));
 
-            var rsp = Path.Combine(tempOutputStrippedSpaces, "dotnet-compile-csc.rsp");
+            // Resource has two parts separated by a comma
+            // Only the first should be quoted. This is handled
+            // in dotnet-compile where the information is present.
+            allArgs.AddRange(resources.Select(resource => $"-resource:{resource}"));
+            
+            allArgs.AddRange(sources.Select(s => $"\"{s}\""));
+
+            var rsp = Path.Combine(tempOutDir, "dotnet-compile-csc.rsp");
 
             File.WriteAllLines(rsp, allArgs, Encoding.UTF8);
 
@@ -204,7 +208,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
 
             if (options.GenerateXmlDocumentation == true)
             {
-                commonArgs.Add($"-doc:\"{Path.ChangeExtension(outputName.Trim('"'), "xml")}\"");
+                commonArgs.Add($"-doc:{Path.ChangeExtension(outputName, "xml")}");
             }
 
             if (options.EmitEntryPoint != true)

--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -80,9 +80,6 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 return returnCode;
             }
 
-            outputName = outputName.Trim('"');
-            tempOutDir = tempOutDir.Trim('"');
-
             var translated = TranslateCommonOptions(commonOptions, outputName);
 
             var allArgs = new List<string>(translated);
@@ -115,9 +112,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 allArgs.Add("--targetprofile:netcore");
             }
 
-            allArgs.AddRange(references.Select(r => $"-r:{r.Trim('"')}"));
-            allArgs.AddRange(resources.Select(resource => $"--resource:{resource.Trim('"')}"));
-            allArgs.AddRange(sources.Select(s => $"{s.Trim('"')}"));
+            allArgs.AddRange(references.Select(r => $"-r:{r}"));
+            allArgs.AddRange(resources.Select(resource => $"--resource:{resource}"));
+            allArgs.AddRange(sources.Select(s => $"{s}"));
 
             var rsp = Path.Combine(tempOutDir, "dotnet-compile-fsc.rsp");
             File.WriteAllLines(rsp, allArgs, Encoding.UTF8);

--- a/src/dotnet/commands/dotnet-compile/Compiler.cs
+++ b/src/dotnet/commands/dotnet-compile/Compiler.cs
@@ -56,8 +56,8 @@ namespace Microsoft.DotNet.Tools.Compiler
                 {
                     var arguments = new[]
                     {
-                        $"\"{resgenFile.InputFile}\"",
-                        $"-o:\"{resgenFile.OutputFile}\"",
+                        $"{resgenFile.InputFile}",
+                        $"-o:{resgenFile.OutputFile}",
                         $"-v:{project.Version.Version}"
                     };
 
@@ -89,7 +89,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             string outputPath)
         {
             var referencePaths = CompilerUtil.GetReferencePathsForCultureResgen(dependencies);
-            var resgenReferenceArgs = referencePaths.Select(path => $"-r:\"{path}\"").ToList();
+            var resgenReferenceArgs = referencePaths.Select(path => $"-r:{path}").ToList();
             var cultureResgenFiles = CompilerUtil.GetCultureResources(project, outputPath);
 
             foreach (var resgenFile in cultureResgenFiles)
@@ -104,10 +104,10 @@ namespace Microsoft.DotNet.Tools.Compiler
                 var arguments = new List<string>();
 
                 arguments.AddRange(resgenReferenceArgs);
-                arguments.Add($"-o:\"{resgenFile.OutputFile}\"");
+                arguments.Add($"-o:{resgenFile.OutputFile}");
                 arguments.Add($"-c:{resgenFile.Culture}");
                 arguments.Add($"-v:{project.Version.Version}");
-                arguments.AddRange(resgenFile.InputFileToMetadata.Select(fileToMetadata => $"\"{fileToMetadata.Key}\",{fileToMetadata.Value}"));
+                arguments.AddRange(resgenFile.InputFileToMetadata.Select(fileToMetadata => $"{fileToMetadata.Key},{fileToMetadata.Value}"));
                 var rsp = Path.Combine(intermediateOutputPath, $"dotnet-resgen.rsp");
                 File.WriteAllLines(rsp, arguments);
 

--- a/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
+++ b/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
@@ -72,8 +72,8 @@ namespace Microsoft.DotNet.Tools.Compiler
             // Assemble args
             var compilerArgs = new List<string>()
             {
-                $"--temp-output:\"{intermediateOutputPath}\"",
-                $"--out:\"{outputName}\""
+                $"--temp-output:{intermediateOutputPath}",
+                $"--out:{outputName}"
             };
 
             var compilationOptions = CompilerUtil.ResolveCompilationOptions(context, args.ConfigValue);
@@ -90,15 +90,15 @@ namespace Microsoft.DotNet.Tools.Compiler
             foreach (var dependency in dependencies)
             {
                 references.AddRange(dependency.CompilationAssemblies.Select(r => r.ResolvedPath));
-                compilerArgs.AddRange(dependency.SourceReferences.Select(s => $"\"{s}\""));
+                compilerArgs.AddRange(dependency.SourceReferences.Select(s => $"{s}"));
 
                 // Add analyzer references
                 compilerArgs.AddRange(dependency.AnalyzerReferences
                     .Where(a => a.AnalyzerLanguage == languageId)
-                    .Select(a => $"--analyzer:\"{a.AssemblyPath}\""));
+                    .Select(a => $"--analyzer:{a.AssemblyPath}"));
             }
 
-            compilerArgs.AddRange(references.Select(r => $"--reference:\"{r}\""));
+            compilerArgs.AddRange(references.Select(r => $"--reference:{r}"));
 
             if (compilationOptions.PreserveCompilationContext == true)
             {
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                     writer.Write(dependencyContext, fileStream);
                 }
 
-                compilerArgs.Add($"--resource:\"{depsJsonFile}\",{context.ProjectFile.Name}.deps.json");
+                compilerArgs.Add($"--resource:{depsJsonFile},{context.ProjectFile.Name}.deps.json");
             }
 
             if (!AddNonCultureResources(context.ProjectFile, compilerArgs, intermediateOutputPath))

--- a/src/dotnet/commands/dotnet-resgen/ResgenCommand.cs
+++ b/src/dotnet/commands/dotnet-resgen/ResgenCommand.cs
@@ -20,13 +20,7 @@ namespace Microsoft.DotNet.Tools.Resgen
         public int Execute()
         {
             var inputResourceFiles = Args.Select(ParseInputFile).ToArray();
-            var outputResourceFile = ResourceFile.Create(OutputFileName.Trim('"'));
-
-            var trimmedCompilationReferences = default(string[]);
-            if (CompilationReferences != null)
-            {
-                trimmedCompilationReferences = CompilationReferences.Select(r => r.Trim('"')).ToArray();
-            }
+            var outputResourceFile = ResourceFile.Create(OutputFileName);
 
             switch (outputResourceFile.Type)
             {
@@ -43,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Resgen
                             outputStream,
                             metadata,
                             Path.GetFileNameWithoutExtension(outputResourceFile.File.Name),
-                            trimmedCompilationReferences
+                            CompilationReferences.ToArray()
                             );
                     }
                     break;
@@ -81,10 +75,6 @@ namespace Microsoft.DotNet.Tools.Resgen
                 name = arg;
                 metadataName = arg;
             }
-
-            // Remove surrounding quotes
-            name = name.Trim('"');
-            metadataName = metadataName.Trim('"');
 
             return new ResourceSource(ResourceFile.Create(name), metadataName);
         }


### PR DESCRIPTION
CSC is the only program which requires quotes in the response file it consumes.

System.CommandLine will parse things correctly even with a space in the arg value.

These changes cleanup all the unnecessary Trims and quoting going on.

cc @Sridhar-MS @livarcocc 