### PR TITLE
Add ability to specify `outputPath` when creating a `ProjectContext`s `AssemblyLoadContext`.

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel.Loader/LoaderProjectContextExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/LoaderProjectContextExtensions.cs
@@ -10,7 +10,10 @@ namespace Microsoft.DotNet.ProjectModel.Loader
 {
     public static class LoaderProjectContextExtensions
     {
-        public static AssemblyLoadContext CreateLoadContext(this ProjectContext context, string configuration = "Debug")
+        public static AssemblyLoadContext CreateLoadContext(
+            this ProjectContext context, 
+            string configuration = "Debug", 
+            string outputPath = null)
         {
             var exporter = context.CreateExporter(configuration);
             var assemblies = new Dictionary<AssemblyName, string>(AssemblyNameComparer.OrdinalIgnoreCase);
@@ -38,7 +41,7 @@ namespace Microsoft.DotNet.ProjectModel.Loader
                 dllImports,
 
                 // Add the project's output directory path to ensure project-to-project references get located
-                new[] { context.GetOutputPaths(configuration).CompilationOutputPath });
+                new[] { context.GetOutputPaths(configuration, outputPath: outputPath).CompilationOutputPath });
         }
 
         private class AssemblyNameComparer : IEqualityComparer<AssemblyName>


### PR DESCRIPTION
- Prior to this change `outputPath` would always default to `null` which didn't work well with `VisualStudio` tooling. The tooling enables the user to specify a project's `outputPath` but more importantly defaults the project's `outputPath` to the root directory (instead of the project directory).