### PR TITLE
Change dotnet run to call the muxer

### DIFF
--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -158,7 +158,7 @@ namespace Microsoft.DotNet.Tools.Run
                 // The executable is a ".dll", we need to call it through dotnet.exe
                 var muxer = new Muxer();
 
-                command = Command.Create(muxer.MuxerPath, Enumerable.Concat(new[] { outputName }, _args));
+                command = Command.Create(muxer.MuxerPath, Enumerable.Concat(new[] { "exec", outputName }, _args));
             }
             else
             {

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -124,6 +124,12 @@ namespace Microsoft.DotNet.Tools.Run
                 return result;
             }
 
+            // Add Nuget Packages Probing Path
+            var nugetPackagesRoot = _context.PackagesDirectory;
+            var probingPathArg = "--additionalprobingpath";
+            _args.Insert(0, nugetPackagesRoot);
+            _args.Insert(0, probingPathArg);
+
             // Now launch the output and give it the results
             var outputPaths = _context.GetOutputPaths(Configuration);
             var outputName = outputPaths.RuntimeFiles.Executable;
@@ -150,7 +156,9 @@ namespace Microsoft.DotNet.Tools.Run
             if (outputName.EndsWith(FileNameSuffixes.DotNet.DynamicLib, StringComparison.OrdinalIgnoreCase))
             {
                 // The executable is a ".dll", we need to call it through dotnet.exe
-                command = Command.Create("corehost", Enumerable.Concat(new[] { outputName }, _args));
+                var muxer = new Muxer();
+
+                command = Command.Create(muxer.MuxerPath, Enumerable.Concat(new[] { outputName }, _args));
             }
             else
             {

--- a/test/dotnet-run.Tests/RunTests.cs
+++ b/test/dotnet-run.Tests/RunTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.Tools.Run.Tests
 {
     public class RunTests : TestBase
     {
+        private const string PortableAppsTestBase = "PortableTests";
         private const string RunTestsBase = "RunTestsApps";
 
         [WindowsOnlyFact]
@@ -39,6 +40,34 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                                                      .WithBuildArtifacts();
             new RunCommand(instance.TestRoot).Execute().Should().Fail();
         }
+
+        [Fact]
+        public void ItRunsPortableApps()
+        {
+            TestInstance instance = TestAssetsManager.CreateTestInstance(Path.Combine(PortableAppsTestBase, "PortableApp"))
+                                                     .WithLockFiles()
+                                                     .WithBuildArtifacts();
+            new RunCommand(instance.TestRoot).Execute().Should().Pass();
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/cli/issues/1940")]
+        public void ItRunsPortableAppsWithNative()
+        {
+            TestInstance instance = TestAssetsManager.CreateTestInstance(Path.Combine(PortableAppsTestBase, "PortableAppWithNative"))
+                                                     .WithLockFiles()
+                                                     .WithBuildArtifacts();
+            new RunCommand(instance.TestRoot).Execute().Should().Pass();
+        }
+
+        [Fact]
+        public void ItRunsStandaloneApps()
+        {
+            TestInstance instance = TestAssetsManager.CreateTestInstance(Path.Combine(PortableAppsTestBase, "StandaloneApp"))
+                                                     .WithLockFiles()
+                                                     .WithBuildArtifacts();
+            new RunCommand(instance.TestRoot).Execute().Should().Pass();
+        }
+
 
         private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)
         {


### PR DESCRIPTION
Fixes #1606 

this will pass --additionalprobingpath to the host when using dotnet run.
@schellap any way you could test this in your branch?

cc @gkhanna79

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/1851)
<!-- Reviewable:end -->