### PR TITLE
The multitarget framework build tests is failing in VSO for net20 and net40

### DIFF
--- a/test/dotnet-build.Tests/BuildOutputTests.cs
+++ b/test/dotnet-build.Tests/BuildOutputTests.cs
@@ -131,8 +131,6 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
         }
 
         [Theory]
-        [InlineData("net20", false, true)]
-        [InlineData("net40", true, true)]
         [InlineData("net461", true, true)]
         [InlineData("dnxcore50", true, false)]
         public void MultipleFrameworks_ShouldHaveValidTargetFrameworkAttribute(string frameworkName, bool shouldHaveTargetFrameworkAttribute, bool windowsOnly)


### PR DESCRIPTION
The multitarget framework build tests is failing in VSO for net20 and net40 because it requires specific things installed at the machine. Removing the tests for these two frameworks.

cc @davidfowl @pakrym 