### PR TITLE
Removes usage of DOTNET_HOME in CLI repo.

### DIFF
--- a/Documentation/manpages/dotnet-compile.1
+++ b/Documentation/manpages/dotnet-compile.1
@@ -150,15 +150,6 @@ Prints\ verbose\ logging\ information,\ to\ follow\ the\ flow\ of\ execution\ of
 Show\ short\ help.\ 
 \f[]
 .fi
-.SH ENVIRONMENT
-.PP
-\f[C]DOTNET_HOME\f[]
-.IP
-.nf
-\f[C]
-Points\ to\ the\ base\ directory\ that\ contains\ the\ runtime\ and\ the\ binaries\ directories.\ The\ runtime\ will\ be\ used\ to\ run\ the\ executable\ file\ that\ is\ dropped\ after\ compiling.\ Not\ needed\ for\ native\ compilation.\ \ 
-\f[]
-.fi
 .SH SEE ALSO
 .PP
 dotnet\-restore(1), dotnet\-publish(1), dotnet(1)

--- a/Documentation/manpages/dotnet-run.1
+++ b/Documentation/manpages/dotnet-run.1
@@ -39,15 +39,6 @@ Temporary files are written to the child \f[C]obj\f[] folder.
 Prints\ verbose\ logging\ information,\ to\ follow\ the\ flow\ of\ execution\ of\ the\ command.
 \f[]
 .fi
-.SH ENVIRONMENT
-.PP
-\f[C]DOTNET_HOME\f[]
-.IP
-.nf
-\f[C]
-Points\ to\ the\ base\ directory\ that\ contains\ the\ runtime\ and\ the\ binaries\ directories.\ The\ runtime\ will\ be\ used\ to\ run\ the\ executable\ file\ that\ is\ dropped\ after\ compiling.\ Not\ needed\ for\ native\ compilation.\ \ \ 
-\f[]
-.fi
 .SH SEE ALSO
 .PP
 dotnet\-compile(1), dotnet\-publish(1)

--- a/Documentation/manpages/dotnet.1
+++ b/Documentation/manpages/dotnet.1
@@ -121,14 +121,6 @@ Compiles\ the\ application\ in\ a\ given\ directory.\
 .fi
 .SH ENVIRONMENT
 .PP
-\f[C]DOTNET_HOME\f[]
-.IP
-.nf
-\f[C]
-Points\ to\ the\ base\ directory\ that\ contains\ the\ runtime\ and\ the\ binaries\ directories.\ The\ runtime\ will\ be\ used\ to\ run\ the\ executable\ file\ that\ is\ dropped\ after\ compiling.\ Not\ needed\ for\ native\ compilation.\ \ 
-\f[]
-.fi
-.PP
 \f[C]DOTNET_PACKAGES\f[]
 .IP
 .nf

--- a/Documentation/specs/corehost.md
+++ b/Documentation/specs/corehost.md
@@ -76,16 +76,18 @@ Satellite Assemblies (assemblies containing only embedded resources used in plac
 
 ## Runtime Resolution
 
-Runtime resolution is controlled by two environment variables:
+Runtime resolution is controlled by these environment variables:
 
 * `DOTNET_RUNTIME_SERVICING` -> Global override for runtime
-* `DOTNET_HOME` -> Default location for runtime
+* `DOTNET_PACKAGES_CACHE` -> Secondary cache
+* `DOTNET_PACKAGES` -> Package restore location
 
 The runtime is located by searching the following paths in order, where `APP_BASE` refers to the directory containing the managed application assembly and `LIBCORECLR` refers to the platform-specific name for the CoreCLR library (`libcoreclr.so` on Unix, `libcoreclr.dylib` on Mac OS X, `coreclr.dll` on Windows). The first path that matches is used as the path to load the CoreCLR from.
 
 * `$DOTNET_RUNTIME_SERVICING/runtime/coreclr/LIBCORECLR`
+* `$DOTNET_PACKAGES_CACHE/<Package Id>/<Package Version>/runtimes/<RID>/native/LICORECLR`
 * `APP_BASE/LIBCORECLR`
-* `$DOTNET_HOME/runtime/coreclr/LIBCORECLR`
+* `$DOTNET_PACKAGES/<Package Id>/<Package Version>/runtimes/<RID>/native/LIBCORECLR`
 * On Unix:
     * `/usr/local/share/dotnet/runtime/coreclr/LIBCORECLR` [1]
     * `/usr/share/dotnet/runtime/coreclr/LIBCORECLR`

--- a/README.md
+++ b/README.md
@@ -72,9 +72,7 @@ For more details, please refer to the [documentation](https://github.com/dotnet/
 Building from source
 --------------------
 
-If you are building from source, take note that the build depends on NuGet packages hosted on Myget, so if it is down, the build may fail. If that happens, you can always see the [Myget status page](http://status.myget.org/) for more info.  
-
-Also, when building from source, you need to set up the `DOTNET_HOME` environment variable. It needs to point to the parent directory of where `bin` and `runtime` directories are. 
+If you are building from source, take note that the build depends on NuGet packages hosted on Myget, so if it is down, the build may fail. If that happens, you can always see the [Myget status page](http://status.myget.org/) for more info. 
 
 Known issues
 ------------

--- a/packaging/windows/registrykeys.wxs
+++ b/packaging/windows/registrykeys.wxs
@@ -25,7 +25,6 @@
         </RegistryKey>
 
         <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]bin" Part="last" Action="set" System="yes" />
-        <Environment Id="E_DOTNET_HOME" Name="DOTNET_HOME" Value="[DOTNETHOME]" Part="all" Action="set" System="yes" />
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/scripts/common/_common.sh
+++ b/scripts/common/_common.sh
@@ -18,7 +18,7 @@ export CHANNEL=$RELEASE_SUFFIX
 
 [ -z "$DOTNET_INSTALL_DIR" ] && export DOTNET_INSTALL_DIR=$REPOROOT/.dotnet_stage0/$RID
 [ -z "$DOTNET_CLI_VERSION" ] && export DOTNET_CLI_VERSION=0.1.0.0
-[ -z "$DOTNET_HOME" ] && export DOTNET_HOME=$STAGE2_DIR && export PATH=$STAGE2_DIR/bin:$PATH
+[ -z "$DOTNET_ON_PATH" ] && export DOTNET_ON_PATH=$STAGE2_DIR && export PATH=$STAGE2_DIR/bin:$PATH
 [ -z "$CONFIGURATION" ] && export CONFIGURATION=Debug
 
 #TODO this is a workaround for a nuget bug on ubuntu. Remove

--- a/scripts/common/_utility.ps1
+++ b/scripts/common/_utility.ps1
@@ -36,7 +36,7 @@ function setVarIfDefault([string]$varName, [string]$value)
 
 function setPathAndHomeIfDefault([string]$rootPath)
 {
-    If ($env:DOTNET_HOME -eq $null)
+    If ($env:DOTNET_ON_PATH -eq $null)
     {
         setPathAndHome $rootPath
     }
@@ -44,7 +44,7 @@ function setPathAndHomeIfDefault([string]$rootPath)
 
 function setPathAndHome([string]$rootPath)
 {
-        $env:DOTNET_HOME=$rootPath
+        $env:DOTNET_ON_PATH=$rootPath
         $env:PATH="$rootPath\bin;$env:PATH"
 }
 

--- a/scripts/run-build.ps1
+++ b/scripts/run-build.ps1
@@ -74,6 +74,5 @@ if($LASTEXITCODE -ne 0) { throw "Failed to compile build scripts" }
 # Run the builder
 Write-Host "Invoking Build Scripts..."
 Write-Host " Configuration: $env:CONFIGURATION"
-$env:DOTNET_HOME="$env:DOTNET_INSTALL_DIR\cli"
 & "$PSScriptRoot\dotnet-cli-build\bin\dotnet-cli-build.exe" @args
 if($LASTEXITCODE -ne 0) { throw "Build failed" }

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -106,10 +106,10 @@ echo "Invoking Build Scripts..."
 echo "Configuration: $CONFIGURATION"
 
 if [ -f "$DIR/dotnet-cli-build/bin/dotnet-cli-build" ]; then
-    DOTNET_HOME="$DOTNET_INSTALL_DIR/share/dotnet/cli" $DIR/dotnet-cli-build/bin/dotnet-cli-build "$@"
+    $DIR/dotnet-cli-build/bin/dotnet-cli-build "$@"
     exit $?
 else
     # We're on an older CLI. This is temporary while Ubuntu and CentOS VSO builds are stalled.
-    DOTNET_HOME="$DOTNET_INSTALL_DIR/share/dotnet/cli" $DIR/dotnet-cli-build/bin/Debug/dnxcore50/dotnet-cli-build "$@"
+    $DIR/dotnet-cli-build/bin/Debug/dnxcore50/dotnet-cli-build "$@"
     exit $?
 fi

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -73,10 +73,6 @@ The following commands exist for dotnet.
 
 # ENVIRONMENT 
 
-`DOTNET_HOME`
-
-    Points to the base directory that contains the runtime and the binaries directories. The runtime will be used to run the executable file that is dropped after compiling. Not needed for native compilation.  
-
 `DOTNET_PACKAGES`
 
     The primary package cache. If not set, defaults to $HOME/.nuget/packages on Unix or %LOCALAPPDATA%\NuGet\Packages (TBD) on Windows.

--- a/src/dotnet/commands/dotnet-compile-csc/README.md
+++ b/src/dotnet/commands/dotnet-compile-csc/README.md
@@ -61,10 +61,5 @@ Prints verbose logging information, to follow the flow of execution of the comma
 `-h, --help`
 Show short help. 
 
-# ENVIRONMENT 
-
-`DOTNET_HOME`
-Points to the runtime that will be used to run the executable file that is dropped after compiling. Not needed for native compilation.  
-
 # SEE ALSO
 dotnet-restore(1), dotnet-publish(1), dotnet(1)

--- a/src/dotnet/commands/dotnet-compile/README.md
+++ b/src/dotnet/commands/dotnet-compile/README.md
@@ -74,12 +74,6 @@ This command relies on the following artifacts: source files, project.json proje
 `-h, --help`
     
     Show short help. 
-
-# ENVIRONMENT 
-
-`DOTNET_HOME`
-
-    Points to the base directory that contains the runtime and the binaries directories. The runtime will be used to run the executable file that is dropped after compiling. Not needed for native compilation.  
-    
+  
 # SEE ALSO
 dotnet-restore(1), dotnet-publish(1), dotnet(1)

--- a/src/dotnet/commands/dotnet-run/README.md
+++ b/src/dotnet/commands/dotnet-run/README.md
@@ -20,12 +20,6 @@ Output files, are written to the child `bin` folder, which will be created if it
 -v, --verbose
 
     Prints verbose logging information, to follow the flow of execution of the command.
-    
-# ENVIRONMENT 
-
-`DOTNET_HOME`
-
-    Points to the base directory that contains the runtime and the binaries directories. The runtime will be used to run the executable file that is dropped after compiling. Not needed for native compilation.   
 
 # SEE ALSO
 

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -133,23 +133,9 @@ namespace Microsoft.DotNet.Tools.Run
                 }
             }
 
-            // Locate the runtime
-            string dotnetHome = Environment.GetEnvironmentVariable("DOTNET_HOME");
-            if (string.IsNullOrEmpty(dotnetHome))
-            {
-                // Use the runtime deployed with the tools, if present
-                var candidateBase = Path.Combine(AppContext.BaseDirectory, "..");
-                var candidate = Path.Combine(candidateBase, "runtime/coreclr");
-                if (File.Exists(Path.Combine(candidate, Constants.LibCoreClrName)))
-                {
-                    dotnetHome = Path.GetFullPath(candidateBase);
-                }
-            }
-
             result = Command.Create(outputName, _args)
                 .ForwardStdOut()
                 .ForwardStdErr()
-                .EnvironmentVariable("DOTNET_HOME", dotnetHome)
                 .Execute()
                 .ExitCode;
 


### PR DESCRIPTION
DOTNET_HOME is no longer required, though it is a documented override, so this change removes all unnecessary references to DOTNET_HOME from the CLI Repo.

/cc @brthor @gkhanna79 @schellap @Sridhar-MS @robmen @davidfowl 