### PR TITLE
Build Conditional Targets & Coreclr/Deb Package Dependencies Check

### DIFF
--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/BuildContext.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/BuildContext.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             BuildTarget target;
             if (!Targets.TryGetValue(name, out target))
             {
-                Reporter.Verbose.WriteLine($"Skipping undefined target: {name}");
+                throw new Exception($"Undefined target: {name}");
             }
 
             // Check if it's been completed
@@ -82,6 +82,11 @@ namespace Microsoft.DotNet.Cli.Build.Framework
 
         private BuildTargetResult ExecTarget(BuildTarget target)
         {
+            if (target == null)
+            {
+                throw new ArgumentNullException("target");
+            }
+
             var sectionName = $"{target.Name.PadRight(_maxTargetLen + 2).Yellow()} ({target.Source.White()})";
             BuildReporter.BeginSection("TARGET", sectionName);
 

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/BuildContext.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/BuildContext.cs
@@ -42,7 +42,13 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             BuildTarget target;
             if (!Targets.TryGetValue(name, out target))
             {
-                throw new Exception($"Undefined target: {name}");
+                throw new UndefinedTargetException($"Undefined target: {name}");
+            }
+
+            if (!EvaluateTargetConditions(target))
+            {
+                Reporter.Verbose.WriteLine($"Skipping, Target Conditions not met: {target.Name}");
+                return new BuildTargetResult(target, success: true);
             }
 
             // Check if it's been completed
@@ -52,7 +58,6 @@ namespace Microsoft.DotNet.Cli.Build.Framework
                 Reporter.Verbose.WriteLine($"Skipping completed target: {target.Name}");
                 return result;
             }
-
 
             // It hasn't, or we're forcing, so run it
             result = ExecTarget(target);
@@ -78,6 +83,29 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         public void Error(string message)
         {
             Reporter.Error.WriteLine("error".Red().Bold() + $": {message}");
+        }
+
+        private bool EvaluateTargetConditions(BuildTarget target)
+        {
+            if (target == null)
+            {
+                throw new ArgumentNullException("target");
+            }
+
+            if (target.Conditions == null)
+            {
+                return true;
+            }
+
+            foreach (var condition in target.Conditions)
+            {
+                if (!condition())
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private BuildTargetResult ExecTarget(BuildTarget target)

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/BuildSetup.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/BuildSetup.cs
@@ -52,8 +52,6 @@ namespace Microsoft.DotNet.Cli.Build.Framework
 
         public int Run(string[] args)
         {
-            DebugHelper.HandleDebugSwitch(ref args);
-
             var targets = new[] { BuildContext.DefaultTarget };
             if(args.Length > 0)
             {
@@ -104,18 +102,40 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         private static IEnumerable<BuildTarget> CollectTargets(Type typ)
         {
             return from m in typ.GetMethods()
-                   let attr = m.GetCustomAttribute<TargetAttribute>()
-                   where attr != null
-                   select CreateTarget(m, attr);
+                   let targetAttribute = m.GetCustomAttribute<TargetAttribute>()
+                   let conditionalAttributes = m.GetCustomAttributes<TargetConditionAttribute>(false)
+                   where targetAttribute != null
+                   select CreateTarget(m, targetAttribute, conditionalAttributes);
         }
 
-        private static BuildTarget CreateTarget(MethodInfo m, TargetAttribute attr)
+        private static BuildTarget CreateTarget(
+            MethodInfo methodInfo, 
+            TargetAttribute targetAttribute, 
+            IEnumerable<TargetConditionAttribute> targetConditionAttributes)
         {
+            var name = targetAttribute.Name ?? methodInfo.Name;
+
+            var conditions = ExtractTargetConditionsFromAttributes(targetConditionAttributes);
+
             return new BuildTarget(
-                attr.Name ?? m.Name,
-                $"{m.DeclaringType.FullName}.{m.Name}",
-                attr.Dependencies,
-                (Func<BuildTargetContext, BuildTargetResult>)m.CreateDelegate(typeof(Func<BuildTargetContext, BuildTargetResult>)));
+                name,
+                $"{methodInfo.DeclaringType.FullName}.{methodInfo.Name}",
+                targetAttribute.Dependencies,
+                conditions,
+                (Func<BuildTargetContext, BuildTargetResult>)methodInfo.CreateDelegate(typeof(Func<BuildTargetContext, BuildTargetResult>)));
+        }
+
+        private static IEnumerable<Func<bool>> ExtractTargetConditionsFromAttributes(
+            IEnumerable<TargetConditionAttribute> targetConditionAttributes)
+        {
+            if (targetConditionAttributes == null || targetConditionAttributes.Count() == 0)
+            {
+                return Enumerable.Empty<Func<bool>>();
+            }
+
+            return targetConditionAttributes
+                    .Select<TargetConditionAttribute, Func<bool>>(c => c.EvaluateCondition)
+                    .ToArray();
         }
 
         private string GenerateSourceString(string file, int? line, string member)

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/BuildTarget.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/BuildTarget.cs
@@ -4,21 +4,28 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.Build.Framework
 {
-	public class BuildTarget
-	{
-		public string Name { get; }
+    public class BuildTarget
+    {
+        public string Name { get; }
         public string Source { get; }
-		public IEnumerable<string> Dependencies { get; }
-		public Func<BuildTargetContext, BuildTargetResult> Body { get; }
+        public IEnumerable<string> Dependencies { get; }
+        public IEnumerable<Func<bool>> Conditions { get; }
+        public Func<BuildTargetContext, BuildTargetResult> Body { get; }
 
-        public BuildTarget(string name, string source) : this(name, source, Enumerable.Empty<string>(), null) { }
-        public BuildTarget(string name, string source, IEnumerable<string> dependencies) : this(name, source, dependencies, null) { }
-		public BuildTarget(string name, string source, IEnumerable<string> dependencies, Func<BuildTargetContext, BuildTargetResult> body)
-		{
-			Name = name;
+        public BuildTarget(string name, string source) : this(name, source, Enumerable.Empty<string>(), Enumerable.Empty<Func<bool>>(), null) { }
+        public BuildTarget(string name, string source, IEnumerable<string> dependencies) : this(name, source, dependencies, Enumerable.Empty<Func<bool>>(), null) { }
+        public BuildTarget(
+            string name, 
+            string source, 
+            IEnumerable<string> dependencies, 
+            IEnumerable<Func<bool>> conditions, 
+            Func<BuildTargetContext, BuildTargetResult> body)
+        {
+            Name = name;
             Source = source;
-			Dependencies = dependencies;
-			Body = body;
-		}
-	}
+            Dependencies = dependencies;
+            Conditions = conditions;
+            Body = body;
+        }
+    }
 }

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/CurrentArchitecture.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/CurrentArchitecture.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.Extensions.PlatformAbstractions;
+
+namespace Microsoft.DotNet.Cli.Build.Framework
+{
+    public static class CurrentArchitecture
+    {
+        public static BuildArchitecture Current
+        {
+            get
+            {
+                return DetermineCurrentArchitecture();
+            }
+        }
+
+        public static bool Isx86
+        {
+            get
+            {
+                var archName = PlatformServices.Default.Runtime.RuntimeArchitecture;
+                return string.Equals(archName, "x86", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        public static bool Isx64
+        {
+            get
+            {
+                var archName = PlatformServices.Default.Runtime.RuntimeArchitecture;
+                return string.Equals(archName, "x64", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private static BuildArchitecture DetermineCurrentArchitecture()
+        {
+            if (Isx86)
+            {
+                return BuildArchitecture.x86;
+            }
+            else if (Isx64)
+            {
+                return BuildArchitecture.x64;
+            }
+            else
+            {
+                return default(BuildArchitecture);
+            }
+        }
+    }
+}

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/CurrentPlatform.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/CurrentPlatform.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.PlatformAbstractions;
+
+public static class CurrentPlatform
+{
+    public static bool IsWindows
+    {
+        get
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+    }
+
+    public static bool IsOSX
+    {
+        get
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+        }
+    }
+
+    public static bool IsLinux
+    {
+        get
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        }
+    }
+
+    public static bool IsUbuntu
+    {
+        get
+        {
+            var osname = PlatformServices.Default.Runtime.OperatingSystem;
+            return string.Equals(osname, "ubuntu", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    public static bool IsCentOS
+    {
+        get
+        {
+            var osname = PlatformServices.Default.Runtime.OperatingSystem;
+            return string.Equals(osname, "centos", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/CurrentPlatform.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/CurrentPlatform.cs
@@ -2,47 +2,74 @@ using System;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.PlatformAbstractions;
 
-public static class CurrentPlatform
+namespace Microsoft.DotNet.Cli.Build.Framework
 {
-    public static bool IsWindows
+    public static class CurrentPlatform
     {
-        get
+        public static BuildPlatform Current
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            get
+            {
+                return DetermineCurrentPlatform();
+            }
         }
-    }
 
-    public static bool IsOSX
-    {
-        get
+        public static bool IsWindows
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            get
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            }
         }
-    }
 
-    public static bool IsLinux
-    {
-        get
+        public static bool IsOSX
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            get
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            }
         }
-    }
 
-    public static bool IsUbuntu
-    {
-        get
+        public static bool IsUbuntu
         {
-            var osname = PlatformServices.Default.Runtime.OperatingSystem;
-            return string.Equals(osname, "ubuntu", StringComparison.OrdinalIgnoreCase);
+            get
+            {
+                var osname = PlatformServices.Default.Runtime.OperatingSystem;
+                return string.Equals(osname, "ubuntu", StringComparison.OrdinalIgnoreCase);
+            }
         }
-    }
 
-    public static bool IsCentOS
-    {
-        get
+        public static bool IsCentOS
         {
-            var osname = PlatformServices.Default.Runtime.OperatingSystem;
-            return string.Equals(osname, "centos", StringComparison.OrdinalIgnoreCase);
+            get
+            {
+                var osname = PlatformServices.Default.Runtime.OperatingSystem;
+                return string.Equals(osname, "centos", StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        private static BuildPlatform DetermineCurrentPlatform()
+        {
+            if (IsWindows)
+            {
+                return BuildPlatform.Windows;
+            }
+            else if (IsOSX)
+            {
+                return BuildPlatform.OSX;
+            }
+            else if (IsUbuntu)
+            {
+                return BuildPlatform.Ubuntu;
+            }
+            else if (IsCentOS)
+            {
+                return BuildPlatform.CentOS;
+            }
+            else
+            {
+                return default(BuildPlatform);
+            }
         }
     }
 }

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildArchitecture.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildArchitecture.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.DotNet.Cli.Build.Framework
+{
+    public enum BuildArchitecture
+    {
+        x86 = 1,
+        x64 = 2
+    }
+}

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildPlatform.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildPlatform.cs
@@ -1,0 +1,10 @@
+namespace Microsoft.DotNet.Cli.Build.Framework
+{
+    public enum BuildPlatform
+    {
+        Windows = 1,
+        OSX = 2,
+        Ubuntu = 3,
+        CentOS = 4
+    }
+}

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetAttribute.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetAttribute.cs
@@ -5,8 +5,8 @@ using System.Linq;
 namespace Microsoft.DotNet.Cli.Build.Framework
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-	public class TargetAttribute : Attribute
-	{
+    public class TargetAttribute : Attribute
+    {
         public string Name { get; set; }
         public IEnumerable<string> Dependencies { get; }
 
@@ -20,5 +20,5 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         {
             Dependencies = dependencies;
         }
-	}
+    }
 }

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/BuildArchitecturesAttribute.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/BuildArchitecturesAttribute.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Cli.Build.Framework
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class BuildArchitecturesAttribute : TargetConditionAttribute
+    {
+        private IEnumerable<BuildArchitecture> _buildArchitectures;
+
+        public BuildArchitecturesAttribute(params BuildArchitecture[] architectures)
+        {
+            if (architectures == null)
+            {
+                throw new ArgumentNullException("architectures");
+            }
+
+            _buildArchitectures = architectures;
+        }
+
+        public override bool EvaluateCondition()
+        {
+            var currentArchitecture = CurrentArchitecture.Current;
+
+            if (currentArchitecture == default(BuildArchitecture))
+            {
+                throw new Exception("Unrecognized Architecture");
+            }
+
+            foreach (var architecture in _buildArchitectures)
+            {
+                if (architecture == currentArchitecture)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/BuildPlatformsAttribute.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/BuildPlatformsAttribute.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Cli.Build.Framework
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    public class BuildPlatformsAttribute : TargetConditionAttribute
+    {
+        private IEnumerable<BuildPlatform> _buildPlatforms;
+
+        public BuildPlatformsAttribute(params BuildPlatform[] platforms)
+        {
+            if (platforms == null)
+            {
+                throw new ArgumentNullException("platforms");
+            }
+
+            _buildPlatforms = platforms;
+        }
+
+        public override bool EvaluateCondition()
+        {
+            var currentPlatform = CurrentPlatform.Current;
+
+            if (currentPlatform == default(BuildPlatform))
+            {
+                throw new Exception("Unrecognized Platform.");
+            }
+
+            foreach (var platform in _buildPlatforms)
+            {
+                if (platform == currentPlatform)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/TargetConditionAttribute.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/TargetConditionAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Microsoft.DotNet.Cli.Build.Framework
+{
+    public abstract class TargetConditionAttribute : Attribute
+    {
+        public abstract bool EvaluateCondition();
+    }
+}

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/UndefinedTargetException.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/UndefinedTargetException.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Microsoft.DotNet.Cli.Build.Framework
+{
+    public class UndefinedTargetException : Exception 
+    { 
+        public UndefinedTargetException(string message) : base(message) { }
+    }
+}

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/project.json
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/project.json
@@ -3,7 +3,8 @@
 
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23811",
-        "System.Diagnostics.Process": "4.1.0-rc2-23811"
+        "System.Diagnostics.Process": "4.1.0-rc2-23811",
+        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537"
     },
 
     "frameworks": {

--- a/scripts/docker/ubuntu/Dockerfile
+++ b/scripts/docker/ubuntu/Dockerfile
@@ -6,39 +6,80 @@
 # Dockerfile that creates a container suitable to build dotnet-cli
 FROM ubuntu:14.04
 
+# Misc Dependencies for build
+RUN apt-get update && apt-get -qqy install curl unzip gettext sudo
+
 # This could become a "microsoft/coreclr" image, since it just installs the dependencies for CoreCLR (and stdlib)
-# Install CoreCLR and CoreFx dependencies
-RUN apt-get update && \
-    apt-get -qqy install unzip curl libicu-dev libunwind8 gettext libssl-dev libcurl4-openssl-dev zlib1g liblttng-ust-dev lldb-3.6-dev lldb-3.6 
+RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main"  | tee /etc/apt/sources.list.d/llvm.list && \
+    curl http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - && \
+    apt-get update && apt-get -qqy install\
+	libc6 \
+	libedit2 \
+	libffi6 \
+	libgcc1 \
+	libicu52 \
+	liblldb-3.6 \
+	libllvm3.6 \
+	liblttng-ust0 \
+	liblzma5 \
+	libncurses5 \
+	libpython2.7 \
+	libstdc++6 \
+	libtinfo5 \
+	libunwind8 \
+	liburcu1 \
+	libuuid1 \
+	zlib1g \
+	libasn1-8-heimdal \
+	libcomerr2 \
+	libcurl3 \
+	libgcrypt11 \
+	libgnutls26 \
+	libgpg-error0 \
+	libgssapi3-heimdal \
+	libgssapi-krb5-2 \
+	libhcrypto4-heimdal \
+	libheimbase1-heimdal \
+	libheimntlm0-heimdal \
+	libhx509-5-heimdal \
+	libidn11 \
+	libk5crypto3 \
+	libkeyutils1 \
+	libkrb5-26-heimdal \
+	libkrb5-3 \
+	libkrb5support0 \
+	libldap-2.4-2 \
+	libp11-kit0 \
+	libroken18-heimdal \
+	librtmp0 \
+	libsasl2-2 \
+	libsqlite3-0 \
+	libssl1.0.0 \
+	libtasn1-6 \
+	libwind0-heimdal
 
 # Install Dotnet CLI dependencies.
 # clang is required for dotnet-compile-native
 RUN apt-get -qqy install clang-3.5
 
 # Install Build Prereqs
-RUN echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | tee /etc/apt/sources.list.d/llvm.list && \
-    curl http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - && \
-    apt-get update && \
-    apt-get install -y debhelper build-essential devscripts git cmake
+RUN apt-get -qq install -y debhelper build-essential devscripts git cmake
 
 # Use clang as c++ compiler
 RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.5 100
 RUN update-alternatives --set c++ /usr/bin/clang++-3.5
 
 # Install azure cli. We need this to publish artifacts.
-RUN apt-get -y install nodejs-legacy && \
-    apt-get -y install npm && \
+RUN apt-get -qqy install nodejs-legacy && \
+    apt-get -qqy install npm && \
     npm install -g azure-cli
-
-
-RUN apt-get install -qqy sudo
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0
 RUN useradd -m code_executor -u ${USER_ID} -g sudo
 RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-# With the User Change, we need to change permssions on these directories
+# With the User Change, we need to change permissions on these directories
 RUN chmod -R a+rwx /usr/local
 RUN chmod -R a+rwx /home
 RUN chmod -R 755 /usr/lib/sudo

--- a/scripts/docker/ubuntu/Dockerfile
+++ b/scripts/docker/ubuntu/Dockerfile
@@ -9,7 +9,7 @@ FROM ubuntu:14.04
 # This could become a "microsoft/coreclr" image, since it just installs the dependencies for CoreCLR (and stdlib)
 # Install CoreCLR and CoreFx dependencies
 RUN apt-get update && \
-    apt-get -qqy install unzip curl libicu-dev libunwind8 gettext libssl-dev libcurl3-gnutls zlib1g liblttng-ust-dev lldb-3.6-dev lldb-3.6 
+    apt-get -qqy install unzip curl libicu-dev libunwind8 gettext libssl-dev libcurl4-openssl-dev zlib1g liblttng-ust-dev lldb-3.6-dev lldb-3.6 
 
 # Install Dotnet CLI dependencies.
 # clang is required for dotnet-compile-native

--- a/scripts/dotnet-cli-build/PackageDependencies.cs
+++ b/scripts/dotnet-cli-build/PackageDependencies.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class PackageDependencies
+    {
+        internal static string[] DebianPackageBuildDependencies
+        {
+            get
+            {
+                return new string[] 
+                {
+                    "devscripts",
+                    "debhelper",
+                    "build-essential"
+                };
+
+            }
+        }
+
+        internal static string[] UbuntuCoreclrAndCoreFxDependencies
+        {
+            get
+            {
+               return new string[]
+               {
+                    "libc6",
+                    "libedit2",
+                    "libffi6",
+                    "libgcc1",
+                    "libicu52",
+                    "liblldb-3.6",
+                    "libllvm3.6",
+                    "liblttng-ust0",
+                    "liblzma5",
+                    "libncurses5",
+                    "libpython2.7",
+                    "libstdc++6",
+                    "libtinfo5",
+                    "libunwind8",
+                    "liburcu1",
+                    "libuuid1",
+                    "zlib1g",
+                    "libasn1-8-heimdal",
+                    "libcomerr2",
+                    "libcurl3",
+                    "libgcrypt11",
+                    "libgnutls26",
+                    "libgpg-error0",
+                    "libgssapi3-heimdal",
+                    "libgssapi-krb5-2",
+                    "libhcrypto4-heimdal",
+                    "libheimbase1-heimdal",
+                    "libheimntlm0-heimdal",
+                    "libhx509-5-heimdal",
+                    "libidn11",
+                    "libk5crypto3",
+                    "libkeyutils1",
+                    "libkrb5-26-heimdal",
+                    "libkrb5-3",
+                    "libkrb5support0",
+                    "libldap-2.4-2",
+                    "libp11-kit0",
+                    "libroken18-heimdal",
+                    "librtmp0",
+                    "libsasl2-2",
+                    "libsqlite3-0",
+                    "libssl1.0.0",
+                    "libtasn1-6",
+                    "libwind0-heimdal"
+               };
+            }
+        }
+
+        internal static string[] CentosCoreclrAndCoreFxDependencies
+        {
+            get
+            {
+               return new string[]
+               {
+                    "unzip",
+                    "libunwind",
+                    "gettext",
+                    "libcurl-devel",
+                    "openssl-devel",
+                    "zlib",
+                    "libicu-devel"
+               };
+            }
+        }
+
+    }
+}

--- a/scripts/dotnet-cli-build/Program.cs
+++ b/scripts/dotnet-cli-build/Program.cs
@@ -4,9 +4,14 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class Program
     {
-        public static int Main(string[] args) => BuildSetup.Create(".NET Core CLI")
-            .UseStandardGoals()
-            .UseAllTargetsFromAssembly<Program>()
-            .Run(args);
+        public static int Main(string[] args)
+        {
+            DebugHelper.HandleDebugSwitch(ref args);
+
+            return BuildSetup.Create(".NET Core CLI")
+                .UseStandardGoals()
+                .UseAllTargetsFromAssembly<Program>()
+                .Run(args);
+        } 
     }
 }

--- a/scripts/dotnet-cli-build/Utils/AptDependencyUtility.cs
+++ b/scripts/dotnet-cli-build/Utils/AptDependencyUtility.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Cli.Build.Framework;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class AptDependencyUtility
+    {
+        internal static bool PackageIsInstalled(string packageName)
+        {
+            var result = Command.Create("dpkg", "-s", packageName)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .QuietBuildReporter()
+                .Execute();
+
+            return result.ExitCode == 0;
+        }
+    }
+}

--- a/scripts/dotnet-cli-build/Utils/YumDependencyUtility.cs
+++ b/scripts/dotnet-cli-build/Utils/YumDependencyUtility.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Cli.Build.Framework;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class YumDependencyUtility
+    {
+        internal static bool PackageIsInstalled(string packageName)
+        {
+            var result = Command.Create("yum", "list", "installed", packageName)
+                .CaptureStdOut()
+                .CaptureStdErr()
+                .QuietBuildReporter()
+                .Execute();
+
+            return result.ExitCode == 0;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #832 
Fixes #1503 

This PR adds conditional targets to the build framework. Since you can't have delegates in an attribute constructor, this works be defining an abstract base class `TargetConditionAttribute`. The framework looks for these on any targets and will evaluate the method `EvaluateCondition`. If the method returns false, the target is not run.

I've added two implementations of the TargetConditionAttribute: `BuildArchitectureAttribute` and `BuildPlatformAttribute`. They provide conditionally running a target based on architecture and platform, respectively. New implementations should be simple to add for further conditions.

It could be extended to provide general purpose attributes as well through some workarounds for the delegate issue.

Also, checks for coreclr dependencies on centOS, Ubuntu have been added as well as checks for package_tool dependencies on Ubuntu.

cc @Sridhar-MS @anurse @piotrpMSFT @davidfowl @livarcocc 

