### PR TITLE
Add hostfxr.dll to windows host msi

### DIFF
--- a/packaging/host/windows/host.wxs
+++ b/packaging/host/windows/host.wxs
@@ -38,6 +38,7 @@
         <ComponentGroup Id="InstallFiles">
             <Component Id="cmpCoreHost" Directory="DOTNETHOME" Guid="{45399BBB-DDA5-4386-A2E9-618FB3C54A18}">
                 <File Id="fileCoreHostExe" KeyPath="yes" Source="$(var.HostSrc)\dotnet.exe" />
+                <File Id="fileHostFxrDll" Source="$(var.HostSrc)\hostfxr.dll" />
             </Component>
         </ComponentGroup>
     </Fragment>


### PR DESCRIPTION
hostfxr.dll needs to be added to the host installer. Just a one line change here, verified locally.