### PR TITLE
Updating dependencies from last known good builds

### DIFF
--- a/TestAssets/FSharpTestProjects/CompileFail/project.json
+++ b/TestAssets/FSharpTestProjects/CompileFail/project.json
@@ -1,20 +1,19 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-    "compilerName": "fsc",
-    "compileFiles": [
-        "Program.fs"
-    ],
-    "dependencies": {
-        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "compilerName": "fsc",
+  "compileFiles": [
+    "Program.fs"
+  ],
+  "dependencies": {
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/FSharpTestProjects/TestApp/project.json
+++ b/TestAssets/FSharpTestProjects/TestApp/project.json
@@ -1,21 +1,20 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-    "compilerName": "fsc",
-    "compileFiles": [
-        "Program.fs"
-    ],
-    "dependencies": {
-        "TestLibrary": "1.0.0-*",
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "compilerName": "fsc",
+  "compileFiles": [
+    "Program.fs"
+  ],
+  "dependencies": {
+    "TestLibrary": "1.0.0-*",
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/FSharpTestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/FSharpTestProjects/TestAppWithArgs/project.json
@@ -1,20 +1,19 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-    "compilerName": "fsc",
-    "compileFiles": [
-        "Program.fs"
-    ],
-    "dependencies": {
-        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "compilerName": "fsc",
+  "compileFiles": [
+    "Program.fs"
+  ],
+  "dependencies": {
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/FSharpTestProjects/TestLibrary/project.json
+++ b/TestAssets/FSharpTestProjects/TestLibrary/project.json
@@ -1,17 +1,17 @@
 {
-    "version": "1.0.0-*",
-    "dependencies": {
-        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-    "compilerName": "fsc",
-    "compileFiles": [
-        "Helper2.fs",
-        "Helper.fs"
-    ],
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "compilerName": "fsc",
+  "compileFiles": [
+    "Helper2.fs",
+    "Helper.fs"
+  ],
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
@@ -1,11 +1,11 @@
 {
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "EmptyLibrary": "1.0.0-*"
-    },
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "EmptyLibrary": "1.0.0-*"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
@@ -1,12 +1,12 @@
 {
-  "dependencies": { },
+  "dependencies": {},
   "frameworks": {
     "netstandardapp1.5": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
+        "NETStandard.Library": "1.5.0-rc2-23911"
       }
     },
-    "dnx451": { }
+    "dnx451": {}
   }
 }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyLibrary/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyLibrary/project.json
@@ -1,11 +1,11 @@
 {
   "version": "1.0.0-*",
-  "dependencies": { },
+  "dependencies": {},
   "frameworks": {
     "netstandard1.3": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
+        "NETStandard.Library": "1.5.0-rc2-23911"
       }
     }
   }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
@@ -3,9 +3,9 @@
     "netstandardapp1.5": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
+        "NETStandard.Library": "1.5.0-rc2-23911"
       }
     }
   },
-  "dependencies": { }
+  "dependencies": {}
 }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
@@ -1,11 +1,11 @@
 {
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "Microsoft.Web.Administration": "7.0.0"
-    },
-    "frameworks": {
-      "netstandardapp1.5": {
-        "imports": "dnxcore50"
-      }
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "Microsoft.Web.Administration": "7.0.0"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
+++ b/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
@@ -1,14 +1,12 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23811"
-    },
-
-    "frameworks": {
-        "dnxcore50": { }
-    }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
 }

--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
@@ -1,16 +1,14 @@
 {
-    "version": "1.0.0",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
@@ -1,16 +1,14 @@
 {
-    "version": "2.0.0",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "2.0.0",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
@@ -1,23 +1,25 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "dotnet-hello": { "version": "1.0.0", "target": "package" }
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
-    },
-
-    "testRunner": "must-be-specified-to-generate-deps",
-
-    "tools": {
-        "dotnet-hello": { "version": "2.0.0", "target": "package" }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "dotnet-hello": {
+      "version": "1.0.0",
+      "target": "package"
     }
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
+    }
+  },
+  "testRunner": "must-be-specified-to-generate-deps",
+  "tools": {
+    "dotnet-hello": {
+      "version": "2.0.0",
+      "target": "package"
+    }
+  }
 }

--- a/TestAssets/TestProjects/AppWithDirectDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependency/project.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "testRunner": "must-be-specified-to-generate-deps",
-    
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "dotnet-hello": {"version": "1.0.0", "target": "package"}
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "testRunner": "must-be-specified-to-generate-deps",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "dotnet-hello": {
+      "version": "1.0.0",
+      "target": "package"
     }
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
+    }
+  }
 }

--- a/TestAssets/TestProjects/AppWithToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithToolDependency/project.json
@@ -1,20 +1,20 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
-    },
-
-    "tools": {
-        "dotnet-hello": { "version": "2.0.0", "target": "package" }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  },
+  "tools": {
+    "dotnet-hello": {
+      "version": "2.0.0",
+      "target": "package"
+    }
+  }
 }

--- a/TestAssets/TestProjects/CompileFail/project.json
+++ b/TestAssets/TestProjects/CompileFail/project.json
@@ -1,16 +1,14 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
@@ -1,16 +1,15 @@
 {
-    "version": "1.0.0-*",
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "Microsoft.Extensions.DependencyModel": {
-            "target": "project",
-            "version": "1.0.0-*"
-        }
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "Microsoft.Extensions.DependencyModel": {
+      "target": "project",
+      "version": "1.0.0-*"
     }
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
+    }
+  }
 }

--- a/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
@@ -1,18 +1,16 @@
-﻿{
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true,
-        "preserveCompilationContext": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "DependencyContextValidator": "1.0.0-*"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "DependencyContextValidator": "1.0.0-*"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
@@ -1,17 +1,15 @@
-﻿{
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "DependencyContextValidator": "1.0.0-*"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "DependencyContextValidator": "1.0.0-*"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
+++ b/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
@@ -1,16 +1,14 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/PortableTests/PortableApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableApp/project.json
@@ -1,18 +1,17 @@
 {
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-    "dependencies": {
-    },
-    "frameworks": {
-        "netstandard1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ],
-            "dependencies": {
-                "Microsoft.NETCore.App": "1.0.0-rc2-23911"
-            }
-        }
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {},
+  "frameworks": {
+    "netstandard1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": "1.0.0-rc2-23911"
+      }
     }
+  }
 }

--- a/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
@@ -1,26 +1,26 @@
 {
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ],
-            "dependencies": {
-                "Microsoft.NETCore.App": "1.0.0-rc2-23911"
-            }
-        }
-    },
-    "runtimes": {
-        "win7-x64": {},
-        "win7-x86": {},
-        "osx.10.10-x64": {},
-        "osx.10.11-x64": {},
-        "ubuntu.14.04-x64": {},
-        "centos.7-x64": {},
-        "rhel.7.2-x64": {},
-        "debian.8.2-x64": {}
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": "1.0.0-rc2-23911"
+      }
     }
+  },
+  "runtimes": {
+    "win7-x64": { },
+    "win7-x86": { },
+    "osx.10.10-x64": { },
+    "osx.10.11-x64": { },
+    "ubuntu.14.04-x64": { },
+    "centos.7-x64": { },
+    "rhel.7.2-x64": { },
+    "debian.8.2-x64": { }
+  }
 }

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
@@ -1,16 +1,15 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-23911"
+      }
     },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50",
-            "dependencies": {
-                "NETStandard.Library": "1.0.0-rc2-23901"
-            }
-        },
-        "net451": { }
-    }
+    "net451": {}
+  }
 }

--- a/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
@@ -1,19 +1,16 @@
-﻿{
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true,
-        "preserveCompilationContext": true
-    },
-
-    "dependencies": {
-        "TestLibrary": "1.0.0-*",
-
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+  "dependencies": {
+    "TestLibrary": "1.0.0-*",
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestAppCompilationContext/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppCompilationContext/TestLibrary/project.json
@@ -1,17 +1,20 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "nowarn": [ "CS1591" ],
-        "xmlDoc": true,
-        "additionalArguments": [ "-highentropyva+" ]
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "nowarn": [
+      "CS1591"
+    ],
+    "xmlDoc": true,
+    "additionalArguments": [
+      "-highentropyva+"
+    ]
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/TestAppWithArgs/project.json
@@ -1,16 +1,14 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithContentPackage/project.json
+++ b/TestAssets/TestProjects/TestAppWithContentPackage/project.json
@@ -1,11 +1,10 @@
-﻿{
+{
   "version": "1.0.0-*",
   "compilationOptions": {
     "emitEntryPoint": true
   },
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
+    "NETStandard.Library": "1.5.0-rc2-23911",
     "SharedContentA": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/TestAppWithContents/project.json
+++ b/TestAssets/TestProjects/TestAppWithContents/project.json
@@ -1,18 +1,15 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "content": "testcontentfile.txt",
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "content": "testcontentfile.txt",
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true,
-        "preserveCompilationContext": true
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+  "dependencies": {
+    "TestLibrary": {
+      "target": "project",
+      "version": "1.0.0-*"
     },
-
-    "dependencies": {
-        "TestLibrary": { "target":"project", "version":"1.0.0-*" },
-
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestLibrary/project.json
@@ -1,17 +1,20 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "nowarn": [ "CS1591" ],
-        "xmlDoc": true,
-        "additionalArguments": [ "-highentropyva+" ]
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23811"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "nowarn": [
+      "CS1591"
+    ],
+    "xmlDoc": true,
+    "additionalArguments": [
+      "-highentropyva+"
+    ]
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithScripts/project.json
+++ b/TestAssets/TestProjects/TestAppWithScripts/project.json
@@ -1,24 +1,21 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
-    },
-
-    "scripts": {
-        "prepublish" : ["echoscript prepublish_output ?%publish:ProjectPath%? ?%publish:Configuration%? ?%publish:OutputPath%? ?%publish:TargetFramework%? ?%publish:Runtime%?"],
-        "postpublish" : ["echoscript postpublish_output ?%publish:ProjectPath%? ?%publish:Configuration%? ?%publish:OutputPath%? ?%publish:TargetFramework%? ?%publish:Runtime%?"],
-
-        "precompile" : ["echoscript precompile_output ?%compile:ProjectPath%? ?%compile:Configuration%? ?%compile:OutputPath%? ?%compile:TargetFramework%? ?%compile:Runtime%?"],
-        "postcompile" : ["echoscript postcompile_output ?%compile:ProjectPath%? ?%compile:Configuration%? ?%compile:OutputPath%? ?%compile:TargetFramework%? ?%compile:Runtime%?"]
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  },
+  "scripts": {
+    "prepublish": [ "echoscript prepublish_output ?%publish:ProjectPath%? ?%publish:Configuration%? ?%publish:OutputPath%? ?%publish:TargetFramework%? ?%publish:Runtime%?" ],
+    "postpublish": [ "echoscript postpublish_output ?%publish:ProjectPath%? ?%publish:Configuration%? ?%publish:OutputPath%? ?%publish:TargetFramework%? ?%publish:Runtime%?" ],
+
+    "precompile": [ "echoscript precompile_output ?%compile:ProjectPath%? ?%compile:Configuration%? ?%compile:OutputPath%? ?%compile:TargetFramework%? ?%compile:Runtime%?" ],
+    "postcompile": [ "echoscript postcompile_output ?%compile:ProjectPath%? ?%compile:Configuration%? ?%compile:OutputPath%? ?%compile:TargetFramework%? ?%compile:Runtime%?" ]
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
@@ -1,24 +1,27 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true,
-        "preserveCompilationContext": true
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+  "dependencies": {
+    "TestLibrary": {
+      "target": "project",
+      "version": "1.0.0-*"
     },
-
-    "dependencies": {
-        "TestLibrary": { "target":"project", "version":"1.0.0-*" },
-
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
-    },
-
-    "scripts": {
-        "prepublish" : ["echo prepublish_output ?%publish:ProjectPath%? ?%publish:Configuration%? ?%publish:OutputPath%? ?%publish:Framework%? ?%publish:Runtime%?"],
-        "postpublish" : ["echo postpublish_output ?%publish:ProjectPath%? ?%publish:Configuration%? ?%publish:OutputPath%? ?%publish:Framework%? ?%publish:Runtime%?"]
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  },
+  "scripts": {
+    "prepublish": [
+      "echo prepublish_output ?%publish:ProjectPath%? ?%publish:Configuration%? ?%publish:OutputPath%? ?%publish:Framework%? ?%publish:Runtime%?"
+    ],
+    "postpublish": [
+      "echo postpublish_output ?%publish:ProjectPath%? ?%publish:Configuration%? ?%publish:OutputPath%? ?%publish:Framework%? ?%publish:Runtime%?"
+    ]
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary/project.json
@@ -1,17 +1,20 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "nowarn": [ "CS1591" ],
-        "xmlDoc": true,
-        "additionalArguments": [ "-highentropyva+" ]
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "nowarn": [
+      "CS1591"
+    ],
+    "xmlDoc": true,
+    "additionalArguments": [
+      "-highentropyva+"
+    ]
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
@@ -1,18 +1,18 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "TestLibraryWithAppDependency": {
+      "target": "project",
+      "version": "1.0.0-*"
     },
-
-    "dependencies": {
-        "TestLibraryWithAppDependency":  { "target":"project", "version":"1.0.0-*" },
-
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibraryWithAppDependency/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibraryWithAppDependency/project.json
@@ -1,14 +1,15 @@
 {
-    "version": "1.0.0-*",
-    "dependencies": {
-        "TestApp":  { "target":"project", "version":"1.0.0-*" },
-
-        "NETStandard.Library": "1.0.0-rc2-23901"
+  "version": "1.0.0-*",
+  "dependencies": {
+    "TestApp": {
+      "target": "project",
+      "version": "1.0.0-*"
     },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
@@ -1,19 +1,19 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true,
-        "preserveCompilationContext": true
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true,
+    "preserveCompilationContext": true
+  },
+  "dependencies": {
+    "TestLibrary": {
+      "target": "project",
+      "version": "1.0.0-*"
     },
-
-    "dependencies": {
-        "TestLibrary": { "target":"project", "version":"1.0.0-*" },
-
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryGreater/project.json
+++ b/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryGreater/project.json
@@ -1,20 +1,19 @@
-﻿{
-    "version": "1.0.0-*",
-    "testRunner": "xunit",
-    "dependencies": {
-        "Newtonsoft.Json": "7.0.1"
-    },
-
-    "frameworks": {
-        "net451": { },
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+wp80+win8"
-            ],
-            "dependencies": {
-                "NETStandard.Library": "1.0.0-rc2-23901"
-            }
-        }
+{
+  "version": "1.0.0-*",
+  "testRunner": "xunit",
+  "dependencies": {
+    "Newtonsoft.Json": "7.0.1"
+  },
+  "frameworks": {
+    "net451": {},
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+wp80+win8"
+      ],
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-23911"
+      }
     }
+  }
 }

--- a/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
+++ b/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
@@ -1,21 +1,22 @@
 {
-    "version": "1.0.0-*",
-    "testRunner": "xunit",
-    "dependencies": {
-        "Newtonsoft.Json": "6.0.0",
-        "TestLibraryGreater": {"target":"project"}
-    },
-
-    "frameworks": {
-        "net451": { },
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+wp80+win8"
-            ],
-            "dependencies": {
-                "NETStandard.Library": "1.0.0-rc2-23901"
-            }
-        }
+  "version": "1.0.0-*",
+  "testRunner": "xunit",
+  "dependencies": {
+    "Newtonsoft.Json": "6.0.0",
+    "TestLibraryGreater": {
+      "target": "project"
     }
+  },
+  "frameworks": {
+    "net451": {},
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+wp80+win8"
+      ],
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-23911"
+      }
+    }
+  }
 }

--- a/TestAssets/TestProjects/TestLibraryWithAnalyzer/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithAnalyzer/project.json
@@ -1,17 +1,18 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "System.Runtime.Analyzers": { "version": "1.1.0", "type": "build" }
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.Runtime.Analyzers": {
+      "version": "1.1.0",
+      "type": "build"
     }
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
+    }
+  }
 }

--- a/TestAssets/TestProjects/TestLibraryWithConfiguration/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithConfiguration/project.json
@@ -1,21 +1,23 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "nowarn": [ "CS1591" ],
-        "xmlDoc": true,
-        "additionalArguments": [ "-highentropyva+" ]
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-    "configurations": {
-        "Test": {
-
-        }
-    },
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "nowarn": [
+      "CS1591"
+    ],
+    "xmlDoc": true,
+    "additionalArguments": [
+      "-highentropyva+"
+    ]
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "configurations": {
+    "Test": {}
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
@@ -1,21 +1,19 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": false
-    },
-
-    "dependencies": { },
-
-    "frameworks": {
-        "net20": { },
-        "net35": { },
-        "net40": { },
-        "net461": { },
-        "netstandardapp1.5": {
-            "imports": "dnxcore50",
-            "dependencies": {
-                "NETStandard.Library": "1.0.0-rc2-23901"
-            }
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": false
+  },
+  "dependencies": {},
+  "frameworks": {
+    "net20": {},
+    "net35": {},
+    "net40": {},
+    "net461": {},
+    "netstandardapp1.5": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-23911"
+      }
     }
+  }
 }

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
@@ -1,17 +1,17 @@
 {
-    "version": "1.0.0",
-    "dependencies": { },
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50",
-            "dependencies": {
-                "NETStandard.Library": "1.0.0-rc2-23901"
-            }
-        },
-        "dnx451": {
-            "dependencies": {
-                "Microsoft.CSharp": "4.0.1-*"
-            }
-        }
+  "version": "1.0.0",
+  "dependencies": {},
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-23911"
+      }
+    },
+    "dnx451": {
+      "dependencies": {
+        "Microsoft.CSharp": "4.0.1-rc2-23911"
+      }
     }
+  }
 }

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
@@ -1,19 +1,16 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "L11": "1.0.0-*",
-        "L12": "1.0.0-*",
-
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "L11": "1.0.0-*",
+    "L12": "1.0.0-*",
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L11/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L11/project.json
@@ -1,16 +1,13 @@
 {
-    "version": "1.0.0-*",
-
-    "dependencies": {
-        "L12": "1.0.0-*",
-        "L21": "1.0.0-*",
-
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "dependencies": {
+    "L12": "1.0.0-*",
+    "L21": "1.0.0-*",
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L12/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L12/project.json
@@ -1,15 +1,12 @@
 {
-    "version": "1.0.0-*",
-
-    "dependencies": {
-        "L22": "1.0.0-*",
-
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "dependencies": {
+    "L22": "1.0.0-*",
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L21/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L21/project.json
@@ -1,13 +1,11 @@
 {
-    "version": "1.0.0-*",
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L22/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L22/project.json
@@ -1,13 +1,11 @@
 {
-    "version": "1.0.0-*",
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
@@ -1,16 +1,14 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestProjectWithResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithResource/project.json
@@ -1,16 +1,14 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
+++ b/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
@@ -1,17 +1,15 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true,
-        "xmlDoc": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true,
+    "xmlDoc": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/project.json
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/project.json
@@ -1,15 +1,13 @@
 {
-    "version": "1.0.0-*",
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "System.Diagnostics.Process": "4.1.0-rc2-23901",
-        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537"
-    },
-
-    "frameworks": {
-        "netstandard1.3": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.Diagnostics.Process": "4.1.0-rc2-23911",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -335,7 +335,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         private static List<string> GetAssembliesToCrossGen()
         {
-            var list = new List<string>
+            return new List<string>
             {
                 "System.Collections.Immutable.dll",
                 "System.Reflection.Metadata.dll",
@@ -345,15 +345,6 @@ namespace Microsoft.DotNet.Cli.Build
                 "csc.dll",
                 "vbc.dll"
             };
-
-            // mscorlib is already crossgenned on Windows
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // mscorlib has to be crossgenned first
-                list.Insert(0, "mscorlib.dll");
-            }
-
-            return list;
         }
     }
 }

--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class CompileTargets
     {
-        public static readonly string CoreCLRVersion = "1.0.2-rc2-23901";
+        public static readonly string CoreCLRVersion = "1.0.2-rc2-23911";
         public static readonly string AppDepSdkVersion = "1.0.6-prerelease-00003";
         public static readonly bool IsWinx86 = CurrentPlatform.IsWindows && CurrentArchitecture.Isx86;
 

--- a/scripts/dotnet-cli-build/project.json
+++ b/scripts/dotnet-cli-build/project.json
@@ -1,23 +1,21 @@
 ﻿{
-    "version": "1.0.0-*",
-    "description": "Build scripts for dotnet-cli",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "System.IO.Compression.ZipFile": "4.0.1-rc2-23901",
-        "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23901",
-        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
-        "Microsoft.DotNet.Cli.Build.Framework": "1.0.0-*",
-        "WindowsAzure.Storage" : "6.2.2-preview",
-        "System.Reflection.Metadata" : "1.2.0"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": ["dnxcore50", "portable-net45+win8"]
-        }
+  "version": "1.0.0-*",
+  "description": "Build scripts for dotnet-cli",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression.ZipFile": "4.0.1-rc2-23911",
+    "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23911",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
+    "Microsoft.DotNet.Cli.Build.Framework": "1.0.0-*",
+    "WindowsAzure.Storage": "6.2.2-preview",
+    "System.Reflection.Metadata": "1.2.0"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": [ "dnxcore50", "portable-net45+win8" ]
     }
+  }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -1,27 +1,27 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "keyFile": "../../tools/Key.snk",
-        "warningsAsErrors": true
-    },
-    "dependencies": {
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537"
-    },
-    "frameworks": {
-        "net451": {
-            "frameworkAssemblies": {
-                "System.Runtime": {
-                    "type": "build"
-                }
-            }
-        },
-        "netstandard1.3": {
-            "imports": "dnxcore50",
-            "dependencies": {
-                "NETStandard.Library": "1.0.0-rc2-23901",
-                "System.Diagnostics.Process": "4.1.0-rc2-23901"
-            }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk",
+    "warningsAsErrors": true
+  },
+  "dependencies": {
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537"
+  },
+  "frameworks": {
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Runtime": {
+          "type": "build"
         }
+      }
+    },
+    "netstandard1.3": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-23911",
+        "System.Diagnostics.Process": "4.1.0-rc2-23911"
+      }
     }
+  }
 }

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -1,23 +1,23 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "keyFile": "../../tools/Key.snk"
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "System.CommandLine": "0.1.0-e160119-1",
-        "Microsoft.CodeAnalysis.CSharp": "1.2.0-beta1-20160202-02",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-        "Microsoft.DotNet.Files": "1.0.0-*"
-    },
-    "frameworks": {
-        "netstandard1.3": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ]
-        }
-    },
-    "scripts": {}
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk"
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.CommandLine": "0.1.0-e160119-1",
+    "Microsoft.CodeAnalysis.CSharp": "1.2.0-beta1-20160202-02",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
+    "Microsoft.DotNet.Files": "1.0.0-*"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "scripts": {}
 }

--- a/src/Microsoft.DotNet.Files/project.json
+++ b/src/Microsoft.DotNet.Files/project.json
@@ -1,20 +1,20 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "keyFile": "../../tools/Key.snk"
-    },
-    "description": "Abstraction to interact with the file system and file paths.",
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "System.Linq.Expressions": "4.0.11-rc2-23901",
-        "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15996",
-        "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*"
-    },
-    "frameworks": {
-        "netstandard1.3": {
-            "imports": "dnxcore50"
-        }
-    },
-    "scripts": {}
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk"
+  },
+  "description": "Abstraction to interact with the file system and file paths.",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.Linq.Expressions": "4.0.11-rc2-23911",
+    "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15996",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": "dnxcore50"
+    }
+  },
+  "scripts": {}
 }

--- a/src/Microsoft.DotNet.InternalAbstractions/project.json
+++ b/src/Microsoft.DotNet.InternalAbstractions/project.json
@@ -13,14 +13,13 @@
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537"
   },
   "frameworks": {
-    "net451": { },
+    "net451": {},
     "netstandard1.3": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
+        "NETStandard.Library": "1.5.0-rc2-23911"
       }
     }
   },
-  "scripts": {
-  }
+  "scripts": {}
 }

--- a/src/Microsoft.DotNet.ProjectModel.Loader/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/project.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "keyFile": "../../tools/Key.snk"
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "System.Runtime.Loader": "4.0.0-rc2-23901"
-    },
-    "frameworks": {
-        "netstandard1.3": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk"
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "System.Runtime.Loader": "4.0.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -1,20 +1,20 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "keyFile": "../../tools/Key.snk"
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
-        "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.2.0-beta1-20160202-02"
-    },
-    "frameworks": {
-        "netstandard1.3": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ]
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk"
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
+    "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.2.0-beta1-20160202-02"
+  },
+  "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
     }
+  }
 }

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -1,47 +1,47 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "keyFile": "../../tools/Key.snk"
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk"
+  },
+  "description": "Types to model a .NET Project",
+  "dependencies": {
+    "System.Reflection.Metadata": "1.2.0-rc2-23911",
+    "NuGet.Packaging": "3.4.0-rtm-0733",
+    "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15996",
+    "Microsoft.Extensions.JsonParser.Sources": {
+      "type": "build",
+      "version": "1.0.0-rc2-16453"
     },
-    "description": "Types to model a .NET Project",
-    "dependencies": {
-        "System.Reflection.Metadata": "1.2.0-rc2-23901",
-        "NuGet.Packaging": "3.4.0-rtm-0733",
-        "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15996",
-        "Microsoft.Extensions.JsonParser.Sources": {
-            "type": "build",
-            "version": "1.0.0-rc2-16453"
-        },
-        "Microsoft.Extensions.HashCodeCombiner.Sources": {
-            "type": "build",
-            "version": "1.0.0-rc2-16054"
-        },
-        "Microsoft.Extensions.DependencyModel": "1.0.0-*"
+    "Microsoft.Extensions.HashCodeCombiner.Sources": {
+      "type": "build",
+      "version": "1.0.0-rc2-16054"
     },
-    "frameworks": {
-        "net451": {
-            "frameworkAssemblies": {
-                "System.Runtime": {
-                    "type": "build"
-                },
-                "System.Collections": {
-                    "type": "build"
-                },
-                "System.IO": {
-                    "type": "build"
-                }
-            }
+    "Microsoft.Extensions.DependencyModel": "1.0.0-*"
+  },
+  "frameworks": {
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Runtime": {
+          "type": "build"
         },
-        "netstandard1.3": {
-            "imports": "dnxcore50",
-            "dependencies": {
-                "NETStandard.Library": "1.0.0-rc2-23901",
-                "System.Dynamic.Runtime": "4.0.11-rc2-23901",
-                "System.Runtime.Loader": "4.0.0-rc2-23901",
-                "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23901",
-                "Microsoft.CSharp": "4.0.1-rc2-23901",
-                "System.Xml.XDocument": "4.0.11-rc2-23901"
-            }
+        "System.Collections": {
+          "type": "build"
+        },
+        "System.IO": {
+          "type": "build"
         }
+      }
+    },
+    "netstandard1.3": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-23911",
+        "System.Dynamic.Runtime": "4.0.11-rc2-23911",
+        "System.Runtime.Loader": "4.0.0-rc2-23911",
+        "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23911",
+        "Microsoft.CSharp": "4.0.1-rc2-23911",
+        "System.Xml.XDocument": "4.0.11-rc2-23911"
+      }
     }
+  }
 }

--- a/src/Microsoft.DotNet.TestFramework/project.json
+++ b/src/Microsoft.DotNet.TestFramework/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0-*",
   "description": "Microsoft.DotNet.TestFramework Class Library",
   "authors": [
@@ -11,7 +11,7 @@
   "licenseUrl": "",
   "dependencies": {
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-    "NETStandard.Library": "1.0.0-rc2-23901"
+    "NETStandard.Library": "1.5.0-rc2-23911"
   },
   "frameworks": {
     "netstandard1.3": {

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -1,39 +1,38 @@
 {
-    "description": "Abstractions for reading `.deps` files.",
-    "version": "1.0.0-*",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/dotnet/cli"
+  "description": "Abstractions for reading `.deps` files.",
+  "version": "1.0.0-*",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/dotnet/cli"
+  },
+  "compilationOptions": {
+    "warningsAsErrors": true,
+    "keyFile": "../../tools/Key.snk"
+  },
+  "dependencies": {
+    "Microsoft.Extensions.HashCodeCombiner.Sources": {
+      "type": "build",
+      "version": "1.0.0-rc2-16054"
     },
-    "compilationOptions": {
-        "warningsAsErrors": true,
-        "keyFile": "../../tools/Key.snk"
+    "Microsoft.DotNet.InternalAbstractions": {
+      "target": "project",
+      "version": "1.0.0-*"
     },
-    "dependencies": {
-        "Microsoft.Extensions.HashCodeCombiner.Sources": {
-          "type": "build",
-          "version": "1.0.0-rc2-16054"
-        },
-        "Microsoft.DotNet.InternalAbstractions": {
-            "target": "project",
-            "version": "1.0.0-*"
-        },
-
-        "Newtonsoft.Json": "7.0.1",
-        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537"
-    },
-    "frameworks": {
-        "net451": {},
-        "netstandard1.3": {
-            "imports": "dnxcore50",
-            "dependencies": {
-                "System.IO.FileSystem": "4.0.1-rc2-23901",
-                "System.Linq": "4.0.1-rc2-23901",
-                "System.Runtime": "4.0.21-rc2-23901",
-                "System.Reflection": "4.1.0-rc2-23901",
-                "System.Dynamic.Runtime": "4.0.11-rc2-23901"
-            }
-        }
-    },
-    "scripts": {}
+    "Newtonsoft.Json": "7.0.1",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537"
+  },
+  "frameworks": {
+    "net451": {},
+    "netstandard1.3": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "System.IO.FileSystem": "4.0.1-rc2-23911",
+        "System.Linq": "4.0.1-rc2-23911",
+        "System.Runtime": "4.0.21-rc2-23911",
+        "System.Reflection": "4.1.0-rc2-23911",
+        "System.Dynamic.Runtime": "4.0.11-rc2-23911"
+      }
+    }
+  },
+  "scripts": {}
 }

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -21,7 +21,8 @@
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-23911",
         "System.Resources.ResourceManager": "4.0.1-rc2-23911",
-        "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23911"
+        "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23911",
+        "System.Reflection.TypeExtensions": "4.1.0-rc2-23911"
       }
     }
   },

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -1,29 +1,29 @@
 {
-    "description": "Abstractions for test runners to communicate to a tool, such as Visual Studio.",
-    "version": "1.0.0-*",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/dotnet/cli"
-    },
-    "compilationOptions": {
-        "warningsAsErrors": true,
-        "keyFile": "../../tools/Key.snk"
-    },
-    "dependencies": {
-        "Newtonsoft.Json": "7.0.1",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-16040"
-    },
-    "frameworks": {
-        "net451": {},
-        "netstandard1.3": {
-            "imports": "dnxcore50",
-            "dependencies": {
-                "NETStandard.Library": "1.0.0-rc2-23901",
-                "System.Resources.ResourceManager": "4.0.1-rc2-23901",
-                "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23901"
-            }
-        }
-    },
-    "scripts": {}
+  "description": "Abstractions for test runners to communicate to a tool, such as Visual Studio.",
+  "version": "1.0.0-*",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/dotnet/cli"
+  },
+  "compilationOptions": {
+    "warningsAsErrors": true,
+    "keyFile": "../../tools/Key.snk"
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "7.0.1",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-16040"
+  },
+  "frameworks": {
+    "net451": {},
+    "netstandard1.3": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc2-23911",
+        "System.Resources.ResourceManager": "4.0.1-rc2-23911",
+        "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23911"
+      }
+    }
+  },
+  "scripts": {}
 }

--- a/src/dotnet/commands/dotnet-compile-native/appdep/project.json
+++ b/src/dotnet/commands/dotnet-compile-native/appdep/project.json
@@ -1,15 +1,15 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "Microsoft.DotNet.AppDep":"1.0.6-prerelease-00003"
-    },
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "Microsoft.DotNet.AppDep": "1.0.6-prerelease-00003"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
@@ -1,16 +1,14 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
@@ -1,22 +1,19 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "compilerName": "fsc",
-    "compileFiles": [
-        "Program.fs"
-    ],
-
-    "dependencies": {
-        "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
-        "NETStandard.Library": "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "compilerName": "fsc",
+  "compileFiles": [
+    "Program.fs"
+  ],
+  "dependencies": {
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-151221",
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
     }
+  }
 }

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -57,7 +57,11 @@
     "System.IO.Compression.ZipFile": "4.0.1-rc2-23911",
     "System.Threading.ThreadPool": "4.0.10-rc2-23911",
     "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23911",
-    "System.Private.DataContractSerialization": "4.1.0-rc2-23911"
+    "System.Private.DataContractSerialization": "4.1.0-rc2-23911",
+    "Microsoft.Win32.Registry": {
+      "version": "4.0.0-rc2-23911",
+      "exclude": "Compile"
+    }
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -1,77 +1,71 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "compileExclude": [
+    "commands/dotnet-new/CSharp_Console/**",
+    "commands/dotnet-new/FSharp_Console/**"
+  ],
+  "resource": [
+    "commands/dotnet-new/CSharp_Console/NuGet.Config",
+    "commands/dotnet-new/CSharp_Console/Program.cs",
+    "commands/dotnet-new/CSharp_Console/project.json.template",
+    "commands/dotnet-new/FSharp_Console/NuGet.config",
+    "commands/dotnet-new/FSharp_Console/Program.fs",
+    "commands/dotnet-new/FSharp_Console/project.json.template"
+  ],
+  "dependencies": {
+    "Newtonsoft.Json": "7.0.1",
+    "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160225-02",
+    "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-151218",
+    "Microsoft.Net.CSharp.Interactive.netcore": "1.3.0-beta1-20160225-02",
+    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160225-02",
+    "Microsoft.DiaSymReader.Native": "1.3.3",
+    "NuGet.CommandLine.XPlat": "3.4.0-rtm-0733",
+    "System.CommandLine": "0.1.0-e160119-1",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
+    "Microsoft.DotNet.ILCompiler.SDK": "1.0.6-prerelease-00003",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-16040",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-16040",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
+    "Microsoft.Extensions.CommandLineUtils.Sources": {
+      "type": "build",
+      "version": "1.0.0-rc2-16453"
     },
-    "compileExclude": [
-        "commands/dotnet-new/CSharp_Console/**",
-        "commands/dotnet-new/FSharp_Console/**"
-    ],
-    "resource": [
-        "commands/dotnet-new/CSharp_Console/NuGet.Config",
-        "commands/dotnet-new/CSharp_Console/Program.cs",
-        "commands/dotnet-new/CSharp_Console/project.json.template",
-        "commands/dotnet-new/FSharp_Console/NuGet.config",
-        "commands/dotnet-new/FSharp_Console/Program.fs",
-        "commands/dotnet-new/FSharp_Console/project.json.template"
-    ],
-    "dependencies": {
-        "Newtonsoft.Json": "7.0.1",
-
-        "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160225-02",
-        "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-151218",
-        "Microsoft.Net.CSharp.Interactive.netcore": "1.3.0-beta1-20160225-02",
-        "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160225-02",
-        "Microsoft.DiaSymReader.Native": "1.3.3",
-
-        "NuGet.CommandLine.XPlat": "3.4.0-rtm-0733",
-        "System.CommandLine": "0.1.0-e160119-1",
-
-        "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-        "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
-        "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-        "Microsoft.DotNet.ILCompiler.SDK": "1.0.6-prerelease-00003",
-
-        "Microsoft.Extensions.Logging": "1.0.0-rc2-16040",
-        "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-16040",
-        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
-        "Microsoft.Extensions.CommandLineUtils.Sources": {
-            "type": "build",
-            "version": "1.0.0-rc2-16453"
-        },
-        "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
-            "version": "1.0.0-rc2-16453",
-            "type": "build"
-        },
-        "Microsoft.Dnx.Runtime.Sources": {
-            "version": "1.0.0-rc2-16453",
-            "type": "build"
-        },
-        "Microsoft.Extensions.Testing.Abstractions": "1.0.0-*",
-        "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23901",
-        "Microsoft.NETCore.TestHost": "1.0.0-rc2-23901",
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "System.Reflection.Metadata": "1.3.0-beta-23901",
-        "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23901",
-        "System.Diagnostics.TraceSource": "4.0.0-rc2-23901",
-        "System.Linq.Expressions": "4.0.11-rc2-23901",
-        "System.Xml.XDocument": "4.0.11-rc2-23901",
-        "System.Resources.ReaderWriter": "4.0.0-rc2-23901",
-        "System.Net.Sockets": "4.1.0-rc2-23901",
-        "System.IO.Compression.ZipFile": "4.0.1-rc2-23901",
-        "System.Threading.ThreadPool": "4.0.10-rc2-23901",
-        "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23901",
-
-        "System.Private.DataContractSerialization": "4.1.0-rc2-23901"
+    "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
+      "version": "1.0.0-rc2-16453",
+      "type": "build"
     },
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ]
-        }
+    "Microsoft.Dnx.Runtime.Sources": {
+      "version": "1.0.0-rc2-16453",
+      "type": "build"
     },
-    "scripts": {
+    "Microsoft.Extensions.Testing.Abstractions": "1.0.0-*",
+    "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23911",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23911",
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.Reflection.Metadata": "1.3.0-rc2-23911",
+    "System.Diagnostics.TextWriterTraceListener": "4.0.0-rc2-23911",
+    "System.Diagnostics.TraceSource": "4.0.0-rc2-23911",
+    "System.Linq.Expressions": "4.0.11-rc2-23911",
+    "System.Xml.XDocument": "4.0.11-rc2-23911",
+    "System.Resources.ReaderWriter": "4.0.0-rc2-23911",
+    "System.Net.Sockets": "4.1.0-rc2-23911",
+    "System.IO.Compression.ZipFile": "4.0.1-rc2-23911",
+    "System.Threading.ThreadPool": "4.0.10-rc2-23911",
+    "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23911",
+    "System.Private.DataContractSerialization": "4.1.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
     }
+  },
+  "scripts": {}
 }

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -1,31 +1,33 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.ProjectModel": {
+      "target": "project"
     },
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "System.IO.Compression": "4.1.0-rc2-23901",
-
-        "Microsoft.DotNet.ProjectModel": { "target": "project" },
-        "Microsoft.DotNet.Cli.Utils": { "target": "project" },
-        "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
-
-        "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-79755-47"
+    "Microsoft.DotNet.Cli.Utils": {
+      "target": "project"
     },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ]
-        }
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
     },
-
-    "testRunner": "xunit",
-
-    "scripts": { "precompile": "dotnet build ../ArgumentsReflector/project.json --framework netstandardapp1.5 --runtime %compile:RuntimeIdentifier% --output %compile:RuntimeOutputDir%" }
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "testRunner": "xunit",
+  "scripts": {
+    "precompile": "dotnet build ../ArgumentsReflector/project.json --framework netstandardapp1.5 --runtime %compile:RuntimeIdentifier% --output %compile:RuntimeOutputDir%"
+  }
 }

--- a/test/ArgumentsReflector/project.json
+++ b/test/ArgumentsReflector/project.json
@@ -1,18 +1,17 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-        "NETStandard.Library" : "1.0.0-rc2-23901"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": "dnxcore50"
-        }
-    },
-
-    "content": ["reflector_cmd.cmd"]
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": "dnxcore50"
+    }
+  },
+  "content": [
+    "reflector_cmd.cmd"
+  ]
 }

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -3,20 +3,22 @@
   "compilationOptions": {
     "emitEntryPoint": true
   },
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-
-    "Microsoft.DotNet.ProjectModel": { "target": "project" },
-    "Microsoft.DotNet.Cli.Utils": { "target": "project" },
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
-
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.ProjectModel": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.Cli.Utils": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
     "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -25,6 +27,5 @@
       ]
     }
   },
-
   "testRunner": "xunit"
 }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -1,39 +1,38 @@
 {
-    "version": "1.0.0-*",
-    "compilationOptions": {
-        "emitEntryPoint": true
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.ProjectModel": {
+      "target": "project"
     },
-
-    "dependencies": {
-        "NETStandard.Library" : "1.0.0-rc2-23901",
-        "System.IO.Compression": "4.1.0-rc2-23901",
-
-        "Microsoft.DotNet.ProjectModel": { "target": "project" },
-        "Microsoft.DotNet.Cli.Utils": { "target": "project" },
-
-        "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
-        
-        "moq.netcore": "4.4.0-beta8",
-        "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-79755-47"
+    "Microsoft.DotNet.Cli.Utils": {
+      "target": "project"
     },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ]
-        }
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
     },
-
-    "content": [
-        "../../TestAssets/TestProjects/OutputStandardOutputAndError/*",
-        "../../TestAssets/TestProjects/TestAppWithArgs/*",
-        "../../TestAssets/TestProjects/AppWithDirectAndToolDependency/**/*",
-        "../../TestAssets/TestProjects/AppWithDirectDependency/**/*",
-        "../../TestAssets/TestProjects/AppWithToolDependency/**/*"
-    ],
-
-    "testRunner": "xunit"
+    "moq.netcore": "4.4.0-beta8",
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "content": [
+    "../../TestAssets/TestProjects/OutputStandardOutputAndError/*",
+    "../../TestAssets/TestProjects/TestAppWithArgs/*",
+    "../../TestAssets/TestProjects/AppWithDirectAndToolDependency/**/*",
+    "../../TestAssets/TestProjects/AppWithDirectDependency/**/*",
+    "../../TestAssets/TestProjects/AppWithToolDependency/**/*"
+  ],
+  "testRunner": "xunit"
 }

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -1,26 +1,27 @@
 {
-    "version": "1.0.0-*",
-
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "System.IO.Compression": "4.1.0-rc2-23901",
-
-        "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
-        "Microsoft.DotNet.ProjectModel": { "target": "project" },
-        "Microsoft.DotNet.Compiler.Common": { "target": "project" },
-        
-        "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-79755-47"
+  "version": "1.0.0-*",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
     },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ]
-        }
+    "Microsoft.DotNet.ProjectModel": {
+      "target": "project"
     },
-
-    "testRunner": "xunit"
+    "Microsoft.DotNet.Compiler.Common": {
+      "target": "project"
+    },
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "testRunner": "xunit"
 }

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -1,10 +1,14 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-    "Microsoft.DotNet.ProjectModel": { "target": "project" },
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.ProjectModel": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -1,32 +1,30 @@
 {
-    "version": "1.0.0-*",
-    "description": "Microsoft.DotNet.Tools.Tests.Utilities Class Library",
-    "compilationOptions": {
-        "keyFile": "../../tools/Key.snk"
-    },
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23901",
-        "System.Collections.Immutable": "1.2.0-rc2-23901",
-        "System.IO.Compression": "4.1.0-rc2-23901",
-        "FluentAssertions": "4.0.0",
-        "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-91790-12",
-
-        "Microsoft.DotNet.TestFramework": "1.0.0-*",
-        "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
-        "Microsoft.DotNet.InternalAbstractions": {
-            "target": "project",
-            "version": "1.0.0-*"
-        }
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ]
-        }
-    },
+  "version": "1.0.0-*",
+  "description": "Microsoft.DotNet.Tools.Tests.Utilities Class Library",
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk"
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.Collections.Immutable": "1.2.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "FluentAssertions": "4.0.0",
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-91790-12",
+    "Microsoft.DotNet.TestFramework": "1.0.0-*",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
+    "Microsoft.DotNet.InternalAbstractions": {
+      "target": "project",
+      "version": "1.0.0-*"
+    }
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  }
 }

--- a/test/Microsoft.Extensions.DependencyModel.Tests/project.json
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/project.json
@@ -5,16 +5,16 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "FluentAssertions": "4.0.0",
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -23,6 +23,5 @@
       ]
     }
   },
-
   "testRunner": "xunit"
 }

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -1,17 +1,19 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-
-    "Microsoft.DotNet.ProjectModel": { "target": "project" },
-    "Microsoft.DotNet.Cli.Utils": { "target": "project" },
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
-
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "Microsoft.DotNet.ProjectModel": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.Cli.Utils": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -20,10 +22,8 @@
       ]
     }
   },
-
   "content": [
     "../../TestAssets/TestProjects/TestApp/**/*"
   ],
-
   "testRunner": "xunit"
 }

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -1,19 +1,17 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -22,6 +20,5 @@
       ]
     }
   },
-
   "testRunner": "xunit"
 }

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -1,19 +1,17 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -22,7 +20,6 @@
       ]
     }
   },
-
   "content": [
     "../../TestAssets/TestProjects/DependencyContextValidator/**/*",
     "../../TestAssets/TestProjects/TestLibraryWithAnalyzer/*",
@@ -31,6 +28,5 @@
     "../../TestAssets/TestProjects/TestAppCompilationContext/**/*",
     "../../TestAssets/TestProjects/global.json"
   ],
-
   "testRunner": "xunit"
 }

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -1,23 +1,22 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-
-    "dotnet": { "target": "project" },
-    "Microsoft.DotNet.ProjectModel": { "target": "project" },
-
+    "dotnet": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.ProjectModel": {
+      "target": "project"
+    },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-91790-12",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -26,10 +25,8 @@
       ]
     }
   },
-
   "content": [
     "../../TestAssets/TestProjects/TestAppWithLibrary/**/*"
   ],
-
   "testRunner": "xunit"
 }

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -9,6 +9,10 @@
     "dotnet": {
       "target": "project"
     },
+    "Microsoft.Win32.Registry": {
+      "version": "4.0.0-rc2-23911",
+      "exclude": "Compile"
+    },
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -1,19 +1,17 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression.ZipFile": "4.0.1-rc2-23901",
-
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression.ZipFile": "4.0.1-rc2-23911",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -22,10 +20,8 @@
       ]
     }
   },
-
   "content": [
     "../../TestAssets/TestProjects/TestLibraryWithConfiguration/*"
   ],
-
   "testRunner": "xunit"
 }

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -3,6 +3,10 @@
     "dotnet": {
       "target": "project"
     },
+    "Microsoft.Win32.Registry": {
+      "version": "4.0.0-rc2-23911",
+      "exclude": "Compile"
+    },
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -1,20 +1,25 @@
 {
   "dependencies": {
-    "dotnet": { "target": "project" },
-    "Microsoft.DotNet.ProjectModel": { "target": "project" },
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "dotnet": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.ProjectModel": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-91790-12",
-
-    "System.Net.NameResolution": "4.0.0-rc2-23901"
+    "System.Net.NameResolution": "4.0.0-rc2-23911"
   },
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50",
-                "portable-net45+win8"
-            ]
-        }
-    },
-    "testRunner": "xunit"
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "testRunner": "xunit"
 }

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -1,21 +1,19 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
     "Microsoft.DotNet.TestFramework": "1.0.0-*",
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
     "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -24,6 +22,5 @@
       ]
     }
   },
-
   "testRunner": "xunit"
 }

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -1,20 +1,18 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
     "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -23,10 +21,8 @@
       ]
     }
   },
-
   "content": [
     "../../TestAssets/TestProjects/TestProjectWithResource/**/*"
   ],
-
   "testRunner": "xunit"
 }

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -1,19 +1,17 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-79755-47"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -22,6 +20,5 @@
       ]
     }
   },
-
   "testRunner": "xunit"
 }

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -6,6 +6,10 @@
     "dotnet": {
       "target": "project"
     },
+    "Microsoft.Win32.Registry": {
+      "version": "4.0.0-rc2-23911",
+      "exclude": "Compile"
+    },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-91790-12",
     "moq.netcore": "4.4.0-beta8",

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -1,18 +1,16 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
-    "NETStandard.Library": "1.0.0-rc2-23901",
-
-    "dotnet": { "target": "project" },
-
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "dotnet": {
+      "target": "project"
+    },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-91790-12",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -21,6 +19,5 @@
       ]
     }
   },
-
   "testRunner": "xunit"
 }

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -1,20 +1,18 @@
 {
   "version": "1.0.0-*",
-
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23901",
-    "System.IO.Compression": "4.1.0-rc2-23901",
-
-    "Microsoft.DotNet.Tools.Tests.Utilities": { "target": "project" },
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "System.IO.Compression": "4.1.0-rc2-23911",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project",
       "type": "build"
     },
-
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
-
   "frameworks": {
     "netstandardapp1.5": {
       "imports": [
@@ -23,12 +21,10 @@
       ]
     }
   },
-
   "content": [
-        "../../TestAssets/TestProjects/AppWithDirectAndToolDependency/**/*",
-        "../../TestAssets/TestProjects/AppWithDirectDependency/**/*",
-        "../../TestAssets/TestProjects/AppWithToolDependency/**/*"
+    "../../TestAssets/TestProjects/AppWithDirectAndToolDependency/**/*",
+    "../../TestAssets/TestProjects/AppWithDirectDependency/**/*",
+    "../../TestAssets/TestProjects/AppWithToolDependency/**/*"
   ],
-
   "testRunner": "xunit"
 }

--- a/tools/MultiProjectValidator/project.json
+++ b/tools/MultiProjectValidator/project.json
@@ -1,21 +1,19 @@
 {
-    "version": "1.0.0-*",
-    "name": "pjvalidate",
-    "compilationOptions": {
-        "emitEntryPoint": true
-    },
-
-    "dependencies": {
-      "NETStandard.Library": "1.0.0-rc2-23901",
-      "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-      "Microsoft.DotNet.Cli.Utils": "1.0.0-*"
-    },
-
-    "frameworks": {
-        "netstandardapp1.5": {
-            "imports": [
-                "dnxcore50"
-            ]
-        }
+  "version": "1.0.0-*",
+  "name": "pjvalidate",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-23911",
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-*"
+  },
+  "frameworks": {
+    "netstandardapp1.5": {
+      "imports": [
+        "dnxcore50"
+      ]
     }
+  }
 }


### PR DESCRIPTION
This commit was generated by the new "update-dependencies" scripts that I'm working on.  The scripts need to format the JSON files because it uses simple Newtonsoft deserialization.

I'd recommend using the `?w=1` option in github when reviewing this change.

Subsequent changes will be better since all the JSON files will already be formatted.

(If you want to see the scripts:  https://github.com/dotnet/cli/tree/eerhardt/Test/scripts/update-dependencies.  I plan on cleaning them up and getting them into the rel/1.0.0 branch next week.)

@piotrpMSFT @anurse @livarcocc 