### PR TITLE
Fixes in corehost for building x86 arch.

### DIFF
--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -195,6 +195,10 @@ namespace Microsoft.DotNet.Cli.Build
                 }
             }
 
+            // dotnet.exe is from stage0. But we must be using the newly built corehost in stage1
+            File.Delete(Path.Combine(binDir, $"dotnet{Constants.ExeSuffix}"));
+            File.Copy(Path.Combine(binDir, $"corehost{Constants.ExeSuffix}"), Path.Combine(binDir, $"dotnet{Constants.ExeSuffix}"));
+
             // Crossgen Roslyn
             var result = Crossgen(c, binDir);
             if (!result.Success)

--- a/src/corehost/cli/coreclr.cpp
+++ b/src/corehost/cli/coreclr.cpp
@@ -9,7 +9,7 @@
 static pal::dll_t g_coreclr = nullptr;
 
 // Prototype of the coreclr_initialize function from coreclr.dll
-typedef pal::hresult_t(*coreclr_initialize_fn)(
+typedef pal::hresult_t(__stdcall *coreclr_initialize_fn)(
     const char* exePath,
     const char* appDomainFriendlyName,
     int propertyCount,
@@ -19,12 +19,12 @@ typedef pal::hresult_t(*coreclr_initialize_fn)(
     unsigned int* domainId);
 
 // Prototype of the coreclr_shutdown function from coreclr.dll
-typedef pal::hresult_t(*coreclr_shutdown_fn)(
+typedef pal::hresult_t(__stdcall *coreclr_shutdown_fn)(
     coreclr::host_handle_t hostHandle,
     unsigned int domainId);
 
 // Prototype of the coreclr_execute_assembly function from coreclr.dll
-typedef pal::hresult_t(*coreclr_execute_assembly_fn)(
+typedef pal::hresult_t(__stdcall *coreclr_execute_assembly_fn)(
     coreclr::host_handle_t hostHandle,
     unsigned int domainId,
     int argc,

--- a/src/corehost/cli/coreclr.cpp
+++ b/src/corehost/cli/coreclr.cpp
@@ -9,7 +9,7 @@
 static pal::dll_t g_coreclr = nullptr;
 
 // Prototype of the coreclr_initialize function from coreclr.dll
-typedef pal::hresult_t(__stdcall *coreclr_initialize_fn)(
+typedef pal::hresult_t(STDMETHODCALLTYPE *coreclr_initialize_fn)(
     const char* exePath,
     const char* appDomainFriendlyName,
     int propertyCount,
@@ -19,12 +19,12 @@ typedef pal::hresult_t(__stdcall *coreclr_initialize_fn)(
     unsigned int* domainId);
 
 // Prototype of the coreclr_shutdown function from coreclr.dll
-typedef pal::hresult_t(__stdcall *coreclr_shutdown_fn)(
+typedef pal::hresult_t(STDMETHODCALLTYPE *coreclr_shutdown_fn)(
     coreclr::host_handle_t hostHandle,
     unsigned int domainId);
 
 // Prototype of the coreclr_execute_assembly function from coreclr.dll
-typedef pal::hresult_t(__stdcall *coreclr_execute_assembly_fn)(
+typedef pal::hresult_t(STDMETHODCALLTYPE *coreclr_execute_assembly_fn)(
     coreclr::host_handle_t hostHandle,
     unsigned int domainId,
     int argc,

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -77,6 +77,8 @@ namespace pal
         #define SHARED_API
     #endif
 
+    #define STDMETHODCALLTYPE __stdcall
+
     typedef wchar_t char_t;
     typedef std::wstring string_t;
     typedef std::wstringstream stringstream_t;
@@ -106,6 +108,11 @@ namespace pal
     #else
         #define SHARED_API
     #endif
+
+    #define __cdecl    /* nothing */
+    #define __stdcall  /* nothing */
+    #define __fastcall /* nothing */
+    #define STDMETHODCALLTYPE __stdcall
 
     typedef char char_t;
     typedef std::string string_t;


### PR DESCRIPTION
- Set the calling convention to '__stdcall' explicitly else the default is '_cdecl' on windows which mismatches with coreclr hosting APIs.
- Use the newly built 'corehost' in stage1 instead of one from stage0.

cc @schellap 