### PR TITLE
Use System.Console for colors on Unix

### DIFF
--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
@@ -8,28 +8,22 @@ namespace Microsoft.DotNet.Cli.Build.Framework
 {
     public class AnsiConsole
     {
-        private AnsiConsole(TextWriter writer, bool useConsoleColor)
+        private AnsiConsole(TextWriter writer)
         {
             Writer = writer;
-
-            _useConsoleColor = useConsoleColor;
-            if (_useConsoleColor)
-            {
-                OriginalForegroundColor = Console.ForegroundColor;
-            }
+            OriginalForegroundColor = Console.ForegroundColor;
         }
 
         private int _boldRecursion;
-        private bool _useConsoleColor;
 
-        public static AnsiConsole GetOutput(bool useConsoleColor)
+        public static AnsiConsole GetOutput()
         {
-            return new AnsiConsole(Console.Out, useConsoleColor);
+            return new AnsiConsole(Console.Out);
         }
 
-        public static AnsiConsole GetError(bool useConsoleColor)
+        public static AnsiConsole GetError()
         {
-            return new AnsiConsole(Console.Error, useConsoleColor);
+            return new AnsiConsole(Console.Error);
         }
 
         public TextWriter Writer { get; }
@@ -54,12 +48,6 @@ namespace Microsoft.DotNet.Cli.Build.Framework
 
         public void WriteLine(string message)
         {
-            if (!_useConsoleColor)
-            {
-                Writer.WriteLine(message);
-                return;
-            }
-
             var escapeScan = 0;
             for (;;)
             {

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
@@ -11,30 +11,37 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         private AnsiConsole(TextWriter writer)
         {
             Writer = writer;
+    
             OriginalForegroundColor = Console.ForegroundColor;
         }
-
+    
         private int _boldRecursion;
-
+    
         public static AnsiConsole GetOutput()
         {
             return new AnsiConsole(Console.Out);
         }
-
+    
         public static AnsiConsole GetError()
         {
             return new AnsiConsole(Console.Error);
         }
-
+    
         public TextWriter Writer { get; }
-
+    
         public ConsoleColor OriginalForegroundColor { get; }
-
+    
         private void SetColor(ConsoleColor color)
         {
-            Console.ForegroundColor = (ConsoleColor)(((int)Console.ForegroundColor & 0x08) | ((int)color & 0x07));
-        }
+            const int Light = 0x08;
+            int c = (int)color;
 
+            Console.ForegroundColor = 
+                c < 0 ? color :                                   // unknown, just use it
+                _boldRecursion > 0 ? (ConsoleColor)(c & ~Light) : // ensure color is dark
+                (ConsoleColor)(c | Light);                        // ensure color is light
+        }
+    
         private void SetBold(bool bold)
         {
             _boldRecursion += bold ? 1 : -1;
@@ -42,11 +49,19 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             {
                 return;
             }
-
-            Console.ForegroundColor = (ConsoleColor)((int)Console.ForegroundColor ^ 0x08);
+            
+            // switches on _boldRecursion to handle boldness
+            SetColor(Console.ForegroundColor);        
         }
 
         public void WriteLine(string message)
+        {
+            Write(message);
+            Writer.WriteLine();
+        }
+
+
+        public void Write(string message)
         {
             var escapeScan = 0;
             for (;;)
@@ -68,14 +83,14 @@ namespace Microsoft.DotNet.Cli.Build.Framework
                     {
                         endIndex += 1;
                     }
-
+    
                     var text = message.Substring(escapeScan, escapeIndex - escapeScan);
                     Writer.Write(text);
                     if (endIndex == message.Length)
                     {
                         break;
                     }
-
+    
                     switch (message[endIndex])
                     {
                         case 'm':
@@ -121,11 +136,10 @@ namespace Microsoft.DotNet.Cli.Build.Framework
                             }
                             break;
                     }
-
+    
                     escapeScan = endIndex + 1;
                 }
             }
-            Writer.WriteLine();
         }
     }
 }

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/Reporter.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/Reporter.cs
@@ -19,16 +19,9 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             _console = console;
         }
 
-        public static Reporter Output { get; } = Create(AnsiConsole.GetOutput);
-        public static Reporter Error { get; } = Create(AnsiConsole.GetOutput);
-        public static Reporter Verbose { get; } = Create(AnsiConsole.GetOutput);
-
-        public static Reporter Create(Func<bool, AnsiConsole> getter)
-        {
-            var stripColors = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                string.Equals(Environment.GetEnvironmentVariable("NO_COLOR"), "1");
-            return new Reporter(getter(stripColors));
-        }
+        public static Reporter Output { get; } = new Reporter(AnsiConsole.GetOutput());
+        public static Reporter Error { get; } = new Reporter(AnsiConsole.GetOutput());
+        public static Reporter Verbose { get; } = new Reporter(AnsiConsole.GetOutput());
 
         public void WriteLine(string message)
         {

--- a/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
@@ -33,7 +33,13 @@ namespace Microsoft.DotNet.Cli.Utils
     
         private void SetColor(ConsoleColor color)
         {
-            Console.ForegroundColor = (ConsoleColor)(((int)Console.ForegroundColor & 0x08) | ((int)color & 0x07));
+            const int Light = 0x08;
+            int c = (int)color;
+
+            Console.ForegroundColor = 
+                c < 0 ? color :                                   // unknown, just use it
+                _boldRecursion > 0 ? (ConsoleColor)(c & ~Light) : // ensure color is dark
+                (ConsoleColor)(c | Light);                        // ensure color is light
         }
     
         private void SetBold(bool bold)
@@ -43,8 +49,9 @@ namespace Microsoft.DotNet.Cli.Utils
             {
                 return;
             }
-    
-            Console.ForegroundColor = (ConsoleColor)((int)Console.ForegroundColor ^ 0x08);
+            
+            // switches on _boldRecursion to handle boldness
+            SetColor(Console.ForegroundColor);        
         }
 
         public void WriteLine(string message)

--- a/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
@@ -8,28 +8,23 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class AnsiConsole
     {
-        private AnsiConsole(TextWriter writer, bool useConsoleColor)
+        private AnsiConsole(TextWriter writer)
         {
             Writer = writer;
     
-            _useConsoleColor = useConsoleColor;
-            if (_useConsoleColor)
-            {
-                OriginalForegroundColor = Console.ForegroundColor;
-            }
+            OriginalForegroundColor = Console.ForegroundColor;
         }
     
         private int _boldRecursion;
-        private bool _useConsoleColor;
     
-        public static AnsiConsole GetOutput(bool useConsoleColor)
+        public static AnsiConsole GetOutput()
         {
-            return new AnsiConsole(Console.Out, useConsoleColor);
+            return new AnsiConsole(Console.Out);
         }
     
-        public static AnsiConsole GetError(bool useConsoleColor)
+        public static AnsiConsole GetError()
         {
-            return new AnsiConsole(Console.Error, useConsoleColor);
+            return new AnsiConsole(Console.Error);
         }
     
         public TextWriter Writer { get; }
@@ -61,12 +56,6 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public void Write(string message)
         {
-            if (!_useConsoleColor)
-            {
-                Writer.Write(message);
-                return;
-            }
-    
             var escapeScan = 0;
             for (;;)
             {

--- a/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
@@ -19,14 +19,11 @@ namespace Microsoft.DotNet.Cli.Utils
             _console = console;
         }
 
-        public static Reporter Output { get; } = Create(AnsiConsole.GetOutput);
-        public static Reporter Error { get; } = Create(AnsiConsole.GetError);
-        public static Reporter Verbose { get; } = CommandContext.IsVerbose() ? Create(AnsiConsole.GetOutput) : NullReporter;
-
-        public static Reporter Create(Func<bool, AnsiConsole> getter)
-        {
-            return new Reporter(getter(PlatformServices.Default.Runtime.OperatingSystemPlatform == Platform.Windows));
-        }
+        public static Reporter Output { get; } = new Reporter(AnsiConsole.GetOutput());
+        public static Reporter Error { get; } = new Reporter(AnsiConsole.GetError());
+        public static Reporter Verbose { get; } = CommandContext.IsVerbose() ? 
+            new Reporter(AnsiConsole.GetOutput()) : 
+            NullReporter;
 
         public void WriteLine(string message)
         {


### PR DESCRIPTION
Stop Writing Ansi Console colors directly to the console on Unix, and use the System.Console API like we do on Windows.

cc @stephentoub @anurse 