### PR TITLE
Revert to full PDB on Windows as a default

### DIFF
--- a/src/dotnet/commands/dotnet-compile-csc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-csc/Program.cs
@@ -213,9 +213,18 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 commonArgs.Add("-t:library");
             }
 
-            commonArgs.Add((string.IsNullOrEmpty(options.DebugType) || options.DebugType == "portable")
-                ? "-debug:portable"
-                : "-debug:full");
+            if (string.IsNullOrEmpty(options.DebugType))
+            {
+                commonArgs.Add(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "-debug:full"
+                    : "-debug:portable");
+            }
+            else
+            {
+                commonArgs.Add(options.DebugType == "portable"
+                    ? "-debug:portable"
+                    : "-debug:full");
+            }
 
             return commonArgs;
         }


### PR DESCRIPTION
The change to default to Portable PDB by default has broken a number of downstream consumers.  Moving back to full PDBs by default on Windows.

This leaves the option for portable PDB in place.  Hence you can still enable it via the following entry in project.json:

``` json
"compilationOptions": {
    "debugType": "portable"
}
```