### PR TITLE
Logging and case format fix

### DIFF
--- a/src/corehost/cli/args.h
+++ b/src/corehost/cli/args.h
@@ -15,8 +15,6 @@ struct arguments_t
     pal::string_t app_dir;
     pal::string_t deps_path;
     pal::string_t dotnet_servicing;
-    pal::string_t dotnet_runtime_servicing;
-    pal::string_t dotnet_home;
     pal::string_t probe_dir;
     pal::string_t dotnet_packages_cache;
     pal::string_t managed_application;
@@ -25,6 +23,15 @@ struct arguments_t
     const pal::char_t** app_argv;
 
     arguments_t();
+
+    inline void print()
+    {
+        if (trace::is_enabled())
+        {
+            trace::verbose(_X("args: own_path=%s app_dir=%s deps=%s servicing=%s probe_dir=%s packages_cache=%s mgd_app=%s"),
+                own_path.c_str(), app_dir.c_str(), deps_path.c_str(), dotnet_servicing.c_str(), probe_dir.c_str(), dotnet_packages_cache.c_str(), managed_application.c_str());
+        }
+    }
 };
 
 bool parse_arguments(const pal::string_t& deps_path, const pal::string_t& probe_dir, host_mode_t mode, const int argc, const pal::char_t* argv[], arguments_t* args);

--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -292,6 +292,21 @@ bool deps_json_t::load_standalone(const json_value& json, const pal::string_t& t
             }
         }
     }
+
+    if (trace::is_enabled())
+    {
+        trace::verbose(_X("The rid fallback graph is: {"));
+        for (const auto& rid : m_rid_fallback_graph)
+        {
+            trace::verbose(_X("%s => ["), rid.first.c_str());
+            for (const auto& fallback : rid.second)
+            {
+                trace::verbose(_X("%s, "), fallback.c_str());
+            }
+            trace::verbose(_X("]"));
+        }
+        trace::verbose(_X("}"));
+    }
     return true;
 }
 
@@ -304,6 +319,7 @@ bool deps_json_t::load(bool portable, const pal::string_t& deps_path, const rid_
     // If file doesn't exist, then assume parsed.
     if (!pal::file_exists(deps_path))
     {
+        trace::verbose(_X("Deps file does not exist [%s]"), deps_path.c_str());
         return true;
     }
 
@@ -311,6 +327,7 @@ bool deps_json_t::load(bool portable, const pal::string_t& deps_path, const rid_
     pal::ifstream_t file(deps_path);
     if (!file.good())
     {
+        trace::error(_X("Could not open file stream on deps file [%s]"), deps_path.c_str());
         return false;
     }
 
@@ -320,6 +337,8 @@ bool deps_json_t::load(bool portable, const pal::string_t& deps_path, const rid_
 
         const auto& runtime_target = json.at(_X("runtimeTarget"));
         const pal::string_t& name = runtime_target.as_string();
+
+        trace::verbose(_X("Loading deps file... %s as portable=[%d]"), deps_path.c_str(), portable);
 
         return (portable) ? load_portable(json, name, rid_fallback_graph) : load_standalone(json, name);
     }

--- a/src/corehost/cli/deps_resolver.h
+++ b/src/corehost/cli/deps_resolver.h
@@ -36,6 +36,8 @@ public:
         if (m_portable)
         {
             m_fx_deps_file = get_fx_deps(fx_dir, config->get_fx_name());
+            trace::verbose(_X("Using %s FX deps file"), m_fx_deps_file.c_str());
+            trace::verbose(_X("Using %s deps file"), m_deps_file.c_str());
             m_fx_deps = std::unique_ptr<deps_json_t>(new deps_json_t(false, m_fx_deps_file));
             m_deps = std::unique_ptr<deps_json_t>(new deps_json_t(true, m_deps_file, m_fx_deps->get_rid_fallback_graph()));
         }
@@ -74,7 +76,7 @@ private:
     static pal::string_t get_fx_deps(const pal::string_t& fx_dir, const pal::string_t& fx_name)
     {
         pal::string_t fx_deps = fx_dir;
-        pal::string_t fx_deps_name = pal::to_lower(fx_name) + _X(".deps.json");
+        pal::string_t fx_deps_name = fx_name + _X(".deps.json");
         append_path(&fx_deps, fx_deps_name.c_str());
         return fx_deps;
     }

--- a/src/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/corehost/cli/fxr/fx_muxer.cpp
@@ -277,6 +277,7 @@ int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
         {
             std::vector<pal::string_t> known_opts = { _X("--depsfile"), _X("--additionalprobingpath") };
 
+            trace::verbose(_X("Exec mode, parsing known args"));
             int num_args = 0;
             std::unordered_map<pal::string_t, pal::string_t> opts;
             if (!parse_known_args(argc - 2, &argv[2], known_opts, &opts, &num_args))
@@ -302,8 +303,11 @@ int fx_muxer_t::execute(const int argc, const pal::char_t* argv[])
             pal::string_t deps_file = opts.count(opts_deps_file) ? opts[opts_deps_file] : _X("");
             pal::string_t probe_path = opts.count(opts_probe_path) ? opts[opts_probe_path] : _X("");
 
+            trace::verbose(_X("Current argv is %s"), argv[cur_i]);
+
             pal::string_t app_or_deps = deps_file.empty() ? argv[cur_i] : deps_file;
-            auto config_file = get_runtime_config_from_file(app_or_deps);
+            pal::string_t no_json = deps_file.empty() ? app_or_deps : strip_file_ext(app_or_deps);
+            auto config_file = get_runtime_config_from_file(no_json);
             runtime_config_t config(config_file);
             if (!config.is_valid())
             {

--- a/src/corehost/cli/hostpolicy.cpp
+++ b/src/corehost/cli/hostpolicy.cpp
@@ -205,11 +205,29 @@ SHARED_API int corehost_main(const int argc, const pal::char_t* argv[])
 
     assert(g_init);
 
+    if (trace::is_enabled())
+    {
+        trace::info(_X("--- Invoked policy main = {"));
+        for (int i = 0; i < argc; ++i)
+        {
+            trace::info(_X("%s"), argv[i]);
+        }
+        trace::info(_X("}"));
+
+        trace::info(_X("Host mode: %d"), g_init->host_mode());
+        trace::info(_X("Deps file: %s"), g_init->deps_file().c_str());
+        trace::info(_X("Probe dir: %s"), g_init->probe_dir().c_str());
+    }
+
     // Take care of arguments
     arguments_t args;
     if (!parse_arguments(g_init->deps_file(), g_init->probe_dir(), g_init->host_mode(), argc, argv, &args))
     {
         return StatusCode::LibHostInvalidArgs;
+    }
+    if (trace::is_enabled())
+    {
+        args.print();
     }
 
     if (g_init->runtime_config())

--- a/src/corehost/cli/libhost.cpp
+++ b/src/corehost/cli/libhost.cpp
@@ -9,7 +9,6 @@
 pal::string_t get_runtime_config_from_file(const pal::string_t& file)
 {
     auto name = get_filename_without_ext(file);
-    name = name.substr(0, name.find(_X('.')));
     auto json_name = name + _X(".runtimeconfig.json");
     auto json_path = get_directory(file);
 
@@ -40,7 +39,7 @@ host_mode_t detect_operating_mode(const int argc, const pal::char_t* argv[], pal
     pal::string_t own_dll_filename = strip_file_ext(own_name) + _X(".dll");
     pal::string_t own_dll = own_dir;
     append_path(&own_dll, own_dll_filename.c_str());
-    trace::info(_X("Exists %s"), own_dll.c_str());
+    trace::info(_X("Own DLL path=[%s]"), own_dll.c_str());
     if (coreclr_exists_in_dir(own_dir) || pal::file_exists(own_dll))
     {
         pal::string_t own_deps_json = own_dir;

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #include "pal.h"
+#include "trace.h"
 #include "utils.h"
 #include "cpprest/json.h"
 #include "runtime_config.h"
@@ -13,6 +14,7 @@ runtime_config_t::runtime_config_t(const pal::string_t& path)
     , m_portable(false)
 {
     m_valid = ensure_parsed();
+    trace::verbose(_X("Runtime config [%s] is valid=[%d]"), path.c_str(), m_valid);
 } 
 
 bool runtime_config_t::parse_opts(const json_value& opts)
@@ -70,6 +72,7 @@ bool runtime_config_t::ensure_parsed()
     pal::ifstream_t file(m_path);
     if (!file.good())
     {
+        trace::verbose(_X("File stream not good %s"), m_path.c_str());
         return false;
     }
 
@@ -85,6 +88,7 @@ bool runtime_config_t::ensure_parsed()
     }
     catch (...)
     {
+        trace::warning(_X("Json exception occurred."));
         return false;
     }
     return true;

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -77,7 +77,13 @@ pal::string_t strip_file_ext(const pal::string_t& path)
     {
         return path;
     }
-    return path.substr(0, path.rfind(_X('.')));
+    size_t sep_pos = path.rfind(_X("/\\"));
+    size_t dot_pos = path.rfind(_X('.'));
+    if (sep_pos != pal::string_t::npos && sep_pos > dot_pos)
+    {
+	    return path;
+    }
+    return path.substr(0, dot_pos);
 }
 
 pal::string_t get_filename_without_ext(const pal::string_t& path)
@@ -167,6 +173,7 @@ bool parse_known_args(
             return false;
         }
 
+        trace::verbose(_X("Parsed known arg %s = %s"), arg.c_str(), argv[arg_i + 1]);
         (*opts)[arg] = argv[arg_i + 1];
 
         // Increment for both the option and its value.


### PR DESCRIPTION
Cc @eerhardt 

@gkhanna79 PTAL.

At one point we spec'ed the deps.json in the fx would be called `netcoreapp.deps.json`, so I cautiously did a `to_lower`, but now the name has changed to be a namespace `Microsoft.NETCore.App.deps.json`, which is case sensitive. This is an issue for OSX and Ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2021)
<!-- Reviewable:end -->
