### PR TITLE
Disable deb creation & publishing

### DIFF
--- a/scripts/dotnet-cli-build/InstallerTargets.cs
+++ b/scripts/dotnet-cli-build/InstallerTargets.cs
@@ -14,16 +14,17 @@ namespace Microsoft.DotNet.Cli.Build
     {
         [Target(nameof(MsiTargets.GenerateMsis),
         nameof(MsiTargets.GenerateBundle),
-        nameof(PkgTargets.GeneratePkgs),
-        nameof(InstallerTargets.GenerateDebs))]
+        nameof(PkgTargets.GeneratePkgs)]//,
+        //nameof(InstallerTargets.GenerateDebs))]
         public static BuildTargetResult GenerateInstaller(BuildTargetContext c)
         {
             return c.Success();
         }
 
-        [Target(nameof(InstallerTargets.GenerateSdkDeb),
-        nameof(InstallerTargets.GenerateSharedFrameworkDeb),
-        nameof(InstallerTargets.GenerateSharedHostDeb))]
+        [Target(
+            nameof(InstallerTargets.GenerateSdkDeb),
+            nameof(InstallerTargets.GenerateSharedFrameworkDeb),
+            nameof(InstallerTargets.GenerateSharedHostDeb))]
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult GenerateDebs(BuildTargetContext c)
         {

--- a/scripts/dotnet-cli-build/InstallerTargets.cs
+++ b/scripts/dotnet-cli-build/InstallerTargets.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli.Build
     {
         [Target(nameof(MsiTargets.GenerateMsis),
         nameof(MsiTargets.GenerateBundle),
-        nameof(PkgTargets.GeneratePkgs)]//,
+        nameof(PkgTargets.GeneratePkgs))]//,
         //nameof(InstallerTargets.GenerateDebs))]
         public static BuildTargetResult GenerateInstaller(BuildTargetContext c)
         {

--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -44,12 +44,13 @@ namespace Microsoft.DotNet.Cli.Build
             return c.Success();
         }
 
-        [Target(nameof(PublishTargets.PublishVersionBadge),
-        nameof(PublishTargets.PublishSdkInstallerFile),
-        nameof(PublishTargets.PublishDebFileToDebianRepo),
-        nameof(PublishTargets.PublishCombinedFrameworkSDKHostFile),
-        nameof(PublishTargets.PublishCombinedFrameworkHostFile),
-        nameof(PublishTargets.PublishLatestVersionTextFile))]
+        [Target(
+            nameof(PublishTargets.PublishVersionBadge),
+            nameof(PublishTargets.PublishSdkInstallerFile),
+            //nameof(PublishTargets.PublishDebFileToDebianRepo),
+            nameof(PublishTargets.PublishCombinedFrameworkSDKHostFile),
+            nameof(PublishTargets.PublishCombinedFrameworkHostFile),
+            nameof(PublishTargets.PublishLatestVersionTextFile))]
         public static BuildTargetResult PublishArtifacts(BuildTargetContext c)
         {
             return c.Success();
@@ -68,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Build
         }
 
         [Target]
-        [BuildPlatforms(BuildPlatform.Windows, BuildPlatform.OSX, BuildPlatform.Ubuntu)]
+        [BuildPlatforms(BuildPlatform.Windows, BuildPlatform.OSX)]//, BuildPlatform.Ubuntu)]
         public static BuildTargetResult PublishSdkInstallerFile(BuildTargetContext c)
         {
             var installerFile = c.BuildContext.Get<string>("CombinedFrameworkSDKHostInstallerFile");

--- a/scripts/obtain/install.sh
+++ b/scripts/obtain/install.sh
@@ -99,6 +99,16 @@ make_link() {
     ln -s $src $dest
 }
 
+make_bootstrap_link() {
+    local src=$INSTALLDIR/cli/bin/dotnet
+    local dest=$INSTALLDIR/cli/dotnet
+    say "Linking $dest -> $src"
+    if [ -e $dest ]; then
+        rm $dest
+    fi
+    ln -s $src $dest
+}
+
 install_dotnet()
 {
     if ! machine_has "curl"; then
@@ -130,6 +140,10 @@ install_dotnet()
     local installLocation="$INSTALLDIR"
     local dotnet_url="https://dotnetcli.blob.core.windows.net/dotnet/$CHANNEL/Binaries/$VERSION"
     local dotnet_filename="dotnet-dev-$os-x64.$fileVersion.tar.gz"
+    
+    if [ "$os" = "ubuntu" ]; then
+        dotnet_filename="dotnet-$os-x64.$fileVersion.tar.gz"
+    fi
 
     if [ "$RELINK" = "0" ]; then
         if [ "$FORCE" = "0" ]; then
@@ -178,6 +192,10 @@ install_dotnet()
         [ $? != 0 ] && say_err "Failed to clean current dotnet install" && return 1
 
         mv "$installLocation/cli_new" "$installLocation/cli"
+         
+        if [ "$os" = "ubuntu" ]; then
+            make_bootstrap_link
+        fi
     elif [ ! -e "$installLocation/cli" ]; then
         say_err "${red}cannot relink dotnet, it is not installed in $PREFIX!"
         return 1


### PR DESCRIPTION
Temporarily disabling Debian. While PR #1890 is getting quite close, there is still work there and we need to unblock builds.