### PR TITLE
Publish shared framework and host zips to azure

### DIFF
--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -46,6 +46,8 @@ namespace Microsoft.DotNet.Cli.Build
         [Target(nameof(PublishTargets.PublishVersionBadge),
         nameof(PublishTargets.PublishCompressedFile),
         nameof(PublishTargets.PublishSdkInstallerFile),
+        nameof(PublishTargets.PublishSharedFrameworkCompressedFile),
+        nameof(PublishTargets.PublishSharedHostCompressedFile),
         nameof(PublishTargets.PublishLatestVersionTextFile))]
         public static BuildTargetResult PublishArtifacts(BuildTargetContext c)
         {
@@ -138,6 +140,30 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             return uploadJson;
+        }
+
+        public static BuildTargetResult PublishSharedFrameworkCompressedFile(BuildTargetContext c)
+        {
+            var compressedFile = c.BuildContext.Get<string>("SharedFrameworkCompressedFile");
+            var compressedFileBlob = $"{Channel}/Binaries/{Version}/{Path.GetFileName(compressedFile)}";
+            var latestCompressedFile = compressedFile.Replace(Version, "latest");
+            var latestCompressedFileBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(latestCompressedFile)}";
+
+            PublishFileAzure(compressedFileBlob, compressedFile);
+            PublishFileAzure(latestCompressedFileBlob, compressedFile);
+            return c.Success();
+        }
+
+        public static BuildTargetResult PublishSharedHostCompressedFile(BuildTargetContext c)
+        {
+            var compressedFile = c.BuildContext.Get<string>("SharedHostCompressedFile");
+            var compressedFileBlob = $"{Channel}/Binaries/{Version}/{Path.GetFileName(compressedFile)}";
+            var latestCompressedFile = compressedFile.Replace(Version, "latest");
+            var latestCompressedFileBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(latestCompressedFile)}";
+
+            PublishFileAzure(compressedFileBlob, compressedFile);
+            PublishFileAzure(latestCompressedFileBlob, compressedFile);
+            return c.Success();
         }
 
         private static BuildTargetResult PublishFile(BuildTargetContext c, string file)


### PR DESCRIPTION
This adds a couple of extra targets, which publish the shared framework and shared host zip (targz) files to Azure. They use the build context properties which are already defined earlier in the build.