### PR TITLE
Update to latest NuGet and add manual RID inference to preserve current behavior

### DIFF
--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -36,6 +36,17 @@ namespace Microsoft.DotNet.Tools.Restore
             var quiet = args.Any(s => s.Equals("--quiet", StringComparison.OrdinalIgnoreCase));
             args = args.Where(s => !s.Equals("--quiet", StringComparison.OrdinalIgnoreCase)).ToArray();
 
+            // NuGet disabled RID inference, but we need it back for now, while we implement the rest of the portable app stuff.
+            // Re-enabling it like this won't mess with our ability to support the other scenarios, it just means we're restoring more than we need for now.
+            // This **will** mean we are ignoring the RIDs provided in the project.json, if any, though.
+            if(!args.Contains("--runtime", StringComparer.OrdinalIgnoreCase))
+            {
+                args = Enumerable.Concat(
+                        args,
+                        PlatformServices.Default.Runtime.GetOverrideRestoreRuntimeIdentifiers().SelectMany(s => new [] { "--runtime", s })
+                    ).ToArray();
+            }
+
             app.OnExecute(() =>
             {
                 try

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -24,7 +24,7 @@
         "Microsoft.CodeAnalysis.CSharp":  "1.3.0-beta1-20160225-02",
         "Microsoft.DiaSymReader.Native": "1.3.3",
 
-        "NuGet.CommandLine.XPlat": "3.4.0-beta-632",
+        "NuGet.CommandLine.XPlat": "3.4.0-beta-680",
         "System.CommandLine": "0.1.0-e160119-1",
 
         "Microsoft.DotNet.ProjectModel": "1.0.0-*",


### PR DESCRIPTION
The newest NuGet disabled RID inference (as we requested). Unfortunately, we don't actually have support for Portable App publishing, so we still need RID inference :). So this introduces a temporary new switch (`--infer-runtime`) to re-enable RID inference. This is used in dotnet cli and will be used by ASP.NET Core to ensure we can keep advancing to new NuGet versions without breaking our builds.

/cc @pakrym @piotrpMSFT @brthor @Sridhar-MS @davidfowl @muratg 