### PR TITLE
[WIP] Patch lock file with lock file fragments

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/Graph/IMergeable.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/IMergeable.cs
@@ -1,0 +1,7 @@
+namespace Microsoft.DotNet.ProjectModel.Graph
+{
+    public interface IMergeable<T>
+    {
+        void MergeWith(T m);
+    }
+}

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFile.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
     {
         public static readonly int CurrentVersion = 2;
         public static readonly string FileName = "project.lock.json";
+        public static readonly string FragmentFileName = "project.fragment.lock.json";
 
         public string LockFilePath { get; }
 

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePackageLibrary.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePackageLibrary.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ProjectModel.Graph
 {
-    public class LockFilePackageLibrary
+    public class LockFilePackageLibrary : IMergeable<LockFilePackageLibrary>
     {
         public string Name { get; set; }
 
@@ -17,5 +18,13 @@ namespace Microsoft.DotNet.ProjectModel.Graph
         public string Sha512 { get; set; }
 
         public IList<string> Files { get; set; } = new List<string>();
+
+        public void MergeWith(LockFilePackageLibrary m)
+        {
+            // a package gets completely replaced
+            Sha512 = m.Sha512;
+            IsServiceable = m.IsServiceable;
+            Files = m.Files;
+        }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePackageLibrary.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePackageLibrary.cs
@@ -19,6 +19,8 @@ namespace Microsoft.DotNet.ProjectModel.Graph
 
         public IList<string> Files { get; set; } = new List<string>();
 
+        public string MSBuildProject { get; set; }
+
         public void MergeWith(LockFilePackageLibrary m)
         {
             // a package gets completely replaced

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileProjectLibrary.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileProjectLibrary.cs
@@ -5,12 +5,17 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ProjectModel.Graph
 {
-    public class LockFileProjectLibrary
+    public class LockFileProjectLibrary : IMergeable<LockFileProjectLibrary>
     {
         public string Name { get; set; }
 
         public NuGetVersion Version { get; set; }
 
         public string Path { get; set; }
+        public void MergeWith(LockFileProjectLibrary m)
+        {
+            Path = Path ?? m.Path;
+            BuildTimeDependency = BuildTimeDependency ?? m.BuildTimeDependency;
+        }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileProjectLibrary.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileProjectLibrary.cs
@@ -12,10 +12,13 @@ namespace Microsoft.DotNet.ProjectModel.Graph
         public NuGetVersion Version { get; set; }
 
         public string Path { get; set; }
+
+        public string MSBuildProjectPath { get; set; }
+
         public void MergeWith(LockFileProjectLibrary m)
         {
             Path = Path ?? m.Path;
-            BuildTimeDependency = BuildTimeDependency ?? m.BuildTimeDependency;
+            MSBuildProjectPath = MSBuildProjectPath ?? m.MSBuildProjectPath;
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
@@ -116,14 +116,32 @@ namespace Microsoft.DotNet.ProjectModel.Graph
 
                 if (type == null || string.Equals(type, "package", StringComparison.OrdinalIgnoreCase))
                 {
-                    lockFile.PackageLibraries.Add(new LockFilePackageLibrary
+
+                    var msbuildProject = value.Value("msbuildProject");
+                    LockFilePackageLibrary packageLibrary;
+
+                    if (msbuildProject == null)
                     {
-                        Name = name,
-                        Version = version,
-                        IsServiceable = ReadBool(value, "serviceable", defaultValue: false),
-                        Sha512 = ReadString(value.Value("sha512")),
-                        Files = ReadPathArray(value.Value("files"), ReadString)
-                    });
+                        packageLibrary = new LockFilePackageLibrary
+                        {
+                            Name = name,
+                            Version = version,
+                            IsServiceable = ReadBool(value, "serviceable", defaultValue: false),
+                            Sha512 = ReadString(value.Value("sha512")),
+                            Files = ReadPathArray(value.Value("files"), ReadString)
+                        };
+                    }
+                    else
+                    {
+                        packageLibrary = new LockFilePackageLibrary
+                        {
+                            Name = name,
+                            Version = version,
+                            MSBuildProject = ReadString(msbuildProject)
+                        };
+                    }
+
+                    lockFile.PackageLibraries.Add(packageLibrary);
                 }
                 else if (type == "project")
                 {
@@ -136,8 +154,8 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                     var pathValue = value.Value("path");
                     projectLibrary.Path = pathValue == null ? null : ReadString(pathValue);
 
-                    var buildTimeDependencyValue = value.Value("msbuildProject");
-                    projectLibrary.MSBuildProjectPath = buildTimeDependencyValue == null ? null : ReadString(buildTimeDependencyValue);
+                    //var msbuildProject = value.Value("msbuildProject");
+                    //projectLibrary.MSBuildProjectPath = msbuildProject == null ? null : ReadString(msbuildProject);
 
                     lockFile.ProjectLibraries.Add(projectLibrary);
                 }

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
@@ -105,12 +105,19 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                 }
                 else if (type == "project")
                 {
-                    lockFile.ProjectLibraries.Add(new LockFileProjectLibrary
+                    var projectLibrary = new LockFileProjectLibrary
                     {
                         Name = name,
-                        Version = version,
-                        Path = ReadString(value.Value("path"))
-                    });
+                        Version = version
+                    };
+
+                    var pathValue = value.Value("path");
+                    projectLibrary.Path = pathValue == null ? null : ReadString(pathValue);
+
+                    var buildTimeDependencyValue = value.Value("msbuildProject");
+                    projectLibrary.MSBuildProjectPath = buildTimeDependencyValue == null ? null : ReadString(buildTimeDependencyValue);
+
+                    lockFile.ProjectLibraries.Add(projectLibrary);
                 }
             }
         }

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileTarget.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileTarget.cs
@@ -6,12 +6,17 @@ using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.ProjectModel.Graph
 {
-    public class LockFileTarget
+    public class LockFileTarget : IMergeable<LockFileTarget>
     {
         public NuGetFramework TargetFramework { get; set; }
 
         public string RuntimeIdentifier { get; set; }
 
         public IList<LockFileTargetLibrary> Libraries { get; set; } = new List<LockFileTargetLibrary>();
+
+        public void MergeWith(LockFileTarget m)
+        {
+            Libraries.MergeWith(m.Libraries, l => l.Name);
+        }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileTargetLibrary.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileTargetLibrary.cs
@@ -3,13 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ProjectModel.Graph
 {
-    public class LockFileTargetLibrary
+    public class LockFileTargetLibrary : IMergeable<LockFileTargetLibrary>
     {
         public string Name { get; set; }
 
@@ -34,5 +35,50 @@ namespace Microsoft.DotNet.ProjectModel.Graph
         public IList<LockFileContentFile> ContentFiles { get; set; } = new List<LockFileContentFile>();
 
         public IList<LockFileRuntimeTarget> RuntimeTargets { get; set; } = new List<LockFileRuntimeTarget>();
+
+        public void MergeWith(LockFileTargetLibrary m)
+        {
+            TargetFramework = TargetFramework ?? m.TargetFramework;
+
+            if (Dependencies == null || !Dependencies.Any())
+            {
+                Dependencies = m.Dependencies;
+            }
+
+            if (FrameworkAssemblies == null || !FrameworkAssemblies.Any())
+            {
+                FrameworkAssemblies = m.FrameworkAssemblies;
+            }
+
+            if (RuntimeAssemblies == null || !RuntimeAssemblies.Any())
+            {
+                RuntimeAssemblies = m.RuntimeAssemblies;
+            }
+
+            if (CompileTimeAssemblies == null || !CompileTimeAssemblies.Any())
+            {
+                CompileTimeAssemblies = m.CompileTimeAssemblies;
+            }
+
+            if (ResourceAssemblies == null || !ResourceAssemblies.Any())
+            {
+                ResourceAssemblies = m.ResourceAssemblies;
+            }
+
+            if (NativeLibraries == null || !NativeLibraries.Any())
+            {
+                NativeLibraries = m.NativeLibraries;
+            }
+
+            if (ContentFiles == null || !ContentFiles.Any())
+            {
+                ContentFiles = m.ContentFiles;
+            }
+
+            if (RuntimeTargets == null || !RuntimeTargets.Any())
+            {
+                RuntimeTargets = m.RuntimeTargets;
+            }
+        }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/Graph/MergeableExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/MergeableExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NuGet.Packaging;
+
+namespace Microsoft.DotNet.ProjectModel.Graph
+{
+    internal static class CollectionExtensions
+    {
+        public static void MergeWith<T>(this ICollection<T> main, ICollection<T> incoming, Func<T, string> keyGenerator) where T : IMergeable<T>
+        {
+            var incomingDict = incoming.ToDictionary(keyGenerator);
+            var mainDict = main.ToDictionary(keyGenerator);
+
+            // merge with overlapping incoming items
+            var commonKeys = incomingDict.Keys.Intersect(mainDict.Keys);
+            foreach (var commonKey in commonKeys)
+            {
+                mainDict[commonKey].MergeWith(incomingDict[commonKey]);
+            }
+
+            // add new incoming items
+            var newKeys = incomingDict.Keys.Except(mainDict.Keys);
+            main.AddRange(newKeys.Select(k => incomingDict[k]));
+        }
+    }
+}

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -151,7 +151,11 @@ namespace Microsoft.DotNet.ProjectModel
                 .Where(t => t.TargetFramework.Equals(TargetFramework))
                 .Any(t => !string.IsNullOrEmpty(t.RuntimeIdentifier));
 
-            var context = Create(ProjectFile.ProjectFilePath, TargetFramework, standalone ? runtimeIdentifiers : Enumerable.Empty<string>());
+            var context = CreateBuilder(ProjectFile.ProjectFilePath, TargetFramework)
+                .WithRuntimeIdentifiers(standalone ? runtimeIdentifiers : Enumerable.Empty<string>())
+                .WithLockFile(LockFile)
+                .Build();
+
             if (standalone && context.RuntimeIdentifier == null)
             {
                 // We are standalone, but don't support this runtime

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
@@ -355,8 +355,10 @@ namespace Microsoft.DotNet.ProjectModel
 
                     if (projectLibrary != null)
                     {
-                        var path = Path.GetFullPath(Path.Combine(ProjectDirectory, projectLibrary.Path));
-                        description = projectDependencyProvider.GetDescription(library.Name, path, library, ProjectResolver);
+                        var projectPath = projectLibrary.Path ?? projectLibrary.MSBuildProjectPath;
+                        var fullProjectPath = Path.GetFullPath(Path.Combine(ProjectDirectory, projectPath));
+
+                        description = projectDependencyProvider.GetDescription(library.Name, fullProjectPath, library, ProjectResolver);
                     }
 
                     type = LibraryType.Project;

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
@@ -342,7 +342,7 @@ namespace Microsoft.DotNet.ProjectModel
             }
         }
 
-        private void ScanLibraries(LockFileTarget target, LockFileLookup lockFileLookup, Dictionary<LibraryKey, LibraryDescription> libraries, PackageDependencyProvider packageResolver, ProjectDependencyProvider projectDependencyProvider)
+        private void ScanLibraries(LockFileTarget target, LockFileLookup lockFileLookup, Dictionary<LibraryKey, LibraryDescription> libraries, PackageDependencyProvider packageDependencyProvider, ProjectDependencyProvider projectDependencyProvider)
         {
             foreach (var library in target.Libraries)
             {
@@ -369,7 +369,7 @@ namespace Microsoft.DotNet.ProjectModel
 
                     if (packageEntry != null)
                     {
-                        description = packageResolver.GetDescription(TargetFramework, packageEntry, library);
+                        description = packageDependencyProvider.GetDescription(TargetFramework, packageEntry, library);
                     }
 
                     type = LibraryType.Package;

--- a/src/Microsoft.DotNet.ProjectModel/ProjectFileDependencyGroup.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectFileDependencyGroup.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.ProjectModel.Graph;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.ProjectModel
 {
-    public class ProjectFileDependencyGroup
+    public class ProjectFileDependencyGroup : IMergeable<ProjectFileDependencyGroup>
     {
         public ProjectFileDependencyGroup(NuGetFramework frameworkName, IEnumerable<string> dependencies)
         {
@@ -16,6 +18,11 @@ namespace Microsoft.DotNet.ProjectModel
 
         public NuGetFramework FrameworkName { get; }
 
-        public IEnumerable<string> Dependencies { get; }
+        public IEnumerable<string> Dependencies { get; private set; }
+
+        public void MergeWith(ProjectFileDependencyGroup m)
+        {
+            Dependencies = Dependencies?.Union(m.Dependencies) ?? m.Dependencies;
+        }
     }
 }


### PR DESCRIPTION
This refers to the scenario where VS drives the build and there are xproj projects referencing csproj projects.

When a project.json project references a csproj project, nuget cannot follow the dependency path toward the csproj. Those dependencies are only available at build time. Therefore, there will be a special msbuild target that generates a fragment lock file describing all the csproj projects that an xproj depends upon.

By convention, the fragment lock file is placed besides the master lock file. If the fragment is there, LockfileReader merges with it. 

A tentative fragment lock file format is here: https://gist.github.com/cdmihai/3ebda8bd9c52e33f235a

TODOs:
- [ ] make new library description for msbuild projects. The current code marks it as unresolved because path points to a csproj and not a project.json
- [ ] extract merging algorithm into new file and update to use an immutable LockFile
- [ ] write unit tests
- [ ] update documentation
- [ ] detect if lock file has holes and did not get merged with a fragment. Saves the user from weird unresolved dependencies errors.



@davidfowl 
@abpiskunov 