### PR TITLE
Add RHEL and Windows x86 to CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ If you don't find your issue, please file one! However, given that this is a ver
 Build Status
 ------------
 
-|Ubuntu 14.04 |Windows |Mac OS X |CentOS 7.1 |
-|:------:|:------:|:------:|:------:|
-|![](https://devdiv.visualstudio.com/DefaultCollection/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/601/badge)|![](https://devdiv.visualstudio.com/DefaultCollection/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/602/badge)|![](https://devdiv.visualstudio.com/DefaultCollection/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/600/badge) |![](https://devdiv.visualstudio.com/DefaultCollection/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/597/badge) |
+|Ubuntu 14.04 |Windows x64 |Windows x86 |Mac OS X |CentOS 7.1 |RHEL 7.2 |
+|:------:|:------:|:------:|:------:|:------:|:------:|
+|![](https://devdiv.visualstudio.com/DefaultCollection/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/601/badge)|![](https://mseng.visualstudio.com/DefaultCollection/_apis/public/build/definitions/d09b7a4d-0a51-4c0e-a15a-07921d5b558f/3022/badge)|![](https://mseng.visualstudio.com/DefaultCollection/_apis/public/build/definitions/d09b7a4d-0a51-4c0e-a15a-07921d5b558f/3071/badge)|![](https://devdiv.visualstudio.com/DefaultCollection/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/600/badge) |![](https://devdiv.visualstudio.com/DefaultCollection/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/597/badge) |![](https://devdiv.visualstudio.com/DefaultCollection/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/897/badge) |
 
 Installers
 ----------
 
-|         |Ubuntu 14.04 |Windows |Mac OS X |CentOS 7.1 |
-|---------|:------:|:------:|:------:|:------:|
-|**Version**|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/Ubuntu_x64_Release_version_badge.svg)|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/Windows_x64_Release_version_badge.svg)|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/OSX_x64_Release_version_badge.svg)|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/CentOS_x64_Release_version_badge.svg)|
-|**Installers**|[Download Debian Package](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-ubuntu-x64.latest.deb)|[Download Msi](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-win-x64.latest.exe)|[Download Pkg](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-osx-x64.latest.pkg) |N/A |
-|**Binaries**|[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-ubuntu-x64.latest.tar.gz)|[Download zip file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-win-x64.latest.zip)|[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-osx-x64.latest.tar.gz) |[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-centos-x64.latest.tar.gz) |
+|         |Ubuntu 14.04 |Windows x64 |Windows x86 |Mac OS X |CentOS 7.1 |RHEL 7.2 |
+|---------|:------:|:------:|:------:|:------:|:------:|:------:|
+|**Version**|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/Ubuntu_x64_Release_version_badge.svg)|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/Windows_x64_Release_version_badge.svg)|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/Windows_x86_Release_version_badge.svg)|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/OSX_x64_Release_version_badge.svg)|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/CentOS_x64_Release_version_badge.svg)|![](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/RHEL_x64_Release_version_badge.svg)|
+|**Installers**|[Download Debian Package](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-ubuntu-x64.latest.deb)|[Download Msi](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-win-x64.latest.exe)|[Download Msi](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-win-x86.latest.exe)|[Download Pkg](https://dotnetcli.blob.core.windows.net/dotnet/beta/Installers/Latest/dotnet-osx-x64.latest.pkg) |N/A |N/A |
+|**Binaries**|[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-ubuntu-x64.latest.tar.gz)|[Download zip file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-win-x64.latest.zip)|[Download zip file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-win-x86.latest.zip)|[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-osx-x64.latest.tar.gz) |[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-centos-x64.latest.tar.gz)|[Download tar file](https://dotnetcli.blob.core.windows.net/dotnet/beta/Binaries/Latest/dotnet-rhel-x64.latest.tar.gz) |
 
 Interested in .NET Core + ASP.NET Core 1.0 RC1 bits?
 ----------------------------------------------------

--- a/netci.groovy
+++ b/netci.groovy
@@ -7,61 +7,56 @@ import jobs.generation.Utilities;
 
 def project = GithubProject
 def branch = GithubBranchName
+def isPR = true
 
-def osList = ['Ubuntu', 'OSX', 'Windows_NT', 'Windows_2016', 'CentOS7.1']
+def platformList = ['Ubuntu:x64:Debug', 'Ubuntu:x64:Release', 'OSX:x64:Release', 'Windows_NT:x64:Release', 'Windows_2016:x64:Release', 'Windows_2016:x86:Debug', 'RHEL7.2:x64:Release', 'CentOS7.1:x64:Debug']
 
-def static getBuildJobName(def configuration, def os) {
-    return configuration.toLowerCase() + '_' + os.toLowerCase()
+def static getBuildJobName(def configuration, def os, def architecture) {
+    return configuration.toLowerCase() + '_' + os.toLowerCase() + '_' + architecture.toLowerCase()
 }
 
-[true, false].each { isPR ->
-    ['Debug', 'Release'].each { configuration ->
-        osList.each { os ->
-            // Calculate names
-            def lowerConfiguration = configuration.toLowerCase()
 
-            // Calculate job name
-            def jobName = getBuildJobName(configuration, os)
-            def buildCommand = '';
+platformList.each { platform ->
+    // Calculate names
+    def (os, architecture, configuration) = platform.tokenize(':')
 
-            // Calculate the build command
-            if (os == 'Windows_NT') {
-                buildCommand = ".\\build.cmd -Configuration ${lowerConfiguration} -Targets Default"
-            }
-            else if (os == 'Windows_2016') {
-                buildCommand = ".\\build.cmd -Configuration ${lowerConfiguration} -RunInstallerTestsInDocker -Targets Default"
-            }
-            else if (os == 'Ubuntu') {
-                buildCommand = "./build.sh --skip-prereqs --configuration ${lowerConfiguration} --docker ubuntu --targets Default"
+    // Calculate job name
+    def jobName = getBuildJobName(configuration, os, architecture)
+    def buildCommand = '';
+
+    // Calculate the build command
+    if (os == 'Windows_NT') {
+        buildCommand = ".\\build.cmd -Configuration ${configuration} -Architecture ${architecture} -Targets Default"
+    }
+    else if (os == 'Windows_2016') {
+        buildCommand = ".\\build.cmd -Configuration ${configuration} -Architecture ${architecture} -RunInstallerTestsInDocker -Targets Default"
+    }
+    else if (os == 'Ubuntu') {
+        buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --docker ubuntu --targets Default"
+    }
+    else {
+        // Jenkins non-Ubuntu CI machines don't have docker
+        buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --targets Default"
+    }
+
+    def newJob = job(Utilities.getFullJobName(project, jobName, isPR)) {
+        // Set the label.
+        steps {
+            if (os == 'Windows_NT' || os == 'Windows_2016') {
+                // Batch
+                batchFile(buildCommand)
             }
             else {
-                // Jenkins non-Ubuntu CI machines don't have docker
-                buildCommand = "./build.sh --skip-prereqs --configuration ${lowerConfiguration} --targets Default"
-            }
-
-            def newJob = job(Utilities.getFullJobName(project, jobName, isPR)) {
-                // Set the label.
-                steps {
-                    if (os == 'Windows_NT' || os == 'Windows_2016') {
-                        // Batch
-                        batchFile(buildCommand)
-                    }
-                    else {
-                        // Shell
-                        shell(buildCommand)
-                    }
-                }
-            }
-
-            Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
-            Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-            Utilities.addXUnitDotNETResults(newJob, '**/*-testResults.xml')
-            if (isPR) {
-                Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${configuration} Build")
-            }
-            else {
-                Utilities.addGithubPushTrigger(newJob)
+                // Shell
+                shell(buildCommand)
             }
         }
     }
+
+    Utilities.setMachineAffinity(newJob, os, 'latest-or-auto')
+    Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+    Utilities.addXUnitDotNETResults(newJob, '**/*-testResults.xml')
+    Utilities.addGithubPRTriggerForBranch(newJob, branch, "${os} ${architecture} ${configuration} Build")
 }
+
+

--- a/scripts/obtain/install.sh
+++ b/scripts/obtain/install.sh
@@ -84,7 +84,7 @@ current_os()
         elif [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
             echo "centos"
         elif [ "$(cat /etc/*-release | grep -cim1 rhel)" -eq 1 ]; then
-            echo "rhel.7"
+            echo "rhel"
         elif [ "$(cat /etc/*-release | grep -cim1 debian)" -eq 1 ]; then
             echo "debian"
         fi


### PR DESCRIPTION
- Changes in netci.groovy to delete post-merge builds. We are using VSO
  for that.
- Also add RHEL and Windows x86 to PR CI jobs. Instead of doing 'debug'
  and 'release' for all platforms we selectively have a mixture
  of debug and release builds. (For ubuntu we are doing debug and release
  but that will change when we have 'Debian 8.2' support. Ubuntu:Debug
  will be replaced by Debian8.2:Debug)
- Minor change in install.sh to maintain uniformity in OS names.

cc: @mmitche for netci.groovy changes
cc: @anurse @eerhardt @brthor @piotrpMSFT