### PR TITLE
Fix run behaviour when only single target exists

### DIFF
--- a/TestAssets/TestProjects/CompileFail/.noautobuild
+++ b/TestAssets/TestProjects/CompileFail/.noautobuild
@@ -1,0 +1,1 @@
+noautobuild

--- a/TestAssets/TestProjects/RunTestsApps/TestAppFullClr/.noautobuild
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppFullClr/.noautobuild
@@ -1,0 +1,1 @@
+noautobuild

--- a/TestAssets/TestProjects/RunTestsApps/TestAppFullClr/Program.cs
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppFullClr/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            .WriteLine("NET451");
+        }
+    }
+}

--- a/TestAssets/TestProjects/RunTestsApps/TestAppFullClr/project.json
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppFullClr/project.json
@@ -1,0 +1,10 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "frameworks": {
+        "net451": { }
+    }
+}

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/.noautobuild
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/.noautobuild
@@ -1,0 +1,1 @@
+noautobuild

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/Program.cs
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+#if NET451
+            Console.WriteLine("NET451");
+#else
+            Console.WriteLine("CoreCLR");
+#endif
+        }
+    }
+}

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "NETStandard.Library": "1.0.0-rc2-23811"
+            },
+        },
+        "net451": { }
+    }
+}

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTargetNoCoreClr/.noautobuild
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTargetNoCoreClr/.noautobuild
@@ -1,0 +1,1 @@
+noautobuild

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTargetNoCoreClr/Program.cs
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTargetNoCoreClr/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+#if NET451
+            Console.WriteLine("NET451");
+#else
+            Console.WriteLine("CoreCLR");
+#endif
+        }
+    }
+}

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTargetNoCoreClr/project.json
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTargetNoCoreClr/project.json
@@ -1,0 +1,11 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "frameworks": {
+        "dummy1": { },
+        "net451": { }
+    }
+}

--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -114,10 +114,10 @@ namespace Microsoft.DotNet.Cli.Build
         public static BuildTargetResult BuildTestAssetProjects(BuildTargetContext c)
         {
             var dotnet = DotNetCli.Stage2;
+            var nobuildFileName = ".noautobuild";
             string testProjectsRoot = Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "TestProjects");
-            List<string> exclusionList = new List<string> { Path.Combine(testProjectsRoot, "CompileFail", "project.json") };
             var projects = Directory.GetFiles(testProjectsRoot, "project.json", SearchOption.AllDirectories)
-                                    .Where(p => !exclusionList.Any(e => e.Contains(p)));
+                                    .Where(p => !File.Exists(Path.Combine(Path.GetDirectoryName(p), nobuildFileName)));
 
             foreach (var project in projects)
             {

--- a/test/dotnet-run.Tests/RunTests.cs
+++ b/test/dotnet-run.Tests/RunTests.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Compiler.Tests
+{
+    public class CompilerTests : TestBase
+    {
+        private static const string RunTestsBase = "RunTestsApps";
+
+        [WindowsOnlyFact]
+        public void RunsSingleTarget()
+        {
+            TestInstance instance = TestAssetsManager.CreateTestInstance(Path.Combine(RunTestsBase, "TestAppDesktopClr"))
+                                                     .WithLockFiles()
+                                                     .WithBuildArtifacts();
+            new RunCommand(testInstance.TestRoot).Execute().Should().Pass();
+        }
+
+        public void RunsDefaultWhenPresent()
+        {
+            TestInstance instance = TestAssetsManager.CreateTestInstance(Path.Combine(RunTestsBase, "TestAppMultiTarget"))
+                                                     .WithLockFiles()
+                                                     .WithBuildArtifacts();
+            new RunCommand(testInstance.TestRoot).Execute().Should().Pass();
+        }
+
+        public void FailsWithMultipleTargetAndNoDefault()
+        {
+            TestInstance instance = TestAssetsManager.CreateTestInstance(RunTestsBase, "TestAppMultiTargetNoCoreClr")
+                                                     .WithLockFiles()
+                                                     .WithBuildArtifacts();
+            new RunCommand(testInstance.TestRoot).Execute().Should().Fail();
+        }
+
+        private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)
+        {
+            // copy all the files to temp dir
+            foreach (var file in Directory.EnumerateFiles(projectDir))
+            {
+                tempDir.CopyFile(file);
+            }
+        }
+
+        private string GetProjectPath(TempDirectory projectDir)
+        {
+            return Path.Combine(projectDir.Path, "project.json");
+        }
+    }
+}

--- a/test/dotnet-run.Tests/dotnet-run.Tests.xproj
+++ b/test/dotnet-run.Tests/dotnet-run.Tests.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.24720" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>35e3c2dc-9b38-4ec5-8dd7-c32458dc485f</ProjectGuid>
+    <RootNamespace>dotnet-run.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0.0-*",
+  
+  "dependencies": {
+    "NETStandard.Library": "1.0.0-rc2-23811",      
+
+    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "Microsoft.DotNet.Cli.Utils": {
+      "target": "project"
+    },
+
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+  },
+
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
+  },
+
+  "testRunner": "xunit"
+}


### PR DESCRIPTION
Plays good with https://github.com/dotnet/cli/issues/1497 which shows nice error message if selected target is not restored for current runtime.

@davidfowl 