### PR TITLE
Trying to use corehost again

### DIFF
--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                     newArgs += " " + args;
                 }
                 args = newArgs;
-                executable = "dotnet";
+                executable = "corehost";
             }
 
             if (!Path.IsPathRooted(executable))


### PR DESCRIPTION
I think corehost should be working. Let's find out why it's not in the debian package, if that's the case.

Woo! PRs to PRs! I just want to get a Ubuntu build going and this is the easiest way to do that. I'm also spinning up my docker machine to try it locally.