### PR TITLE
Crossgen by default, add additional dependency to shared framework

### DIFF
--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -477,9 +477,9 @@ namespace Microsoft.DotNet.Cli.Build
         public static BuildTargetResult CrossgenSharedFx(BuildTargetContext c, string pathToAssemblies)
         {
             // Check if we need to skip crossgen
-            if (!string.Equals(Environment.GetEnvironmentVariable("CROSSGEN_SHAREDFRAMEWORK"), "1"))
+            if (string.Equals(Environment.GetEnvironmentVariable("DONT_CROSSGEN_SHAREDFRAMEWORK"), "1"))
             {
-                c.Warn("Skipping crossgen for SharedFx because CROSSGEN_SHAREDFRAMEWORK is not set to 1");
+                c.Warn("Skipping crossgen for SharedFx because DONT_CROSSGEN_SHAREDFRAMEWORK is set to 1");
                 return c.Success();
             }
 

--- a/src/sharedframework/framework/project.json
+++ b/src/sharedframework/framework/project.json
@@ -5,7 +5,8 @@
     },
 
     "dependencies": {
-        "Microsoft.NETCore.App": "1.0.0-rc2-23911"
+        "Microsoft.NETCore.App": "1.0.0-rc2-23911",
+        "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160318-02"
     },
 
     "runtimes": {


### PR DESCRIPTION
This turns on crossgen for the shared framework by default. No assemblies are skipped.

We need a newer version of Microsoft.CodeAnalysis.CSharp than the one that NETCore.App depends on. When a newer version of NETCore.App is published with a higher dependency, we can remove this explicit reference.

@Sridhar-MS , @ellismg , @piotrpMSFT