### PR TITLE
Adding a new SendWaitingCommand message to the test sinks

### DIFF
--- a/src/Microsoft.Extensions.Testing.Abstractions/ITestSink.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/ITestSink.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Extensions.Testing.Abstractions
 {
     public interface ITestSink
     {
+        void SendWaitingCommand();
+
         void SendTestCompleted();
     }
 }

--- a/src/Microsoft.Extensions.Testing.Abstractions/StreamingTestSink.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/StreamingTestSink.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 
 namespace Microsoft.Extensions.Testing.Abstractions
@@ -19,6 +20,14 @@ namespace Microsoft.Extensions.Testing.Abstractions
             Stream.Send(new Message
             {
                 MessageType = "TestRunner.TestCompleted"
+            });
+        }
+
+        public void SendWaitingCommand()
+        {
+            Stream.Send(new Message
+            {
+                MessageType = "TestRunner.WaitingCommand"
             });
         }
     }


### PR DESCRIPTION
Adding a new SendWaitingCommand message to the test sinks so that they can tell dotnet test that the runner is ready to receive commands.

cc @piotrpMSFT 