### PR TITLE
Fix the VSO signing builds

### DIFF
--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -12,7 +12,9 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public static class PackageTargets
     {
-        [Target]
+        [Target(nameof(PackageTargets.CopyCLISDKLayout),
+        nameof(SharedFrameworkTargets.PublishSharedHost),
+        nameof(SharedFrameworkTargets.PublishSharedFramework))]
         public static BuildTargetResult InitPackage(BuildTargetContext c)
         {
             Directory.CreateDirectory(Dirs.Packages);
@@ -22,9 +24,6 @@ namespace Microsoft.DotNet.Cli.Build
         [Target(nameof(PrepareTargets.Init),
         nameof(PackageTargets.InitPackage),
         nameof(PackageTargets.GenerateVersionBadge),
-        nameof(PackageTargets.CopyCLISDKLayout),
-        nameof(SharedFrameworkTargets.PublishSharedHost),
-        nameof(SharedFrameworkTargets.PublishSharedFramework),
         nameof(PackageTargets.GenerateCompressedFile),
         nameof(InstallerTargets.GenerateInstaller),
         nameof(PackageTargets.GenerateNugetPackages))]


### PR DESCRIPTION
As a part of Package init create all the SharedFx, SharedHost and CLI SDK
layouts. This way all other package targets can take a dependency only on
InitPackage.

cc: @mellinoe