### PR TITLE
Added output param to dotnet test

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -67,12 +67,14 @@ namespace Microsoft.DotNet.Cli.Utils
             string commandName, 
             IEnumerable<string> args, 
             NuGetFramework framework = null, 
-            string configuration = Constants.DefaultConfiguration)
+            string configuration = Constants.DefaultConfiguration,
+            string outputPath = null)
         {
             var commandSpec = CommandResolver.TryResolveCommandSpec(commandName, 
                 args, 
                 framework, 
-                configuration: configuration);
+                configuration: configuration,
+                outputPath: outputPath);
 
             if (commandSpec == null)
             {

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolver.cs
@@ -13,10 +13,15 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     internal static class CommandResolver
     {
-        public static CommandSpec TryResolveCommandSpec(string commandName, IEnumerable<string> args, NuGetFramework framework = null, string configuration=Constants.DefaultConfiguration)
+        public static CommandSpec TryResolveCommandSpec(
+            string commandName,
+            IEnumerable<string> args,
+            NuGetFramework framework = null,
+            string configuration = Constants.DefaultConfiguration,
+            string outputPath = null)
         {
             return ResolveFromRootedCommand(commandName, args) ??
-                   ResolveFromProjectDependencies(commandName, args, framework, configuration) ??
+                   ResolveFromProjectDependencies(commandName, args, framework, configuration, outputPath) ??
                    ResolveFromProjectTools(commandName, args) ??
                    ResolveFromAppBase(commandName, args) ??
                    ResolveFromPath(commandName, args);
@@ -67,10 +72,11 @@ namespace Microsoft.DotNet.Cli.Utils
         }
 
         public static CommandSpec ResolveFromProjectDependencies(
-            string commandName, 
-            IEnumerable<string> args, 
-            NuGetFramework framework, 
-            string configuration)
+            string commandName,
+            IEnumerable<string> args,
+            NuGetFramework framework,
+            string configuration,
+            string outputPath)
         {
             if (framework == null) return null;
 
@@ -82,7 +88,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
             if (commandPackage == null) return null;
 
-            var depsPath = projectContext.GetOutputPaths(configuration).RuntimeFiles.Deps;
+            var depsPath = projectContext.GetOutputPaths(configuration, outputPath: outputPath).RuntimeFiles.Deps;
 
             return ConfigureCommandFromPackage(commandName, args, commandPackage, projectContext, depsPath);
         }

--- a/src/Microsoft.DotNet.Cli.Utils/FixedPathCommandFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/FixedPathCommandFactory.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public class FixedPathCommandFactory : ICommandFactory
+    {
+        private readonly string _configuration;
+        private readonly string _outputPath;
+
+        public FixedPathCommandFactory(string configuration, string outputPath)
+        {
+            _configuration = configuration;
+            _outputPath = outputPath;
+        }
+
+        public ICommand Create(
+            string commandName,
+            IEnumerable<string> args,
+            NuGetFramework framework = null,
+            string configuration = Constants.DefaultConfiguration)
+        {
+            if (string.IsNullOrEmpty(configuration))
+            {
+                configuration = _configuration;
+            }
+
+            return Command.Create(commandName, args, framework, configuration, _outputPath);
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-test/TestRunners/TestRunner.cs
+++ b/src/dotnet/commands/dotnet-test/TestRunners/TestRunner.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Tools.Test
                 $"dotnet-{_testRunner}",
                 commandArgs,
                 new NuGetFramework("DNXCore", Version.Parse("5.0")),
-                Constants.DefaultConfiguration);
+                null);
         }
     }
 }

--- a/test/dotnet-test.UnitTests/GivenATestRunner.cs
+++ b/test/dotnet-test.UnitTests/GivenATestRunner.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                 $"dotnet-{_runner}",
                 _testRunnerArguments,
                 new NuGetFramework("DNXCore", Version.Parse("5.0")),
-                Constants.DefaultConfiguration)).Returns(_commandMock.Object).Verifiable();
+                null)).Returns(_commandMock.Object).Verifiable();
         }
 
         [Fact]


### PR DESCRIPTION
Added a command factory where you can fix the output parameters that will flow to the commands, like configuration, outputpath and in the future, framework, runtime and base path.

cc @piotrpMSFT @brthor @vijayrkn 