### PR TITLE
Modified the protocol to send a the list of tests to run in a message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,3 +277,6 @@ test/PackagedCommands/Consumers/*/project.json
 # Vim swp files
 *.swp
 *.*~
+
+# VS generated files
+launchSettings.json

--- a/src/Microsoft.DotNet.Cli.Utils/CollectionsExtensions.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CollectionsExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public static class CollectionsExtensions
+    {
+        public static IEnumerable<T> OrEmptyIfNull<T>(this IEnumerable<T> enumerable)
+        {
+            return enumerable == null
+                ? Enumerable.Empty<T>()
+                : enumerable;
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-test/DotnetTest.cs
+++ b/src/dotnet/commands/dotnet-test/DotnetTest.cs
@@ -20,6 +20,8 @@ namespace Microsoft.DotNet.Tools.Test
 
         public string PathToAssemblyUnderTest { get; }
 
+        public IEnumerable<string> TestsToRun { get; set; }
+
         public DotnetTest(ITestMessagesCollection messages, string pathToAssemblyUnderTest)
         {
             PathToAssemblyUnderTest = pathToAssemblyUnderTest;

--- a/src/dotnet/commands/dotnet-test/DotnetTestExtensions.cs
+++ b/src/dotnet/commands/dotnet-test/DotnetTestExtensions.cs
@@ -48,12 +48,14 @@ namespace Microsoft.DotNet.Tools.Test
 
         public static IDotnetTest AddTestRunnnersMessageHandlers(
             this IDotnetTest dotnetTest,
-            IReportingChannel adapterChannel)
+            IReportingChannel adapterChannel,
+            IReportingChannelFactory reportingChannelFactory)
         {
             dotnetTest.AddMessageHandler(new TestRunnerTestStartedMessageHandler(adapterChannel));
             dotnetTest.AddMessageHandler(new TestRunnerTestResultMessageHandler(adapterChannel));
             dotnetTest.AddMessageHandler(new TestRunnerTestFoundMessageHandler(adapterChannel));
             dotnetTest.AddMessageHandler(new TestRunnerTestCompletedMessageHandler(adapterChannel));
+            dotnetTest.AddMessageHandler(new TestRunnerWaitingCommandMessageHandler(reportingChannelFactory));
 
             return dotnetTest;
         }

--- a/src/dotnet/commands/dotnet-test/IDotnetTest.cs
+++ b/src/dotnet/commands/dotnet-test/IDotnetTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Tools.Test
 {
@@ -16,6 +17,8 @@ namespace Microsoft.DotNet.Tools.Test
         IDotnetTestMessageHandler TestSessionTerminateMessageHandler { set; }
 
         IDotnetTestMessageHandler UnknownMessageHandler { set; }
+
+        IEnumerable<string> TestsToRun { get; set; }
 
         void StartHandlingMessages();
 

--- a/src/dotnet/commands/dotnet-test/IReportingChannelFactory.cs
+++ b/src/dotnet/commands/dotnet-test/IReportingChannelFactory.cs
@@ -1,12 +1,16 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.DotNet.Tools.Test
 {
     public interface IReportingChannelFactory
     {
-        IReportingChannel CreateChannelWithAnyAvailablePort();
+        event EventHandler<IReportingChannel> TestRunnerChannelCreated;
 
-        IReportingChannel CreateChannelWithPort(int port);
+        IReportingChannel CreateTestRunnerChannel();
+
+        IReportingChannel CreateAdapterChannel(int port);
     }
 }

--- a/src/dotnet/commands/dotnet-test/MessageHandlers/GetTestRunnerProcessStartInfoMessageHandler.cs
+++ b/src/dotnet/commands/dotnet-test/MessageHandlers/GetTestRunnerProcessStartInfoMessageHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Test
 
         private void DoHandleMessage(IDotnetTest dotnetTest, Message message)
         {
-            var testRunnerChannel = _reportingChannelFactory.CreateChannelWithAnyAvailablePort();
+            var testRunnerChannel = _reportingChannelFactory.CreateTestRunnerChannel();
 
             dotnetTest.StartListeningTo(testRunnerChannel);
 
@@ -45,6 +45,8 @@ namespace Microsoft.DotNet.Tools.Test
 
             var testRunner = _testRunnerFactory.CreateTestRunner(
                 new RunTestsArgumentsBuilder(dotnetTest.PathToAssemblyUnderTest, testRunnerChannel.Port, message));
+
+            dotnetTest.TestsToRun = message.Payload?.ToObject<RunTestsMessage>().Tests;
 
             var processStartInfo = testRunner.GetProcessStartInfo();
 

--- a/src/dotnet/commands/dotnet-test/MessageHandlers/TestDiscoveryStartMessageHandler.cs
+++ b/src/dotnet/commands/dotnet-test/MessageHandlers/TestDiscoveryStartMessageHandler.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Cli.Tools.Test
 
             try
             {
-                var testRunnerChannel = _reportingChannelFactory.CreateChannelWithAnyAvailablePort();
+                var testRunnerChannel = _reportingChannelFactory.CreateTestRunnerChannel();
 
                 dotnetTest.StartListeningTo(testRunnerChannel);
 

--- a/src/dotnet/commands/dotnet-test/MessageHandlers/TestMessageTypes.cs
+++ b/src/dotnet/commands/dotnet-test/MessageHandlers/TestMessageTypes.cs
@@ -5,6 +5,8 @@ namespace Microsoft.DotNet.Tools.Test
 {
     public static class TestMessageTypes
     {
+        public const string TestRunnerExecute = "TestRunner.Execute";
+        public const string TestRunnerWaitingCommand = "TestRunner.WaitingCommand";
         public const string TestRunnerTestResult = "TestExecution.TestResult";
         public const string TestRunnerTestStarted = "TestExecution.TestStarted";
         public const string TestRunnerTestCompleted = "TestRunner.TestCompleted";

--- a/src/dotnet/commands/dotnet-test/MessageHandlers/TestRunnerWaitingCommandMessageHandler.cs
+++ b/src/dotnet/commands/dotnet-test/MessageHandlers/TestRunnerWaitingCommandMessageHandler.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Testing.Abstractions;
+using Newtonsoft.Json.Linq;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.Test
+{
+    public class TestRunnerWaitingCommandMessageHandler : IDotnetTestMessageHandler
+    {
+        private readonly IReportingChannelFactory _reportingChannelFactory;
+        private IReportingChannel _testRunnerChannel;
+
+        public TestRunnerWaitingCommandMessageHandler(IReportingChannelFactory reportingChannelFactory)
+        {
+            _reportingChannelFactory = reportingChannelFactory;
+
+            _reportingChannelFactory.TestRunnerChannelCreated += OnTestRunnerChannelCreated;
+        }
+
+        public DotnetTestState HandleMessage(IDotnetTest dotnetTest, Message message)
+        {
+            var nextState = DotnetTestState.NoOp;
+
+            if (CanHandleMessage(dotnetTest, message))
+            {
+                HandleMessage(dotnetTest);
+                nextState = DotnetTestState.TestExecutionSentTestRunnerProcessStartInfo;
+            }
+
+            return nextState;
+        }
+
+        private void HandleMessage(IDotnetTest dotnetTest)
+        {
+            if (_testRunnerChannel == null)
+            {
+                const string errorMessage =
+                    "A test runner channel hasn't been created for TestRunnerWaitingCommandMessageHandler";
+                throw new InvalidOperationException(errorMessage);
+            }
+
+            _testRunnerChannel.Send(new Message
+            {
+                MessageType = TestMessageTypes.TestRunnerExecute,
+                Payload = JToken.FromObject(new RunTestsMessage
+                {
+                    Tests = new List<string>(dotnetTest.TestsToRun.OrEmptyIfNull())
+                })
+            });
+        }
+
+        private void OnTestRunnerChannelCreated(object sender, IReportingChannel testRunnerChannel)
+        {
+            if (_testRunnerChannel != null)
+            {
+                const string errorMessage = "TestRunnerWaitingCommandMessageHandler already has a test runner channel";
+                throw new InvalidOperationException(errorMessage);
+            }
+
+            _testRunnerChannel = testRunnerChannel;
+        }
+
+        private static bool CanHandleMessage(IDotnetTest dotnetTest, Message message)
+        {
+            return dotnetTest.State == DotnetTestState.TestExecutionSentTestRunnerProcessStartInfo &&
+                message.MessageType == TestMessageTypes.TestRunnerWaitingCommand;
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Tools.Test
             string outputPath)
         {
             var reportingChannelFactory = new ReportingChannelFactory();
-            var adapterChannel = reportingChannelFactory.CreateChannelWithPort(port);
+            var adapterChannel = reportingChannelFactory.CreateAdapterChannel(port);
 
             try
             {
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.Tools.Test
                 var messages = new TestMessagesCollection();
                 using (var dotnetTest = new DotnetTest(messages, assemblyUnderTest))
                 {
-                    var commandFactory = 
+                    var commandFactory =
                         new FixedPathCommandFactory(projectContext.TargetFramework, configuration, outputPath);
                     var testRunnerFactory = new TestRunnerFactory(GetCommandName(testRunner), commandFactory);
 
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Tools.Test
                         .AddNonSpecificMessageHandlers(messages, adapterChannel)
                         .AddTestDiscoveryMessageHandlers(adapterChannel, reportingChannelFactory, testRunnerFactory)
                         .AddTestRunMessageHandlers(adapterChannel, reportingChannelFactory, testRunnerFactory)
-                        .AddTestRunnnersMessageHandlers(adapterChannel);
+                        .AddTestRunnnersMessageHandlers(adapterChannel, reportingChannelFactory);
 
                     dotnetTest.StartListeningTo(adapterChannel);
 

--- a/src/dotnet/commands/dotnet-test/ReportingChannelFactory.cs
+++ b/src/dotnet/commands/dotnet-test/ReportingChannelFactory.cs
@@ -1,16 +1,24 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.DotNet.Tools.Test
 {
     public class ReportingChannelFactory : IReportingChannelFactory
     {
-        public IReportingChannel CreateChannelWithAnyAvailablePort()
+        public event EventHandler<IReportingChannel> TestRunnerChannelCreated;
+
+        public IReportingChannel CreateTestRunnerChannel()
         {
-            return ReportingChannel.ListenOn(0);
+            var testRunnerChannel = ReportingChannel.ListenOn(0);
+
+            TestRunnerChannelCreated?.Invoke(this, testRunnerChannel);
+
+            return testRunnerChannel;
         }
 
-        public IReportingChannel CreateChannelWithPort(int port)
+        public IReportingChannel CreateAdapterChannel(int port)
         {
             return ReportingChannel.ListenOn(port);
         }

--- a/src/dotnet/commands/dotnet-test/TestRunners/RunTestsArgumentsBuilder.cs
+++ b/src/dotnet/commands/dotnet-test/TestRunners/RunTestsArgumentsBuilder.cs
@@ -26,18 +26,9 @@ namespace Microsoft.DotNet.Tools.Test
                 _assemblyUnderTest,
                 "--designtime",
                 "--port",
-                $"{_port}"
+                $"{_port}",
+                "--wait-command"
             };
-
-            var tests = _message.Payload?.ToObject<RunTestsMessage>().Tests;
-            if (tests != null)
-            {
-                foreach (var test in tests)
-                {
-                    commandArgs.Add("--test");
-                    commandArgs.Add(test);
-                }
-            }
 
             return commandArgs;
         }

--- a/test/dotnet-test.UnitTests/DotnetTestMessageScenario.cs
+++ b/test/dotnet-test.UnitTests/DotnetTestMessageScenario.cs
@@ -31,8 +31,11 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         {
             var reportingChannelFactoryMock = new Mock<IReportingChannelFactory>();
             reportingChannelFactoryMock
-                .Setup(r => r.CreateChannelWithAnyAvailablePort())
-                .Returns(TestRunnerChannelMock.Object);
+                .Setup(r => r.CreateTestRunnerChannel())
+                .Returns(TestRunnerChannelMock.Object)
+                .Raises(
+                    r => r.TestRunnerChannelCreated += null,
+                    reportingChannelFactoryMock.Object, TestRunnerChannelMock.Object);
 
             var commandFactoryMock = new Mock<ICommandFactory>();
 
@@ -56,7 +59,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                     .AddNonSpecificMessageHandlers(_messages, adapterChannel)
                     .AddTestDiscoveryMessageHandlers(adapterChannel, reportingChannelFactory, testRunnerFactory)
                     .AddTestRunMessageHandlers(adapterChannel, reportingChannelFactory, testRunnerFactory)
-                    .AddTestRunnnersMessageHandlers(adapterChannel);
+                    .AddTestRunnnersMessageHandlers(adapterChannel, reportingChannelFactory);
 
                 DotnetTestUnderTest.StartListeningTo(adapterChannel);
 

--- a/test/dotnet-test.UnitTests/GivenARunTestsArgumentsBuilder.cs
+++ b/test/dotnet-test.UnitTests/GivenARunTestsArgumentsBuilder.cs
@@ -32,10 +32,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                 "--designtime",
                 "--port",
                 $"{port}",
-                "--test",
-                "test1",
-                "--test",
-                "test2");
+                "--wait-command");
         }
     }
 }

--- a/test/dotnet-test.UnitTests/GivenATestDiscoveryStartMessageHandler.cs
+++ b/test/dotnet-test.UnitTests/GivenATestDiscoveryStartMessageHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
 
             _reportingChannelFactoryMock = new Mock<IReportingChannelFactory>();
             _reportingChannelFactoryMock.Setup(r =>
-                r.CreateChannelWithAnyAvailablePort()).Returns(_testRunnerChannelMock.Object);
+                r.CreateTestRunnerChannel()).Returns(_testRunnerChannelMock.Object);
 
             _testDiscoveryStartMessageHandler = new TestDiscoveryStartMessageHandler(
                 _testRunnerFactoryMock.Object,
@@ -131,7 +131,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                     _dotnetTestMock.Object,
                     _validMessage);
 
-            _reportingChannelFactoryMock.Verify(r => r.CreateChannelWithAnyAvailablePort(), Times.Once);
+            _reportingChannelFactoryMock.Verify(r => r.CreateTestRunnerChannel(), Times.Once);
         }
 
         [Fact]

--- a/test/dotnet-test.UnitTests/GivenATestRunnerWaitingCommandMessageHandler.cs
+++ b/test/dotnet-test.UnitTests/GivenATestRunnerWaitingCommandMessageHandler.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test;
+using Microsoft.Extensions.Testing.Abstractions;
+using Moq;
+using Xunit;
+using System.Linq;
+
+namespace Microsoft.Dotnet.Tools.Test.Tests
+{
+    public class GivenATestRunnerWaitingCommandMessageHandler
+    {
+        private Mock<IDotnetTest> _dotnetTestMock;
+        private Mock<IReportingChannel> _testRunnerChannelMock;
+        private Mock<IReportingChannelFactory> _reportingChannelFactory;
+        private List<string> _testsToRun;
+
+        private Message _validMessage;
+        private TestRunnerWaitingCommandMessageHandler _testRunnerWaitingCommandMessageHandler;
+
+        public GivenATestRunnerWaitingCommandMessageHandler()
+        {
+            _testsToRun = new List<string> { "test1", "test2" };
+            _dotnetTestMock = new Mock<IDotnetTest>();
+            _dotnetTestMock.Setup(d => d.State).Returns(DotnetTestState.TestExecutionSentTestRunnerProcessStartInfo);
+            _dotnetTestMock.Setup(d => d.TestsToRun).Returns(_testsToRun);
+
+            _validMessage = new Message
+            {
+                MessageType = TestMessageTypes.TestRunnerWaitingCommand
+            };
+
+            _testRunnerChannelMock = new Mock<IReportingChannel>();
+            _reportingChannelFactory = new Mock<IReportingChannelFactory>();
+
+            _testRunnerWaitingCommandMessageHandler =
+                new TestRunnerWaitingCommandMessageHandler(_reportingChannelFactory.Object);
+        }
+
+        [Fact]
+        public void It_returns_NoOp_if_the_dotnet_test_state_is_not_TestExecutionSentTestRunnerProcessStartInfo_or_TestExecutionTestStarted()
+        {
+            var dotnetTestMock = new Mock<IDotnetTest>();
+            dotnetTestMock.Setup(d => d.State).Returns(DotnetTestState.Terminated);
+
+            var nextState = _testRunnerWaitingCommandMessageHandler.HandleMessage(
+                dotnetTestMock.Object,
+                _validMessage);
+
+            nextState.Should().Be(DotnetTestState.NoOp);
+        }
+
+        [Fact]
+        public void It_returns_NoOp_if_the_message_is_not_TestRunnerWaitingCommand()
+        {
+            var nextState = _testRunnerWaitingCommandMessageHandler.HandleMessage(
+                _dotnetTestMock.Object,
+                new Message { MessageType = "Something different from TestRunner.WaitingCommand" });
+
+            nextState.Should().Be(DotnetTestState.NoOp);
+        }
+
+        [Fact]
+        public void It_returns_TestExecutionSentTestRunnerProcessStartInfo_when_it_handles_the_message()
+        {
+            _reportingChannelFactory.Raise(
+                r => r.TestRunnerChannelCreated += null,
+                _reportingChannelFactory.Object, _testRunnerChannelMock.Object);
+
+            var nextState = _testRunnerWaitingCommandMessageHandler.HandleMessage(
+                    _dotnetTestMock.Object,
+                    _validMessage);
+
+            nextState.Should().Be(DotnetTestState.TestExecutionSentTestRunnerProcessStartInfo);
+        }
+
+        [Fact]
+        public void It_sends_a_TestRunnerExecute_when_it_handles_the_message()
+        {
+            _reportingChannelFactory.Raise(
+                r => r.TestRunnerChannelCreated += null,
+                _reportingChannelFactory.Object, _testRunnerChannelMock.Object);
+
+            _testRunnerChannelMock
+                .Setup(a => a.Send(It.Is<Message>(m => m.MessageType == TestMessageTypes.TestRunnerExecute)))
+                .Verifiable();
+
+            _testRunnerWaitingCommandMessageHandler.HandleMessage(
+                    _dotnetTestMock.Object,
+                    _validMessage);
+
+            _testRunnerChannelMock.Verify();
+        }
+
+        [Fact]
+        public void It_sends_a_the_list_of_tests_to_run_when_it_handles_the_message()
+        {
+            _testRunnerChannelMock.Setup(a => a.Send(It.Is<Message>(m =>
+                m.MessageType == TestMessageTypes.TestRunnerExecute &&
+                m.Payload.ToObject<RunTestsMessage>().Tests.All(t => _testsToRun.Contains(t)) &&
+                m.Payload.ToObject<RunTestsMessage>().Tests.Count == _testsToRun.Count))).Verifiable();
+
+            _reportingChannelFactory.Raise(
+                r => r.TestRunnerChannelCreated += null,
+                _reportingChannelFactory.Object, _testRunnerChannelMock.Object);
+
+            _testRunnerWaitingCommandMessageHandler.HandleMessage(
+                    _dotnetTestMock.Object,
+                    _validMessage);
+
+            _testRunnerChannelMock.Verify();
+        }
+
+        [Fact]
+        public void It_throws_InvalidOperationException_when_a_second_test_runner_channel_gets_created()
+        {
+            _reportingChannelFactory.Raise(
+                r => r.TestRunnerChannelCreated += null,
+                _reportingChannelFactory.Object, _testRunnerChannelMock.Object);
+
+            Action action = () => _reportingChannelFactory.Raise(
+                r => r.TestRunnerChannelCreated += null,
+                _reportingChannelFactory.Object, _testRunnerChannelMock.Object);
+
+            const string errorMessage = "TestRunnerWaitingCommandMessageHandler already has a test runner channel";
+            action.ShouldThrow<InvalidOperationException>().WithMessage(errorMessage);
+        }
+
+        [Fact]
+        public void It_throws_InvalidOperationException_when_no_test_runner_channel_has_been_created()
+        {
+            Action action = () => _testRunnerWaitingCommandMessageHandler.HandleMessage(
+                    _dotnetTestMock.Object,
+                    _validMessage);
+
+            const string errorMessage =
+                    "A test runner channel hasn't been created for TestRunnerWaitingCommandMessageHandler";
+            action.ShouldThrow<InvalidOperationException>().WithMessage(errorMessage);
+        }
+    }
+}

--- a/test/dotnet-test.UnitTests/GivenThatWeWantToRunTests.cs
+++ b/test/dotnet-test.UnitTests/GivenThatWeWantToRunTests.cs
@@ -41,6 +41,18 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                     dotnetTestMessageScenario.DotnetTestUnderTest,
                     new Message
                     {
+                        MessageType = TestMessageTypes.TestRunnerWaitingCommand
+                    }))
+                .Verifiable();
+
+            dotnetTestMessageScenario.TestRunnerChannelMock
+                .Setup(a => a.Send(
+                    It.Is<Message>(m => m.MessageType == TestMessageTypes.TestRunnerExecute)))
+                .Callback(() => dotnetTestMessageScenario.TestRunnerChannelMock.Raise(
+                    t => t.MessageReceived += null,
+                    dotnetTestMessageScenario.DotnetTestUnderTest,
+                    new Message
+                    {
                         MessageType = TestMessageTypes.TestRunnerTestStarted
                     }))
                 .Verifiable();


### PR DESCRIPTION
Modified the protocol to send a the list of tests to run and to invoke the test runner with the wait command flag so that the runner waits for this list.

Modified the reporting channel factory to have a create for the adapter and a create for the runner channel. Also added an event to the create runner channel that people can listen and be notified when a test runner channel was created. I use this event to give the message handler access to the runner channel.

Added the new message handler to DotnetTest.

This is the dotnet side of the fix for https://github.com/dotnet/cli/issues/1685. I will have a PR for the runner as soon as we have a new package with the TestAbstractions changes that I merged earlier.

cc @piotrpMSFT @brthor @vijayrkn