### PR TITLE
Fixing the README.md and adding issues filing guide

### DIFF
--- a/Documentation/issue-filing-guide.md
+++ b/Documentation/issue-filing-guide.md
@@ -7,15 +7,15 @@ get a lot of issues. This, in turn, may mean that some issues get
 lost in the noise and/or are not reacted on with the needed speed. 
 
 In order to help with the above situation, we need to have a certain way to file 
-issues in order for the core team of maintainers can react as fast as (humanly)
-possible.
+issues so that the core team of maintainers can react as fast as 
+possible and can triage effectively. 
 
 The below steps are something that we believe is not a huge increase in process, 
 but would help us react much faster to any issues that are filed. 
 
 1. Check if the [known issues](known-issues.md) cover the issue you are running 
 into. We are collecting issues that are known and that have workarounds, so it 
-could be that you can get unblocked pretty easy. 
+could be that you can get unblocked pretty easily. 
 
 2. Add a label to determine which type of issue it is. If it is a defect, use 
 the "bug" label, if it is a suggestion for a feature, use the "enhancement" 
@@ -27,7 +27,8 @@ label. This helps the team get to defects more effectively.
 first to @blackdwarf and he will triage it from there. 
 
 5. /cc the person that the issue is assigned to (or @blackdwarf) so that person 
-would get notified. In this way
+would get notified. In this way the correct person can immediately jump on the 
+issue and triage it.
 
 6. For bugs, please be as concrete as possible on what is working, what 
 is not working. Things like operating system, the version of the tools, the 

--- a/Documentation/issue-filing-guide.md
+++ b/Documentation/issue-filing-guide.md
@@ -1,0 +1,41 @@
+Filing issues for .NET Core CLI
+===============================
+
+As you may notice based on our issues page, the CLI repo is what is known as a 
+"high-profile" and "high-volume" repo; we 
+get a lot of issues. This, in turn, may mean that some issues get 
+lost in the noise and/or are not reacted on with the needed speed. 
+
+In order to help with the above situation, we need to have a certain way to file 
+issues in order for the core team of maintainers can react as fast as (humanly)
+possible.
+
+The below steps are something that we believe is not a huge increase in process, 
+but would help us react much faster to any issues that are filed. 
+
+1. Check if the [known issues](known-issues.md) cover the issue you are running 
+into. We are collecting issues that are known and that have workarounds, so it 
+could be that you can get unblocked pretty easy. 
+
+2. Add a label to determine which type of issue it is. If it is a defect, use 
+the "bug" label, if it is a suggestion for a feature, use the "enhancement" 
+label. This helps the team get to defects more effectively. 
+
+3. Unless you are sure in which milestone the issue falls into, leave it blank.
+
+4. If you don't know who is on point to fix it or should be on point, assign it 
+first to @blackdwarf and he will triage it from there. 
+
+5. /cc the person that the issue is assigned to (or @blackdwarf) so that person 
+would get notified. In this way
+
+6. For bugs, please be as concrete as possible on what is working, what 
+is not working. Things like operating system, the version of the tools, the 
+version of the installer and when you installed all help us determine the 
+potential problem and allows us to easily reproduce the problem at hand.
+
+7. For enhancements please be as concrete as possible on what is the addition 
+you would like to see, what scenario it covers and especially why the current 
+tools cannot satisfy that scenario. 
+
+Thanks and happy filing! :)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Compiling to IL is done using:
 	
 	dotnet build
 
-This will drop a binary in `./bin/[configuration]/[framework]/[binary name]` that you can just run.
+This will drop a binary in `./bin/[configuration]/[framework]/[rid]/[binary name]` that you can just run.
 
 For more details, please refer to the [documentation](https://github.com/dotnet/corert/tree/master/Documentation).
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Installers
 |**Installers**|[Download Debian Package](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-ubuntu-x64.latest.deb)|[Download Msi](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-win-x64.latest.exe)|[Download Pkg](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-osx-x64.latest.pkg) |N/A |
 |**Binaries**|[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-ubuntu-x64.latest.tar.gz)|[Download zip file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-win-x64.latest.zip)|[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-osx-x64.latest.tar.gz) |[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-centos-x64.latest.tar.gz) |
 
-Interested in .NET Core + ASP.NET Core 1.0 bits?
-----------------------------------------
+Interested in .NET Core + ASP.NET Core 1.0 RC1 bits?
+----------------------------------------------------
 
-This toolchain is independent from the DNX-based .NET Core + ASP.NET Core 1.0 bits. If you are looking for .NET Core + ASP.NET Core 1.0 bits, you can find instructions on the http://get.asp.net/.  
+This toolchain is independent from the DNX-based .NET Core + ASP.NET Core 1.0 RC1 bits. If you are looking for .NET Core + ASP.NET Core 1.0 RC1 bits, you can find instructions on the http://get.asp.net/.  
 
 Docker
 ------

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ This repo contains the source code for cross-platform [.NET Core](http://github.
 
 New to .NET CLI?
 ------------
-Check out our http://dotnet.github.io/getting-started/
+Check out our http://dotnet.github.io/getting-started/ page. 
+
+Found an issue?
+---------------
+You can consult the [known issues page](Documentation/known-issues.md) to find out the current issues and 
+to see the workarounds.  
+
+If you don't find your issue, please file one! However, given that this is a very high-frequency repo, we've setup some [basic guidelines](Documentation/issue-filing-guide.md) to help you. Please consult those first.
 
 Build Status
 ------------
@@ -24,10 +31,10 @@ Installers
 |**Installers**|[Download Debian Package](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-ubuntu-x64.latest.deb)|[Download Msi](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-win-x64.latest.exe)|[Download Pkg](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-osx-x64.latest.pkg) |N/A |
 |**Binaries**|[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-ubuntu-x64.latest.tar.gz)|[Download zip file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-win-x64.latest.zip)|[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-osx-x64.latest.tar.gz) |[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-centos-x64.latest.tar.gz) |
 
-Interested in .NET Core + ASP.NET 5 RC bits?
+Interested in .NET Core + ASP.NET Core 1.0 bits?
 ----------------------------------------
 
-This toolchain is independent from the DNX-based .NET Core + ASP.NET 5 RC bits. If you are looking for .NET Core + ASP.NET 5 RC bits, you can find instructions on the http://get.asp.net/.  
+This toolchain is independent from the DNX-based .NET Core + ASP.NET Core 1.0 bits. If you are looking for .NET Core + ASP.NET Core 1.0 bits, you can find instructions on the http://get.asp.net/.  
 
 Docker
 ------
@@ -53,19 +60,8 @@ Then you can either run from source or compile the sample. Running from source i
 Compiling to IL is done using:
 	
 	dotnet build
+
 This will drop a binary in `./bin/[configuration]/[framework]/[binary name]` that you can just run.
-
-Finally, you can also try out native compilation using RyuJIT as shown below:  
-
-	dotnet build --native
-
-The following command will perform native compilation using the C++ Codegenerator:
-
-    dotnet build --native --cpp
-
-If you are in Windows, make sure that you run the above command inside the *VS 2015 x64 Native Tools* prompt, otherwise you will get errors. This command will drop a native single binary in `./bin/[configuration]/[framework]/native/[binary name]` that you can run.
-
-**Note:** At this point, only the `helloworld` and `dotnetbot` samples will work with native compilation.
 
 For more details, please refer to the [documentation](https://github.com/dotnet/corert/tree/master/Documentation).
 
@@ -73,12 +69,6 @@ Building from source
 --------------------
 
 If you are building from source, take note that the build depends on NuGet packages hosted on Myget, so if it is down, the build may fail. If that happens, you can always see the [Myget status page](http://status.myget.org/) for more info. 
-
-Known issues
-------------
-
-You can also consult the [known issues page](Documentation/known-issues.md) to find out the current issues and 
-to see the workarounds.  
 
 Questions & Comments
 --------------------


### PR DESCRIPTION
The README.md contained some errors, corrected those. Removed the
native compilation bits for now.
Added an issue filing guide to make the issue process slightly better so we can
triage better.

/cc @piotrpMSFT 