### PR TITLE
Fixing the name of the OS X package

### DIFF
--- a/packaging/osx/package-osx.sh
+++ b/packaging/osx/package-osx.sh
@@ -28,7 +28,7 @@ fi
 PACKAGE_DIR=$REPOROOT/artifacts/packages/pkg
 [ -d "$PACKAGE_DIR" ] || mkdir -p $PACKAGE_DIR
 
-PACKAGE_NAME=$PACKAGE_DIR/dotnet-cli-x64.${DOTNET_CLI_VERSION}.pkg
+PACKAGE_NAME=$PACKAGE_DIR/dotnet-osx-x64.${DOTNET_CLI_VERSION}.pkg
 #chmod -R 755 $STAGE2_DIR
 pkgbuild --root $STAGE2_DIR \
          --version $DOTNET_CLI_VERSION \

--- a/packaging/osx/package-osx.sh
+++ b/packaging/osx/package-osx.sh
@@ -28,21 +28,22 @@ fi
 PACKAGE_DIR=$REPOROOT/artifacts/packages/pkg
 [ -d "$PACKAGE_DIR" ] || mkdir -p $PACKAGE_DIR
 
-PACKAGE_NAME=$PACKAGE_DIR/dotnet-osx-x64.${DOTNET_CLI_VERSION}.pkg
+PACKAGE_ID=dotnet-osx-x64.${DOTNET_CLI_VERSION}.pkg
+PACKAGE_NAME=$PACKAGE_DIR/$PACKAGE_ID
 #chmod -R 755 $STAGE2_DIR
 pkgbuild --root $STAGE2_DIR \
          --version $DOTNET_CLI_VERSION \
          --scripts $DIR/scripts \
          --identifier com.microsoft.dotnet.cli.pkg.dotnet-osx-x64 \
          --install-location /usr/local/share/dotnet \
-         $DIR/dotnet-osx-x64.$DOTNET_CLI_VERSION.pkg
+         $DIR/$PACKAGE_ID
 
 cat $DIR/Distribution-Template | sed "/{VERSION}/s//$DOTNET_CLI_VERSION/g" > $DIR/Dist
 
 productbuild --version $DOTNET_CLI_VERSION --identifier com.microsoft.dotnet.cli --package-path $DIR --resources $DIR/resources --distribution $DIR/Dist $PACKAGE_NAME
 
 #Clean temp files
-rm $DIR/dotnet-osx-x64.$DOTNET_CLI_VERSION.pkg
+rm $DIR/$PACKAGE_ID
 rm $DIR/Dist
 
 $REPOROOT/scripts/publish/publish.sh $PACKAGE_NAME


### PR DESCRIPTION
There was a bug in naming the versioned PKG for OSX when it is being packaged. This resulted
in two different names for the latest and versioned, which is not what we want.

Fix #1537 

/cc @glennc @Sridhar-MS @piotrpMSFT 