### PR TITLE
Ensure .version file is added to the debian package

### DIFF
--- a/tools/DebianPackageTool/scripts/debian_build_lib.sh
+++ b/tools/DebianPackageTool/scripts/debian_build_lib.sh
@@ -142,6 +142,7 @@ _get_files_in_dir_tree(){
 
     # Use Globstar expansion to enumerate all directories and files in the tree
     shopt -s globstar
+    shopt -s dotglob
     dir_tree_list=( "${root_dir}/"** )
 
     # Build a new array with only the Files contained in $dir_tree_list


### PR DESCRIPTION
Small fix, this enables dot files to get picked up inside of any of the directories we package.

This should fix the issue with .version files not being available via debian.

cc @davidfowl