### PR TITLE
Dotnet test creating the command using dotnet-test-xunit

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandFactory.cs
@@ -6,12 +6,15 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
-    public interface ICommandFactory
+    public class CommandFactory : ICommandFactory
     {
-        ICommand Create(
+        public ICommand Create(
             string commandName,
             IEnumerable<string> args,
             NuGetFramework framework = null,
-            string configuration = Constants.DefaultConfiguration);
+            string configuration = Constants.DefaultConfiguration)
+        {
+            return Command.Create(commandName, args, framework, configuration);
+        }
     }
 }

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.Tools.Test
                 var messages = new TestMessagesCollection();
                 using (var dotnetTest = new DotnetTest(messages, assemblyUnderTest))
                 {
-                    var commandFactory = new DotNetCommandFactory();
+                    var commandFactory = new CommandFactory();
                     var testRunnerFactory = new TestRunnerFactory(GetCommandName(testRunner), commandFactory);
 
                     dotnetTest

--- a/src/dotnet/commands/dotnet-test/ReportingChannel.cs
+++ b/src/dotnet/commands/dotnet-test/ReportingChannel.cs
@@ -129,7 +129,10 @@ namespace Microsoft.DotNet.Tools.Test
 
         public void Dispose()
         {
-            Socket.Dispose();
+            if (Socket != null)
+            {
+                Socket.Dispose();
+            }
         }
     }
 }

--- a/src/dotnet/commands/dotnet-test/TestRunners/TestRunner.cs
+++ b/src/dotnet/commands/dotnet-test/TestRunners/TestRunner.cs
@@ -51,9 +51,10 @@ namespace Microsoft.DotNet.Tools.Test
             var commandArgs = _argumentsBuilder.BuildArguments();
 
             return _commandFactory.Create(
-                _testRunner,
+                $"dotnet-{_testRunner}",
                 commandArgs,
-                new NuGetFramework("DNXCore", Version.Parse("5.0")));
+                new NuGetFramework("DNXCore", Version.Parse("5.0")),
+                Constants.DefaultConfiguration);
         }
     }
 }

--- a/test/dotnet-test.UnitTests/GivenATestRunner.cs
+++ b/test/dotnet-test.UnitTests/GivenATestRunner.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
 
             _commandFactoryMock = new Mock<ICommandFactory>();
             _commandFactoryMock.Setup(c => c.Create(
-                _runner,
+                $"dotnet-{_runner}",
                 _testRunnerArguments,
                 new NuGetFramework("DNXCore", Version.Parse("5.0")),
-                null)).Returns(_commandMock.Object).Verifiable();
+                Constants.DefaultConfiguration)).Returns(_commandMock.Object).Verifiable();
         }
 
         [Fact]


### PR DESCRIPTION
Adding a new factory that creates the command as is, without adding the dotnet to it. We need it so that the runner can pass dotnet-test-xunit and get back the final corehost command, which is the right one for VS to use and attach to.

cc @piotrpMSFT 