### PR TITLE
Create combined zip/tar for framework-host-sdk and framework-host

### DIFF
--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -14,7 +14,9 @@ namespace Microsoft.DotNet.Cli.Build
     {
         [Target(nameof(PackageTargets.CopyCLISDKLayout),
         nameof(SharedFrameworkTargets.PublishSharedHost),
-        nameof(SharedFrameworkTargets.PublishSharedFramework))]
+        nameof(SharedFrameworkTargets.PublishSharedFramework),
+        nameof(PackageTargets.CopyCombinedFrameworkSDKHostLayout),
+        nameof(PackageTargets.CopyCombinedFrameworkHostLayout))]
         public static BuildTargetResult InitPackage(BuildTargetContext c)
         {
             Directory.CreateDirectory(Dirs.Packages);
@@ -90,6 +92,39 @@ namespace Microsoft.DotNet.Cli.Build
             return c.Success();
         }
 
+        [Target]
+        public static BuildTargetResult CopyCombinedFrameworkSDKHostLayout(BuildTargetContext c)
+        {
+            var combinedRoot = Path.Combine(Dirs.Output, "obj", "combined-framework-sdk-host");
+
+            string sdkPublishRoot = c.BuildContext.Get<string>("CLISDKRoot");
+            Utils.CopyDirectoryRecursively(sdkPublishRoot, combinedRoot);
+
+            string sharedFrameworkPublishRoot = c.BuildContext.Get<string>("SharedFrameworkPublishRoot");
+            Utils.CopyDirectoryRecursively(sharedFrameworkPublishRoot, combinedRoot);
+
+            string sharedHostPublishRoot = c.BuildContext.Get<string>("SharedHostPublishRoot");
+            Utils.CopyDirectoryRecursively(sharedHostPublishRoot, combinedRoot);
+
+            c.BuildContext["CombinedFrameworkSDKHostRoot"] = combinedRoot;
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult CopyCombinedFrameworkHostLayout(BuildTargetContext c)
+        {
+            var combinedRoot = Path.Combine(Dirs.Output, "obj", "combined-framework-host");
+
+            string sharedFrameworkPublishRoot = c.BuildContext.Get<string>("SharedFrameworkPublishRoot");
+            Utils.CopyDirectoryRecursively(sharedFrameworkPublishRoot, combinedRoot);
+
+            string sharedHostPublishRoot = c.BuildContext.Get<string>("SharedHostPublishRoot");
+            Utils.CopyDirectoryRecursively(sharedHostPublishRoot, combinedRoot);
+
+            c.BuildContext["CombinedFrameworkHostRoot"] = combinedRoot;
+            return c.Success();
+        }
+
         [Target(nameof(PackageTargets.GenerateZip), nameof(PackageTargets.GenerateTarBall))]
         public static BuildTargetResult GenerateCompressedFile(BuildTargetContext c)
         {
@@ -103,6 +138,8 @@ namespace Microsoft.DotNet.Cli.Build
             CreateZipFromDirectory(c.BuildContext.Get<string>("SharedHostPublishRoot"), c.BuildContext.Get<string>("SharedHostCompressedFile"));
             CreateZipFromDirectory(c.BuildContext.Get<string>("SharedFrameworkPublishRoot"), c.BuildContext.Get<string>("SharedFrameworkCompressedFile"));
             CreateZipFromDirectory(c.BuildContext.Get<string>("CLISDKRoot"), c.BuildContext.Get<string>("SdkCompressedFile"));
+            CreateZipFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkSDKHostRoot"), c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile"));
+            CreateZipFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkHostRoot"), c.BuildContext.Get<string>("CombinedFrameworkHostCompressedFile"));
 
             return c.Success();
         }
@@ -113,7 +150,8 @@ namespace Microsoft.DotNet.Cli.Build
         {
             CreateTarBallFromDirectory(c.BuildContext.Get<string>("SharedHostPublishRoot"), c.BuildContext.Get<string>("SharedHostCompressedFile"));
             CreateTarBallFromDirectory(c.BuildContext.Get<string>("SharedFrameworkPublishRoot"), c.BuildContext.Get<string>("SharedFrameworkCompressedFile"));
-            CreateTarBallFromDirectory(c.BuildContext.Get<string>("CLISDKRoot"), c.BuildContext.Get<string>("SdkCompressedFile"));
+            CreateTarBallFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkSDKHostRoot"), c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile"));
+            CreateTarBallFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkHostRoot"), c.BuildContext.Get<string>("CombinedFrameworkHostCompressedFile"));
 
             return c.Success();
         }

--- a/scripts/dotnet-cli-build/PrepareTargets.cs
+++ b/scripts/dotnet-cli-build/PrepareTargets.cs
@@ -115,6 +115,8 @@ namespace Microsoft.DotNet.Cli.Build
             AddInstallerArtifactToContext(c, "dotnet", "Sdk");
             AddInstallerArtifactToContext(c, "dotnet-host", "SharedHost");
             AddInstallerArtifactToContext(c, "dotnet-sharedframework", "SharedFramework");
+            AddInstallerArtifactToContext(c, "dotnet-combined-framework-sdk-host", "CombinedFrameworkSDKHost");
+            AddInstallerArtifactToContext(c, "dotnet-combined-framework-host", "CombinedFrameworkHost");
 
             return c.Success();
         }

--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -49,6 +49,8 @@ namespace Microsoft.DotNet.Cli.Build
         nameof(PublishTargets.PublishDebFileToDebianRepo),
         nameof(PublishTargets.PublishSharedFrameworkCompressedFile),
         nameof(PublishTargets.PublishSharedHostCompressedFile),
+        nameof(PublishTargets.PublishCombinedFrameworkSDKHostFile),
+        nameof(PublishTargets.PublishCombinedFrameworkHostFile),
         nameof(PublishTargets.PublishLatestVersionTextFile))]
         public static BuildTargetResult PublishArtifacts(BuildTargetContext c)
         {
@@ -160,6 +162,32 @@ namespace Microsoft.DotNet.Cli.Build
         public static BuildTargetResult PublishSharedHostCompressedFile(BuildTargetContext c)
         {
             var compressedFile = c.BuildContext.Get<string>("SharedHostCompressedFile");
+            var compressedFileBlob = $"{Channel}/Binaries/{Version}/{Path.GetFileName(compressedFile)}";
+            var latestCompressedFile = compressedFile.Replace(Version, "latest");
+            var latestCompressedFileBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(latestCompressedFile)}";
+
+            PublishFileAzure(compressedFileBlob, compressedFile);
+            PublishFileAzure(latestCompressedFileBlob, compressedFile);
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult PublishCombinedFrameworkSDKHostFile(BuildTargetContext c)
+        {
+            var compressedFile = c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile");
+            var compressedFileBlob = $"{Channel}/Binaries/{Version}/{Path.GetFileName(compressedFile)}";
+            var latestCompressedFile = compressedFile.Replace(Version, "latest");
+            var latestCompressedFileBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(latestCompressedFile)}";
+
+            PublishFileAzure(compressedFileBlob, compressedFile);
+            PublishFileAzure(latestCompressedFileBlob, compressedFile);
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult PublishCombinedFrameworkHostFile(BuildTargetContext c)
+        {
+            var compressedFile = c.BuildContext.Get<string>("CombinedFrameworkHostCompressedFile");
             var compressedFileBlob = $"{Channel}/Binaries/{Version}/{Path.GetFileName(compressedFile)}";
             var latestCompressedFile = compressedFile.Replace(Version, "latest");
             var latestCompressedFileBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(latestCompressedFile)}";

--- a/scripts/dotnet-cli-build/Utils/Utils.cs
+++ b/scripts/dotnet-cli-build/Utils/Utils.cs
@@ -100,5 +100,15 @@ namespace Microsoft.DotNet.Cli.Build
                 Directory.Delete(path, true);
             }
         }
+
+        public static void CopyDirectoryRecursively(string path, string destination)
+        {
+            foreach (var file in Directory.GetFiles(path, "*", SearchOption.AllDirectories))
+            {
+                string destFile = file.Replace(path, destination);
+                Directory.CreateDirectory(Path.GetDirectoryName(destFile));
+                File.Copy(file, destFile, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
This creates two new zip files produced by the build. The names for these are messy, we should come up with something better.

* Combined zip/tar containing the shared framework, host, and SDK
* Combined zip/tar containing the shared framework and host

The second commit adds some steps that publish these to Azure.

@piotrpMSFT @Sridhar-MS