### PR TITLE
Fix issue preventing MVC gate to take a new dotnet cli

### DIFF
--- a/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
+++ b/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                 var dependencyContext = new DependencyContextBuilder().Build(compilationOptions,
                     allExports,
                     allExports,
-                    string.IsNullOrEmpty(context.RuntimeIdentifier),
+                    args.PortableMode,
                     context.TargetFramework,
                     context.RuntimeIdentifier ?? string.Empty);
 


### PR DESCRIPTION
`context.RuntimeIdentifier` was always null there because that's compilation context.
@anurse 