### PR TITLE
Make corehost pick pre-release SDK version when no production releases.

### DIFF
--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -52,12 +52,7 @@ namespace Microsoft.DotNet.Cli.Build
         [Target]
         public static BuildTargetResult CopyCLISDKLayout(BuildTargetContext c)
         {
-            // CLI SDK must be layed out in path which has a Nuget version.
-            // But the muxer does not currently support the pre-release CLI SDK without a global.json file.
-            // So we are creating a production version.
-            // var nugetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").NuGetVersion;
-            var nugetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").ProductionVersion;
-
+            var nugetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").NuGetVersion;
             var cliSdkRoot = Path.Combine(Dirs.Output, "obj", "clisdk");
             var cliSdk = Path.Combine(cliSdkRoot, "sdk", nugetVersion);
 

--- a/src/corehost/cli/args.cpp
+++ b/src/corehost/cli/args.cpp
@@ -87,8 +87,10 @@ bool parse_arguments(const pal::string_t& deps_path, const pal::string_t& probe_
 
     args.app_argc -= num_args;
     args.app_argv += num_args;
-    pal::string_t deps_file = opts.count(_X("--depsfile")) ? opts[_X("--depsfile")] : deps_path;
-    pal::string_t probe_path = opts.count(_X("--additionalprobingpath")) ? opts[_X("--additionalprobingpath")] : probe_dir;
+    pal::string_t opts_deps_file = _X("--depsfile");
+    pal::string_t opts_probe_path = _X("--additionalprobingpath");
+    pal::string_t deps_file = opts.count(opts_deps_file) ? opts[opts_deps_file] : deps_path;
+    pal::string_t probe_path = opts.count(opts_probe_path) ? opts[opts_probe_path] : probe_dir;
 
     if (!deps_file.empty())
     {


### PR DESCRIPTION
Also fix STL crash.

cc: @schellap