### PR TITLE
Fix net20 compatibility

### DIFF
--- a/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/Program.cs
+++ b/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": false
+    },
+
+    "dependencies": { },
+
+    "frameworks": {
+        "net20": { },
+        "net35": { },
+        "net40": { },
+        "net461": { },
+        "dnxcore50": { 
+            "dependencies": {
+                "NETStandard.Library": "1.0.0-rc2-23811"
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using System.IO;
 using System.Runtime.Versioning;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli.Compiler.Common
 {
@@ -59,7 +60,10 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
         private static Dictionary<Type, string> GetProjectAttributes(AssemblyInfoOptions metadata)
         {
-            var attributes = new Dictionary<Type, string>() {
+            NuGetFramework targetFramework = NuGetFramework.Parse(metadata.TargetFramework);
+
+            var attributes = new Dictionary<Type, string>()
+            {
                 [typeof(AssemblyTitleAttribute)] = EscapeCharacters(metadata.Title),
                 [typeof(AssemblyDescriptionAttribute)] = EscapeCharacters(metadata.Description),
                 [typeof(AssemblyCopyrightAttribute)] = EscapeCharacters(metadata.Copyright),
@@ -71,7 +75,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             };
             
             // only .net 4.0+ compatible
-            if (metadata.TargetFrameworkVersion == null || metadata.TargetFrameworkVersion >= new Version(4, 0)) {
+            if (targetFramework.Version >= new Version(4, 0))
+            {
                 attributes[typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework);
             };
             return attributes;

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
@@ -60,8 +60,6 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
         private static Dictionary<Type, string> GetProjectAttributes(AssemblyInfoOptions metadata)
         {
-            NuGetFramework targetFramework = NuGetFramework.Parse(metadata.TargetFramework);
-
             var attributes = new Dictionary<Type, string>()
             {
                 [typeof(AssemblyTitleAttribute)] = EscapeCharacters(metadata.Title),
@@ -74,10 +72,10 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 [typeof(NeutralResourcesLanguageAttribute)] = EscapeCharacters(metadata.NeutralLanguage)
             };
             
-            // only .net 4.0+ compatible
-            if (targetFramework.Version >= new Version(4, 0))
+            NuGetFramework targetFramework = string.IsNullOrEmpty(metadata.TargetFramework) ? null : NuGetFramework.Parse(metadata.TargetFramework);
+            if (targetFramework != null && !(targetFramework.IsDesktop() && targetFramework.Version < new Version(4, 0)))
             {
-                attributes[typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework);
+                attributes[typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework); // TargetFrameworkAttribute only exists since .NET 4.0
             };
             return attributes;
         }

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
@@ -74,7 +74,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
             if (SupportsTargetFrameworkAttribute(metadata))
             {
-                attributes[typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework); // TargetFrameworkAttribute only exists since .NET 4.0
+                // TargetFrameworkAttribute only exists since .NET 4.0
+                attributes[typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework);
             };
 
             return attributes;
@@ -88,7 +89,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 return false;
             }
 
-            NuGetFramework targetFramework = NuGetFramework.Parse(metadata.TargetFramework);
+            var targetFramework = NuGetFramework.Parse(metadata.TargetFramework);
             if (!targetFramework.IsDesktop())
             {
                 // assuming .NET Core, which should support .NET 4.0 attributes

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 [typeof(NeutralResourcesLanguageAttribute)] = EscapeCharacters(metadata.NeutralLanguage)
             };
 
-            if (IsAllowV4Attributes(metadata))
+            if (SupportsTargetFrameworkAttribute(metadata))
             {
                 attributes[typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework); // TargetFrameworkAttribute only exists since .NET 4.0
             };
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             return attributes;
         }
 
-        private static bool IsAllowV4Attributes(AssemblyInfoOptions metadata)
+        private static bool SupportsTargetFrameworkAttribute(AssemblyInfoOptions metadata)
         {
             if (string.IsNullOrEmpty(metadata.TargetFramework))
             {

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
@@ -59,8 +59,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
         private static Dictionary<Type, string> GetProjectAttributes(AssemblyInfoOptions metadata)
         {
-            return new Dictionary<Type, string>()
-            {
+            var attributes = new Dictionary<Type, string>() {
                 [typeof(AssemblyTitleAttribute)] = EscapeCharacters(metadata.Title),
                 [typeof(AssemblyDescriptionAttribute)] = EscapeCharacters(metadata.Description),
                 [typeof(AssemblyCopyrightAttribute)] = EscapeCharacters(metadata.Copyright),
@@ -68,9 +67,14 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 [typeof(AssemblyVersionAttribute)] = EscapeCharacters(metadata.AssemblyVersion?.ToString()),
                 [typeof(AssemblyInformationalVersionAttribute)] = EscapeCharacters(metadata.InformationalVersion),
                 [typeof(AssemblyCultureAttribute)] = EscapeCharacters(metadata.Culture),
-                [typeof(NeutralResourcesLanguageAttribute)] = EscapeCharacters(metadata.NeutralLanguage),
-                [typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework)
+                [typeof(NeutralResourcesLanguageAttribute)] = EscapeCharacters(metadata.NeutralLanguage)
             };
+            
+            // only .net 4.0+ compatible
+            if (metadata.TargetFrameworkVersion == null || metadata.TargetFrameworkVersion >= new Version(4, 0)) {
+                attributes[typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework);
+            };
+            return attributes;
         }
 
         private static bool IsSameAttribute(Type attributeType, AttributeSyntax attributeSyntax)

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.DotNet.ProjectModel;
 using System.Collections.Generic;
 using System.CommandLine;

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
@@ -49,8 +49,6 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
         public string TargetFramework { get; set; }
 
-        public Version TargetFrameworkVersion { get; set; }
-
         public static AssemblyInfoOptions CreateForProject(ProjectContext context)
         {
             var project = context.ProjectFile;
@@ -74,8 +72,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 Description = project.Description,
                 Title = project.Title,
                 NeutralLanguage = project.Language,
-                TargetFramework = targetFramework.DotNetFrameworkName,
-                TargetFrameworkVersion = targetFramework.Version
+                TargetFramework = targetFramework.DotNetFrameworkName
             };
         }
 
@@ -110,8 +107,6 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
             syntax.DefineOption(TargetFrameworkOptionName, ref targetFramework, UnescapeNewlines, "Assembly target framework");
 
-            syntax.DefineOption(TargetFrameworkVersionOptionName, ref targetFrameworkVersion, UnescapeNewlines, "Assembly target framework version");
-
             return new AssemblyInfoOptions()
             {
                 AssemblyFileVersion = fileVersion,
@@ -121,8 +116,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 Description = description,
                 InformationalVersion = informationalVersion,
                 Title = title,
-                TargetFramework = targetFramework,
-                TargetFrameworkVersion = new Version(targetFrameworkVersion)
+                TargetFramework = targetFramework
             };
         }
 
@@ -165,10 +159,6 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             if (!string.IsNullOrWhiteSpace(assemblyInfoOptions.TargetFramework))
             {
                 options.Add(FormatOption(TargetFrameworkOptionName, assemblyInfoOptions.TargetFramework));
-            }
-            if (assemblyInfoOptions.TargetFrameworkVersion != null)
-            {
-                options.Add(FormatOption(TargetFrameworkVersionOptionName, assemblyInfoOptions.TargetFrameworkVersion.ToString()));
             }
 
             return options;

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.DotNet.ProjectModel;
 using System.Collections.Generic;
 using System.CommandLine;
@@ -28,6 +29,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
         private const string TargetFrameworkOptionName = "target-framework";
 
+        private const string TargetFrameworkVersionOptionName = "target-framework-version";
+
         public string Title { get; set; }
 
         public string Description { get; set; }
@@ -45,6 +48,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
         public string NeutralLanguage { get; set; }
 
         public string TargetFramework { get; set; }
+
+        public Version TargetFrameworkVersion { get; set; }
 
         public static AssemblyInfoOptions CreateForProject(ProjectContext context)
         {
@@ -69,7 +74,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 Description = project.Description,
                 Title = project.Title,
                 NeutralLanguage = project.Language,
-                TargetFramework = targetFramework.DotNetFrameworkName
+                TargetFramework = targetFramework.DotNetFrameworkName,
+                TargetFrameworkVersion = targetFramework.Version
             };
         }
 
@@ -84,6 +90,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             string culture = null;
             string neutralCulture = null;
             string targetFramework = null;
+            string targetFrameworkVersion = null;
 
             syntax.DefineOption(AssemblyVersionOptionName, ref version, UnescapeNewlines, "Assembly version");
 
@@ -103,6 +110,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
             syntax.DefineOption(TargetFrameworkOptionName, ref targetFramework, UnescapeNewlines, "Assembly target framework");
 
+            syntax.DefineOption(TargetFrameworkVersionOptionName, ref targetFrameworkVersion, UnescapeNewlines, "Assembly target framework version");
+
             return new AssemblyInfoOptions()
             {
                 AssemblyFileVersion = fileVersion,
@@ -112,7 +121,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 Description = description,
                 InformationalVersion = informationalVersion,
                 Title = title,
-                TargetFramework = targetFramework
+                TargetFramework = targetFramework,
+                TargetFrameworkVersion = new Version(targetFrameworkVersion)
             };
         }
 
@@ -155,6 +165,10 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             if (!string.IsNullOrWhiteSpace(assemblyInfoOptions.TargetFramework))
             {
                 options.Add(FormatOption(TargetFrameworkOptionName, assemblyInfoOptions.TargetFramework));
+            }
+            if (assemblyInfoOptions.TargetFrameworkVersion != null)
+            {
+                options.Add(FormatOption(TargetFrameworkVersionOptionName, assemblyInfoOptions.TargetFrameworkVersion.ToString()));
             }
 
             return options;

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
@@ -29,8 +29,6 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
         private const string TargetFrameworkOptionName = "target-framework";
 
-        private const string TargetFrameworkVersionOptionName = "target-framework-version";
-
         public string Title { get; set; }
 
         public string Description { get; set; }
@@ -87,7 +85,6 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             string culture = null;
             string neutralCulture = null;
             string targetFramework = null;
-            string targetFrameworkVersion = null;
 
             syntax.DefineOption(AssemblyVersionOptionName, ref version, UnescapeNewlines, "Assembly version");
 

--- a/test/dotnet-build.Tests/BuildOutputTests.cs
+++ b/test/dotnet-build.Tests/BuildOutputTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.DotNet.Tools.Test.Utilities;
@@ -130,12 +131,17 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
         }
 
         [Theory]
-        [InlineData("net20", false)]
-        [InlineData("net40", true)]
-        [InlineData("net461", true)]
-        [InlineData("dnxcore50", true)]
-        public void MultipleFrameworks_ShouldHaveValidTargetFrameworkAttribute(string frameworkName, bool shouldHaveTargetFrameworkAttribute)
+        [InlineData("net20", false, true)]
+        [InlineData("net40", true, true)]
+        [InlineData("net461", true, true)]
+        [InlineData("dnxcore50", true, false)]
+        public void MultipleFrameworks_ShouldHaveValidTargetFrameworkAttribute(string frameworkName, bool shouldHaveTargetFrameworkAttribute, bool windowsOnly)
         {
+            if (windowsOnly && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return; // don't run test for desktop framework on non-windows
+            }
+
             var framework = NuGetFramework.Parse(frameworkName);
 
             var testInstance = TestAssetsManager.CreateTestInstance("TestLibraryWithMultipleFrameworks")


### PR DESCRIPTION
Fixes #1480

Added TargetFrameworkVersion to AssemblyInfoOptions in order to let AssemblyInfoFileGenerator decide if attributes are compatible with framework version. E.g. TargetFrameworkAttribute is not .NET 2.0 compatible.