### PR TITLE
fix dotnet-compile.deps.json space in the path issue.

### DIFF
--- a/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
+++ b/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                     writer.Write(dependencyContext, fileStream);
                 }
 
-                compilerArgs.Add($"--resource:{depsJsonFile},{context.ProjectFile.Name}.deps.json");
+                compilerArgs.Add($"--resource:\"{depsJsonFile}\",{context.ProjectFile.Name}.deps.json");
             }
 
             if (!AddNonCultureResources(context.ProjectFile, compilerArgs, intermediateOutputPath))

--- a/test/dotnet-compile.Tests/CompilerTests.cs
+++ b/test/dotnet-compile.Tests/CompilerTests.cs
@@ -88,6 +88,24 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
             Assert.Contains("CA1018", result.StdErr);
         }
 
+        [Fact]
+        public void CompilingAppWithPreserveCompilationContextWithSpaceInThePathShouldSucceed()
+        {
+            var root = Temp.CreateDirectory();
+
+            var spaceBufferDirectory = root.CreateDirectory("space directory");
+            var testAppDir = spaceBufferDirectory.CreateDirectory("TestAppCompilationContext");
+
+            CopyProjectToTempDir(Path.Combine(_testProjectsRoot, "TestAppCompilationContext"), testAppDir);
+
+            var testProjectDir = Path.Combine(_testProjectsRoot, "TestAppCompilationContext", "TestApp");
+            var testProject = Path.Combine(testProjectDir, "project.json");
+            
+            var buildCommand = new BuildCommand(testProject);
+
+            buildCommand.Execute().Should().Pass();
+        }
+
         private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)
         {
             // copy all the files to temp dir

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -23,6 +23,7 @@
     "../../TestAssets/TestProjects/TestLibraryWithAnalyzer/*",
     "../../TestAssets/TestProjects/TestAppWithLibrary/TestLibrary/*",
     "../../TestAssets/TestProjects/TestProjectWithCultureSpecificResource/*",
+    "../../TestAssets/TestProjects/TestAppCompilationContext/**/*",
     "../../TestAssets/TestProjects/global.json"
   ],
 


### PR DESCRIPTION
Resources are a special case in quoting for CSC in response files.

This is the quick fix. Going to work on some abstractions so this stops happening.

cc @pakrym 