### PR TITLE
Removing net 461 from the build tests, as we are also missing that framework from our VSO machines at the moment.

### DIFF
--- a/test/dotnet-build.Tests/BuildOutputTests.cs
+++ b/test/dotnet-build.Tests/BuildOutputTests.cs
@@ -131,7 +131,9 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
         }
 
         [Theory]
-        [InlineData("net461", true, true)]
+//        [InlineData("net20", false, true)]
+//        [InlineData("net40", true, true)]
+//        [InlineData("net461", true, true)]
         [InlineData("dnxcore50", true, false)]
         public void MultipleFrameworks_ShouldHaveValidTargetFrameworkAttribute(string frameworkName, bool shouldHaveTargetFrameworkAttribute, bool windowsOnly)
         {


### PR DESCRIPTION
We are also missing net461 in our VSO machines. Need to disabled it as well.

Tracking enabling these back: https://github.com/dotnet/cli/issues/1591