### PR TITLE
Test Runner test started needs to handle messages when dotnet test is in TestStarted state

### DIFF
--- a/src/dotnet/commands/dotnet-test/MessageHandlers/TestRunnerTestStartedMessageHandler.cs
+++ b/src/dotnet/commands/dotnet-test/MessageHandlers/TestRunnerTestStartedMessageHandler.cs
@@ -14,8 +14,14 @@ namespace Microsoft.DotNet.Tools.Test
 
         protected override bool CanHandleMessage(IDotnetTest dotnetTest, Message message)
         {
-            return dotnetTest.State == DotnetTestState.TestExecutionSentTestRunnerProcessStartInfo &&
+            return IsAtAnAcceptableState(dotnetTest) &&
                    message.MessageType == TestMessageTypes.TestRunnerTestStarted;
+        }
+
+        private static bool IsAtAnAcceptableState(IDotnetTest dotnetTest)
+        {
+            return dotnetTest.State == DotnetTestState.TestExecutionSentTestRunnerProcessStartInfo ||
+                dotnetTest.State == DotnetTestState.TestExecutionStarted;
         }
     }
 }

--- a/src/dotnet/commands/dotnet-test/ReportingChannel.cs
+++ b/src/dotnet/commands/dotnet-test/ReportingChannel.cs
@@ -114,6 +114,11 @@ namespace Microsoft.DotNet.Tools.Test
                     var message = JsonConvert.DeserializeObject<Message>(rawMessage);
 
                     MessageReceived?.Invoke(this, message);
+
+                    if (ShouldStopListening(message))
+                    {
+                        break;
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -125,6 +130,12 @@ namespace Microsoft.DotNet.Tools.Test
                     throw;
                 }
             }
+        }
+
+        private static bool ShouldStopListening(Message message)
+        {
+            return message.MessageType == TestMessageTypes.TestRunnerTestCompleted ||
+                message.MessageType == TestMessageTypes.TestSessionTerminate;
         }
 
         public void Dispose()

--- a/test/dotnet-test.UnitTests/GivenATestRunnerTestStartedMessageHandler.cs
+++ b/test/dotnet-test.UnitTests/GivenATestRunnerTestStartedMessageHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         }
 
         [Fact]
-        public void It_returns_NoOp_if_the_dotnet_test_state_is_not_TestExecutionSentTestRunnerProcessStartInfo()
+        public void It_returns_NoOp_if_the_dotnet_test_state_is_not_TestExecutionSentTestRunnerProcessStartInfo_or_TestExecutionTestStarted()
         {
             var dotnetTestMock = new Mock<IDotnetTest>();
             dotnetTestMock.Setup(d => d.State).Returns(DotnetTestState.Terminated);
@@ -59,10 +59,23 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         }
 
         [Fact]
-        public void It_returns_TestExecutionStarted_when_it_handles_the_message()
+        public void It_returns_TestExecutionStarted_when_it_handles_the_message_and_current_state_is_TestExecutionSentTestRunnerProcessStartInfo()
         {
             var nextState = _testRunnerTestStartedMessageHandler.HandleMessage(
                     _dotnetTestMock.Object,
+                    _validMessage);
+
+            nextState.Should().Be(DotnetTestState.TestExecutionStarted);
+        }
+
+        [Fact]
+        public void It_returns_TestExecutionStarted_when_it_handles_the_message_and_current_state_is_TestExecutionTestStarted()
+        {
+            var dotnetTestMock = new Mock<IDotnetTest>();
+            dotnetTestMock.Setup(d => d.State).Returns(DotnetTestState.TestExecutionStarted);
+
+            var nextState = _testRunnerTestStartedMessageHandler.HandleMessage(
+                    dotnetTestMock.Object,
                     _validMessage);
 
             nextState.Should().Be(DotnetTestState.TestExecutionStarted);


### PR DESCRIPTION
Test Runner test started needs to handle messages when dotnet test is in a TestStarted state, as we will receive multiple test started messages. Also, to prevent a crash, when we get a message that terminates the adapter or the runner, we need to stop listening. Unfortunately, this needs to be directly where we read the messages, because if we give a handler a chance to handle that message, the reader will already be trying to read again.

cc @piotrpMSFT 