### PR TITLE
Fix dependency context builder regression

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Extensions.DependencyModel
             var type = export.Library.Identity.Type;
 
             var serviceable = (export.Library as PackageDescription)?.Library.IsServiceable ?? false;
-            var libraryDependencies = new List<Dependency>();
+            var libraryDependencies = new HashSet<Dependency>();
 
             var libraryAssets = runtime ? export.RuntimeAssemblies : export.CompilationAssemblies;
 

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextBuilderTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextBuilderTests.cs
@@ -135,6 +135,34 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             asm.Assemblies.Should().OnlyContain(l => l.Path == "System.Collections.dll");
         }
 
+        [Fact]
+        public void FiltersDuplicatedDependencies()
+        {
+            var context = Build(runtimeExports: new[]
+              {
+                Export(PackageDescription("Pack.Age",
+                    dependencies: new[]
+                    {
+                        new LibraryRange("System.Collections",
+                            new VersionRange(new NuGetVersion(2, 0, 0)),
+                            LibraryType.ReferenceAssembly,
+                            LibraryDependencyType.Default),
+                        new LibraryRange("System.Collections",
+                            new VersionRange(new NuGetVersion(2, 1, 2)),
+                            LibraryType.Package,
+                            LibraryDependencyType.Default)
+                    })
+                    ),
+                Export(ReferenceAssemblyDescription("System.Collections",
+                    version: new NuGetVersion(2, 0, 0)))
+            });
+
+            context.RuntimeLibraries.Should().HaveCount(2);
+
+            var lib = context.RuntimeLibraries.Should().Contain(l => l.Name == "Pack.Age").Subject;
+            lib.Dependencies.Should().HaveCount(1);
+            lib.Dependencies.Should().OnlyContain(l => l.Name == "System.Collections" && l.Version == "2.0.0");
+        }
 
         [Fact]
         public void FillsCompileLibraryProperties()


### PR DESCRIPTION
Fix regression in dependency builder when having multiple dependencies with same name.
@anurse 