### PR TITLE
Pass DockerHub env vars to container used for build

### DIFF
--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -102,5 +102,7 @@ docker run $INTERACTIVE -t --rm --sig-proxy=true \
     -e REPO_SERVER \
     -e DOTNET_BUILD_SKIP_CROSSGEN \
     -e PUBLISH_TO_AZURE_BLOB \
+    -e DOCKER_HUB_REPO \
+    -e DOCKER_HUB_TRIGGER_TOKEN \
     $DOTNET_BUILD_CONTAINER_TAG \
     $BUILD_COMMAND "$@"


### PR DESCRIPTION
These environment variables need to be set for the
TriggerDockerHubBuilds build target declared in PublishTargets.cs.

This fixes https://github.com/dotnet/dotnet-docker-preview/issues/4.

cc: @MichaelSimons @brthor @Sridhar-MS