### PR TITLE
Layout the CLI SDK in the "1.0.0" instead of "1.0.0-beta-001793"

### DIFF
--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -51,7 +51,12 @@ namespace Microsoft.DotNet.Cli.Build
         [Target]
         public static BuildTargetResult CopyCLISDKLayout(BuildTargetContext c)
         {
-            var nugetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").NuGetVersion;
+            // CLI SDK must be layed out in path which has a Nuget version.
+            // But the muxer does not currently support the pre-release CLI SDK without a global.json file.
+            // So we are creating a production version.
+            // var nugetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").NuGetVersion;
+            var nugetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").ProductionVersion;
+
             var cliSdkRoot = Path.Combine(Dirs.Output, "obj", "clisdk");
             var cliSdk = Path.Combine(cliSdkRoot, "sdk", nugetVersion);
 

--- a/scripts/dotnet-cli-build/Utils/BuildVersion.cs
+++ b/scripts/dotnet-cli-build/Utils/BuildVersion.cs
@@ -12,6 +12,7 @@
         public string SimpleVersion => $"{Major}.{Minor}.{Patch}.{CommitCountString}";
         public string VersionSuffix => $"{ReleaseSuffix}-{CommitCountString}";
         public string NuGetVersion => $"{Major}.{Minor}.{Patch}-{VersionSuffix}";
+        public string ProductionVersion => $"{Major}.{Minor}.{Patch}";
 
         public string GenerateMsiVersion()
         {


### PR DESCRIPTION
dotnet host muxer does not support pre-release CLI SDK when no global.json
file is present. So fixing the CLI layout to be in production version
layout. THIS IS A TEMP HACK.

cc: @mellinoe @Petermarcu