### PR TITLE
Updating tests to use the latest version of dotnet-test-xunit

### DIFF
--- a/TestAssets/TestProjects/TestAppWithLibrary/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestLibrary/project.json
@@ -6,7 +6,7 @@
         "additionalArguments": [ "-highentropyva+" ]
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23808"
+        "NETStandard.Library": "1.0.0-rc2-23811"
     },
 
     "frameworks": {

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary/project.json
@@ -6,7 +6,7 @@
         "additionalArguments": [ "-highentropyva+" ]
     },
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23808"
+        "NETStandard.Library": "1.0.0-rc2-23811"
     },
 
     "frameworks": {

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "TestLibraryWithAppDependency":  { "target":"project", "version":"1.0.0-*" },
 
-        "NETStandard.Library": "1.0.0-rc2-23808"
+        "NETStandard.Library": "1.0.0-rc2-23811"
     },
 
     "frameworks": {

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibraryWithAppDependency/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibraryWithAppDependency/project.json
@@ -3,7 +3,7 @@
     "dependencies": {
         "TestApp":  { "target":"project", "version":"1.0.0-*" },
 
-        "NETStandard.Library": "1.0.0-rc2-23808",
+        "NETStandard.Library": "1.0.0-rc2-23811",
     },
 
     "frameworks": {

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/Microsoft.DotNet.Cli.Build.Framework.xproj
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/Microsoft.DotNet.Cli.Build.Framework.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>49beb486-ab5a-4416-91ea-8cd34abb0c9d</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Cli.Build.Framework</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -34,7 +34,8 @@ namespace Microsoft.DotNet.Cli.Build
             "Microsoft.DotNet.Compiler.Common.Tests",
             "Microsoft.DotNet.ProjectModel.Tests",
             "Microsoft.Extensions.DependencyModel.Tests",
-            "ArgumentForwardingTests"
+            "ArgumentForwardingTests",
+            "dotnet-test.UnitTests"
         };
 
         [Target(nameof(PrepareTargets.Init), nameof(SetupTests), nameof(RestoreTests), nameof(BuildTests), nameof(RunTests), nameof(ValidateDependencies))]

--- a/scripts/dotnet-cli-build/dotnet-cli-build.xproj
+++ b/scripts/dotnet-cli-build/dotnet-cli-build.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>d7b9695d-23eb-4ea8-b8ab-707a0092e1d5</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Cli.Build</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.xproj
+++ b/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.xproj
@@ -10,7 +10,7 @@
     <ProjectGuid>61b7c351-c77d-43f7-b56f-bb1440178e10</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Cli.Utils</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Compiler.Common/Microsoft.Dotnet.Compiler.Common.xproj
+++ b/src/Microsoft.DotNet.Compiler.Common/Microsoft.Dotnet.Compiler.Common.xproj
@@ -10,7 +10,7 @@
     <ProjectGuid>a16958e1-24c7-4f1e-b317-204ad91625dd</ProjectGuid>
     <RootNamespace>Microsoft.Dotnet.Cli.Compiler.Common</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.Files/Microsoft.DotNet.Files.xproj
+++ b/src/Microsoft.DotNet.Files/Microsoft.DotNet.Files.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>d521dd9f-0614-4929-93b4-d8fa5682c174</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Files</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Microsoft.DotNet.InternalAbstractions/Microsoft.DotNet.InternalAbstractions.xproj
+++ b/src/Microsoft.DotNet.InternalAbstractions/Microsoft.DotNet.InternalAbstractions.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>bd4f0750-4e81-4ad2-90b5-e470881792c3</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.InternalAbstractions</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Microsoft.DotNet.ProjectModel.Loader/Microsoft.DotNet.ProjectModel.Loader.xproj
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/Microsoft.DotNet.ProjectModel.Loader.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>c7af0290-ef0d-44dc-9edc-600803b664f8</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.ProjectModel.Loader</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/Microsoft.DotNet.ProjectModel.Workspaces.xproj
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/Microsoft.DotNet.ProjectModel.Workspaces.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>bd7833f8-3209-4682-bf75-b4bca883e279</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.ProjectModel.Workspaces</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.DotNet.ProjectModel/Microsoft.DotNet.ProjectModel.xproj
+++ b/src/Microsoft.DotNet.ProjectModel/Microsoft.DotNet.ProjectModel.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>303677d5-7312-4c3f-baee-beb1a9bd9fe6</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.ProjectModel</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.xproj
+++ b/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.xproj
@@ -10,7 +10,7 @@
     <ProjectGuid>0724ed7c-56e3-4604-9970-25e600611383</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.TestFramework</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.xproj
+++ b/src/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>688870c8-9843-4f9e-8576-d39290ad0f25</ProjectGuid>
     <RootNamespace>Microsoft.Extensions.DependencyModel</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Microsoft.Extensions.Testing.Abstractions/Microsoft.Extensions.Testing.Abstractions.xproj
+++ b/src/Microsoft.Extensions.Testing.Abstractions/Microsoft.Extensions.Testing.Abstractions.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>dcdfe282-03de-4dbc-b90c-cc3ce3ec8162</ProjectGuid>
     <RootNamespace>Microsoft.Extensions.Testing.Abstractions</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/dotnet/commands/dotnet-test/CommandTestRunnerExtensions.cs
+++ b/src/dotnet/commands/dotnet-test/CommandTestRunnerExtensions.cs
@@ -1,16 +1,19 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.Test
 {
     public static class CommandTestRunnerExtensions
     {
-        public static ProcessStartInfo ToProcessStartInfo(this ICommand command)
+        public static TestStartInfo ToTestStartInfo(this ICommand command)
         {
-            return new ProcessStartInfo(command.CommandName, command.CommandArgs);
+            return new TestStartInfo
+            {
+                FileName = command.CommandName,
+                Arguments = command.CommandArgs
+            };
         }
     }
 }

--- a/src/dotnet/commands/dotnet-test/TestRunners/TestRunner.cs
+++ b/src/dotnet/commands/dotnet-test/TestRunners/TestRunner.cs
@@ -29,11 +29,11 @@ namespace Microsoft.DotNet.Tools.Test
             ExecuteRunnerCommand();
         }
 
-        public ProcessStartInfo GetProcessStartInfo()
+        public TestStartInfo GetProcessStartInfo()
         {
             var command = CreateTestRunnerCommand();
 
-            return command.ToProcessStartInfo();
+            return command.ToTestStartInfo();
         }
 
         private void ExecuteRunnerCommand()

--- a/src/dotnet/commands/dotnet-test/TestStartInfo.cs
+++ b/src/dotnet/commands/dotnet-test/TestStartInfo.cs
@@ -3,10 +3,10 @@
 
 namespace Microsoft.DotNet.Tools.Test
 {
-    public interface ITestRunner
+    public class TestStartInfo
     {
-        void RunTestCommand();
+        public string FileName { get; set; }
 
-        TestStartInfo GetProcessStartInfo();
+        public string Arguments { get; set; }
     }
 }

--- a/src/dotnet/dotnet.xproj
+++ b/src/dotnet/dotnet.xproj
@@ -8,8 +8,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>60cf7e6c-d6c8-439d-b7b7-d8a27e29be2c</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Cli</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests.xproj
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>6973e08d-11ec-49dc-82ef-d5effec7c6e9</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Tests.ArgumentForwarding</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -12,7 +12,7 @@
         "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
 
         "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-48273-16"
+        "dotnet-test-xunit": "1.0.0-dev-79755-47"
     },
 
     "frameworks": {

--- a/test/ArgumentsReflector/Reflector.xproj
+++ b/test/ArgumentsReflector/Reflector.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>6f2e6f25-b43b-495d-9ca5-7f207d1dd604</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Tests.ArgumentForwarding</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/EndToEnd/EndToEnd.xproj
+++ b/test/EndToEnd/EndToEnd.xproj
@@ -9,11 +9,13 @@
     <ProjectGuid>65741cb1-8aee-4c66-8198-10a7ea0e4258</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Tests.EndToEnd</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -13,7 +13,7 @@
 
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.xproj
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>09c52f96-efdd-4448-95ec-6d362dd60baa</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Cli.Utils</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -13,7 +13,7 @@
         "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
         
         "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-48273-16"
+        "dotnet-test-xunit": "1.0.0-dev-79755-47"
     },
 
     "frameworks": {

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/Microsoft.DotNet.Compiler.Common.Tests.xproj
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/Microsoft.DotNet.Compiler.Common.Tests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>44e7d1ac-dcf1-4a18-9c22-f09e6bb302b5</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Cli.Utils</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -9,7 +9,7 @@
         "Microsoft.DotNet.Compiler.Common": { "target": "project" },
         
         "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-48273-16"
+        "dotnet-test-xunit": "1.0.0-dev-79755-47"
     },
 
     "frameworks": {

--- a/test/Microsoft.DotNet.ProjectModel.Tests/Microsoft.DotNet.ProjectModel.Tests.xproj
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/Microsoft.DotNet.ProjectModel.Tests.xproj
@@ -9,11 +9,13 @@
     <ProjectGuid>0745410a-6629-47eb-aab5-08d6288cad72</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.ProjectModel.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -5,7 +5,7 @@
     "Microsoft.DotNet.ProjectModel": { "target": "project" },
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
   "frameworks": {
     "dnxcore50": {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Test.Utilities.xproj
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Test.Utilities.xproj
@@ -10,7 +10,7 @@
     <ProjectGuid>e4f46eab-b5a5-4e60-9b9d-40a1fadbf45c</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Tools.Test.Utilities</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -9,7 +9,7 @@
         "System.Collections.Immutable": "1.2.0-rc2-23811",
         "FluentAssertions": "4.0.0",
         "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-48273-16",
+        "dotnet-test-xunit": "1.0.0-dev-79755-47",
 
         "Microsoft.DotNet.TestFramework": "1.0.0-*",
         "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
@@ -19,7 +19,6 @@
             "version": "1.0.0-*"
         }
     },
-
 
     "frameworks": {
         "dnxcore50": {

--- a/test/Microsoft.Extensions.DependencyModel.Tests/Microsoft.Extensions.DependencyModel.Tests.xproj
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/Microsoft.Extensions.DependencyModel.Tests.xproj
@@ -9,11 +9,13 @@
     <ProjectGuid>4a4711d8-4312-49fc-87b5-4f183f4c6a51</ProjectGuid>
     <RootNamespace>Microsoft.Extensions.DependencyModel.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Microsoft.Extensions.DependencyModel.Tests/project.json
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/project.json
@@ -11,7 +11,7 @@
     "FluentAssertions": "4.0.0",
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/test/ScriptExecutorTests/ScriptExecutorTests.xproj
+++ b/test/ScriptExecutorTests/ScriptExecutorTests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>833ffee1-7eed-4f51-8dfd-946d48833333</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Cli.Utils.ScriptExecutorTests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -2,14 +2,14 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23805",
+    "NETStandard.Library": "1.0.0-rc2-23811",
 
     "Microsoft.DotNet.ProjectModel": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": { "target": "project" },
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
 
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/test/dotnet-build.Tests/dotnet-build.Tests.xproj
+++ b/test/dotnet-build.Tests/dotnet-build.Tests.xproj
@@ -9,11 +9,13 @@
     <ProjectGuid>833ffee1-7eed-4f51-8dfd-946d48833333</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Tools.Builder.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.0-*",
-  
+
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23811",      
+    "NETStandard.Library": "1.0.0-rc2-23811",
 
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": {
@@ -10,7 +10,7 @@
     },
 
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/test/dotnet-compile.Tests/dotnet-compile.Tests.xproj
+++ b/test/dotnet-compile.Tests/dotnet-compile.Tests.xproj
@@ -9,11 +9,13 @@
     <ProjectGuid>833ffee1-7eed-4f51-8dfd-946d48893d6e</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Tools.Compiler.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -3,14 +3,14 @@
 
   "dependencies": {
     "NETStandard.Library": "1.0.0-rc2-23811",
-    
+
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
 
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/test/dotnet-compile.UnitTests/dotnet-compile.UnitTests.xproj
+++ b/test/dotnet-compile.UnitTests/dotnet-compile.UnitTests.xproj
@@ -9,11 +9,13 @@
     <ProjectGuid>920b71d8-62da-4f5e-8a26-926c113f1d97</ProjectGuid>
     <RootNamespace>dotnet-compile.UnitTests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -12,7 +12,7 @@
     "Microsoft.DotNet.ProjectModel": { "target": "project" },
 
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16",
+    "dotnet-test-xunit": "1.0.0-dev-79755-47",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet-pack.Tests/dotnet-pack.Tests.xproj
+++ b/test/dotnet-pack.Tests/dotnet-pack.Tests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>5fda6d37-3a3e-4333-ba5c-f0b28be316f4</ProjectGuid>
     <RootNamespace>dotnet-pack.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -11,7 +11,7 @@
     },
 
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/test/dotnet-projectmodel-server.Tests/dotnet-projectmodel-server.Tests.xproj
+++ b/test/dotnet-projectmodel-server.Tests/dotnet-projectmodel-server.Tests.xproj
@@ -8,8 +8,8 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>11c77123-e4da-499f-8900-80c88c2c69f2</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.ProjectModel.Server.Tests</RootNamespace>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -1,11 +1,11 @@
 {
-    "dependencies": {
-        "dotnet": { "target": "project" },
-        "Microsoft.DotNet.ProjectModel": { "target": "project" },
-        "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
-        "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-48273-16"
-    },
+  "dependencies": {
+    "dotnet": { "target": "project" },
+    "Microsoft.DotNet.ProjectModel": { "target": "project" },
+    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+  },
     "frameworks": {
         "dnxcore50": {
             "imports": "portable-net45+win8"

--- a/test/dotnet-publish.Tests/dotnet-publish.Tests.xproj
+++ b/test/dotnet-publish.Tests/dotnet-publish.Tests.xproj
@@ -9,11 +9,14 @@
     <ProjectGuid>386d412c-003c-47b1-8258-0e35865cb7c4</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Tools.Publish.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -12,7 +12,7 @@
 
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/test/dotnet-resgen.Tests/dotnet-resgen.Tests.xproj
+++ b/test/dotnet-resgen.Tests/dotnet-resgen.Tests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>386d412c-003c-47b1-8258-0e35865cb7c4</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Tools.Resgen.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -11,7 +11,7 @@
 
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/test/dotnet-run.Tests/dotnet-run.Tests.xproj
+++ b/test/dotnet-run.Tests/dotnet-run.Tests.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>35e3c2dc-9b38-4ec5-8dd7-c32458dc485f</ProjectGuid>
     <RootNamespace>dotnet-run.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -10,7 +10,7 @@
     },
 
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/test/dotnet-test.UnitTests/GivenATestExecutionGetTestRunnerProcessStartInfoMessageHandler.cs
+++ b/test/dotnet-test.UnitTests/GivenATestExecutionGetTestRunnerProcessStartInfoMessageHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
 
         private GetTestRunnerProcessStartInfoMessageHandler _testGetTestRunnerProcessStartInfoMessageHandler;
         private Message _validMessage;
-        private ProcessStartInfo _processStartInfo;
+        private TestStartInfo _testStartInfo;
 
         private Mock<ITestRunner> _testRunnerMock;
         private Mock<ITestRunnerFactory> _testRunnerFactoryMock;
@@ -42,10 +42,14 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
             _dotnetTestMock.Setup(d => d.State).Returns(DotnetTestState.VersionCheckCompleted);
             _dotnetTestMock.Setup(d => d.PathToAssemblyUnderTest).Returns(AssemblyUnderTest);
 
-            _processStartInfo = new ProcessStartInfo("runner", "arguments");
+            _testStartInfo = new TestStartInfo
+            {
+                FileName = "runner",
+                Arguments = "arguments"
+            };
 
             _testRunnerMock = new Mock<ITestRunner>();
-            _testRunnerMock.Setup(t => t.GetProcessStartInfo()).Returns(_processStartInfo);
+            _testRunnerMock.Setup(t => t.GetProcessStartInfo()).Returns(_testStartInfo);
 
             _testRunnerFactoryMock = new Mock<ITestRunnerFactory>();
             _testRunnerFactoryMock
@@ -128,8 +132,8 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         {
             _adapterChannelMock.Setup(r => r.Send(It.Is<Message>(m =>
                 m.MessageType == TestMessageTypes.TestExecutionTestRunnerProcessStartInfo &&
-                m.Payload.ToObject<ProcessStartInfo>().FileName == _processStartInfo.FileName &&
-                m.Payload.ToObject<ProcessStartInfo>().Arguments == _processStartInfo.Arguments))).Verifiable();
+                m.Payload.ToObject<ProcessStartInfo>().FileName == _testStartInfo.FileName &&
+                m.Payload.ToObject<ProcessStartInfo>().Arguments == _testStartInfo.Arguments))).Verifiable();
 
             _testGetTestRunnerProcessStartInfoMessageHandler.HandleMessage(
                     _dotnetTestMock.Object,

--- a/test/dotnet-test.UnitTests/GivenThatWeWantToRunTests.cs
+++ b/test/dotnet-test.UnitTests/GivenThatWeWantToRunTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
 
             dotnetTestMessageScenario.TestRunnerMock
                 .Setup(t => t.GetProcessStartInfo())
-                .Returns(new ProcessStartInfo())
+                .Returns(new TestStartInfo())
                 .Verifiable();
 
             dotnetTestMessageScenario.AdapterChannelMock

--- a/test/dotnet-test.UnitTests/dotnet-test.UnitTests.xproj
+++ b/test/dotnet-test.UnitTests/dotnet-test.UnitTests.xproj
@@ -9,10 +9,13 @@
     <ProjectGuid>857274ac-e741-4266-a7fd-14dee0c1cc96</ProjectGuid>
     <RootNamespace>Microsoft.Dotnet.Tools.Test.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -8,7 +8,7 @@
     "dotnet": { "target": "project" },
 
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16",
+    "dotnet-test-xunit": "1.0.0-dev-79755-47",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet.Tests/dotnet.Tests.xproj
+++ b/test/dotnet.Tests/dotnet.Tests.xproj
@@ -9,10 +9,13 @@
     <ProjectGuid>cb710268-4a82-48e4-9531-faf1c8f78f4b</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Tests</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -1,8 +1,8 @@
 {
   "version": "1.0.0-*",
-  
+
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23810",
+    "NETStandard.Library": "1.0.0-rc2-23811",
 
     "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": {
@@ -11,7 +11,7 @@
     },
 
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-48273-16"
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
 
   "frameworks": {

--- a/tools/MultiProjectValidator/MultiProjectValidator.xproj
+++ b/tools/MultiProjectValidator/MultiProjectValidator.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>08a68c6a-86f6-4ed2-89a7-b166d33e9f85</ProjectGuid>
     <RootNamespace>ProjectSanity</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\tools\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>


### PR DESCRIPTION
Updating tests to use the latest version of dotnet-test-xunit, which supports debugging from VS. Also updating our xproj files so that we can build the CLI from VS using the CLI.

cc @brthor @Sridhar-MS @piotrpMSFT 