### PR TITLE
Trigger rebuild when the CLI changed

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public static class DotnetFiles
+    {
+        /// <summary>
+        /// The CLI ships with a .version file that stores the commit information and CLI version
+        /// </summary>
+        public static string VersionFile => Path.GetFullPath(Path.Combine(typeof(DotnetFiles).GetTypeInfo().Assembly.Location, "..", ".version"));
+    }
+}

--- a/src/Microsoft.DotNet.Compiler.Common/ProjectContextExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/ProjectContextExtensions.cs
@@ -31,6 +31,11 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             return baseOption;
         }
 
+        public static string GetSDKVersionFile(this ProjectContext context, string configuration, string buildBasePath, string outputPath)
+        {
+            var intermediatePath = context.GetOutputPaths(configuration, buildBasePath, outputPath).IntermediateOutputDirectoryPath;
+            return Path.Combine(intermediatePath, ".SDKVersion");
+        }
 
         // used in incremental compilation for the key file
         public static CommonCompilerOptions ResolveCompilationOptions(this ProjectContext context, string configuration)

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -159,8 +159,7 @@ namespace Microsoft.DotNet.Cli
         
         private static string GetCommitSha()
         {
-            // The CLI ships with a .version file that stores the commit information
-            var versionFile = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, ".version"));
+            var versionFile = DotnetFiles.VersionFile;
             
             if (File.Exists(versionFile))
             {

--- a/test/dotnet-build.Tests/IncrementalTestBase.cs
+++ b/test/dotnet-build.Tests/IncrementalTestBase.cs
@@ -124,5 +124,12 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
             return executablePath;
         }
+
+        protected string GetIntermediaryOutputPath()
+        {
+            var executablePath = Path.Combine(TestProjectRoot, "obj", "Debug", "netstandardapp1.5");
+
+            return executablePath;
+        }
     }
 }


### PR DESCRIPTION
- Stamp each project with the CLI version it was last compiled with
- Rebuild those projects with a local version file that does not match the one of the current CLI that is building it

This corrects the behaviour in which the user updates the CLI but his projects do not get recompiled.

For the CLI repo itself there are some issues:
- I noticed that the output directories for stage1 and 2 get deleted each time, so there's no incrementality.
- Even if the CLI build were incremental, the .version file for stage1 and stage2 would be the same, therefore, only stage1 would get recompiled when stage0 gets updated. This issue should be unique to the CLI repo.
 - To fix this, I can:
   - make the CLI build incremental again
    - set a clean property to true every time the sh / ps1 scripts decide to update stage0. The CompileStage targets would use the Clean property to decide on whether to delete compilation output or not 
     - Or, just append _stage1 into the stage 1 .version file :). The benefit to this is exercising the feature on each build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/1847)
<!-- Reviewable:end -->