### PR TITLE
Enable crossgen for shared framework, provide opt-out

### DIFF
--- a/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
+++ b/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
@@ -173,7 +173,7 @@ namespace Microsoft.DotNet.Cli.Build
         }
 
         [Target]
-        [Environment("CROSSGEN_SHAREDFRAMEWORK", "1", "true")]
+        [Environment("DONT_CROSSGEN_SHAREDFRAMEWORK", null, "0", "false")]
         public static BuildTargetResult CrossGenAllManagedAssemblies(BuildTargetContext c)
         {
             string pathToAssemblies = c.BuildContext.Get<string>("SharedFrameworkNameAndVersionRoot");

--- a/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
+++ b/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
@@ -22,6 +22,11 @@ namespace Microsoft.DotNet.Cli.Build
         private const string DotnetHostFxrBaseName = "hostfxr";
         private const string HostPolicyBaseName = "hostpolicy";
 
+        private static readonly HashSet<string> crossgenSkippedAssemblies = new HashSet<string>()
+        {
+            "Microsoft.CodeAnalysis.dll"
+        };
+
         [Target(nameof(PackageSharedFramework), nameof(CrossGenAllManagedAssemblies))]
         public static BuildTargetResult PublishSharedFramework(BuildTargetContext c)
         {
@@ -177,7 +182,7 @@ namespace Microsoft.DotNet.Cli.Build
             {
                 string fileName = Path.GetFileName(file);
 
-                if (fileName == "mscorlib.dll" || fileName == "mscorlib.ni.dll" || !HasMetadata(file))
+                if (fileName == "mscorlib.dll" || fileName == "mscorlib.ni.dll" || !HasMetadata(file) || crossgenSkippedAssemblies.Contains(fileName))
                 {
                     continue;
                 }

--- a/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
+++ b/scripts/dotnet-cli-build/SharedFrameworkTargets.cs
@@ -24,7 +24,9 @@ namespace Microsoft.DotNet.Cli.Build
 
         private static readonly HashSet<string> crossgenSkippedAssemblies = new HashSet<string>()
         {
-            "Microsoft.CodeAnalysis.dll"
+            "Microsoft.CodeAnalysis.dll",
+            "System.Collections.Immutable.dll",
+            "System.ObjectModel.dll"
         };
 
         [Target(nameof(PackageSharedFramework), nameof(CrossGenAllManagedAssemblies))]
@@ -195,10 +197,13 @@ namespace Microsoft.DotNet.Cli.Build
                 // we need to be able to look at the project.lock.json file and figure out what version of Microsoft.NETCore.Runtime.CoreCLR
                 // was used, and then select that version.
                 ExecSilent(Crossgen.GetCrossgenPathForVersion(CompileTargets.CoreCLRVersion),
-                    "-readytorun", "-in", file, "-out", tempPathName, "-platform_assemblies_paths", pathToAssemblies);                  
-
-                File.Delete(file);
-                File.Move(tempPathName, file);
+                    "-FragileNonVersionable", "-in", file, "-out", tempPathName, "-platform_assemblies_paths", pathToAssemblies);
+            }
+            foreach (var file in Directory.EnumerateFiles(pathToAssemblies, "*.readytorun"))
+            {
+                string original = Path.ChangeExtension(file, "dll");
+                File.Delete(original);
+                File.Move(file, original);
             }
 
             return c.Success();


### PR DESCRIPTION
crossgen fails on `Microsoft.CodeAnalysis.dll` for a few reasons, so that assembly is currently skipped. This step is now on by default, and there is an opt-out variable which can be set to skip crossgen for all assemblies in the shared framework.