### PR TITLE
Cleanup equality / hash code implementations

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/AnalyzerOptions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/AnalyzerOptions.cs
@@ -1,9 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
 
 namespace Microsoft.DotNet.ProjectModel
 {
-    public class AnalyzerOptions
+    public sealed class AnalyzerOptions : IEquatable<AnalyzerOptions>
     {
         /// <summary>
         /// The identifier indicating the project language as defined by NuGet.
@@ -15,7 +16,7 @@ namespace Microsoft.DotNet.ProjectModel
 
         public static bool operator ==(AnalyzerOptions left, AnalyzerOptions right)
         {
-            return left.LanguageId == right.LanguageId;
+            return object.Equals(left, right);
         }
 
         public static bool operator !=(AnalyzerOptions left, AnalyzerOptions right)
@@ -25,18 +26,22 @@ namespace Microsoft.DotNet.ProjectModel
 
         public override bool Equals(object obj)
         {
-            if (obj == null)
+            return Equals(obj as AnalyzerOptions);
+        }
+
+        public bool Equals(AnalyzerOptions options)
+        {
+            if (options == null)
             {
                 return false;
             }
 
-            var options = obj as AnalyzerOptions;
-            return obj != null && (this == options);
+            return LanguageId == options.LanguageId;
         }
 
         public override int GetHashCode()
         {
-            return LanguageId.GetHashCode();
+            return LanguageId?.GetHashCode() ?? 0;
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/CommonCompilerOptions.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.ProjectModel
 {
-    public class CommonCompilerOptions
+    public sealed class CommonCompilerOptions : IEquatable<CommonCompilerOptions>
     {
         public IEnumerable<string> Defines { get; set; }
 
@@ -41,7 +42,11 @@ namespace Microsoft.DotNet.ProjectModel
 
         public override bool Equals(object obj)
         {
-            var other = obj as CommonCompilerOptions;
+            return Equals(obj as CommonCompilerOptions);
+        }
+
+        public bool Equals(CommonCompilerOptions other)
+        {
             return other != null &&
                    LanguageVersion == other.LanguageVersion &&
                    Platform == other.Platform &&
@@ -65,7 +70,17 @@ namespace Microsoft.DotNet.ProjectModel
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return
+                Hash.Combine(LanguageVersion ?? string.Empty,
+                Hash.Combine(Platform ?? string.Empty,
+                Hash.Combine(AllowUnsafe ?? false,
+                Hash.Combine(WarningsAsErrors ?? false,
+                Hash.Combine(Optimize ?? false,
+                Hash.Combine(KeyFile ?? string.Empty,
+                Hash.Combine(DelaySign ?? false,
+                Hash.Combine(PublicSign ?? false,
+                Hash.Combine(EmitEntryPoint ?? false,
+                Hash.Combine(GenerateXmlDocumentation ?? false, (PreserveCompilationContext ?? false).GetHashCode()))))))))));
         }
 
         private static IEnumerable<string> Combine(IEnumerable<string> @new, IEnumerable<string> old)

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryAsset.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryAsset.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Internal;
 
 namespace Microsoft.DotNet.ProjectModel.Compilation
 {
-    public struct LibraryAsset
+    public struct LibraryAsset : IEquatable<LibraryAsset>
     {
         public string Name { get; }
         public string RelativePath { get; }

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -3,6 +3,7 @@
     "compilationOptions": {
         "keyFile": "../../tools/Key.snk"
     },
+    "compile" : "../Shared/*.cs",
     "description": "Types to model a .NET Project",
     "dependencies": {
         "System.Reflection.Metadata": "1.2.0-rc2-23901",

--- a/src/Shared/Hash.cs
+++ b/src/Shared/Hash.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+
+namespace Microsoft.DotNet.Utilities
+{
+    internal static class Hash
+    {
+        internal static int Combine(int newKey, int currentKey)
+        {
+            return unchecked((currentKey * (int)0xA5555529) + newKey);
+        }
+
+        internal static int Combine(bool newKeyPart, int currentKey)
+        {
+            return Combine(currentKey, newKeyPart ? 1 : 0);
+        }
+
+        /// <summary>
+        /// PERF: Do not use with enum types because that involves multiple
+        /// unnecessary boxing operations.  Unfortunately, we can't constrain
+        /// T to "non-enum", so we'll use a more restrictive constraint.
+        /// </summary>
+        internal static int Combine<T>(T newKeyPart, int currentKey) where T : class
+        {
+            int hash = unchecked(currentKey * (int)0xA5555529);
+
+            if (newKeyPart != null)
+            {
+                return unchecked(hash + newKeyPart.GetHashCode());
+            }
+
+            return hash;
+        }
+
+        internal static int CombineValues<T>(IEnumerable<T> values, int maxItemsToHash = int.MaxValue)
+        {
+            if (values == null)
+            {
+                return 0;
+            }
+
+            var hashCode = 0;
+            var count = 0;
+            foreach (var value in values)
+            {
+                if (count++ >= maxItemsToHash)
+                {
+                    break;
+                }
+
+                // Should end up with a constrained virtual call to object.GetHashCode (i.e. avoid boxing where possible).
+                if (value != null)
+                {
+                    hashCode = Hash.Combine(value.GetHashCode(), hashCode);
+                }
+            }
+
+            return hashCode;
+        }
+
+        internal static int CombineValues<T>(T[] values, int maxItemsToHash = int.MaxValue)
+        {
+            if (values == null)
+            {
+                return 0;
+            }
+
+            var maxSize = Math.Min(maxItemsToHash, values.Length);
+            var hashCode = 0;
+
+            for (int i = 0; i < maxSize; i++)
+            {
+                T value = values[i];
+
+                // Should end up with a constrained virtual call to object.GetHashCode (i.e. avoid boxing where possible).
+                if (value != null)
+                {
+                    hashCode = Hash.Combine(value.GetHashCode(), hashCode);
+                }
+            }
+
+            return hashCode;
+        }
+
+        internal static int CombineValues(IEnumerable<string> values, StringComparer stringComparer, int maxItemsToHash = int.MaxValue)
+        {
+            if (values == null)
+            {
+                return 0;
+            }
+
+            var hashCode = 0;
+            var count = 0;
+            foreach (var value in values)
+            {
+                if (count++ >= maxItemsToHash)
+                {
+                    break;
+                }
+
+                if (value != null)
+                {
+                    hashCode = Hash.Combine(stringComparer.GetHashCode(value), hashCode);
+                }
+            }
+
+            return hashCode;
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-projectmodel-server/Models/DependencyItem.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Models/DependencyItem.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.ProjectModel.Server.Models
 {
-    public class DependencyItem
+    public sealed class DependencyItem : IEquatable<DependencyItem>
     {
         public string Name { get; set; }
 
@@ -11,17 +13,19 @@ namespace Microsoft.DotNet.ProjectModel.Server.Models
 
         public override bool Equals(object obj)
         {
-            var other = obj as DependencyItem;
+            return Equals(obj as DependencyItem);
+        }
+
+        public bool Equals(DependencyItem other)
+        {
             return other != null &&
                    string.Equals(Name, other.Name) &&
-                   object.Equals(Version, other.Version);
+                   string.Equals(Version, other.Version);
         }
 
         public override int GetHashCode()
         {
-            // These objects are currently POCOs and we're overriding equals
-            // so that things like Enumerable.SequenceEqual just work.
-            return base.GetHashCode();
+            return Hash.Combine((Name ?? string.Empty).GetHashCode(), (Version ?? string.Empty).GetHashCode());
         }
     }
 }

--- a/src/dotnet/commands/dotnet-projectmodel-server/Models/ErrorMessage.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Models/ErrorMessage.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Microsoft.DotNet.Utilities;
 
 namespace Microsoft.DotNet.ProjectModel.Server.Models
 {
-    public class ErrorMessage
+    public sealed class ErrorMessage : IEquatable<ErrorMessage>
     {
         public string Message { get; set; }
         public string Path { get; set; }
@@ -14,7 +15,11 @@ namespace Microsoft.DotNet.ProjectModel.Server.Models
 
         public override bool Equals(object obj)
         {
-            var payload = obj as ErrorMessage;
+            return Equals(obj as ErrorMessage);
+        }
+
+        public bool Equals(ErrorMessage payload)
+        {
             return payload != null &&
                    string.Equals(Message, payload.Message, StringComparison.Ordinal) &&
                    string.Equals(Path, payload.Path, StringComparison.OrdinalIgnoreCase) &&
@@ -24,7 +29,9 @@ namespace Microsoft.DotNet.ProjectModel.Server.Models
 
         public override int GetHashCode()
         {
-            return base.GetHashCode();
+            return
+                Hash.Combine(Message,
+                Hash.Combine(Line, Column));
         }
     }
 }

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -3,6 +3,7 @@
     "compilationOptions": {
         "emitEntryPoint": true
     },
+    "compile" : "../Shared/*.cs",
     "compileExclude": [ 
         "commands/dotnet-new/CSharp_Console/**", 
         "commands/dotnet-new/FSharp_Console/**" 

--- a/test/Microsoft.DotNet.ProjectModel.Tests/AnalyzerOptionsTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/AnalyzerOptionsTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.DotNet.Utilities;
+
+namespace Microsoft.DotNet.ProjectModel.Tests
+{
+    public class AnalyzerOptionsTests
+    {
+        [Fact]
+        public void Equality_Null()
+        {
+            EqualityUnit
+                .Create(new AnalyzerOptions())
+                .WithEqualValues(new AnalyzerOptions())
+                .WithNotEqualValues(new AnalyzerOptions() { LanguageId = "csharp"})
+                .RunAll(compEquality: (x, y) => x == y, compInequality: (x, y) => x != y);
+        }
+
+        [Fact]
+        public void Equality_Basic()
+        {
+            EqualityUnit
+                .Create(new AnalyzerOptions() { LanguageId = "csharp" })
+                .WithEqualValues(new AnalyzerOptions() { LanguageId = "csharp" })
+                .WithNotEqualValues(new AnalyzerOptions() { LanguageId = "vb" })
+                .RunAll(compEquality: (x, y) => x == y, compInequality: (x, y) => x != y);
+        }
+    }
+}

--- a/test/Microsoft.DotNet.ProjectModel.Tests/BuildActionTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/BuildActionTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.DotNet.Utilities;
+
+namespace Microsoft.DotNet.ProjectModel.Graph.Tests
+{
+    public class BuildActionTests
+    {
+        [Fact]
+        public void Equality()
+        {
+            EqualityUnit
+                .Create(BuildAction.Compile)
+                .WithEqualValues(BuildAction.Compile)
+                .WithNotEqualValues(BuildAction.Resource, BuildAction.EmbeddedResource)
+                .RunAll(compEquality: (x, y) => x == y, compInequality: (x, y) => x != y);
+        }
+    }
+}

--- a/test/Microsoft.DotNet.ProjectModel.Tests/CommonCompilerOptionsTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/CommonCompilerOptionsTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.DotNet.Utilities;
+
+namespace Microsoft.DotNet.ProjectModel.Tests
+{
+    public class CommonCompilerOptionsTests
+    {
+        [Fact]
+        public void Equality1()
+        {
+            EqualityUnit
+                .Create(new CommonCompilerOptions() { PublicSign = true })
+                .WithEqualValues(new CommonCompilerOptions() { PublicSign = true })
+                .WithNotEqualValues(new CommonCompilerOptions() { PublicSign = false })
+                .RunAll();
+        }
+
+        [Fact]
+        public void Equality_Defines()
+        {
+            EqualityUnit
+                .Create(new CommonCompilerOptions() { PublicSign = true, Defines = new[] { "a", "b" } })
+                .WithEqualValues(new CommonCompilerOptions() { PublicSign = true, Defines = new[] {"a", "b" } })
+                .WithNotEqualValues(
+                    new CommonCompilerOptions() { PublicSign = false },
+                    new CommonCompilerOptions() { PublicSign = true, Defines = new[] { "a" } },
+                    new CommonCompilerOptions() { PublicSign = true, Defines = new[] { "b", "a" } },
+                    new CommonCompilerOptions() { PublicSign = true, Defines = new[] { "A", "B" } })
+                .RunAll();
+        }
+    }
+}

--- a/test/Microsoft.DotNet.ProjectModel.Tests/LibraryAssetTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/LibraryAssetTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.DotNet.Utilities;
+
+namespace Microsoft.DotNet.ProjectModel.Compilation.Tests
+{
+    public class LibraryAssetTests
+    {
+        [Fact]
+        public void Equality()
+        {
+            EqualityUnit
+                .Create(new LibraryAsset("a", "b", "c", transform: null))
+                .WithEqualValues(
+                    new LibraryAsset("a", "b", "c", transform: null),
+                    new LibraryAsset("a", "b", "c", transform: (x, y) => { }))
+                .WithNotEqualValues(
+                    new LibraryAsset("A", "b", "c", transform: null),
+                    new LibraryAsset("a", "B", "c", transform: (x ,y) => { }),
+                    new LibraryAsset("a", "B", "C", transform: (x, y) => { }),
+                    new LibraryAsset(null, null, null, transform: (x, y) => { }))
+                .RunAll();
+        }
+    }
+}

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -1,5 +1,6 @@
 {
   "version": "1.0.0-*",
+  "compile" : "../Shared/*.cs",
   "dependencies": {
     "NETStandard.Library": "1.0.0-rc2-23901",
     "System.IO.Compression": "4.1.0-rc2-23901",

--- a/test/Shared/EqualityUtil.cs
+++ b/test/Shared/EqualityUtil.cs
@@ -1,0 +1,289 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.DotNet.Utilities
+{
+    public static class EqualityUnit
+    {
+        public static EqualityUnit<T> Create<T>(T value)
+        {
+            return new EqualityUnit<T>(value);
+        }
+    }
+
+    public sealed class EqualityUnit<T>
+    {
+        private static readonly ReadOnlyCollection<T> s_emptyCollection = new ReadOnlyCollection<T>(new T[] { });
+
+        public readonly T Value;
+        public readonly ReadOnlyCollection<T> EqualValues;
+        public readonly ReadOnlyCollection<T> NotEqualValues;
+        public IEnumerable<T> AllValues
+        {
+            get { return Enumerable.Repeat(Value, 1).Concat(EqualValues).Concat(NotEqualValues); }
+        }
+
+        public EqualityUnit(T value)
+        {
+            Value = value;
+            EqualValues = s_emptyCollection;
+            NotEqualValues = s_emptyCollection;
+        }
+
+        public EqualityUnit(
+            T value,
+            ReadOnlyCollection<T> equalValues,
+            ReadOnlyCollection<T> notEqualValues)
+        {
+            Value = value;
+            EqualValues = equalValues;
+            NotEqualValues = notEqualValues;
+        }
+
+        public EqualityUnit<T> WithEqualValues(params T[] equalValues)
+        {
+            return new EqualityUnit<T>(
+                Value,
+                EqualValues.Concat(equalValues).ToList().AsReadOnly(),
+                NotEqualValues);
+        }
+
+        public EqualityUnit<T> WithNotEqualValues(params T[] notEqualValues)
+        {
+            return new EqualityUnit<T>(
+                Value,
+                EqualValues,
+                NotEqualValues.Concat(notEqualValues).ToList().AsReadOnly());
+        }
+
+        public void RunAll(
+            bool checkIEquatable = true,
+            Func<T, T, bool> compEquality = null,
+            Func<T, T, bool> compInequality = null)
+        {
+            var util = new EqualityUtil<T>(new[] { this }, compEquality, compInequality);
+            util.RunAll(checkIEquatable);
+        }
+    }
+
+    /// <summary>
+    /// Base class which does a lot of the boiler plate work for testing that the equality pattern
+    /// is properly implemented in objects
+    /// </summary>
+    public sealed class EqualityUtil<T>
+    {
+        private readonly ReadOnlyCollection<EqualityUnit<T>> _equalityUnits;
+        private readonly Func<T, T, bool> _compareWithEqualityOperator;
+        private readonly Func<T, T, bool> _compareWithInequalityOperator;
+
+        public EqualityUtil(
+            IEnumerable<EqualityUnit<T>> equalityUnits,
+            Func<T, T, bool> compEquality = null,
+            Func<T, T, bool> compInequality = null)
+        {
+            _equalityUnits = equalityUnits.ToList().AsReadOnly();
+            _compareWithEqualityOperator = compEquality;
+            _compareWithInequalityOperator = compInequality;
+        }
+
+        public void RunAll(bool checkIEquatable = true)
+        {
+            if (_compareWithEqualityOperator != null)
+            {
+                EqualityOperator1();
+                EqualityOperator2();
+            }
+
+            if (_compareWithInequalityOperator != null)
+            {
+                InequalityOperator1();
+                InequalityOperator2();
+            }
+
+            if (checkIEquatable)
+            {
+                ImplementsIEquatable();
+            }
+
+            ObjectEquals1();
+            ObjectEquals2();
+            ObjectEquals3();
+            GetHashCode1();
+
+            if (checkIEquatable)
+            {
+                EquatableEquals1();
+                EquatableEquals2();
+            }
+        }
+
+        private void EqualityOperator1()
+        {
+            foreach (var unit in _equalityUnits)
+            {
+                foreach (var value in unit.EqualValues)
+                {
+                    Assert.True(_compareWithEqualityOperator(unit.Value, value));
+                    Assert.True(_compareWithEqualityOperator(value, unit.Value));
+                }
+
+                foreach (var value in unit.NotEqualValues)
+                {
+                    Assert.False(_compareWithEqualityOperator(unit.Value, value));
+                    Assert.False(_compareWithEqualityOperator(value, unit.Value));
+                }
+            }
+        }
+
+        private void EqualityOperator2()
+        {
+            if (typeof(T).GetTypeInfo().IsValueType)
+            {
+                return;
+            }
+
+            foreach (var value in _equalityUnits.SelectMany(x => x.AllValues))
+            {
+                Assert.False(_compareWithEqualityOperator(default(T), value));
+                Assert.False(_compareWithEqualityOperator(value, default(T)));
+            }
+        }
+
+        private void InequalityOperator1()
+        {
+            foreach (var unit in _equalityUnits)
+            {
+                foreach (var value in unit.EqualValues)
+                {
+                    Assert.False(_compareWithInequalityOperator(unit.Value, value));
+                    Assert.False(_compareWithInequalityOperator(value, unit.Value));
+                }
+
+                foreach (var value in unit.NotEqualValues)
+                {
+                    Assert.True(_compareWithInequalityOperator(unit.Value, value));
+                    Assert.True(_compareWithInequalityOperator(value, unit.Value));
+                }
+            }
+        }
+
+        private void InequalityOperator2()
+        {
+            if (typeof(T).GetTypeInfo().IsValueType)
+            {
+                return;
+            }
+
+            foreach (var value in _equalityUnits.SelectMany(x => x.AllValues))
+            {
+                Assert.True(_compareWithInequalityOperator(default(T), value));
+                Assert.True(_compareWithInequalityOperator(value, default(T)));
+            }
+        }
+
+        private void ImplementsIEquatable()
+        {
+            var type = typeof(T);
+            var targetType = typeof(IEquatable<T>);
+            Assert.True(type.GetTypeInfo().ImplementedInterfaces.Contains(targetType));
+        }
+
+        private void ObjectEquals1()
+        {
+            foreach (var unit in _equalityUnits)
+            {
+                var unitValue = unit.Value;
+                foreach (var value in unit.EqualValues)
+                {
+                    Assert.True(value.Equals(unitValue));
+                    Assert.True(unitValue.Equals(value));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Comparison with Null should be false for reference types
+        /// </summary>
+        private void ObjectEquals2()
+        {
+            if (typeof(T).GetTypeInfo().IsValueType)
+            {
+                return;
+            }
+
+            var allValues = _equalityUnits.SelectMany(x => x.AllValues);
+            foreach (var value in allValues)
+            {
+                Assert.NotNull(value);
+            }
+        }
+
+        /// <summary>
+        /// Passing a value of a different type should just return false
+        /// </summary>
+        private void ObjectEquals3()
+        {
+            var allValues = _equalityUnits.SelectMany(x => x.AllValues);
+            foreach (var value in allValues)
+            {
+                Assert.False(value.Equals((object)42));
+            }
+        }
+
+        private void GetHashCode1()
+        {
+            foreach (var unit in _equalityUnits)
+            {
+                foreach (var value in unit.EqualValues)
+                {
+                    Assert.Equal(value.GetHashCode(), unit.Value.GetHashCode());
+                }
+            }
+        }
+
+        private void EquatableEquals1()
+        {
+            foreach (var unit in _equalityUnits)
+            {
+                var equatableUnit = (IEquatable<T>)unit.Value;
+                foreach (var value in unit.EqualValues)
+                {
+                    Assert.True(equatableUnit.Equals(value));
+                    var equatableValue = (IEquatable<T>)value;
+                    Assert.True(equatableValue.Equals(unit.Value));
+                }
+
+                foreach (var value in unit.NotEqualValues)
+                {
+                    Assert.False(equatableUnit.Equals(value));
+                    var equatableValue = (IEquatable<T>)value;
+                    Assert.False(equatableValue.Equals(unit.Value));
+                }
+            }
+        }
+
+        /// <summary>
+        /// If T is a reference type, null should return false in all cases
+        /// </summary>
+        private void EquatableEquals2()
+        {
+            if (typeof(T).GetTypeInfo().IsValueType)
+            {
+                return;
+            }
+
+            foreach (var cur in _equalityUnits.SelectMany(x => x.AllValues))
+            {
+                var value = (IEquatable<T>)cur;
+                Assert.NotNull(value);
+            }
+        }
+    }
+}

--- a/test/dotnet-projectmodel-server.Tests/DependencyItemTests.cs
+++ b/test/dotnet-projectmodel-server.Tests/DependencyItemTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.DotNet.Utilities;
+
+namespace Microsoft.DotNet.ProjectModel.Server.Models.Tests
+{
+    public class DependencyItemTests
+    {
+        [Fact]
+        public void Equality_Name()
+        {
+            EqualityUnit
+                .Create(new DependencyItem() { Name = "bob" })
+                .WithEqualValues(
+                    new DependencyItem() { Name = "bob" },
+                    new DependencyItem() { Name = "bob", Version = null })
+                .WithNotEqualValues(
+                    new DependencyItem() { Name = "Bob" },
+                    new DependencyItem() { Name = "bob", Version = "" },
+                    new DependencyItem() { Name = "jim", Version = "" })
+                .RunAll();
+        }
+
+        [Fact]
+        public void Equality_Version()
+        {
+            EqualityUnit
+                .Create(new DependencyItem() { Version = "bob" })
+                .WithEqualValues(
+                    new DependencyItem() { Version = "bob" },
+                    new DependencyItem() { Version = "bob", Name = null })
+                .WithNotEqualValues(
+                    new DependencyItem() { Version = "bob", Name = "" },
+                    new DependencyItem() { Version = "jim", Name = "" })
+                .RunAll();
+        }
+
+        [Fact]
+        public void Equality_Both()
+        {
+            EqualityUnit
+                .Create(new DependencyItem() { Name = "bob", Version = "new" })
+                .WithEqualValues(
+                    new DependencyItem() { Name = "bob", Version = "new" })
+                .WithNotEqualValues(
+                    new DependencyItem() { Name = "bob", Version = "NEW" },
+                    new DependencyItem() { Name = "BOB", Version = "new" })
+                .RunAll();
+        }
+    }
+}

--- a/test/dotnet-projectmodel-server.Tests/ErrorMessageTest.cs
+++ b/test/dotnet-projectmodel-server.Tests/ErrorMessageTest.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.DotNet.Utilities;
+
+namespace Microsoft.DotNet.ProjectModel.Server.Models.Tests
+{
+    public class ErrorMessageTests
+    {
+        [Fact]
+        public void Equality_Message()
+        {
+            EqualityUnit
+                .Create(new ErrorMessage () { Name = "hello" })
+                .WithEqualValues(
+                    new ErrorMessage() { Name = "hello" },
+                    new ErrorMessage() { Name = "hello", Line = 0, Column = 0 })
+                .WithNotEqualValues(
+                    new ErrorMessage() { Name = "HELLO" },
+                    new ErrorMessage() { Name = "hello", Line = 1, Column = 0 })
+                .RunAll();
+        }
+
+        [Fact]
+        public void Equality_Span()
+        {
+            EqualityUnit
+                .Create(new ErrorMessage () { Line = 1, Column = 2 })
+                .WithEqualValues(
+                    new ErrorMessage() { Line = 1, Column = 2 },
+                    new ErrorMessage() { Line = 1, Column = 2, Name = null },
+                .WithNotEqualValues(
+                    new ErrorMessage() { Line = 2, Column = 2 },
+                    new ErrorMessage() { Line = 1, Column = 1 },
+                    new ErrorMessage() { Line = 1, Column = 2, Name = "hello" })
+                .RunAll();
+        }
+
+        [Fact]
+        public void Equality_Path()
+        {
+            EqualityUnit
+                .Create(new ErrorMessage () { Path = "file.txt" })
+                .WithEqualValues(
+                    new ErrorMessage() { Path = "file.txt" },
+                    new ErrorMessage() { Path = "FILE.txt" })
+                .WithNotEqualValues(
+                    new ErrorMessage() { Path = "FILE.txt", Name = "hello" })
+                .RunAll();
+        }
+    }
+}

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -1,4 +1,5 @@
 {
+  "compile" : "../Shared/*.cs",
   "dependencies": {
     "dotnet": { "target": "project" },
     "Microsoft.DotNet.ProjectModel": { "target": "project" },


### PR DESCRIPTION
A number of types in CLI had incorrectly implemented equality.  Typically by using object.GetHashCode for the hash value (reference based hashing) when value equality was desired.  The code today wasn't excercising the hashing semantics of the types hence we hadn't noticed.  Decided to clean it up anyways + add some tests.