### PR TITLE
TestMessagesCollection with unbound BlockingQueue

### DIFF
--- a/src/dotnet/commands/dotnet-test/TestMessagesCollection.cs
+++ b/src/dotnet/commands/dotnet-test/TestMessagesCollection.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Tools.Test
 
         public TestMessagesCollection()
         {
-            _readQueue = new BlockingCollection<Message>(boundedCapacity: 1);
+            _readQueue = new BlockingCollection<Message>();
             _terminateWaitHandle = new ManualResetEventSlim();
         }
 


### PR DESCRIPTION
This fixes a race condition where if the runner takes to long to execute and we get two messages before the runner quits, we hit a blocking piece of code when trying to add new messages to the queue, which leads to a deadlock, where we need to finish the runner to process new messages but the runner won't quit because it is waiting for us to accept is other messages.

cc @piotrpMSFT @vijayrkn 