### PR TITLE
Search for package cache hash file in right directory

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/Resolution/PackageCacheCompilationAssemblyResolver.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/PackageCacheCompilationAssemblyResolver.cs
@@ -49,17 +49,16 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
                     throw new InvalidOperationException($"Invalid hash entry '{library.Hash}' for package '{library.PackageName}'");
                 }
 
-                var hashAlgorithm = library.Hash.Substring(0, hashSplitterPos);
-
-                var cacheHashPath = Path.Combine(_packageCacheDirectory, $"{library.PackageName}.{library.Version}.nupkg.{hashAlgorithm}");
-
-                if (_fileSystem.File.Exists(cacheHashPath) &&
-                    _fileSystem.File.ReadAllText(cacheHashPath) == library.Hash.Substring(hashSplitterPos + 1))
+                string packagePath;
+                if (ResolverUtils.TryResolvePackagePath(_fileSystem, library, _packageCacheDirectory, out packagePath))
                 {
-                    string packagePath;
-                    if (ResolverUtils.TryResolvePackagePath(_fileSystem, library, _packageCacheDirectory, out packagePath))
+                    var hashAlgorithm = library.Hash.Substring(0, hashSplitterPos);
+                    var cacheHashPath = Path.Combine(packagePath, $"{library.PackageName}.{library.Version}.nupkg.{hashAlgorithm}");
+
+                    if (_fileSystem.File.Exists(cacheHashPath) &&
+                        _fileSystem.File.ReadAllText(cacheHashPath) == library.Hash.Substring(hashSplitterPos + 1))
                     {
-                        assemblies.AddRange( ResolverUtils.ResolveFromPackagePath(_fileSystem, library, packagePath));
+                        assemblies.AddRange(ResolverUtils.ResolveFromPackagePath(_fileSystem, library, packagePath));
                         return true;
                     }
                 }

--- a/test/Microsoft.Extensions.DependencyModel.Tests/PackageCacheResolverTest.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/PackageCacheResolverTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var packagePath = Path.Combine(CachePath, F.DefaultPackageName, F.DefaultVersion);
             var fileSystem = FileSystemMockBuilder.Create()
                 .AddFile(
-                    Path.Combine(CachePath, $"{F.DefaultPackageName}.{F.DefaultVersion}.nupkg.{F.DefaultHashAlgoritm}"),
+                    Path.Combine(packagePath, $"{F.DefaultPackageName}.{F.DefaultVersion}.nupkg.{F.DefaultHashAlgoritm}"),
                     "WRONGHASH"
                 )
                 .AddFiles(packagePath, F.DefaultAssemblies)
@@ -77,7 +77,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var packagePath = Path.Combine(CachePath, F.DefaultPackageName, F.DefaultVersion);
             var fileSystem = FileSystemMockBuilder.Create()
                 .AddFile(
-                    Path.Combine(CachePath, $"{F.DefaultPackageName}.{F.DefaultVersion}.nupkg.{F.DefaultHashAlgoritm}"),
+                    Path.Combine(packagePath, $"{F.DefaultPackageName}.{F.DefaultVersion}.nupkg.{F.DefaultHashAlgoritm}"),
                     F.DefaultHashValue
                 )
                 .AddFiles(packagePath, F.TwoAssemblies)
@@ -101,7 +101,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var packagePath = Path.Combine(CachePath, F.DefaultPackageName, F.DefaultVersion);
             var fileSystem = FileSystemMockBuilder.Create()
                 .AddFile(
-                    Path.Combine(CachePath, $"{F.DefaultPackageName}.{F.DefaultVersion}.nupkg.{F.DefaultHashAlgoritm}"),
+                    Path.Combine(packagePath, $"{F.DefaultPackageName}.{F.DefaultVersion}.nupkg.{F.DefaultHashAlgoritm}"),
                     F.DefaultHashValue
                 )
                 .AddFiles(packagePath, F.DefaultAssemblyPath)


### PR DESCRIPTION
Searched in `DOTNET_PACKAGES_CACHE\hashfile` changed to `DOTNET_PACKAGES_CACHE\library\version\hashfile`

Targets https://github.com/dotnet/cli/issues/1669

@davidfowl @anurse 