### PR TITLE
Fix a couple of typos in the .md/doc files

### DIFF
--- a/Documentation/manpages/dotnet-compile-native.1
+++ b/Documentation/manpages/dotnet-compile-native.1
@@ -24,7 +24,7 @@ architecture.
 The executable has a default extension of "" on Linux and OS X and
 ".exe" on Windows.
 The source must include a `static void Main(string[] args) entry point
-and specify compilerOptions.emitEntryPoint in the project.json.
+and specify compilationOptions.emitEntryPoint in the project.json.
 .PP
 Output files are written to the child \f[C]bin\f[] folder, which will be
 created if it doesn\[aq]t exist.

--- a/Documentation/manpages/dotnet-compile.1
+++ b/Documentation/manpages/dotnet-compile.1
@@ -14,7 +14,7 @@ dotnet compile [\-\-native] [\-\-output] [\-\-temp\-output]
 .SH DESCRIPTION
 .PP
 The compile command compiles source files from a single project to a
-binary file, either intermmediate language (IL) byte code or native
+binary file, either intermediate language (IL) byte code or native
 machine code, depending on the options provided.
 The default option is compilation to IL byte code, but may change in the
 future.
@@ -36,8 +36,8 @@ project.json:
 .nf
 \f[C]
 {\ 
-\ \ \ \ "compilerOptions":\ {
-\ \ \ \ \ \ "emitEntryPoints":\ true
+\ \ \ \ "compilationOptions":\ {
+\ \ \ \ \ \ "emitEntryPoint":\ true
 \ \ \ \ }
 }
 \f[]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For more details, please refer to the [documentation](https://github.com/dotnet/
 Building from source
 --------------------
 
-If you are building from source, take note that the build depends on NuGet packages hosted on Myget, so if it is down, the build may fail. If that happens, you can always see the [Myget status page](http://status.myget.org/) for more info. 
+If you are building from source, take note that the build depends on NuGet packages hosted on MyGet, so if it is down, the build may fail. If that happens, you can always see the [MyGet status page](http://status.myget.org/) for more info. 
 
 Read over the [contributing guidelines](https://github.com/dotnet/cli/tree/master/CONTRIBUTING.md) and [developer documentation](https://github.com/dotnet/cli/tree/master/Documentation) for prerequisites for building from source.
 

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -35,7 +35,7 @@ The following commands exist for dotnet.
 
 `dotnet-compile(1)`
 
-    Compile the application to either an intermidiate language (IL) or to a native binary. 
+    Compile the application to either an intermediate language (IL) or to a native binary. 
 
 `dotnet-restore(1)`
 
@@ -59,7 +59,7 @@ The following commands exist for dotnet.
 
 # EXAMPLES
 
-`dotnew new`
+`dotnet new`
 
     Initializes a sample .NET Core console application that can be compiled and ran.
 

--- a/src/dotnet/commands/dotnet-compile-csc/README.md
+++ b/src/dotnet/commands/dotnet-compile-csc/README.md
@@ -8,7 +8,7 @@ dotnet-compile -- Compiles source files for a single project to a binary format 
 dotnet compile [--output] [--build-base-path] [--framework] [--configuration] [--output] [--arch] [--verbose]
 
 # DESCRIPTION
-The compile command compiles source files from a single project to a binary file, either intermmediate language (IL) byte code or native machine code, depending on the options provided. The default option is compilation to IL byte code, but may change in the future. Users who want to benefit from incremental builds and who want to compile both the project and its dependencies should use the dotnet-build(1) command.
+The compile command compiles source files from a single project to a binary file, either intermediate language (IL) byte code or native machine code, depending on the options provided. The default option is compilation to IL byte code, but may change in the future. Users who want to benefit from incremental builds and who want to compile both the project and its dependencies should use the dotnet-build(1) command.
 
 The result of compilation is by default an executable file that can be ran. Output files, are written to the child `bin` folder, which will be created if it doesn't exist. Files will be overwritten as needed. The temporary files that are created during compilation are placed in the child `obj` folder. 
  
@@ -16,8 +16,8 @@ The executables also require a special configuration section in project.json:
 
 ```json
 { 
-    "compilerOptions": {
-      "emitEntryPoints": true
+    "compilationOptions": {
+      "emitEntryPoint": true
     }
 }
 ```

--- a/src/dotnet/commands/dotnet-compile-native/README.md
+++ b/src/dotnet/commands/dotnet-compile-native/README.md
@@ -14,7 +14,7 @@ dotnet compile [--appdepsdk] [--configuration]
 # DESCRIPTION
 The `compile-native` command compiles IL assemblies to native machine code. It is used by `dotnet-compile --native`.
 
-The output is a native exe that conforms to the architecture of the underlying operating system (i.e. running on 64-bit OS will produce a native 64-bit exe). This can be overriden via the --arch switch and specifying the wanted architecture. The executable has a default extension of "" on Linux and OS X and ".exe" on Windows. The source must include a `static void Main(string[] args) entry point and specify compilerOptions.emitEntryPoint in the project.json. 
+The output is a native exe that conforms to the architecture of the underlying operating system (i.e. running on 64-bit OS will produce a native 64-bit exe). This can be overriden via the --arch switch and specifying the wanted architecture. The executable has a default extension of "" on Linux and OS X and ".exe" on Windows. The source must include a `static void Main(string[] args) entry point and specify compilationOptions.emitEntryPoint in the project.json. 
 
 Output files are written to the child `bin` folder, which will be created if it doesn't exist. Files will be overwritten as needed.
 

--- a/src/dotnet/commands/dotnet-compile/README.md
+++ b/src/dotnet/commands/dotnet-compile/README.md
@@ -11,7 +11,7 @@ dotnet compile [--native] [--output]
     [--output] [--arch] [--cpp] [-ilc-args] [--verbose]
 
 # DESCRIPTION
-The compile command compiles source files from a single project to a binary file, either intermmediate language (IL) byte code or native machine code, depending on the options provided. The default option is compilation to IL byte code, but may change in the future. Users who want to benefit from incremental builds and who want to compile both the project and its dependencies should use the dotnet-build(1) command.
+The compile command compiles source files from a single project to a binary file, either intermediate language (IL) byte code or native machine code, depending on the options provided. The default option is compilation to IL byte code, but may change in the future. Users who want to benefit from incremental builds and who want to compile both the project and its dependencies should use the dotnet-build(1) command.
 
 The result of compilation is by default an executable file that can be ran. Output files, are written to the child `bin` folder, which will be created if it doesn't exist. Files will be overwritten as needed. The temporary files that are created during compilation are placed in the child `obj` folder. 
  
@@ -19,8 +19,8 @@ The executables also require a special configuration section in project.json:
 
 ```json
 { 
-    "compilerOptions": {
-      "emitEntryPoints": true
+    "compilationOptions": {
+      "emitEntryPoint": true
     }
 }
 ```


### PR DESCRIPTION
A bit of a follow-up on #1945. I noticed there were a bunch of typos in some of the `.md` files, so with the help of `sed -i` I replaced some of them. Here are some of the replaced words:

- intermmediate => intermediate
- compilerOptions => compilationOptions
- emitEntryPoints => emitEntryPoint

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/1946)
<!-- Reviewable:end -->
