### PR TITLE
Add bsymbolic flags to linux linker

### DIFF
--- a/src/corehost/cli/setup.cmake
+++ b/src/corehost/cli/setup.cmake
@@ -37,6 +37,12 @@ else()
     add_compile_options(-Wno-unused-local-typedef)
 endif()
 
+# This is required to map a symbol reference to a matching definition local to the module (.so)
+# containing the reference instead of using definitions from other modules.
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
+endif()
+
 if(CLI_CMAKE_PLATFORM_ARCH_I386)
     add_definitions(-D_TARGET_X86_=1)
 elseif(CLI_CMAKE_PLATFORM_ARCH_AMD64)


### PR DESCRIPTION
The problem with not having these flags are:

`libhostfxr.so` and `libhostpolicy.so` would still keep using common functions that are defined in `dotnet.exe` effectively voiding a servicing override. Of course, servicing of common code would service both `dotnet.exe` and `libhostpolicy.so`, but this is needed to match Windows for consistency and is easier to reason about.