### PR TITLE
Fix issue 1665: prevent sending null error message

### DIFF
--- a/src/dotnet/commands/dotnet-projectmodel-server/Messengers/CompilerOptionsMessenger.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Messengers/CompilerOptionsMessenger.cs
@@ -18,13 +18,13 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
                    Equals(local.CompilerOptions, remote.CompilerOptions);
         }
 
-        protected override object CreatePayload(ProjectContextSnapshot local)
+        protected override void SendPayload(ProjectContextSnapshot local, Action<object> send)
         {
-            return new CompilationOptionsMessage
+            send(new CompilationOptionsMessage
             {
                 Framework = local.TargetFramework.ToPayload(),
                 Options = local.CompilerOptions
-            };
+            });
         }
 
         protected override void SetValue(ProjectContextSnapshot local, ProjectContextSnapshot remote)

--- a/src/dotnet/commands/dotnet-projectmodel-server/Messengers/DependenciesMessenger.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Messengers/DependenciesMessenger.cs
@@ -22,14 +22,14 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
                    Enumerable.SequenceEqual(local.Dependencies, remote.Dependencies);
         }
 
-        protected override object CreatePayload(ProjectContextSnapshot local)
+        protected override void SendPayload(ProjectContextSnapshot local, Action<object> send)
         {
-            return new DependenciesMessage
+            send(new DependenciesMessage
             {
                 Framework = local.TargetFramework.ToPayload(),
                 RootDependency = local.RootDependency,
                 Dependencies = local.Dependencies
-            };
+            });
         }
 
         protected override void SetValue(ProjectContextSnapshot local, ProjectContextSnapshot remote)

--- a/src/dotnet/commands/dotnet-projectmodel-server/Messengers/DependencyDiagnosticsMessenger.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Messengers/DependencyDiagnosticsMessenger.cs
@@ -19,11 +19,11 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
                    Enumerable.SequenceEqual(local.DependencyDiagnostics, remote.DependencyDiagnostics);
         }
 
-        protected override object CreatePayload(ProjectContextSnapshot local)
+        protected override void SendPayload(ProjectContextSnapshot local, Action<object> send)
         {
-            return new DiagnosticsListMessage(
+            send(new DiagnosticsListMessage(
                 local.DependencyDiagnostics,
-                local.TargetFramework?.ToPayload());
+                local.TargetFramework?.ToPayload()));
         }
 
         protected override void SetValue(ProjectContextSnapshot local, ProjectContextSnapshot remote)

--- a/src/dotnet/commands/dotnet-projectmodel-server/Messengers/GlobalErrorMessenger.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Messengers/GlobalErrorMessenger.cs
@@ -16,9 +16,12 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
             return remote != null && Equals(local.GlobalErrorMessage, remote.GlobalErrorMessage);
         }
 
-        protected override object CreatePayload(ProjectSnapshot local)
+        protected override void SendPayload(ProjectSnapshot local, Action<object> send)
         {
-            return local.GlobalErrorMessage;
+            if (local.GlobalErrorMessage != null)
+            {
+                send(local.GlobalErrorMessage);
+            }
         }
 
         protected override void SetValue(ProjectSnapshot local, ProjectSnapshot remote)

--- a/src/dotnet/commands/dotnet-projectmodel-server/Messengers/Messenger.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Messengers/Messenger.cs
@@ -22,16 +22,13 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
         {
             if (!CheckDifference(local, remote))
             {
-                var payload = CreatePayload(local);
-
-                _transmit(MessageType, payload);
-
+                SendPayload(local, payload => _transmit(MessageType, payload));
                 SetValue(local, remote);
             }
         }
 
-        protected abstract void SetValue(T local, T remote);
-        protected abstract object CreatePayload(T local);
+        protected abstract void SetValue(T local, T remote);        
+        protected abstract void SendPayload(T local, Action<object> send);
         protected abstract bool CheckDifference(T local, T remote);
     }
 }

--- a/src/dotnet/commands/dotnet-projectmodel-server/Messengers/ProjectDiagnosticsMessenger.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Messengers/ProjectDiagnosticsMessenger.cs
@@ -19,9 +19,9 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
                    Enumerable.SequenceEqual(local.ProjectDiagnostics, remote.ProjectDiagnostics);
         }
 
-        protected override object CreatePayload(ProjectSnapshot local)
+        protected override void SendPayload(ProjectSnapshot local, Action<object> send)
         {
-            return new DiagnosticsListMessage(local.ProjectDiagnostics);
+            send(new DiagnosticsListMessage(local.ProjectDiagnostics));
         }
 
         protected override void SetValue(ProjectSnapshot local, ProjectSnapshot remote)

--- a/src/dotnet/commands/dotnet-projectmodel-server/Messengers/ProjectInformationMessenger.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Messengers/ProjectInformationMessenger.cs
@@ -20,15 +20,15 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
                    string.Equals(local.Project.Name, remote.Project.Name) &&
                    string.Equals(local.GlobalJsonPath, remote.GlobalJsonPath) &&
                    Enumerable.SequenceEqual(local.Project.GetTargetFrameworks().Select(f => f.FrameworkName),
-                                           remote.Project.GetTargetFrameworks().Select(f => f.FrameworkName)) &&
+                                            remote.Project.GetTargetFrameworks().Select(f => f.FrameworkName)) &&
                    Enumerable.SequenceEqual(local.Project.GetConfigurations(), remote.Project.GetConfigurations()) &&
                    Enumerable.SequenceEqual(local.Project.Commands, remote.Project.Commands) &&
                    Enumerable.SequenceEqual(local.ProjectSearchPaths, remote.ProjectSearchPaths);
         }
 
-        protected override object CreatePayload(ProjectSnapshot local)
+        protected override void SendPayload(ProjectSnapshot local, Action<object> send)
         {
-            return new ProjectInformationMessage(local.Project, local.GlobalJsonPath, local.ProjectSearchPaths);
+            send(new ProjectInformationMessage(local.Project, local.GlobalJsonPath, local.ProjectSearchPaths));
         }
 
         protected override void SetValue(ProjectSnapshot local, ProjectSnapshot remote)

--- a/src/dotnet/commands/dotnet-projectmodel-server/Messengers/ReferencesMessenger.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Messengers/ReferencesMessenger.cs
@@ -22,14 +22,14 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
                    Enumerable.SequenceEqual(local.ProjectReferences, remote.ProjectReferences);
         }
 
-        protected override object CreatePayload(ProjectContextSnapshot local)
+        protected override void SendPayload(ProjectContextSnapshot local, Action<object> send)
         {
-            return new ReferencesMessage
+            send(new ReferencesMessage
             {
                 Framework = local.TargetFramework.ToPayload(),
                 ProjectReferences = local.ProjectReferences,
                 FileReferences = local.FileReferences
-            };
+            });
         }
 
         protected override void SetValue(ProjectContextSnapshot local, ProjectContextSnapshot remote)

--- a/src/dotnet/commands/dotnet-projectmodel-server/Messengers/SourcesMessenger.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Messengers/SourcesMessenger.cs
@@ -20,14 +20,14 @@ namespace Microsoft.DotNet.ProjectModel.Server.Messengers
                    Enumerable.SequenceEqual(local.SourceFiles, remote.SourceFiles);
         }
 
-        protected override object CreatePayload(ProjectContextSnapshot local)
+        protected override void SendPayload(ProjectContextSnapshot local, Action<object> send)
         {
-            return new SourcesMessage
+            send(new SourcesMessage
             {
                 Framework = local.TargetFramework.ToPayload(),
                 Files = local.SourceFiles,
                 GeneratedFiles = new Dictionary<string, string>()
-            };
+            });
         }
 
         protected override void SetValue(ProjectContextSnapshot local, ProjectContextSnapshot remote)


### PR DESCRIPTION
When a global error message is removed, the corresponding property is set to `null`. The `GlobalErrorMessenger` then detects the changes. However a change from *existing* to *non-existing* shouldn't trigger payload send, otherwise it causes `ArgumentNullException`.

*Review guideline*

Most of the changes are reaction to the change of `Messenger` interface. The change fix the problem is in `GlobalErrorMessenger.cs`.

Address issue: #1665 