### PR TITLE
Added InstallDir option for install.ps1.

### DIFF
--- a/scripts/obtain/install.ps1
+++ b/scripts/obtain/install.ps1
@@ -6,7 +6,8 @@
 param(
    [string]$Channel="dev",
    [string]$version="Latest",
-   [string]$Architecture="x64"
+   [string]$Architecture="x64",
+   [string]$InstallDir=$env:DOTNET_INSTALL_DIR
 )
 
 $ErrorActionPreference="Stop"
@@ -25,7 +26,6 @@ function say($str)
     Write-Host "dotnet_install: $str"
 }
 
-$InstallDir = $env:DOTNET_INSTALL_DIR
 if (!$InstallDir) {
     $InstallDir = "$env:LocalAppData\Microsoft\dotnet"
 }


### PR DESCRIPTION
This change brings the "-d" functionality of install.sh into install.ps1. It allows installing dotnetcli from a build script without having to change the environment. This is useful when developing platform independent build scripts using Cake for example. The existing functionality is unaffected, the new option is only used if set explicitly.