### PR TITLE
Fix pthread library option

### DIFF
--- a/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
+++ b/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Linux/LinuxCppCompileStep.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
 
         // TODO: debug/release support
         private readonly string [] _cLibsFlags = { "-lm", "-ldl"};
-        private readonly string [] _cflags = { "-g", "-lstdc++", "-lrt", "-Wno-invalid-offsetof", "-pthread"};
+        private readonly string [] _cflags = { "-g", "-lstdc++", "-lrt", "-Wno-invalid-offsetof", "-lpthread"};
 
         public IEnumerable<string> CompilerArgs { get; set; }
 

--- a/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacCppCompileStep.cs
+++ b/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacCppCompileStep.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         public const string InputExtension = ".cpp";
 
         // TODO: debug/release support
-        private readonly string [] _cflags = { "-g", "-lstdc++", "-Wno-invalid-offsetof", "-pthread"};
+        private readonly string [] _cflags = { "-g", "-lstdc++", "-Wno-invalid-offsetof", "-lpthread"};
         
         // Link to iconv APIs
         private const string LibFlags = "-liconv";

--- a/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
+++ b/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
         private IEnumerable<string> CompilerArgs;
 
         // TODO: debug/release support
-        private readonly string [] _cflags = { "-g", "-lstdc++", "-Wno-invalid-offsetof", "-pthread", "-ldl", "-lm", "-liconv" };
+        private readonly string [] _cflags = { "-g", "-lstdc++", "-Wno-invalid-offsetof", "-lpthread", "-ldl", "-lm", "-liconv" };
 
         private readonly string[] _ilcSdkLibs = 
             {


### PR DESCRIPTION
While building CoreRT on OSX, I have noticed a warning:
clang: warning: argument unused during compilation: `-pthread`
The issue is that the options should be `-lpthread` instead.