### PR TITLE
dotnet-hello package cleanup and no-cache

### DIFF
--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Cli.Build
             return c.Success();
         }
 
-        [Target]
+        [Target(nameof(CleanTestPackages))]
         public static BuildTargetResult BuildTestAssetPackages(BuildTargetContext c)
         {
             var dotnet = DotNetCli.Stage2;
@@ -97,6 +97,14 @@ namespace Microsoft.DotNet.Cli.Build
                     .Execute()
                     .EnsureSuccessful();
             }
+            
+            return c.Success();
+        }
+        
+        [Target]
+        public static BuildTargetResult CleanTestPackages(BuildTargetContext c)
+        {
+            Rmdir(Path.Combine(Dirs.NuGetPackages, "dotnet-hello"));
             
             return c.Success();
         }


### PR DESCRIPTION
This PR addresses two issues:
- Test setup now deletes dotnet-hello from the nuget cache to prevent previous test runs from leaking into current builds
- 'Latest' binaries have caching set to no-cache since they are very volatile

/cc @Sridhar-MS 