### PR TITLE
Update developer-guide

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -17,7 +17,12 @@ In order to build .NET Command Line Interface, you need the following installed 
 
 1. CMake (available from https://cmake.org/) is required to build the native host `corehost`. Make sure to add it to the PATH.
 2. git (available from http://www.git-scm.com/) on the PATH.
-3. clang (available from http://clang.llvm.org) on the PATH.
+3. clang 3.5 (available from http://clang.llvm.org) on the PATH.
+
+On Ubuntu 14.04 you can install all of these dependencies via apt-get
+```
+developer@linux:~$ sudo apt-get install cmake llvm-3.5 clang-3.5 git
+```
 
 ### For OS X
 


### PR DESCRIPTION
For Linux newcomers such as myself, having a simple apt-get command line is much easier to follow than links to those other project websites. Once there the most obvious download links included binaries and archives which must be manually downloaded and then environment variables adjusted by hand. Also those sites offer different versions of their components and the instructions in this repo didn't mention which version to acquire. For example the clang website says the current stable version is 3.7, however when I installed 3.7 both via apt-get or via downloaded binaries I wasn't able to get the build working. Its very possible it was user-error on my part, but since the instructions aren't very specific, I (and other Linux newcomers) don't have any easy way to know.

At this point my build still doesn't work (debuild: command not found), but it seems to have progressed much farther than it did before so I think these steps are at least a step in the right direction.

Feel free to propose/make an entirely different change if there would be something more appropriate. This represents a very pragmatic PR of something that seems to be working for me, but I have no idea if this is the intended setup.