### PR TITLE
Fix asset copy on publish when lock file instance is shared

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -157,13 +157,13 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         private LibraryExport ExportPackage(PackageDescription package)
         {
             var nativeLibraries = new List<LibraryAsset>();
-            PopulateAssets(package, package.Target.NativeLibraries, nativeLibraries);
+            PopulateAssets(package, package.NativeLibraries, nativeLibraries);
 
             var runtimeAssemblies = new List<LibraryAsset>();
-            PopulateAssets(package, package.Target.RuntimeAssemblies, runtimeAssemblies);
+            PopulateAssets(package, package.RuntimeAssemblies, runtimeAssemblies);
 
             var compileAssemblies = new List<LibraryAsset>();
-            PopulateAssets(package, package.Target.CompileTimeAssemblies, compileAssemblies);
+            PopulateAssets(package, package.CompileTimeAssemblies, compileAssemblies);
 
             var sourceReferences = new List<string>();
             foreach (var sharedSource in GetSharedSources(package))

--- a/src/Microsoft.DotNet.ProjectModel/PackageDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/PackageDescription.cs
@@ -1,8 +1,11 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.DotNet.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Resolution;
 
 namespace Microsoft.DotNet.ProjectModel
 {
@@ -27,7 +30,21 @@ namespace Microsoft.DotNet.ProjectModel
             Target = lockFileLibrary;
         }
 
-        public LockFileTargetLibrary Target { get; set; }
-        public LockFilePackageLibrary Library { get; set; }
+        private LockFileTargetLibrary Target { get; }
+        
+        public LockFilePackageLibrary Library { get; }
+
+        public IEnumerable<LockFileItem> RuntimeAssemblies => FilterPlaceholders(Target.RuntimeAssemblies);
+
+        public IEnumerable<LockFileItem> CompileTimeAssemblies => FilterPlaceholders(Target.CompileTimeAssemblies);
+
+        public IEnumerable<LockFileItem> ResourceAssemblies => Target.ResourceAssemblies;
+
+        public IEnumerable<LockFileItem> NativeLibraries => Target.NativeLibraries;
+
+        private IEnumerable<LockFileItem> FilterPlaceholders(IList<LockFileItem> items)
+        {
+            return items.Where(a => !PackageDependencyProvider.IsPlaceholderFile(a));
+        }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
@@ -285,7 +285,7 @@ namespace Microsoft.DotNet.ProjectModel
                 // To make them work seamlessly on those platforms, we fill the gap with a reference
                 // assembly (if available)
                 var package = library as PackageDescription;
-                if (package != null && package.Resolved && !package.Target.CompileTimeAssemblies.Any())
+                if (package != null && package.Resolved && !package.CompileTimeAssemblies.Any())
                 {
                     var replacement = referenceAssemblyDependencyResolver.GetDescription(new LibraryRange(library.Identity.Name, LibraryType.ReferenceAssembly), TargetFramework);
                     if (replacement?.Resolved == true)

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
@@ -42,10 +42,6 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
 
             var path = _packagePathResolver.GetInstallPath(package.Name, package.Version);
 
-            // Remove place holders
-            targetLibrary.CompileTimeAssemblies = targetLibrary.CompileTimeAssemblies.Where(item => !IsPlaceholderFile(item.Path)).ToList();
-            targetLibrary.RuntimeAssemblies = targetLibrary.RuntimeAssemblies.Where(item => !IsPlaceholderFile(item.Path)).ToList();
-
             // If the package's compile time assemblies is for a portable profile then, read the assembly metadata
             // and turn System.* references into reference assembly dependencies
             PopulateLegacyPortableDependencies(targetFramework, dependencies, path, targetLibrary);
@@ -66,6 +62,11 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
 
             foreach (var assembly in targetLibrary.CompileTimeAssemblies)
             {
+                if (IsPlaceholderFile(assembly))
+                {
+                    continue;
+                }
+
                 // (ref/lib)/{tfm}/{assembly}
                 var pathParts = assembly.Path.Split(Path.DirectorySeparatorChar);
 

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.Tools.Restore
 
             var depsPath = Path.Combine(
                 toolDescription.Path,
-                Path.GetDirectoryName(toolDescription.Target.RuntimeAssemblies.First().Path),
+                Path.GetDirectoryName(toolDescription.RuntimeAssemblies.First().Path),
                 toolDescription.Identity.Name + FileNameSuffixes.Deps);
 
             var calculator = context.GetOutputPaths(Constants.DefaultConfiguration, buidBasePath: null, outputPath: context.ProjectDirectory);

--- a/test/Microsoft.DotNet.ProjectModel.Tests/PackageDependencyProviderTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/PackageDependencyProviderTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using Microsoft.DotNet.ProjectModel.Graph;
+using Microsoft.DotNet.ProjectModel.Resolution;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Microsoft.DotNet.ProjectModel.Tests
+{
+    public class PackageDependencyProviderTests
+    {
+        [Fact]
+        public void GetDescriptionShouldNotModifyTarget()
+        {
+            var provider = new PackageDependencyProvider("/foo/packages", new FrameworkReferenceResolver("/foo/references"));
+            var package = new LockFilePackageLibrary();
+            package.Name = "Something";
+            package.Version = NuGetVersion.Parse("1.0.0");
+            package.Files.Add("lib/dotnet/_._");
+            package.Files.Add("runtimes/any/native/Microsoft.CSharp.CurrentVersion.targets");
+
+            var target = new LockFileTargetLibrary();
+            target.Name = "Something";
+            target.Version = package.Version;
+
+            target.RuntimeAssemblies.Add("lib/dotnet/_._");
+            target.CompileTimeAssemblies.Add("lib/dotnet/_._");
+            target.NativeLibraries.Add("runtimes/any/native/Microsoft.CSharp.CurrentVersion.targets");
+
+            var p1 = provider.GetDescription(NuGetFramework.Parse("dnxcore50"), package, target);
+            var p2 = provider.GetDescription(NuGetFramework.Parse("dnxcore50"), package, target);
+
+            Assert.True(p1.Compatible);
+            Assert.True(p2.Compatible);
+
+            Assert.Empty(p1.CompileTimeAssemblies);
+            Assert.Empty(p1.RuntimeAssemblies);
+            
+            Assert.Empty(p2.CompileTimeAssemblies);
+            Assert.Empty(p2.RuntimeAssemblies);
+        }
+    }
+}


### PR DESCRIPTION
- Don't mutate the library target when making a package description.

#1528