### PR TITLE
Use projectcontext.TargetFramwork for dotnet test design time

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/FixedPathCommandFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/FixedPathCommandFactory.cs
@@ -8,11 +8,13 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class FixedPathCommandFactory : ICommandFactory
     {
+        private readonly NuGetFramework _nugetFramework;
         private readonly string _configuration;
         private readonly string _outputPath;
 
-        public FixedPathCommandFactory(string configuration, string outputPath)
+        public FixedPathCommandFactory(NuGetFramework nugetFramework, string configuration, string outputPath)
         {
+            _nugetFramework = nugetFramework;
             _configuration = configuration;
             _outputPath = outputPath;
         }
@@ -26,6 +28,11 @@ namespace Microsoft.DotNet.Cli.Utils
             if (string.IsNullOrEmpty(configuration))
             {
                 configuration = _configuration;
+            }
+
+            if (framework == null)
+            {
+                framework = _nugetFramework;
             }
 
             return Command.Create(commandName, args, framework, configuration, _outputPath);

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -159,7 +159,8 @@ namespace Microsoft.DotNet.Tools.Test
                 var messages = new TestMessagesCollection();
                 using (var dotnetTest = new DotnetTest(messages, assemblyUnderTest))
                 {
-                    var commandFactory = new FixedPathCommandFactory(configuration, outputPath);
+                    var commandFactory = 
+                        new FixedPathCommandFactory(projectContext.TargetFramework, configuration, outputPath);
                     var testRunnerFactory = new TestRunnerFactory(GetCommandName(testRunner), commandFactory);
 
                     dotnetTest

--- a/src/dotnet/commands/dotnet-test/TestRunners/TestRunner.cs
+++ b/src/dotnet/commands/dotnet-test/TestRunners/TestRunner.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Tools.Test
             return _commandFactory.Create(
                 $"dotnet-{_testRunner}",
                 commandArgs,
-                new NuGetFramework("DNXCore", Version.Parse("5.0")),
+                null,
                 null);
         }
     }

--- a/test/dotnet-test.UnitTests/GivenATestRunner.cs
+++ b/test/dotnet-test.UnitTests/GivenATestRunner.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
             _commandFactoryMock.Setup(c => c.Create(
                 $"dotnet-{_runner}",
                 _testRunnerArguments,
-                new NuGetFramework("DNXCore", Version.Parse("5.0")),
+                null,
                 null)).Returns(_commandMock.Object).Verifiable();
         }
 


### PR DESCRIPTION
We had a bug where the framework for design time runs of dotnet test was hard coded into dnxcore50. Moved some things around so that we will pack the target framework from the project context.

cc @piotrpMSFT 