### PR TITLE
Updating the dotnet-test-runner version to 1.0.0-dev-91790-12. Some p…

### DIFF
--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -15,7 +15,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+    "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -16,7 +16,7 @@
     },
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+    "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+    "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+    "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -10,7 +10,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+    "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -10,7 +10,7 @@
     },
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
-    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+    "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -9,7 +9,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-79755-47"
+    "dotnet-test-xunit": "1.0.0-dev-91790-12"
   },
   "frameworks": {
     "netstandardapp1.5": {


### PR DESCRIPTION
…rojects still had the old version, which won't work with VS.

cc @piotrpMSFT @brthor