### PR TITLE
Fix typo in CompileCommand class name

### DIFF
--- a/src/dotnet/commands/dotnet-build/CompileContext.cs
+++ b/src/dotnet/commands/dotnet-build/CompileContext.cs
@@ -314,7 +314,7 @@ namespace Microsoft.DotNet.Tools.Build
                 args.Add(_args.BuildBasePathValue);
             }
 
-            var compileResult = CommpileCommand.Run(args.ToArray());
+            var compileResult = CompileCommand.Run(args.ToArray());
 
             return compileResult == 0;
         }
@@ -395,7 +395,7 @@ namespace Microsoft.DotNet.Tools.Build
 
             args.Add(_rootProject.ProjectDirectory);
 
-            var compileResult = CommpileCommand.Run(args.ToArray());
+            var compileResult = CompileCommand.Run(args.ToArray());
 
             var succeeded = compileResult == 0;
 

--- a/src/dotnet/commands/dotnet-compile/Program.cs
+++ b/src/dotnet/commands/dotnet-compile/Program.cs
@@ -6,7 +6,7 @@ using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.Compiler
 {
-    public class CommpileCommand
+    public class CompileCommand
     {
 
         public static int Run(string[] args)


### PR DESCRIPTION
Happened to notice a typo while reading the source code over, so I did a `sed -i s/Commpile/Compile/g` replacement to fix it. :smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/1945)
<!-- Reviewable:end -->
