### PR TITLE
Add error message when runtime target is not found

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -143,7 +143,13 @@ namespace Microsoft.DotNet.ProjectModel
 
         public ProjectContext CreateRuntimeContext(IEnumerable<string> runtimeIdentifiers)
         {
-            return Create(ProjectFile.ProjectFilePath, TargetFramework, runtimeIdentifiers);
+            var context = Create(ProjectFile.ProjectFilePath, TargetFramework, runtimeIdentifiers);
+            if (context.RuntimeIdentifier == null)
+            {
+                var rids = string.Join(",", runtimeIdentifiers);
+                throw new InvalidOperationException($"Can not find runtime target for framework '{TargetFramework}' and RID's {rids}.");
+            }
+            return context;
         }
 
         public OutputPaths GetOutputPaths(string configuration, string buidBasePath = null, string outputPath = null)

--- a/test/dotnet-compile.UnitTests/GivenACompilationDriver.cs
+++ b/test/dotnet-compile.UnitTests/GivenACompilationDriver.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
 
             _contexts = new List<ProjectContext>
             {
-                ProjectContext.Create(_projectJson, new NuGetFramework(string.Empty))
+                ProjectContext.Create(_projectJson, NuGetFramework.Parse("dnxcore50"))
             };
 
             _args = new CompilerCommandApp("dotnet compile", ".NET Compiler", "Compiler for the .NET Platform");


### PR DESCRIPTION
https://github.com/dotnet/cli/issues/1497

@davidfowl 