### PR TITLE
Trigger automated DockerHub builds

### DIFF
--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/EnvironmentAttribute.cs
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/TargetConditions/EnvironmentAttribute.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.DotNet.Cli.Build.Framework
 {
@@ -13,7 +13,11 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         {
             if (string.IsNullOrEmpty(envVar))
             {
-                throw new ArgumentNullException("envVar");
+                throw new ArgumentNullException(nameof(envVar));
+            }
+            if (expectedVals == null)
+            {
+                throw new ArgumentNullException(nameof(expectedVals));
             }
 
             _envVar = envVar;
@@ -24,15 +28,14 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         {
             var actualVal = Environment.GetEnvironmentVariable(_envVar);
 
-            foreach (var expectedVal in _expectedVals)
+            if (_expectedVals.Any())
             {
-                if (string.Equals(actualVal, expectedVal, StringComparison.Ordinal))
-                {
-                    return true;
-                }
+                return _expectedVals.Any(ev => string.Equals(actualVal, ev, StringComparison.Ordinal));
             }
-
-            return false;
+            else
+            {
+                return !string.IsNullOrEmpty(actualVal);
+            }
         }
     }
 }


### PR DESCRIPTION
This change triggers automated DockerHub builds for successful
official Ubuntu builds of rel.1.0.0. The DockerHub repo for this is
https://hub.docker.com/r/microsoft/dotnet-preview/.

The variables DOCKER_HUB_REPO and DOCKER_HUB_TRIGGER_TOKEN are set in
the "DotNet-CLI-CI (Ubuntu) [rel.1.0.0]" VSTS build definition.

This change also allows the Environment TargetConditionAttribute to be
used to require that an environment variable is set, in addition to the
existing functionality of being able to be used to require that an
environment variable is equal to one of a set of specified values.

cc: @MichaelSimons, @dleeapho, @Sridhar-MS, @brthor