### PR TITLE
Add installer scripts for the shared framework/host, incorporate into build

### DIFF
--- a/packaging/host/debian/dotnet-sharedhost-debian_config.json
+++ b/packaging/host/debian/dotnet-sharedhost-debian_config.json
@@ -1,0 +1,35 @@
+{
+    "maintainer_name":"Microsoft",
+    "maintainer_email": "dotnetcore@microsoft.com",
+
+    "package_name": "dotnet-host",
+    "install_root": "/usr/share/dotnet",
+
+    "short_description": ".NET Core Shared Host",
+    "long_description": ".NET Core is a cross-platform implementation of .NET Framework, a modern, modular platform\n for building diverse kinds of applications, from command-line applications to microservices and \n modern websites.\n This package contains the host that launches a .NET Core application.",
+    "homepage": "https://dotnet.github.io/core",
+
+    "release":{
+        "package_version":"1.0.0.0",
+        "package_revision":"1",
+        "urgency" : "low",
+        "changelog_message" : "Inital shared host."
+    },
+
+    "control": {
+        "priority":"standard",
+        "section":"libs",
+        "architecture":"amd64"
+    },
+
+    "copyright": "2015 Microsoft",
+    "license": {
+        "type": "MIT",
+        "full_text": "Copyright (c) 2015 Microsoft\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+    },
+
+    "debian_dependencies":{
+        "libssl-dev" : {},
+        "libcurl3" : {}
+    }
+}

--- a/packaging/host/windows/generatemsi.ps1
+++ b/packaging/host/windows/generatemsi.ps1
@@ -1,0 +1,109 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+param(
+    [Parameter(Mandatory=$true)][string]$SharedHostPublishRoot,
+    [Parameter(Mandatory=$true)][string]$DotnetHostMSIOutput,
+    [Parameter(Mandatory=$true)][string]$WixRoot,
+    [Parameter(Mandatory=$true)][string]$DotnetMSIVersion,
+    [Parameter(Mandatory=$true)][string]$DotnetCLIVersion,
+    [Parameter(Mandatory=$true)][string]$Architecture,
+    [Parameter(Mandatory=$true)][string]$WixObjRoot
+)
+
+. "$PSScriptRoot\..\..\..\scripts\common\_common.ps1"
+$RepoRoot = Convert-Path "$PSScriptRoot\..\..\.."
+
+function RunCandle
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Host Running candle..
+    $AuthWsxRoot =  Join-Path $RepoRoot "packaging\host\windows"
+
+    .\candle.exe -nologo `
+        -out "$WixObjRoot\" `
+        -ext WixDependencyExtension.dll `
+        -dHostSrc="$SharedHostPublishRoot" `
+        -dMicrosoftEula="$RepoRoot\packaging\osx\resources\en.lproj\eula.rtf" `
+        -dBuildVersion="$DotnetMSIVersion" `
+        -dDisplayVersion="$DotnetCLIVersion" `
+        -arch $Architecture `
+        "$AuthWsxRoot\host.wxs" `
+        "$AuthWsxRoot\provider.wxs" `
+        "$AuthWsxRoot\registrykeys.wxs" | Out-Host        
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Host "Candle failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+function RunLight
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Host Running light..
+
+    .\light.exe -nologo `
+        -ext WixUIExtension.dll `
+        -ext WixDependencyExtension.dll `
+        -ext WixUtilExtension.dll `
+        -cultures:en-us `
+        "$WixObjRoot\host.wixobj" `
+        "$WixObjRoot\provider.wixobj" `
+        "$WixObjRoot\registrykeys.wixobj" `
+        -out $DotnetHostMSIOutput | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Host "Light failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+if(!(Test-Path $SharedHostPublishRoot))
+{
+    throw "$SharedHostPublishRoot not found"
+}
+
+if(!(Test-Path $WixObjRoot))
+{
+    throw "$WixObjRoot not found"
+}
+
+Write-Host "Creating shared host MSI at $DotnetHostMSIOutput"
+
+if([string]::IsNullOrEmpty($WixRoot))
+{
+    Exit -1
+}
+
+if(-Not (RunCandle))
+{
+    Exit -1
+}
+
+if(-Not (RunLight))
+{
+    Exit -1
+}
+
+if(!(Test-Path $DotnetHostMSIOutput))
+{
+    throw "Unable to create the shared host msi."
+    Exit -1
+}
+
+Write-Host -ForegroundColor Green "Successfully created shared host MSI - $DotnetHostMSIOutput"
+
+exit $LastExitCode

--- a/packaging/host/windows/host.wxs
+++ b/packaging/host/windows/host.wxs
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <?include "Variables.wxi" ?>
+    <Product Id="*" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
+        <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
+
+        <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
+
+        <MediaTemplate CompressionLevel="high" EmbedCab="yes" />
+
+        <Feature Id="MainFeature" Title="Main Feature" Level="1">
+            <ComponentGroupRef Id="InstallFiles" />
+            <ComponentGroupRef Id="AuthoredRegistryKeys"/>
+        </Feature>
+        <Feature Id="Provider" Absent="disallow" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" Level="1" InstallDefault="local" Title="RefCounting" TypicalDefault="install">
+            <ComponentRef Id="Dotnet_CLI_SharedHost_$(var.Dotnet_DisplayVersion)" />
+        </Feature>
+        <Property Id="ProductCPU" Value="$(var.Platform)" />
+        <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />
+
+        <Property Id="MSIFASTINSTALL" Value="7" />
+
+        <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
+
+        <Property Id="WIXUI_INSTALLDIR" Value="DOTNETHOME"/>
+        <UIRef Id="WixUI_InstallDir" />
+
+        <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+    </Product>
+    <Fragment>
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="$(var.Program_Files)">
+                <Directory Id="DOTNETHOME" Name="dotnet"/>
+            </Directory>
+        </Directory>
+    </Fragment>
+    <Fragment>
+        <ComponentGroup Id="InstallFiles">
+            <Component Id="cmpCoreHost" Directory="DOTNETHOME" Guid="{45399BBB-DDA5-4386-A2E9-618FB3C54A18}">
+                <File Id="fileCoreHostExe" KeyPath="yes" Source="$(var.HostSrc)\dotnet.exe" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/packaging/host/windows/provider.wxs
+++ b/packaging/host/windows/provider.wxs
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
+  <?include "Variables.wxi" ?>
+  <Fragment>
+    <Component Id="Dotnet_CLI_SharedHost_$(var.Dotnet_DisplayVersion)" Directory="TARGETDIR" Win64="no" Guid="82516259-FF21-446E-A432-1FFCA5A02296">
+      <dep:Provides Key="Dotnet_CLI_SharedHost_$(var.Dotnet_DisplayVersion)" />
+    </Component>
+  </Fragment>
+</Wix>

--- a/packaging/host/windows/registrykeys.wxs
+++ b/packaging/host/windows/registrykeys.wxs
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?include "Variables.wxi" ?>
+  <Fragment>
+    <ComponentGroup Id="AuthoredRegistryKeys">
+      <?if $(var.Platform) = x64?>
+      <Component Id="SetupRegistry_x64" Directory="TARGETDIR" Win64="yes">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\sharedhost\Setup">
+          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
+          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
+          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.Dotnet_ProductVersion)" />
+        </RegistryKey>
+      </Component>
+      <?endif?>
+
+      <?if $(var.Platform) = x64?>
+      <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Win64="no">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\sharedhost\Setup">
+          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
+          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
+          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.Dotnet_ProductVersion)" />
+        </RegistryKey>
+      </Component>
+      <?endif?>
+
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/packaging/host/windows/variables.wxi
+++ b/packaging/host/windows/variables.wxi
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
+
+  <?define Servicing_Key_SP   =   "0" ?>
+  <?define Servicing_Key_SPIndex   =   "0" ?>
+  <?define Servicing_Key_SPName   =   "Beta" ?>
+  <?define Dotnet_ProductVersion   =   "$(var.BuildVersion)" ?>
+  <?define Dotnet_DisplayVersion   =   "$(var.DisplayVersion)" ?>
+  <?define Dotnet_BuildVersion   =   "$(var.BuildVersion)" ?>
+  <?define Manufacturer     =   "Microsoft Corporation" ?>
+  <?define ProductName      =   "Microsoft .NET Core Host for Windows ($(var.DisplayVersion))" ?>
+  <?define ProductLanguage  =   "1033" ?>
+  <?define ProductVersion   =   "$(var.Dotnet_ProductVersion)" ?>
+  <?define LCID  = "$(var.ProductLanguage)"?>
+  <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
+
+  <?define Platform   =   "$(sys.BUILDARCH)" ?>
+  <?if $(var.Platform)=x86?>
+  <?define Program_Files="ProgramFilesFolder"?>
+  <?define Win64AttributeValue=no?>
+  <?define UpgradeCode="66EBF603-F032-4595-B914-10CC99BBED86"?>
+  <?elseif $(var.Platform)=x64?>
+  <?define Program_Files="ProgramFiles64Folder"?>
+  <?define Win64AttributeValue=yes?>
+  <?define UpgradeCode="4553594B-D821-40E0-9A54-9697B13E344C"?>
+  <?else?>
+  <?error Invalid Platform ($(var.Platform))?>
+  <?endif?>
+</Include>

--- a/packaging/osx/sharedframework/scripts/postinstall
+++ b/packaging/osx/sharedframework/scripts/postinstall
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+PACKAGE=$1
+INSTALL_DESTINATION=$2
+
+# A temporary fix for the permissions issue(s)
+chmod -R 755 $INSTALL_DESTINATION/shared
+
+exit 0

--- a/packaging/osx/sharedframework/shared-framework-distribution-template.xml
+++ b/packaging/osx/sharedframework/shared-framework-distribution-template.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<installer-gui-script minSpecVersion="1">
+    <title>.NET Core Shared Framework ({SharedFrameworkNugetVersion})</title>
+    <license file="eula.rtf" mime-type="application/rtf" />
+    <background file="dotnetbackground.png" mime-type="image/png"/>
+    <options customize="never" require-scripts="false" />
+    <volume-check>
+        <allowed-os-version>
+            <os-version min="10.10" />
+        </allowed-os-version>
+    </volume-check>
+    <choices-outline>
+        <line choice="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg" />
+        <line choice="com.microsoft.dotnet.sharedhost.osx.x64" />
+    </choices-outline>
+    <choice id="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg" visible="true" title=".NET Core Shared Framework (x64)" description="The .NET Core Shared Framework">
+        <pkg-ref id="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg" />
+    </choice>
+    <choice id="com.microsoft.dotnet.sharedhost.osx.x64" visible="true" title=".NET Core Shared Host (x64)" description="The .NET Core Shared Host." >
+        <pkg-ref id="com.microsoft.dotnet.sharedhost.osx.x64" />
+    </choice>
+    <pkg-ref id="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg">com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg</pkg-ref>
+    <pkg-ref id="com.microsoft.dotnet.sharedhost.osx.x64">com.microsoft.dotnet.sharedhost.osx.x64.pkg</pkg-ref>
+</installer-gui-script>

--- a/packaging/osx/sharedframework/shared-framework-distribution-template.xml
+++ b/packaging/osx/sharedframework/shared-framework-distribution-template.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <installer-gui-script minSpecVersion="1">
-    <title>.NET Core Shared Framework ({SharedFrameworkNugetVersion})</title>
+    <title>.NET Core Shared Framework ({SharedFrameworkNugetName} {SharedFrameworkNugetVersion})</title>
     <license file="eula.rtf" mime-type="application/rtf" />
     <background file="dotnetbackground.png" mime-type="image/png"/>
     <options customize="never" require-scripts="false" />
@@ -10,15 +10,15 @@
         </allowed-os-version>
     </volume-check>
     <choices-outline>
-        <line choice="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg" />
+        <line choice="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetName}.{SharedFrameworkNugetVersion}.component.osx.x64.pkg" />
         <line choice="com.microsoft.dotnet.sharedhost.osx.x64" />
     </choices-outline>
-    <choice id="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg" visible="true" title=".NET Core Shared Framework (x64)" description="The .NET Core Shared Framework">
-        <pkg-ref id="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg" />
+    <choice id="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetName}.{SharedFrameworkNugetVersion}.component.osx.x64.pkg" visible="true" title=".NET Core Shared Framework (x64)" description="The .NET Core Shared Framework">
+        <pkg-ref id="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetName}.{SharedFrameworkNugetVersion}.component.osx.x64.pkg" />
     </choice>
     <choice id="com.microsoft.dotnet.sharedhost.osx.x64" visible="true" title=".NET Core Shared Host (x64)" description="The .NET Core Shared Host." >
         <pkg-ref id="com.microsoft.dotnet.sharedhost.osx.x64" />
     </choice>
-    <pkg-ref id="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg">com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetVersion}.component.osx.x64.pkg</pkg-ref>
+    <pkg-ref id="com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetName}.{SharedFrameworkNugetVersion}.component.osx.x64.pkg">com.microsoft.dotnet.sharedframework.{SharedFrameworkNugetName}.{SharedFrameworkNugetVersion}.component.osx.x64.pkg</pkg-ref>
     <pkg-ref id="com.microsoft.dotnet.sharedhost.osx.x64">com.microsoft.dotnet.sharedhost.osx.x64.pkg</pkg-ref>
 </installer-gui-script>

--- a/packaging/osx/sharedhost/scripts/postinstall
+++ b/packaging/osx/sharedhost/scripts/postinstall
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+PACKAGE=$1
+INSTALL_DESTINATION=$2
+
+# A temporary fix for the permissions issue(s)
+chmod 755 $INSTALL_DESTINATION/dotnet
+
+exit 0

--- a/packaging/sharedframework/debian/dotnet-sharedframework-debian_config.json
+++ b/packaging/sharedframework/debian/dotnet-sharedframework-debian_config.json
@@ -1,0 +1,35 @@
+{
+    "maintainer_name":"Microsoft",
+    "maintainer_email": "dotnetcore@microsoft.com",
+
+    "package_name": "%SHARED_FRAMEWORK_DEBIAN_PACKAGE_NAME%",
+    "install_root": "/usr/share/dotnet",
+
+    "short_description": ".NET Core Shared Framework %SHARED_FRAMEWORK_NUGET_NAME% %SHARED_FRAMEWORK_NUGET_VERSION%",
+    "long_description": ".NET Core is a cross-platform implementation of .NET Framework, a modern, modular platform\n for building diverse kinds of applications, from command-line applications to microservices and \n modern websites.\n This package contains a runtime and framework which can be used by .NET Core applications.",
+    "homepage": "https://dotnet.github.io/core",
+
+    "release":{
+        "package_version":"1.0.0.0",
+        "package_revision":"1",
+        "urgency" : "low",
+        "changelog_message" : "Inital shared framework."
+    },
+
+    "control": {
+        "priority":"standard",
+        "section":"libs",
+        "architecture":"amd64"
+    },
+
+    "copyright": "2015 Microsoft",
+    "license": {
+        "type": "MIT",
+        "full_text": "Copyright (c) 2015 Microsoft\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
+    },
+
+    "debian_dependencies":{
+        "libssl-dev" : {},
+        "libcurl3" : {}
+    }
+}

--- a/packaging/sharedframework/debian/dotnet-sharedframework-debian_config.json
+++ b/packaging/sharedframework/debian/dotnet-sharedframework-debian_config.json
@@ -29,7 +29,7 @@
     },
 
     "debian_dependencies":{
-        "libssl-dev" : {},
+        "libssl1.0.0" : {},
         "libcurl3" : {}
     }
 }

--- a/packaging/sharedframework/windows/generatemsi.ps1
+++ b/packaging/sharedframework/windows/generatemsi.ps1
@@ -1,0 +1,151 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+param(
+    [Parameter(Mandatory=$true)][string]$SharedFrameworkPublishRoot,
+    [Parameter(Mandatory=$true)][string]$SharedFrameworkMSIOutput,
+    [Parameter(Mandatory=$true)][string]$WixRoot,
+    [Parameter(Mandatory=$true)][string]$DotnetMSIVersion,
+    [Parameter(Mandatory=$true)][string]$SharedFrameworkNugetName,
+    [Parameter(Mandatory=$true)][string]$SharedFrameworkNugetVersion,
+    [Parameter(Mandatory=$true)][string]$SharedFrameworkUpgradeCode,
+    [Parameter(Mandatory=$true)][string]$Architecture,
+    [Parameter(Mandatory=$true)][string]$WixObjRoot
+)
+
+. "$PSScriptRoot\..\..\..\scripts\common\_common.ps1"
+$RepoRoot = Convert-Path "$PSScriptRoot\..\..\.."
+
+$InstallFileswsx = "$WixObjRoot\install-files.wxs"
+$InstallFilesWixobj = "$WixObjRoot\install-files.wixobj"
+
+
+function RunHeat
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Host Running heat..
+
+    .\heat.exe dir `"$SharedFrameworkPublishRoot`" `
+    -nologo `
+    -template fragment `
+    -sreg -gg `
+    -var var.SharedFrameworkSource `
+    -cg InstallFiles `
+    -srd `
+    -dr DOTNETHOME `
+    -out $InstallFileswsx | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Host "Heat failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+function RunCandle
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Host Running candle..
+    $AuthWsxRoot = Join-Path $RepoRoot "packaging\sharedframework\windows"
+    $SharedFrameworkComponentVersion = $SharedFrameworkNugetVersion.Replace('-', '_');
+
+    .\candle.exe -nologo `
+        -out "$WixObjRoot\" `
+        -dSharedFrameworkSource="$SharedFrameworkPublishRoot" `
+        -dMicrosoftEula="$RepoRoot\packaging\osx\resources\en.lproj\eula.rtf" `
+        -dFrameworkName="$SharedFrameworkNugetName" `
+        -dFrameworkDisplayVersion="$SharedFrameworkNugetVersion" `
+        -dFrameworkComponentVersion="$SharedFrameworkComponentVersion" `
+        -dFrameworkUpgradeCode="$SharedFrameworkUpgradeCode" `
+        -dBuildVersion="$DotnetMSIVersion" `
+        -arch $Architecture `
+        -ext WixDependencyExtension.dll `
+        "$AuthWsxRoot\sharedframework.wxs" `
+        "$AuthWsxRoot\provider.wxs" `
+        "$AuthWsxRoot\registrykeys.wxs" `
+        $InstallFileswsx | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Host "Candle failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+function RunLight
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Host Running light..
+    $CabCache = Join-Path $WixRoot "cabcache"
+
+    .\light.exe -nologo -ext WixUIExtension -ext WixDependencyExtension -ext WixUtilExtension `
+        -cultures:en-us `
+        "$WixObjRoot\sharedframework.wixobj" `
+        "$WixObjRoot\provider.wixobj" `
+        "$WixObjRoot\registrykeys.wixobj" `
+        "$InstallFilesWixobj" `
+        -out $SharedFrameworkMSIOutput | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Host "Light failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+if(!(Test-Path $SharedFrameworkPublishRoot))
+{
+    throw "$SharedHostPublishRoot not found"
+}
+
+if(!(Test-Path $WixObjRoot))
+{
+    throw "$WixObjRoot not found"
+}
+
+Write-Host "Creating dotnet shared framework MSI at $SharedFrameworkMSIOutput"
+
+if([string]::IsNullOrEmpty($WixRoot))
+{
+    Exit -1
+}
+
+if(-Not (RunHeat))
+{
+    Exit -1
+}
+
+if(-Not (RunCandle))
+{
+    Exit -1
+}
+
+if(-Not (RunLight))
+{
+    Exit -1
+}
+
+if(!(Test-Path $SharedFrameworkMSIOutput))
+{
+    throw "Unable to create the dotnet shared framework msi."
+    Exit -1
+}
+
+Write-Host -ForegroundColor Green "Successfully created shared framework MSI - $SharedFrameworkMSIOutput"
+
+exit $LastExitCode

--- a/packaging/sharedframework/windows/provider.wxs
+++ b/packaging/sharedframework/windows/provider.wxs
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
+  <?include "Variables.wxi" ?>
+  <Fragment>
+    <Component Id="DotNet_CLI_SharedFramework_$(var.FrameworkName)_$(var.FrameworkComponentVersion)" Directory="TARGETDIR" Win64="no" Guid="F47B3A4D-7CEB-4F18-8464-0F6C5978E08E">
+      <dep:Provides Key="DotNet.CLI.SharedFramework.$(var.FrameworkName)_$(var.FrameworkComponentVersion)" />
+    </Component>
+  </Fragment>
+</Wix>

--- a/packaging/sharedframework/windows/registrykeys.wxs
+++ b/packaging/sharedframework/windows/registrykeys.wxs
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?include "Variables.wxi" ?>
+  <Fragment>
+    <ComponentGroup Id="AuthoredRegistryKeys">
+      <?if $(var.Platform) = x64?>
+      <Component Id="SetupRegistry_x64" Directory="TARGETDIR" Win64="yes">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\sharedframework\$(var.FrameworkName) $(var.FrameworkDisplayVersion)\Setup">
+          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
+          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[SHAREDFRAMEWORKHOME]" />
+          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.FrameworkDisplayVersion)" />
+        </RegistryKey>
+      </Component>
+      <?endif?>
+
+      <?if $(var.Platform) = x86?>
+      <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Win64="no">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\sharedframework\$(var.FrameworkName) $(var.FrameworkDisplayVersion)\Setup">
+          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
+          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[SHAREDFRAMEWORKHOME]" />
+          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.FrameworkDisplayVersion)" />
+        </RegistryKey>
+      </Component>
+      <?endif?>
+
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/packaging/sharedframework/windows/sharedframework.wxs
+++ b/packaging/sharedframework/windows/sharedframework.wxs
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <?include "Variables.wxi" ?>
+    <Product Id="*" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
+        <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
+
+        <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
+
+        <MediaTemplate CompressionLevel="high" EmbedCab="yes"/>
+
+        <Feature Id="MainFeature" Title="Main Feature" Level="1">
+            <ComponentGroupRef Id="InstallFiles" />
+            <ComponentGroupRef Id="AuthoredRegistryKeys"/>
+        </Feature>
+        <Feature Id="Provider" Absent="disallow" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" Level="1" InstallDefault="local" Title="RefCounting" TypicalDefault="install">
+            <ComponentRef Id="DotNet_CLI_SharedFramework_$(var.FrameworkName)_$(var.FrameworkComponentVersion)" />
+        </Feature>
+
+        <Property Id="MSIFASTINSTALL" Value="7" />
+
+        <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
+
+        <Property Id="WIXUI_INSTALLDIR" Value="DOTNETHOME"/>
+        <UIRef Id="WixUI_InstallDir" />
+
+        <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+    </Product>
+    <Fragment>
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="$(var.Program_Files)">
+                <Directory Id="DOTNETHOME" Name="dotnet" />
+            </Directory>
+        </Directory>
+    </Fragment>
+</Wix>

--- a/packaging/sharedframework/windows/variables.wxi
+++ b/packaging/sharedframework/windows/variables.wxi
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
+
+  <?define Servicing_Key_SP   =   "0" ?>
+  <?define Servicing_Key_SPIndex   =   "0" ?>
+  <?define Servicing_Key_SPName   =   "Beta" ?>
+  <?define Manufacturer     =   "Microsoft Corporation" ?>
+  <?define ProductName      =   "Microsoft .NET Core Shared Framework ($(var.FrameworkName) $(var.FrameworkDisplayVersion))" ?>
+  <?define ProductLanguage  =   "1033" ?>
+  <?define ProductVersion   =   "$(var.BuildVersion)" ?>
+  <?define LCID  = "$(var.ProductLanguage)"?>
+  <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
+
+  <?define Platform   =   "$(sys.BUILDARCH)" ?>
+
+  <!--
+    The provided upgrade code already between x86 and x64
+    (since it is a GUID based on a string which includes the architecture)
+  -->
+  <?define UpgradeCode="$(var.FrameworkUpgradeCode)"?>
+
+  <?if $(var.Platform)=x86?>
+  <?define Program_Files="ProgramFilesFolder"?>
+  <?define Win64AttributeValue=no?>
+  <?elseif $(var.Platform)=x64?>
+  <?define Program_Files="ProgramFiles64Folder"?>
+  <?define Win64AttributeValue=yes?>
+  <?else?>
+  <?error Invalid Platform ($(var.Platform))?>
+  <?endif?>
+</Include>

--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -293,40 +293,12 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             // Find crossgen
-            string arch = PlatformServices.Default.Runtime.RuntimeArchitecture;
-            string packageId;
-            if (CurrentPlatform.IsWindows)
-            {
-                packageId = $"runtime.win7-{arch}.Microsoft.NETCore.Runtime.CoreCLR";
-            }
-            else if (CurrentPlatform.IsUbuntu)
-            {
-                packageId = "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR";
-            }
-            else if (CurrentPlatform.IsCentOS || CurrentPlatform.IsRHEL)
-            {
-                // CentOS runtime is in the runtime.rhel.7-x64... package.
-                packageId = "runtime.rhel.7-x64.Microsoft.NETCore.Runtime.CoreCLR";
-            }
-            else if (CurrentPlatform.IsDebian)
-            {
-                packageId = "runtime.debian.8.2-x64.Microsoft.NETCore.Runtime.CoreCLR";
-            }
-            else if (CurrentPlatform.IsOSX)
-            {
-                packageId = "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR";
-            }
-            else
+            var crossGenExePath = Microsoft.DotNet.Cli.Build.Crossgen.GetCrossgenPathForVersion(CoreCLRVersion);
+
+            if (string.IsNullOrEmpty(crossGenExePath))
             {
                 return c.Failed("Unsupported OS Platform");
             }
-
-            var crossGenExePath = Path.Combine(
-                Dirs.NuGetPackages,
-                packageId,
-                CoreCLRVersion,
-                "tools",
-                $"crossgen{Constants.ExeSuffix}");
 
             // We have to copy crossgen next to mscorlib
             var crossgen = Path.Combine(outputDir, $"crossgen{Constants.ExeSuffix}");

--- a/scripts/dotnet-cli-build/InstallerTargets.cs
+++ b/scripts/dotnet-cli-build/InstallerTargets.cs
@@ -104,6 +104,26 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult GenerateSharedFrameworkDeb(BuildTargetContext c)
         {
+            var packageName = Monikers.GetDebianSharedFrameworkPackageName(c);
+            var version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
+            var inputRoot = c.BuildContext.Get<string>("SharedFrameworkPublishRoot");
+            var debFile = c.BuildContext.Get<string>("SharedFrameworkInstallerFile");
+            var objRoot = Path.Combine(Dirs.Output, "obj", "debian", "sharedframework");
+
+            if (Directory.Exists(objRoot))
+            {
+                Directory.Delete(objRoot, true);
+            }
+
+            Directory.CreateDirectory(objRoot);
+
+            Cmd(Path.Combine(Dirs.RepoRoot, "scripts", "package", "package-sharedframework-debian.sh"),
+                    "--input", inputRoot, "--output", debFile, "--package-name", packageName,
+                    "--framework-nuget-name", SharedFrameworkTargets.SharedFrameworkName,
+                    "--framework-nuget-version", c.BuildContext.Get<string>("SharedFrameworkNugetVersion"),
+                    "--obj-root", objRoot, "--version", version)
+                    .Execute()
+                    .EnsureSuccessful();
             return c.Success();
         }
 

--- a/scripts/dotnet-cli-build/InstallerTargets.cs
+++ b/scripts/dotnet-cli-build/InstallerTargets.cs
@@ -97,6 +97,22 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult GenerateSharedHostDeb(BuildTargetContext c)
         {
+            var version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
+            var inputRoot = c.BuildContext.Get<string>("SharedHostPublishRoot");
+            var debFile = c.BuildContext.Get<string>("SharedHostInstallerFile");
+            var objRoot = Path.Combine(Dirs.Output, "obj", "debian", "sharedhost");
+
+            if (Directory.Exists(objRoot))
+            {
+                Directory.Delete(objRoot, true);
+            }
+
+            Directory.CreateDirectory(objRoot);
+
+            Cmd(Path.Combine(Dirs.RepoRoot, "scripts", "package", "package-sharedhost-debian.sh"),
+                    "--input", inputRoot, "--output", debFile, "--obj-root", objRoot, "--version", version)
+                    .Execute()
+                    .EnsureSuccessful();
             return c.Success();
         }
 
@@ -126,6 +142,5 @@ namespace Microsoft.DotNet.Cli.Build
                     .EnsureSuccessful();
             return c.Success();
         }
-
     }
 }

--- a/scripts/dotnet-cli-build/InstallerTargets.cs
+++ b/scripts/dotnet-cli-build/InstallerTargets.cs
@@ -14,45 +14,9 @@ namespace Microsoft.DotNet.Cli.Build
     {
         [Target(nameof(MsiTargets.GenerateMsis),
         nameof(MsiTargets.GenerateBundle),
-        nameof(InstallerTargets.GeneratePkgs),
+        nameof(PkgTargets.GeneratePkgs),
         nameof(InstallerTargets.GenerateDebs))]
         public static BuildTargetResult GenerateInstaller(BuildTargetContext c)
-        {
-            return c.Success();
-        }
-
-        [Target(nameof(InstallerTargets.GenerateSdkPkg),
-        nameof(InstallerTargets.GenerateSharedFrameworkPkg),
-        nameof(InstallerTargets.GenerateSharedHostPkg))]
-        [BuildPlatforms(BuildPlatform.OSX)]
-        public static BuildTargetResult GeneratePkgs(BuildTargetContext c)
-        {
-            return c.Success();
-        }
-
-        [Target]
-        [BuildPlatforms(BuildPlatform.OSX)]
-        public static BuildTargetResult GenerateSdkPkg(BuildTargetContext c)
-        {
-            var version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
-            var pkg = c.BuildContext.Get<string>("SdkInstallerFile");
-            Cmd(Path.Combine(Dirs.RepoRoot, "packaging", "osx", "package-osx.sh"),
-                    "-v", version, "-i", Dirs.Stage2, "-o", pkg)
-                    .Execute()
-                    .EnsureSuccessful();
-            return c.Success();
-        }
-
-        [Target]
-        [BuildPlatforms(BuildPlatform.OSX)]
-        public static BuildTargetResult GenerateSharedFrameworkPkg(BuildTargetContext c)
-        {
-            return c.Success();
-        }
-
-        [Target]
-        [BuildPlatforms(BuildPlatform.OSX)]
-        public static BuildTargetResult GenerateSharedHostPkg(BuildTargetContext c)
         {
             return c.Success();
         }

--- a/scripts/dotnet-cli-build/InstallerTargets.cs
+++ b/scripts/dotnet-cli-build/InstallerTargets.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli.Build
         public static BuildTargetResult GeneratePkg(BuildTargetContext c)
         {
             var version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
-            var pkg = c.BuildContext.Get<string>("InstallerFile");
+            var pkg = c.BuildContext.Get<string>("SdkInstallerFile");
             Cmd(Path.Combine(Dirs.RepoRoot, "packaging", "osx", "package-osx.sh"),
                     "-v", version, "-i", Dirs.Stage2, "-o", pkg)
                     .Execute()
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli.Build
             var channel = c.BuildContext.Get<string>("Channel").ToLower();
             var packageName = Monikers.GetDebianPackageName(c);
             var version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
-            var debFile = c.BuildContext.Get<string>("InstallerFile");
+            var debFile = c.BuildContext.Get<string>("SdkInstallerFile");
             var manPagesDir = Path.Combine(Dirs.RepoRoot, "Documentation", "manpages");
             var previousVersionURL = $"https://dotnetcli.blob.core.windows.net/dotnet/{channel}/Installers/Latest/dotnet-ubuntu-x64.latest.deb";
 

--- a/scripts/dotnet-cli-build/InstallerTargets.cs
+++ b/scripts/dotnet-cli-build/InstallerTargets.cs
@@ -77,8 +77,17 @@ namespace Microsoft.DotNet.Cli.Build
             var manPagesDir = Path.Combine(Dirs.RepoRoot, "Documentation", "manpages");
             var previousVersionURL = $"https://dotnetcli.blob.core.windows.net/dotnet/{channel}/Installers/Latest/dotnet-ubuntu-x64.latest.deb";
 
+            var objRoot = Path.Combine(Dirs.Output, "obj", "debian", "sdk");
+
+            if (Directory.Exists(objRoot))
+            {
+                Directory.Delete(objRoot, true);
+            }
+
+            Directory.CreateDirectory(objRoot);
+
             Cmd(Path.Combine(Dirs.RepoRoot, "scripts", "package", "package-debian.sh"),
-                "-v", version, "-i", Dirs.Stage2, "-o", debFile, "-p", packageName, "-m", manPagesDir, "--previous-version-url", previousVersionURL)
+                "-v", version, "-i", Dirs.Stage2, "-o", debFile, "-p", packageName, "-m", manPagesDir, "--previous-version-url", previousVersionURL, "--obj-root", objRoot)
                     .Execute()
                     .EnsureSuccessful();
             return c.Success();

--- a/scripts/dotnet-cli-build/InstallerTargets.cs
+++ b/scripts/dotnet-cli-build/InstallerTargets.cs
@@ -14,18 +14,25 @@ namespace Microsoft.DotNet.Cli.Build
     {
         [Target(nameof(MsiTargets.GenerateMsis),
         nameof(MsiTargets.GenerateBundle),
-        nameof(InstallerTargets.GeneratePkg),
-        nameof(InstallerTargets.GenerateDeb))]
+        nameof(InstallerTargets.GeneratePkgs),
+        nameof(InstallerTargets.GenerateDebs))]
         public static BuildTargetResult GenerateInstaller(BuildTargetContext c)
         {
             return c.Success();
         }
 
-
+        [Target(nameof(InstallerTargets.GenerateSdkPkg),
+        nameof(InstallerTargets.GenerateSharedFrameworkPkg),
+        nameof(InstallerTargets.GenerateSharedHostPkg))]
+        [BuildPlatforms(BuildPlatform.OSX)]
+        public static BuildTargetResult GeneratePkgs(BuildTargetContext c)
+        {
+            return c.Success();
+        }
 
         [Target]
         [BuildPlatforms(BuildPlatform.OSX)]
-        public static BuildTargetResult GeneratePkg(BuildTargetContext c)
+        public static BuildTargetResult GenerateSdkPkg(BuildTargetContext c)
         {
             var version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
             var pkg = c.BuildContext.Get<string>("SdkInstallerFile");
@@ -37,8 +44,31 @@ namespace Microsoft.DotNet.Cli.Build
         }
 
         [Target]
+        [BuildPlatforms(BuildPlatform.OSX)]
+        public static BuildTargetResult GenerateSharedFrameworkPkg(BuildTargetContext c)
+        {
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.OSX)]
+        public static BuildTargetResult GenerateSharedHostPkg(BuildTargetContext c)
+        {
+            return c.Success();
+        }
+
+        [Target(nameof(InstallerTargets.GenerateSdkDeb),
+        nameof(InstallerTargets.GenerateSharedFrameworkDeb),
+        nameof(InstallerTargets.GenerateSharedHostDeb))]
         [BuildPlatforms(BuildPlatform.Ubuntu)]
-        public static BuildTargetResult GenerateDeb(BuildTargetContext c)
+        public static BuildTargetResult GenerateDebs(BuildTargetContext c)
+        {
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
+        public static BuildTargetResult GenerateSdkDeb(BuildTargetContext c)
         {
             var channel = c.BuildContext.Get<string>("Channel").ToLower();
             var packageName = Monikers.GetDebianPackageName(c);
@@ -53,5 +83,20 @@ namespace Microsoft.DotNet.Cli.Build
                     .EnsureSuccessful();
             return c.Success();
         }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
+        public static BuildTargetResult GenerateSharedHostDeb(BuildTargetContext c)
+        {
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
+        public static BuildTargetResult GenerateSharedFrameworkDeb(BuildTargetContext c)
+        {
+            return c.Success();
+        }
+
     }
 }

--- a/scripts/dotnet-cli-build/MsiTargets.cs
+++ b/scripts/dotnet-cli-build/MsiTargets.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Cli.Build
             return c.Success();
         }
 
-        [Target(nameof(SharedFrameworkTargets.PublishSharedHost))]
+        [Target]
         [BuildPlatforms(BuildPlatform.Windows)]
         public static BuildTargetResult GenerateDotnetSharedHostMsi(BuildTargetContext c)
         {
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Cli.Build
             return c.Success();
         }
 
-        [Target(nameof(SharedFrameworkTargets.PublishSharedFramework))]
+        [Target]
         [BuildPlatforms(BuildPlatform.Windows)]
         public static BuildTargetResult GenerateDotnetSharedFrameworkMsi(BuildTargetContext c)
         {

--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -68,16 +68,10 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Unix)]
         public static BuildTargetResult GenerateTarBall(BuildTargetContext c)
         {
-            var tarFile = c.BuildContext.Get<string>("SdkCompressedFile");
+            CreateTarBallFromDirectory(c.BuildContext.Get<string>("SharedHostPublishRoot"), c.BuildContext.Get<string>("SharedHostCompressedFile"));
+            CreateTarBallFromDirectory(c.BuildContext.Get<string>("SharedFrameworkPublishRoot"), c.BuildContext.Get<string>("SharedFrameworkCompressedFile"));
+            CreateTarBallFromDirectory(Dirs.Stage2, c.BuildContext.Get<string>("SdkCompressedFile"));
 
-            if (File.Exists(tarFile))
-            {
-                File.Delete(tarFile);
-            }
-
-            Cmd("tar", "-czf", tarFile, "-C", Dirs.Stage2, ".")
-                .Execute()
-                .EnsureSuccessful();
             return c.Success();
         }
 
@@ -141,6 +135,18 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             ZipFile.CreateFromDirectory(directory, artifactPath, CompressionLevel.Optimal, false);
+        }
+
+        private static void CreateTarBallFromDirectory(string directory, string artifactPath)
+        {
+            if (File.Exists(artifactPath))
+            {
+                File.Delete(artifactPath);
+            }
+
+            Cmd("tar", "-czf", artifactPath, "-C", directory, ".")
+                .Execute()
+                .EnsureSuccessful();
         }
     }
 }

--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -22,6 +22,8 @@ namespace Microsoft.DotNet.Cli.Build
         [Target(nameof(PrepareTargets.Init),
         nameof(PackageTargets.InitPackage),
         nameof(PackageTargets.GenerateVersionBadge),
+        nameof(SharedFrameworkTargets.PublishSharedHost),
+        nameof(SharedFrameworkTargets.PublishSharedFramework),
         nameof(PackageTargets.GenerateCompressedFile),
         nameof(InstallerTargets.GenerateInstaller),
         nameof(PackageTargets.GenerateNugetPackages))]
@@ -55,14 +57,10 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Windows)]
         public static BuildTargetResult GenerateZip(BuildTargetContext c)
         {
-            var zipFile = c.BuildContext.Get<string>("SdkCompressedFile");
+            CreateZipFromDirectory(c.BuildContext.Get<string>("SharedHostPublishRoot"), c.BuildContext.Get<string>("SharedHostCompressedFile"));
+            CreateZipFromDirectory(c.BuildContext.Get<string>("SharedFrameworkPublishRoot"), c.BuildContext.Get<string>("SharedFrameworkCompressedFile"));
+            CreateZipFromDirectory(Dirs.Stage2, c.BuildContext.Get<string>("SdkCompressedFile"));
 
-            if (File.Exists(zipFile))
-            {
-                File.Delete(zipFile);
-            }
-
-            ZipFile.CreateFromDirectory(Dirs.Stage2, zipFile, CompressionLevel.Optimal, false);
             return c.Success();
         }
 
@@ -133,6 +131,16 @@ namespace Microsoft.DotNet.Cli.Build
             };
 
             return env;
+        }
+
+        private static void CreateZipFromDirectory(string directory, string artifactPath)
+        {
+            if (File.Exists(artifactPath))
+            {
+                File.Delete(artifactPath);
+            }
+
+            ZipFile.CreateFromDirectory(directory, artifactPath, CompressionLevel.Optimal, false);
         }
     }
 }

--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Windows)]
         public static BuildTargetResult GenerateZip(BuildTargetContext c)
         {
-            var zipFile = c.BuildContext.Get<string>("CompressedFile");
+            var zipFile = c.BuildContext.Get<string>("SdkCompressedFile");
 
             if (File.Exists(zipFile))
             {
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Unix)]
         public static BuildTargetResult GenerateTarBall(BuildTargetContext c)
         {
-            var tarFile = c.BuildContext.Get<string>("CompressedFile");
+            var tarFile = c.BuildContext.Get<string>("SdkCompressedFile");
 
             if (File.Exists(tarFile))
             {

--- a/scripts/dotnet-cli-build/PkgTargets.cs
+++ b/scripts/dotnet-cli-build/PkgTargets.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.Extensions.PlatformAbstractions;
+
+using static Microsoft.DotNet.Cli.Build.Framework.BuildHelpers;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class PkgTargets
+    {
+        [Target(nameof(GenerateSdkProductArchive), nameof(GenerateSharedFrameworkProductArchive))]
+        [BuildPlatforms(BuildPlatform.OSX)]
+        public static BuildTargetResult GeneratePkgs(BuildTargetContext c)
+        {
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.OSX)]
+        public static BuildTargetResult GenerateSdkProductArchive(BuildTargetContext c)
+        {
+            var version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
+            var pkg = c.BuildContext.Get<string>("SdkInstallerFile");
+
+            Cmd(Path.Combine(Dirs.RepoRoot, "packaging", "osx", "package-osx.sh"),
+                    "-v", version, "-i", Dirs.Stage2, "-o", pkg)
+                    .Execute()
+                    .EnsureSuccessful();
+            return c.Success();
+        }
+
+        [Target(nameof(GenerateSharedFrameworkPkg), nameof(GenerateSharedHostPkg))]
+        [BuildPlatforms(BuildPlatform.OSX)]
+        public static BuildTargetResult GenerateSharedFrameworkProductArchive(BuildTargetContext c)
+        {
+            string sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
+            string version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
+            string id = $"com.microsoft.dotnet.sharedframework.{sharedFrameworkNugetVersion}.osx.x64";
+            string packageIntermediatesPath = Path.Combine(Dirs.Output, "obj", "pkg");
+            string resourcePath = Path.Combine(Dirs.RepoRoot, "packaging", "osx", "resources");
+            string outFilePath = Path.Combine(packageIntermediatesPath, id + ".pkg");
+
+            string inputDistTemplatePath = Path.Combine(
+                Dirs.RepoRoot,
+                "packaging",
+                "osx",
+                "sharedframework",
+                "shared-framework-distribution-template.xml");
+            string distTemplate = File.ReadAllText(inputDistTemplatePath);
+            string distributionPath = Path.Combine(packageIntermediatesPath, "shared-framework-formatted-distribution.xml");
+            string formattedDistContents = 
+                distTemplate.Replace("{SharedFrameworkNugetVersion}", sharedFrameworkNugetVersion)
+                .Replace("{VERSION}", version);
+            File.WriteAllText(distributionPath, formattedDistContents);
+
+            Cmd("productbuild",
+                "--version", version,
+                "--identifier", id,
+                "--package-path", packageIntermediatesPath,
+                "--resources", resourcePath, 
+                "--distribution", distributionPath,
+                outFilePath
+                )
+            .Execute()
+            .EnsureSuccessful();
+
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.OSX)]
+        public static BuildTargetResult GenerateSharedFrameworkPkg(BuildTargetContext c)
+        {
+            string sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
+            Directory.CreateDirectory(Path.Combine(Dirs.Output, "obj", "pkg"));
+            string version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
+            string id = $"com.microsoft.dotnet.sharedframework.{sharedFrameworkNugetVersion}.component.osx.x64";
+            string outFilePath = Path.Combine(Dirs.Output, "obj", "pkg", id + ".pkg");
+            string installLocation = "/usr/local/share/dotnet";
+            string scriptsLocation = Path.Combine(Dirs.RepoRoot, "packaging", "osx", "sharedframework", "scripts");
+
+            Cmd("pkgbuild",
+                "--root", c.BuildContext.Get<string>("SharedFrameworkPublishRoot"),
+                "--identifier", id,
+                "--version", version,
+                "--install-location", installLocation,
+                "--scripts", scriptsLocation,
+                outFilePath)
+                .Execute()
+                .EnsureSuccessful();
+
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.OSX)]
+        public static BuildTargetResult GenerateSharedHostPkg(BuildTargetContext c)
+        {
+            Directory.CreateDirectory(Path.Combine(Dirs.Output, "obj", "pkg"));
+            string version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
+            string id = $"com.microsoft.dotnet.sharedhost.osx.x64";
+            string outFilePath = Path.Combine(Dirs.Output, "obj", "pkg", id + ".pkg");
+            string installLocation = "/usr/local/share/dotnet";
+            string scriptsLocation = Path.Combine(Dirs.RepoRoot, "packaging", "osx", "sharedhost", "scripts");
+
+            Cmd("pkgbuild",
+                "--root", c.BuildContext.Get<string>("SharedHostPublishRoot"),
+                "--identifier", id,
+                "--version", version,
+                "--install-location", installLocation,
+                "--scripts", scriptsLocation,
+                outFilePath)
+                .Execute()
+                .EnsureSuccessful();
+
+            return c.Success();
+        }
+    }
+}

--- a/scripts/dotnet-cli-build/PkgTargets.cs
+++ b/scripts/dotnet-cli-build/PkgTargets.cs
@@ -37,9 +37,10 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.OSX)]
         public static BuildTargetResult GenerateSharedFrameworkProductArchive(BuildTargetContext c)
         {
+            string sharedFrameworkNugetName = SharedFrameworkTargets.SharedFrameworkName;
             string sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             string version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
-            string id = $"com.microsoft.dotnet.sharedframework.{sharedFrameworkNugetVersion}.osx.x64";
+            string id = $"com.microsoft.dotnet.sharedframework.{sharedFrameworkNugetName}.{sharedFrameworkNugetVersion}.osx.x64";
             string packageIntermediatesPath = Path.Combine(Dirs.Output, "obj", "pkg");
             string resourcePath = Path.Combine(Dirs.RepoRoot, "packaging", "osx", "resources");
             string outFilePath = Path.Combine(packageIntermediatesPath, id + ".pkg");
@@ -54,6 +55,7 @@ namespace Microsoft.DotNet.Cli.Build
             string distributionPath = Path.Combine(packageIntermediatesPath, "shared-framework-formatted-distribution.xml");
             string formattedDistContents = 
                 distTemplate.Replace("{SharedFrameworkNugetVersion}", sharedFrameworkNugetVersion)
+                .Replace("{SharedFrameworkNugetName}", SharedFrameworkTargets.SharedFrameworkName)
                 .Replace("{VERSION}", version);
             File.WriteAllText(distributionPath, formattedDistContents);
 
@@ -63,8 +65,7 @@ namespace Microsoft.DotNet.Cli.Build
                 "--package-path", packageIntermediatesPath,
                 "--resources", resourcePath, 
                 "--distribution", distributionPath,
-                outFilePath
-                )
+                outFilePath)
             .Execute()
             .EnsureSuccessful();
 
@@ -75,10 +76,11 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.OSX)]
         public static BuildTargetResult GenerateSharedFrameworkPkg(BuildTargetContext c)
         {
+            string sharedFrameworkNugetName = SharedFrameworkTargets.SharedFrameworkName;
             string sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             Directory.CreateDirectory(Path.Combine(Dirs.Output, "obj", "pkg"));
             string version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
-            string id = $"com.microsoft.dotnet.sharedframework.{sharedFrameworkNugetVersion}.component.osx.x64";
+            string id = $"com.microsoft.dotnet.sharedframework.{sharedFrameworkNugetName}.{sharedFrameworkNugetVersion}.component.osx.x64";
             string outFilePath = Path.Combine(Dirs.Output, "obj", "pkg", id + ".pkg");
             string installLocation = "/usr/local/share/dotnet";
             string scriptsLocation = Path.Combine(Dirs.RepoRoot, "packaging", "osx", "sharedframework", "scripts");

--- a/scripts/dotnet-cli-build/PrepareTargets.cs
+++ b/scripts/dotnet-cli-build/PrepareTargets.cs
@@ -114,6 +114,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             AddInstallerArtifactToContext(c, "dotnet", "Sdk");
             AddInstallerArtifactToContext(c, "dotnet-host", "SharedHost");
+            AddInstallerArtifactToContext(c, "dotnet-sharedframework", "SharedFramework");
 
             return c.Success();
         }

--- a/scripts/dotnet-cli-build/PrepareTargets.cs
+++ b/scripts/dotnet-cli-build/PrepareTargets.cs
@@ -113,6 +113,7 @@ namespace Microsoft.DotNet.Cli.Build
             c.BuildContext["VersionBadge"] = Path.Combine(Dirs.Output, versionBadgeName);
 
             AddInstallerArtifactToContext(c, "dotnet", "Sdk");
+            AddInstallerArtifactToContext(c, "dotnet-host", "SharedHost");
 
             return c.Success();
         }

--- a/scripts/dotnet-cli-build/PrepareTargets.cs
+++ b/scripts/dotnet-cli-build/PrepareTargets.cs
@@ -108,34 +108,11 @@ namespace Microsoft.DotNet.Cli.Build
         [Target]
         public static BuildTargetResult ExpectedBuildArtifacts(BuildTargetContext c)
         {
-            var productName = Monikers.GetProductMoniker(c);
             var config = Environment.GetEnvironmentVariable("CONFIGURATION");
             var versionBadgeName = $"{CurrentPlatform.Current}_{CurrentArchitecture.Current}_{config}_version_badge.svg";
             c.BuildContext["VersionBadge"] = Path.Combine(Dirs.Output, versionBadgeName);
 
-            var extension = CurrentPlatform.IsWindows ? ".zip" : ".tar.gz";
-            c.BuildContext["CompressedFile"] = Path.Combine(Dirs.Packages, productName + extension);
-
-            string installer = "";
-            switch (CurrentPlatform.Current)
-            {
-                case BuildPlatform.Windows:
-                    installer = productName + ".exe";
-                    break;
-                case BuildPlatform.OSX:
-                    installer = productName + ".pkg";
-                    break;
-                case BuildPlatform.Ubuntu:
-                    installer = productName + ".deb";
-                    break;
-                default:
-                    break;
-            }
-
-            if (!string.IsNullOrEmpty(installer))
-            {
-                c.BuildContext["InstallerFile"] = Path.Combine(Dirs.Packages, installer);
-            }
+            AddInstallerArtifactToContext(c, "dotnet", "Sdk");
 
             return c.Success();
         }
@@ -360,6 +337,36 @@ cmake is required to build the native host 'corehost'";
                 }
             }
             return dict;
+        }
+
+        private static void AddInstallerArtifactToContext(BuildTargetContext c, string artifactPrefix, string contextPrefix)
+        {
+            var productName = Monikers.GetProductMoniker(c, artifactPrefix);
+
+            var extension = CurrentPlatform.IsWindows ? ".zip" : ".tar.gz";
+            c.BuildContext[contextPrefix + "CompressedFile"] = Path.Combine(Dirs.Packages, productName + extension);
+
+            string installer = "";
+            switch (CurrentPlatform.Current)
+            {
+                case BuildPlatform.Windows:
+                    installer = productName + ".exe";
+                    break;
+                case BuildPlatform.OSX:
+                    installer = productName + ".pkg";
+                    break;
+                case BuildPlatform.Ubuntu:
+                    installer = productName + ".deb";
+                    break;
+                default:
+                    break;
+            }
+
+            if (!string.IsNullOrEmpty(installer))
+            {
+                c.BuildContext[contextPrefix + "InstallerFile"] = Path.Combine(Dirs.Packages, installer);
+            }
+
         }
     }
 }

--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         [Target(nameof(PublishTargets.PublishVersionBadge),
         nameof(PublishTargets.PublishCompressedFile),
-        nameof(PublishTargets.PublishInstallerFile),
+        nameof(PublishTargets.PublishSdkInstallerFile),
         nameof(PublishTargets.PublishLatestVersionTextFile))]
         public static BuildTargetResult PublishArtifacts(BuildTargetContext c)
         {
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Cli.Build
         [Target]
         public static BuildTargetResult PublishCompressedFile(BuildTargetContext c)
         {
-            var compressedFile = c.BuildContext.Get<string>("CompressedFile");
+            var compressedFile = c.BuildContext.Get<string>("SdkCompressedFile");
             var compressedFileBlob = $"{Channel}/Binaries/{Version}/{Path.GetFileName(compressedFile)}";
             var latestCompressedFile = compressedFile.Replace(Version, "latest");
             var latestCompressedFileBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(latestCompressedFile)}";
@@ -79,9 +79,9 @@ namespace Microsoft.DotNet.Cli.Build
 
         [Target]
         [BuildPlatforms(BuildPlatform.Windows, BuildPlatform.OSX, BuildPlatform.Ubuntu)]
-        public static BuildTargetResult PublishInstallerFile(BuildTargetContext c)
+        public static BuildTargetResult PublishSdkInstallerFile(BuildTargetContext c)
         {
-            var installerFile = c.BuildContext.Get<string>("InstallerFile");
+            var installerFile = c.BuildContext.Get<string>("SdkInstallerFile");
             var installerFileBlob = $"{Channel}/Installers/{Version}/{Path.GetFileName(installerFile)}";
             var latestInstallerFile = installerFile.Replace(Version, "latest");
             var latestInstallerFileBlob = $"{Channel}/Installers/Latest/{Path.GetFileName(latestInstallerFile)}";
@@ -102,12 +102,12 @@ namespace Microsoft.DotNet.Cli.Build
             return c.Success();
         }
 
-        [Target(nameof(PublishInstallerFile))]
+        [Target(nameof(PublishSdkInstallerFile))]
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult PublishDebFileToDebianRepo(BuildTargetContext c)
         {
             var packageName = Monikers.GetDebianPackageName(c);
-            var installerFile = c.BuildContext.Get<string>("InstallerFile");
+            var installerFile = c.BuildContext.Get<string>("SdkInstallerFile");
             var uploadUrl =  $"https://dotnetcli.blob.core.windows.net/dotnet/{Channel}/Installers/{Version}/{Path.GetFileName(installerFile)}";
             var uploadJson = GenerateUploadJsonFile(packageName, Version, uploadUrl);
 

--- a/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
+++ b/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Text.RegularExpressions;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.Extensions.PlatformAbstractions;
@@ -12,7 +13,46 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class SharedFrameworkTargets
     {
+        public const string SharedFrameworkName = "NETStandard.Library";
+
         private const string CoreHostBaseName = "corehost";
+
+        [Target]
+        public static BuildTargetResult PublishSharedFramework(BuildTargetContext c)
+        {
+            string SharedFrameworkPublishRoot = Path.Combine(Dirs.Output, "obj", "sharedframework");
+            string SharedFrameworkSourceRoot = Path.Combine(Dirs.RepoRoot, "src", "sharedframework", "framework");
+            string SharedFrameworkNugetVersion = GetVersionFromProjectJson(Path.Combine(Path.Combine(Dirs.RepoRoot, "src", "sharedframework", "framework"), "project.json"));
+
+            if (Directory.Exists(SharedFrameworkPublishRoot))
+            {
+                Directory.Delete(SharedFrameworkPublishRoot, true);
+            }
+
+            // We publish to a sub folder of the PublishRoot so tools like heat and zip can generate folder structures easier.
+            string SharedFrameworkNameAndVersionRoot = Path.Combine(SharedFrameworkPublishRoot, "shared", SharedFrameworkName, SharedFrameworkNugetVersion);
+
+            DotNetCli.Stage0.Publish("--output", SharedFrameworkNameAndVersionRoot, SharedFrameworkSourceRoot).Execute().EnsureSuccessful();
+
+            c.BuildContext["SharedFrameworkPublishRoot"] = SharedFrameworkPublishRoot;
+            c.BuildContext["SharedFrameworkNugetVersion"] = SharedFrameworkNugetVersion;
+
+            // Clean up artifacts that dotnet-publish generates which we don't need
+            File.Delete(Path.Combine(SharedFrameworkNameAndVersionRoot, $"framework{Constants.ExeSuffix}"));
+            File.Delete(Path.Combine(SharedFrameworkNameAndVersionRoot, "framework.dll"));
+            File.Delete(Path.Combine(SharedFrameworkNameAndVersionRoot, "framework.pdb"));
+
+            // Rename the .deps file
+            File.Move(Path.Combine(SharedFrameworkNameAndVersionRoot, "framework.deps"), Path.Combine(SharedFrameworkNameAndVersionRoot, $"{SharedFrameworkName}.deps"));
+
+            // corehost will be renamed to dotnet at some point and then this can be removed.
+            File.Move(Path.Combine(SharedFrameworkNameAndVersionRoot, $"{CoreHostBaseName}{Constants.ExeSuffix}"), Path.Combine(SharedFrameworkNameAndVersionRoot, $"dotnet{Constants.ExeSuffix}"));
+
+            // hostpolicy will be renamed to dotnet at some point and then this can be removed.
+            File.Move(Path.Combine(SharedFrameworkNameAndVersionRoot, $"{Constants.DynamicLibPrefix}hostpolicy{Constants.DynamicLibSuffix}"), Path.Combine(SharedFrameworkNameAndVersionRoot, $"{Constants.DynamicLibPrefix}dotnethostimpl{Constants.DynamicLibSuffix}"));
+
+            return c.Success();
+        }
 
         [Target]
         public static BuildTargetResult PublishSharedHost(BuildTargetContext c)
@@ -41,6 +81,23 @@ namespace Microsoft.DotNet.Cli.Build
             c.BuildContext["SharedHostPublishRoot"] = SharedHostPublishRoot;
 
             return c.Success();
+        }
+
+        private static string GetVersionFromProjectJson(string pathToProjectJson)
+        {
+            Regex r = new Regex($"\"{Regex.Escape(SharedFrameworkName)}\"\\s*:\\s*\"(?'version'[^\"]*)\"");
+
+            foreach(var line in File.ReadAllLines(pathToProjectJson))
+            {
+                var m = r.Match(line);
+
+                if (m.Success)
+                {
+                    return m.Groups["version"].Value;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
+++ b/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.Extensions.PlatformAbstractions;
+
+using static Microsoft.DotNet.Cli.Build.Framework.BuildHelpers;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class SharedFrameworkTargets
+    {
+        private const string CoreHostBaseName = "corehost";
+
+        [Target]
+        public static BuildTargetResult PublishSharedHost(BuildTargetContext c)
+        {
+            string SharedHostPublishRoot = Path.Combine(Dirs.Output, "obj", "sharedhost");
+
+            if (Directory.Exists(SharedHostPublishRoot))
+            {
+                Directory.Delete(SharedHostPublishRoot, true);
+            }
+
+            DotNetCli.Stage0.Publish("--output", SharedHostPublishRoot, Path.Combine(Dirs.RepoRoot, "src", "sharedframework", "host")).Execute().EnsureSuccessful();
+
+            // For the shared host, we only want corerun and not any of the other artifacts in the package (like the hostpolicy)
+            foreach (var filePath in Directory.GetFiles(SharedHostPublishRoot))
+            {
+                if (Path.GetFileName(filePath) != $"{CoreHostBaseName}{Constants.ExeSuffix}")
+                {
+                    File.Delete(filePath);
+                }
+            }
+
+            // corehost will be renamed to dotnet at some point and then this can be removed.
+            File.Move(Path.Combine(SharedHostPublishRoot, $"{CoreHostBaseName}{Constants.ExeSuffix}"), Path.Combine(SharedHostPublishRoot, $"dotnet{Constants.ExeSuffix}"));
+
+            c.BuildContext["SharedHostPublishRoot"] = SharedHostPublishRoot;
+
+            return c.Success();
+        }
+    }
+}

--- a/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
+++ b/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
@@ -60,6 +60,10 @@ namespace Microsoft.DotNet.Cli.Build
 
                 CrossGenAllManagedAssemblies(SharedFrameworkNameAndVersionRoot);
             }
+            else
+            {
+                c.Warn("Shared framework will not be crossgen'd because mscorlib.ni.dll does not exist.");
+            }
 
             return c.Success();
         }

--- a/scripts/dotnet-cli-build/Utils/Crossgen.cs
+++ b/scripts/dotnet-cli-build/Utils/Crossgen.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using System.Linq;
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.Extensions.PlatformAbstractions;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    internal static class Crossgen
+    {
+        public static string GetCrossgenPathForVersion(string coreClrVersion)
+        {
+            string arch = PlatformServices.Default.Runtime.RuntimeArchitecture;
+            string packageId;
+            if (CurrentPlatform.IsWindows)
+            {
+                packageId = $"runtime.win7-{arch}.Microsoft.NETCore.Runtime.CoreCLR";
+            }
+            else if (CurrentPlatform.IsUbuntu)
+            {
+                packageId = "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR";
+            }
+            else if (CurrentPlatform.IsCentOS || CurrentPlatform.IsRHEL)
+            {
+                // CentOS runtime is in the runtime.rhel.7-x64... package.
+                packageId = "runtime.rhel.7-x64.Microsoft.NETCore.Runtime.CoreCLR";
+            }
+            else if (CurrentPlatform.IsOSX)
+            {
+                packageId = "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR";
+            }
+            else if (CurrentPlatform.IsDebian)
+            {
+                packageId = "runtime.debian.8.2-x64.Microsoft.NETCore.Runtime.CoreCLR";
+            }
+            else
+            {
+                return null;
+            }
+
+            return Path.Combine(
+                Dirs.NuGetPackages,
+                packageId,
+                coreClrVersion,
+                "tools",
+                $"crossgen{Constants.ExeSuffix}");
+        }
+    }
+}

--- a/scripts/dotnet-cli-build/Utils/Monikers.cs
+++ b/scripts/dotnet-cli-build/Utils/Monikers.cs
@@ -8,12 +8,12 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class Monikers
     {
-        public static string GetProductMoniker(BuildTargetContext c)
+        public static string GetProductMoniker(BuildTargetContext c, string artifactPrefix)
         {
             string osname = GetOSShortName();
             var arch = CurrentArchitecture.Current.ToString();
             var version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
-            return $"dotnet-{osname}-{arch}.{version}";
+            return $"{artifactPrefix}-{osname}-{arch}.{version}";
         }
 
         public static string GetDebianPackageName(BuildTargetContext c)

--- a/scripts/dotnet-cli-build/Utils/Monikers.cs
+++ b/scripts/dotnet-cli-build/Utils/Monikers.cs
@@ -38,6 +38,13 @@ namespace Microsoft.DotNet.Cli.Build
             return packageName;
         }
 
+        public static string GetDebianSharedFrameworkPackageName(BuildTargetContext c)
+        {
+            var sharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
+
+            return $"dotnet-sharedframework-{SharedFrameworkTargets.SharedFrameworkName}-{sharedFrameworkNugetVersion}".ToLower();
+        }
+
         public static string GetOSShortName()
         {
             string osname = "";

--- a/scripts/dotnet-cli-build/Utils/Utils.cs
+++ b/scripts/dotnet-cli-build/Utils/Utils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 
 namespace Microsoft.DotNet.Cli.Build
 {
@@ -33,6 +34,56 @@ namespace Microsoft.DotNet.Cli.Build
             {
                 throw new PlatformNotSupportedException();
             }
+        }
+
+        // Generate a Version 5 (SHA1 Name Based) Guid from a name.
+        public static Guid GenerateGuidFromName(string name)
+        {
+            // Any fixed GUID will do for a namespace.
+            Guid namespaceId = new Guid("28F1468D-672B-489A-8E0C-7C5B3030630C");
+
+            using (SHA1 hasher = SHA1.Create())
+            {
+                var nameBytes = System.Text.Encoding.UTF8.GetBytes(name ?? string.Empty);
+                var namespaceBytes = namespaceId.ToByteArray();
+
+                SwapGuidByteOrder(namespaceBytes);
+
+                var streamToHash = new byte[namespaceBytes.Length + nameBytes.Length];
+
+                Array.Copy(namespaceBytes, streamToHash, namespaceBytes.Length);
+                Array.Copy(nameBytes, 0, streamToHash, namespaceBytes.Length, nameBytes.Length);
+
+                var hashResult = hasher.ComputeHash(streamToHash);
+
+                var res = new byte[16];
+
+                Array.Copy(hashResult, res, res.Length);
+
+                unchecked { res[6] = (byte)(0x50 | (res[6] & 0x0F)); }
+                unchecked { res[8] = (byte)(0x40 | (res[8] & 0x3F)); }
+
+                SwapGuidByteOrder(res);
+
+                return new Guid(res);
+            }
+        }
+
+        // Do a byte order swap, .NET GUIDs store multi byte components in little
+        // endian.
+        private static void SwapGuidByteOrder(byte[] b)
+        {
+            Swap(b, 0, 3);
+            Swap(b, 1, 2);
+            Swap(b, 5, 6);
+            Swap(b, 7, 8);
+        }
+
+        private static void Swap(byte[] b, int x, int y)
+        {
+            byte t = b[x];
+            b[x] = b[y];
+            b[y] = t;
         }
     }
 }

--- a/scripts/dotnet-cli-build/project.json
+++ b/scripts/dotnet-cli-build/project.json
@@ -11,7 +11,8 @@
         "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23901",
         "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
         "Microsoft.DotNet.Cli.Build.Framework": "1.0.0-*",
-        "WindowsAzure.Storage" : "6.2.2-preview"
+        "WindowsAzure.Storage" : "6.2.2-preview",
+        "System.Reflection.Metadata" : "1.2.0"
     },
 
     "frameworks": {

--- a/scripts/dotnet-cli-build/project.json
+++ b/scripts/dotnet-cli-build/project.json
@@ -8,6 +8,7 @@
     "dependencies": {
         "NETStandard.Library": "1.0.0-rc2-23901",
         "System.IO.Compression.ZipFile": "4.0.1-rc2-23901",
+        "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23901",
         "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
         "Microsoft.DotNet.Cli.Build.Framework": "1.0.0-*",
         "WindowsAzure.Storage" : "6.2.2-preview"

--- a/scripts/package/package-debian.sh
+++ b/scripts/package/package-debian.sh
@@ -29,6 +29,7 @@ help(){
     echo "  --output <output debfile>          The full path to which the package will be written."
     echo "  --package-name <package name>      Package to identify during installation. Example - 'dotnet-nightly', 'dotnet'"
     echo "  --previous-version-url <url>           Url to the previous version of the debian packge against which to run the upgrade tests."
+    echo "  --obj-root <object root>           Root folder for intermediate objects."
     exit 1
 }
 
@@ -59,6 +60,10 @@ parseargs(){
             ;;
         --previous-version-url)
             PREVIOUS_VERSION_URL=$2
+            shift
+            ;;
+        --obj-root)
+            OBJECT_DIR=$2
             shift
             ;;
         --help)
@@ -103,9 +108,9 @@ parseargs $@
 PACKAGING_ROOT="$REPOROOT/packaging/debian"
 PACKAGING_TOOL_DIR="$REPOROOT/tools/DebianPackageTool"
 
-PACKAGE_OUTPUT_DIR=$(dirname "${OUTPUT_DEBIAN_FILE}")
-PACKAGE_LAYOUT_DIR="$PACKAGE_OUTPUT_DIR/deb_intermediate"
-TEST_STAGE_DIR="$PACKAGE_OUTPUT_DIR/debian_tests"
+PACKAGE_OUTPUT_DIR="$OBJECT_DIR/deb_output"
+PACKAGE_LAYOUT_DIR="$OBJECT_DIR/deb_intermediate"
+TEST_STAGE_DIR="$OBJECT_DIR/debian_tests"
 
 # remove any residual deb files from earlier builds
 rm -f "$PACKAGE_OUTPUT_DIR/*.deb"

--- a/scripts/package/package-sharedframework-debian.sh
+++ b/scripts/package/package-sharedframework-debian.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Debian Packaging Script
+# Currently Intended to build on ubuntu14.04
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+source "$DIR/../common/_common.sh"
+REPOROOT="$DIR/../.."
+
+help(){
+    echo "Usage: $0"
+    echo ""
+    echo "Options:"
+    echo "  --input <input directory>          Package the entire contents of the directory tree."
+    echo "  --output <output debfile>          The full path to which the package will be written."
+    echo "  --package-name <package name>      Package to identify during installation. Example - 'dotnet-sharedframework'"
+    echo "  --framework-nuget-name <name>      The name of the nuget package that produced this shared framework."
+    echo "  --framework-nuget-version <ver>    The versionf of the nuget package that produced this shared framework."
+    echo "  --obj-root <object root>           Root folder for intermediate objects."
+    echo "  --version <version>                Version for the debain package."
+    exit 1
+}
+
+while [[ $# > 0 ]]; do
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -o|--output)
+            OUTPUT_DEBIAN_FILE=$2
+            shift
+            ;;
+        -i|--input)
+            REPO_BINARIES_DIR=$2
+            shift
+            ;;
+        -p|--package-name)
+            SHARED_FRAMEWORK_DEBIAN_PACKAGE_NAME=$2
+            shift
+            ;;
+        --framework-nuget-name)
+            SHARED_FRAMEWORK_NUGET_NAME=$2
+            shift
+            ;;
+        --framework-nuget-version)
+            SHARED_FRAMEWORK_NUGET_VERSION=$2
+            shift
+            ;;
+        --obj-root)
+            OBJECT_DIR=$2
+            shift
+            ;;
+        --version)
+            SHARED_FRAMEWORK_DEBIAN_VERSION=$2
+            shift
+            ;;
+        --help)
+            help
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+PACKAGING_ROOT="$REPOROOT/packaging/sharedframework/debian"
+PACKAGING_TOOL_DIR="$REPOROOT/tools/DebianPackageTool"
+
+PACKAGE_OUTPUT_DIR="$OBJECT_DIR/deb_output"
+PACKAGE_LAYOUT_DIR="$OBJECT_DIR/deb_intermediate"
+
+execute_build(){
+    create_empty_debian_layout
+    copy_files_to_debian_layout
+    update_debian_json
+    create_debian_package
+}
+
+create_empty_debian_layout(){
+    header "Creating empty debian package layout"
+
+    rm -rf "$PACKAGE_LAYOUT_DIR"
+    mkdir -p "$PACKAGE_LAYOUT_DIR"
+
+    mkdir "$PACKAGE_LAYOUT_DIR/\$"
+    mkdir "$PACKAGE_LAYOUT_DIR/package_root"
+    mkdir "$PACKAGE_LAYOUT_DIR/samples"
+    mkdir "$PACKAGE_LAYOUT_DIR/docs"
+}
+
+copy_files_to_debian_layout(){
+    header "Copying files to debian layout"
+
+    # Copy Built Binaries
+    cp -a "$REPO_BINARIES_DIR/." "$PACKAGE_LAYOUT_DIR/package_root"
+
+    # Copy config file
+    cp "$PACKAGING_ROOT/dotnet-sharedframework-debian_config.json" "$PACKAGE_LAYOUT_DIR/debian_config.json"
+}
+
+create_debian_package(){
+    header "Packing .deb"
+
+    mkdir -p "$PACKAGE_OUTPUT_DIR"
+
+    "$PACKAGING_TOOL_DIR/package_tool" -i "$PACKAGE_LAYOUT_DIR" -o "$PACKAGE_OUTPUT_DIR" -n "$SHARED_FRAMEWORK_DEBIAN_PACKAGE_NAME" -v "$SHARED_FRAMEWORK_DEBIAN_VERSION"
+}
+
+update_debian_json()
+{
+    header "Updating debian.json file"
+    sed -i "s/%SHARED_FRAMEWORK_DEBIAN_PACKAGE_NAME%/$SHARED_FRAMEWORK_DEBIAN_PACKAGE_NAME/g" "$PACKAGE_LAYOUT_DIR"/debian_config.json
+    sed -i "s/%SHARED_FRAMEWORK_NUGET_NAME%/$SHARED_FRAMEWORK_NUGET_NAME/g" "$PACKAGE_LAYOUT_DIR"/debian_config.json
+    sed -i "s/%SHARED_FRAMEWORK_NUGET_VERSION%/$SHARED_FRAMEWORK_NUGET_VERSION/g" "$PACKAGE_LAYOUT_DIR"/debian_config.json
+}
+
+execute_build
+
+DEBIAN_FILE=$(find $PACKAGE_OUTPUT_DIR -iname "*.deb")
+
+mv -f "$DEBIAN_FILE" "$OUTPUT_DEBIAN_FILE"

--- a/scripts/package/package-sharedframework-debian.sh
+++ b/scripts/package/package-sharedframework-debian.sh
@@ -79,6 +79,7 @@ PACKAGING_TOOL_DIR="$REPOROOT/tools/DebianPackageTool"
 
 PACKAGE_OUTPUT_DIR="$OBJECT_DIR/deb_output"
 PACKAGE_LAYOUT_DIR="$OBJECT_DIR/deb_intermediate"
+TEST_STAGE_DIR="$OBJECT_DIR/debian_tests"
 
 execute_build(){
     create_empty_debian_layout
@@ -125,8 +126,29 @@ update_debian_json()
     sed -i "s/%SHARED_FRAMEWORK_NUGET_VERSION%/$SHARED_FRAMEWORK_NUGET_VERSION/g" "$PACKAGE_LAYOUT_DIR"/debian_config.json
 }
 
+test_debian_package(){
+    header "Testing debian package"
+
+    install_bats
+    run_package_integrity_tests
+}
+
+install_bats() {
+    rm -rf $TEST_STAGE_DIR
+    git clone https://github.com/sstephenson/bats.git $TEST_STAGE_DIR
+}
+
+run_package_integrity_tests() {
+    # Set LAST_VERSION_URL to enable upgrade tests
+    # export LAST_VERSION_URL="$PREVIOUS_VERSION_URL"
+
+    $TEST_STAGE_DIR/bin/bats $PACKAGE_OUTPUT_DIR/test_package.bats
+}
+
 execute_build
 
 DEBIAN_FILE=$(find $PACKAGE_OUTPUT_DIR -iname "*.deb")
+
+test_debian_package
 
 mv -f "$DEBIAN_FILE" "$OUTPUT_DEBIAN_FILE"

--- a/scripts/package/package-sharedhost-debian.sh
+++ b/scripts/package/package-sharedhost-debian.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Debian Packaging Script
+# Currently Intended to build on ubuntu14.04
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+source "$DIR/../common/_common.sh"
+REPOROOT="$DIR/../.."
+
+help(){
+    echo "Usage: $0"
+    echo ""
+    echo "Options:"
+    echo "  --input <input directory>          Package the entire contents of the directory tree."
+    echo "  --output <output debfile>          The full path to which the package will be written."
+    echo "  --obj-root <object root>           Root folder for intermediate objects."
+    echo "  --version <version>                Version for the debain package."
+    exit 1
+}
+
+while [[ $# > 0 ]]; do
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -o|--output)
+            OUTPUT_DEBIAN_FILE=$2
+            shift
+            ;;
+        -i|--input)
+            REPO_BINARIES_DIR=$2
+            shift
+            ;;
+        --obj-root)
+            OBJECT_DIR=$2
+            shift
+            ;;
+        --version)
+            SHARED_HOST_DEBIAN_VERSION=$2
+            shift
+            ;;
+        --help)
+            help
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+PACKAGING_ROOT="$REPOROOT/packaging/host/debian"
+PACKAGING_TOOL_DIR="$REPOROOT/tools/DebianPackageTool"
+
+PACKAGE_OUTPUT_DIR="$OBJECT_DIR/deb_output"
+PACKAGE_LAYOUT_DIR="$OBJECT_DIR/deb_intermediate"
+
+execute_build(){
+    create_empty_debian_layout
+    copy_files_to_debian_layout
+    create_debian_package
+}
+
+create_empty_debian_layout(){
+    header "Creating empty debian package layout"
+
+    rm -rf "$PACKAGE_LAYOUT_DIR"
+    mkdir -p "$PACKAGE_LAYOUT_DIR"
+
+    mkdir "$PACKAGE_LAYOUT_DIR/\$"
+    mkdir "$PACKAGE_LAYOUT_DIR/package_root"
+    mkdir "$PACKAGE_LAYOUT_DIR/samples"
+    mkdir "$PACKAGE_LAYOUT_DIR/docs"
+}
+
+copy_files_to_debian_layout(){
+    header "Copying files to debian layout"
+
+    # Copy Built Binaries
+    cp -a "$REPO_BINARIES_DIR/." "$PACKAGE_LAYOUT_DIR/package_root"
+
+    # Copy config file
+    cp "$PACKAGING_ROOT/dotnet-sharedhost-debian_config.json" "$PACKAGE_LAYOUT_DIR/debian_config.json"
+}
+
+create_debian_package(){
+    header "Packing .deb"
+
+    mkdir -p "$PACKAGE_OUTPUT_DIR"
+
+    "$PACKAGING_TOOL_DIR/package_tool" -i "$PACKAGE_LAYOUT_DIR" -o "$PACKAGE_OUTPUT_DIR" -v "$SHARED_HOST_DEBIAN_VERSION"
+}
+
+execute_build
+
+DEBIAN_FILE=$(find $PACKAGE_OUTPUT_DIR -iname "*.deb")
+
+mv -f "$DEBIAN_FILE" "$OUTPUT_DEBIAN_FILE"

--- a/scripts/package/package-sharedhost-debian.sh
+++ b/scripts/package/package-sharedhost-debian.sh
@@ -64,6 +64,7 @@ PACKAGING_TOOL_DIR="$REPOROOT/tools/DebianPackageTool"
 
 PACKAGE_OUTPUT_DIR="$OBJECT_DIR/deb_output"
 PACKAGE_LAYOUT_DIR="$OBJECT_DIR/deb_intermediate"
+TEST_STAGE_DIR="$OBJECT_DIR/debian_tests"
 
 execute_build(){
     create_empty_debian_layout
@@ -101,8 +102,29 @@ create_debian_package(){
     "$PACKAGING_TOOL_DIR/package_tool" -i "$PACKAGE_LAYOUT_DIR" -o "$PACKAGE_OUTPUT_DIR" -v "$SHARED_HOST_DEBIAN_VERSION"
 }
 
+test_debian_package(){
+    header "Testing debian package"
+
+    install_bats
+    run_package_integrity_tests
+}
+
+install_bats() {
+    rm -rf $TEST_STAGE_DIR
+    git clone https://github.com/sstephenson/bats.git $TEST_STAGE_DIR
+}
+
+run_package_integrity_tests() {
+    # Set LAST_VERSION_URL to enable upgrade tests
+    # export LAST_VERSION_URL="$PREVIOUS_VERSION_URL"
+
+    $TEST_STAGE_DIR/bin/bats $PACKAGE_OUTPUT_DIR/test_package.bats
+}
+
 execute_build
 
 DEBIAN_FILE=$(find $PACKAGE_OUTPUT_DIR -iname "*.deb")
+
+test_debian_package
 
 mv -f "$DEBIAN_FILE" "$OUTPUT_DEBIAN_FILE"

--- a/src/sharedframework/framework/Program.cs
+++ b/src/sharedframework/framework/Program.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/src/sharedframework/framework/project.json
+++ b/src/sharedframework/framework/project.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.0-*",
+    "compilationOptions": {
+        "emitEntryPoint": true
+    },
+
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23811"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/src/sharedframework/framework/project.json
+++ b/src/sharedframework/framework/project.json
@@ -5,7 +5,7 @@
     },
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23811"
+        "NETStandard.Library": "1.0.0-rc2-23901"
     },
 
     "frameworks": {

--- a/src/sharedframework/host/project.json
+++ b/src/sharedframework/host/project.json
@@ -1,0 +1,11 @@
+{
+    "version": "1.0.0-*",
+
+    "dependencies": {
+        "NETStandard.Library": "1.0.0-rc2-23811"
+    },
+
+    "frameworks": {
+        "dnxcore50": { }
+    }
+}

--- a/src/sharedframework/host/project.json
+++ b/src/sharedframework/host/project.json
@@ -2,7 +2,7 @@
     "version": "1.0.0-*",
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23811"
+        "NETStandard.Library": "1.0.0-rc2-23901"
     },
 
     "frameworks": {

--- a/tools/DebianPackageTool/package_tool
+++ b/tools/DebianPackageTool/package_tool
@@ -132,7 +132,10 @@ parse_config_and_set_env_vars(){
     DOCS_JSON_PATH="$INPUT_DIR/docs.json"
 
     PACKAGE_SOURCE_DIR="${OUTPUT_DIR}/${PACKAGE_NAME}-${PACKAGE_VERSION}"
-    INSTALL_ROOT="/usr/share/${PACKAGE_NAME}"
+
+    if ! INSTALL_ROOT="$($extract_base_cmd $CONFIG "install_root")"; then
+        INSTALL_ROOT="/usr/share/$PACKAGE_NAME"
+    fi
 
     DEBIAN_DIR="${PACKAGE_SOURCE_DIR}/debian"
     DOCS_DIR="${PACKAGE_SOURCE_DIR}/docs"


### PR DESCRIPTION
Most of the work here is by @ellismg , I am submitting this as i'm going to be keeping this moving along while he's on vacation for a few days.

With this change, we produce many more installers:

* MSI installer for the shared framework and host (x64 and x86)
* deb installer for the shared framework and host (x64)
* pkg installer for the shared framework and host (x64)

There is some shared build logic (in SharedFrameworkTargets.cs) that is responsible for producing the binary layout that all of the installers consume. Essentially, this just performs a "dotnet publish" on a project.json that contains the standard library/host that we want to package (see src/sharedframework/framework/project.json). After that step, platform-specific installer targets take place which handle creating the appropriate bundle for each system.

There is logic for running cross-gen on the shared framework layout before it is packaged up, but this currently is only active on Windows. There is a comment in SharedFrameworkTargets regarding this. The basic problem is we need to update to a newer version of the framework packages in order to pull in mscorlib.ni.dll, but currently doing so is tied with upgrading the rest of the CLI's dependencies. It's possible that we could detach the two and have the shared framework find a matching crossgen version some other way.

@ellismg , @piotrpMSFT , @schellap , @gkhanna79 