### PR TITLE
Fix a couple build issues on OSX/non-Windows

### DIFF
--- a/scripts/obtain/install.sh
+++ b/scripts/obtain/install.sh
@@ -189,7 +189,7 @@ install_dotnet()
             local localVersion=$(tail -n 1 "$installLocation/cli/.version" 2>/dev/null)
             if [ "$VERSION" == "Latest" ]; then
                 # Check if we need to bother
-                local remoteData="$(curl -s https://dotnetcli.blob.core.windows.net/dotnet/$CHANNEL/dnvm/latest.$os.version)"
+                local remoteData="$(curl -s https://dotnetcli.blob.core.windows.net/dotnet/$CHANNEL/dnvm/latest.$os.x64.version)"
                 [ $? != 0 ] && say_err "Unable to determine latest version." && return 1
 
                 local remoteVersion=$(IFS="\n" && echo $remoteData | tail -n 1)

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -114,7 +114,7 @@ echo "Invoking Build Scripts..."
 echo "Configuration: $CONFIGURATION"
 
 if [ -f "$DIR/dotnet-cli-build/bin/dotnet-cli-build" ]; then
-    $DIR/dotnet-cli-build/bin/dotnet-cli-build "${targets[@]}"
+    $DIR/dotnet-cli-build/bin/dotnet-cli-build ${targets[@]}
     exit $?
 else
     # We're on an older CLI. This is temporary while Ubuntu and CentOS VSO builds are stalled.


### PR DESCRIPTION
We were downloading the wrong 'latest version' of the CLI, and targets passed into --targets were not split correctly, resulting in some errors like "target Prepare Compile didn't exist".

@Sridhar-MS @brthor