### PR TITLE
add manual merge of RID fallback graph for Windows

### DIFF
--- a/src/sharedframework/rid-fallbacks/windows.json
+++ b/src/sharedframework/rid-fallbacks/windows.json
@@ -1,0 +1,12 @@
+{
+    "runtimes": {
+        "win10-x64": [ "win10", "win81-x64", "win81", "win8-x64", "win8", "win7-x64", "win7", "win-x64", "win", "any", "base" ],
+        "win10-x86": [ "win10", "win81-x86", "win81", "win8-x86", "win8", "win7-x86", "win7", "win-x86", "win", "any", "base" ],
+        "win81-x64": [ "win81", "win8-x64", "win8", "win7-x64", "win7", "win-x64", "win", "any", "base" ],
+        "win81-x86": [ "win81", "win8-x86", "win8", "win7-x86", "win7", "win-x86", "win", "any", "base" ],
+        "win8-x64": [ "win8", "win7-x64", "win7", "win-x64", "win", "any", "base" ],
+        "win8-x86": [ "win8", "win7-x86", "win7", "win-x86", "win", "any", "base" ],
+        "win7-x64": [ "win7", "win-x64", "win", "any", "base" ],
+        "win7-x86": [ "win7", "win-x86", "win", "any", "base" ]
+    }
+}


### PR DESCRIPTION
Soon, we will have #1688, but until we do, we need to have a RID fallback graph in the shared framework deps file in order to boot Kestrel. This does that via a simple JSON fragment that is merged into the framework deps file after build. I expect the full solution to be available in the next day or so, but I want to get a build that can actually produce a fully working package :).

/cc @mellinoe @davidfowl @pakrym