### PR TITLE
Adding a TestRunner.TestCompleted message to the test sinks.

### DIFF
--- a/src/Microsoft.Extensions.Testing.Abstractions/ITestExecutionSink.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/ITestExecutionSink.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Extensions.Testing.Abstractions
 {
-    public interface ITestExecutionSink
+    public interface ITestExecutionSink : ITestSink
     {
         void SendTestStarted(Test test);
 

--- a/src/Microsoft.Extensions.Testing.Abstractions/ITestSink.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/ITestSink.cs
@@ -1,10 +1,10 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Extensions.Testing.Abstractions
 {
-    public interface ITestDiscoverySink : ITestSink
+    public interface ITestSink
     {
-        void SendTestFound(Test test);
+        void SendTestCompleted();
     }
 }

--- a/src/Microsoft.Extensions.Testing.Abstractions/LineDelimitedJsonStream.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/LineDelimitedJsonStream.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Extensions.Testing.Abstractions
 {
-    class LineDelimitedJsonStream
+    public class LineDelimitedJsonStream
     {
         private readonly StreamWriter _stream;
 

--- a/src/Microsoft.Extensions.Testing.Abstractions/StreamingTestDiscoverySink.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/StreamingTestDiscoverySink.cs
@@ -4,13 +4,10 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Extensions.Testing.Abstractions
 {
-    public class StreamingTestDiscoverySink : ITestDiscoverySink
+    public class StreamingTestDiscoverySink : StreamingTestSink, ITestDiscoverySink
     {
-        private readonly LineDelimitedJsonStream _stream;
-
-        public StreamingTestDiscoverySink(Stream stream)
+        public StreamingTestDiscoverySink(Stream stream) : base(stream)
         {
-            _stream = new LineDelimitedJsonStream(stream);
         }
 
         public void SendTestFound(Test test)
@@ -20,7 +17,7 @@ namespace Microsoft.Extensions.Testing.Abstractions
                 throw new ArgumentNullException(nameof(test));
             }
 
-            _stream.Send(new Message
+            Stream.Send(new Message
             {
                 MessageType = "TestDiscovery.TestFound",
                 Payload = JToken.FromObject(test),

--- a/src/Microsoft.Extensions.Testing.Abstractions/StreamingTestExecutionSink.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/StreamingTestExecutionSink.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Concurrent;
 using System.IO;
@@ -5,18 +8,15 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Extensions.Testing.Abstractions
 {
-    public class StreamingTestExecutionSink : ITestExecutionSink
+    public class StreamingTestExecutionSink : StreamingTestSink, ITestExecutionSink
     {
-        private readonly LineDelimitedJsonStream _stream;
         private readonly ConcurrentDictionary<string, TestState> _runningTests;
 
-
-        public StreamingTestExecutionSink(Stream stream)
+        public StreamingTestExecutionSink(Stream stream) : base(stream)
         {
-            _stream = new LineDelimitedJsonStream(stream);
             _runningTests = new ConcurrentDictionary<string, TestState>();
         }
-        
+
         public void SendTestStarted(Test test)
         {
             if (test == null)
@@ -30,7 +30,7 @@ namespace Microsoft.Extensions.Testing.Abstractions
                 _runningTests.TryAdd(test.FullyQualifiedName, state);
             }
 
-            _stream.Send(new Message
+            Stream.Send(new Message
             {
                 MessageType = "TestExecution.TestStarted",
                 Payload = JToken.FromObject(test),
@@ -57,7 +57,7 @@ namespace Microsoft.Extensions.Testing.Abstractions
                 testResult.EndTime = DateTimeOffset.Now;
             }
 
-            _stream.Send(new Message
+            Stream.Send(new Message
             {
                 MessageType = "TestExecution.TestResult",
                 Payload = JToken.FromObject(testResult),

--- a/src/Microsoft.Extensions.Testing.Abstractions/StreamingTestSink.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/StreamingTestSink.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace Microsoft.Extensions.Testing.Abstractions
+{
+    public abstract class StreamingTestSink : ITestSink
+    {
+        protected LineDelimitedJsonStream Stream { get; }
+
+        protected StreamingTestSink(Stream stream)
+        {
+            Stream = new LineDelimitedJsonStream(stream);
+        }
+
+        public void SendTestCompleted()
+        {
+            Stream.Send(new Message
+            {
+                MessageType = "TestRunner.TestCompleted"
+            });
+        }
+    }
+}


### PR DESCRIPTION
Adding a TestRunner.TestCompleted message that the runner can send to dotnet test.

cc @piotrpMSFT 