### PR TITLE
Publish all installers/archives for sharedfx, host, and the sdk

### DIFF
--- a/packaging/host/debian/dotnet-sharedhost-debian_config.json
+++ b/packaging/host/debian/dotnet-sharedhost-debian_config.json
@@ -28,6 +28,11 @@
         "full_text": "Copyright (c) 2015 Microsoft\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE."
     },
 
+    "package_conflicts" : [
+        "dotnet",
+        "dotnet-nightly"
+    ],
+
     "symlinks": {
         "dotnet" : "/usr/bin/dotnet"
     }

--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -375,7 +375,7 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             // Generate .version file
-            var version = buildVersion.SimpleVersion;
+            var version = buildVersion.NuGetVersion;
             var content = $@"{c.BuildContext["CommitHash"]}{Environment.NewLine}{version}{Environment.NewLine}";
             File.WriteAllText(Path.Combine(outputDir, ".version"), content);
 

--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -301,6 +301,11 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             CrossgenSharedFx(c, SharedFrameworkNameAndVersionRoot);
+
+            // Generate .version file for sharedfx
+            var version = SharedFrameworkNugetVersion;
+            var content = $@"{c.BuildContext["CommitHash"]}{Environment.NewLine}{version}{Environment.NewLine}";
+            File.WriteAllText(Path.Combine(SharedFrameworkNameAndVersionRoot, ".version"), content);
         }
 
         private static BuildTargetResult CompileCliSdk(BuildTargetContext c, DotNetCli dotnet, string outputDir)

--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -30,8 +30,8 @@ namespace Microsoft.DotNet.Cli.Build
             AzurePublisherTool = new AzurePublisher();
             DebRepoPublisherTool = new DebRepoPublisher(Dirs.Packages);
 
-            CliVersion = c.BuildContext.Get<BuildVersion>("BuildCliVersion").SimpleVersion;
-            CliNuGetVersion = c.BuildContext.Get<BuildVersion>("BuildCliVersion").NuGetVersion;
+            CliVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
+            CliNuGetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").NuGetVersion;
             SharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             Channel = c.BuildContext.Get<string>("Channel");
 
@@ -82,12 +82,12 @@ namespace Microsoft.DotNet.Cli.Build
         [Target]
         public static BuildTargetResult PublishCliVersionBadge(BuildTargetContext c)
         {
-            var CliversionBadge = c.BuildContext.Get<string>("CliVersionBadge");
-            var latestCliVersionBadgeBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(CliversionBadge)}";
-            var CliversionBadgeBlob = $"{Channel}/Binaries/{CliVersion}/{Path.GetFileName(CliversionBadge)}";
+            var versionBadge = c.BuildContext.Get<string>("VersionBadge");
+            var latestVersionBadgeBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(versionBadge)}";
+            var versionBadgeBlob = $"{Channel}/Binaries/{CliNuGetVersion}/{Path.GetFileName(versionBadge)}";
 
-            AzurePublisherTool.PublishFile(CliversionBadgeBlob, CliversionBadge);
-            AzurePublisherTool.PublishFile(latestCliVersionBadgeBlob, CliversionBadge);
+            AzurePublisherTool.PublishFile(versionBadgeBlob, versionBadge);
+            AzurePublisherTool.PublishFile(latestVersionBadgeBlob, versionBadge);
             return c.Success();
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.DotNet.Cli.Build
         public static BuildTargetResult PublishSdkInstallerFileToAzure(BuildTargetContext c)
         {
             var version = CliNuGetVersion;
-            var installerFile = c.BuildContext.Get<string>("SDKInstallerFile");
+            var installerFile = c.BuildContext.Get<string>("SdkInstallerFile");
 
             AzurePublisherTool.PublishInstallerFileAndLatest(installerFile, Channel, version);
 
@@ -157,7 +157,7 @@ namespace Microsoft.DotNet.Cli.Build
             var version = CliNuGetVersion;
             var archiveFile = c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile");
 
-            AzurePublisherTool.PublishInstallerFileAndLatest(archiveFile, Channel, version);
+            AzurePublisherTool.PublishArchiveAndLatest(archiveFile, Channel, version);
 
             return c.Success();
         }
@@ -168,7 +168,7 @@ namespace Microsoft.DotNet.Cli.Build
             var version = SharedFrameworkNugetVersion;
             var archiveFile = c.BuildContext.Get<string>("CombinedFrameworkHostCompressedFile");
 
-            AzurePublisherTool.PublishInstallerFileAndLatest(archiveFile, Channel, version);
+            AzurePublisherTool.PublishArchiveAndLatest(archiveFile, Channel, version);
             return c.Success();
         }
 

--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -12,32 +12,35 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public static class PublishTargets
     {
-        private static CloudBlobContainer BlobContainer { get; set; }
+        private static AzurePublisher AzurePublisherTool { get; set; }
+
+        private static DebRepoPublisher DebRepoPublisherTool { get; set; }
 
         private static string Channel { get; set; }
 
-        private static string Version { get; set; }
+        private static string CliVersion { get; set; }
 
-        private static string NuGetVersion { get; set; }
+        private static string CliNuGetVersion { get; set; }
 
+        private static string SharedFrameworkNugetVersion { get; set; }
 
         [Target]
         public static BuildTargetResult InitPublish(BuildTargetContext c)
         {
-            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(Environment.GetEnvironmentVariable("CONNECTION_STRING").Trim('"'));
-            CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
-            BlobContainer = blobClient.GetContainerReference("dotnet");
+            AzurePublisherTool = new AzurePublisher();
+            DebRepoPublisherTool = new DebRepoPublisher(Dirs.Packages);
 
-            Version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
-            NuGetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").NuGetVersion;
+            CliVersion = c.BuildContext.Get<BuildVersion>("BuildCliVersion").SimpleVersion;
+            CliNuGetVersion = c.BuildContext.Get<BuildVersion>("BuildCliVersion").NuGetVersion;
+            SharedFrameworkNugetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
             Channel = c.BuildContext.Get<string>("Channel");
+
             return c.Success();
         }
 
         [Target(nameof(PrepareTargets.Init),
         nameof(PublishTargets.InitPublish),
-        nameof(PublishTargets.PublishArtifacts),
-        nameof(PublishTargets.TriggerDockerHubBuilds))]
+        nameof(PublishTargets.PublishArtifacts))]
         [Environment("PUBLISH_TO_AZURE_BLOB", "1", "true")] // This is set by CI systems
         public static BuildTargetResult Publish(BuildTargetContext c)
         {
@@ -45,53 +48,26 @@ namespace Microsoft.DotNet.Cli.Build
         }
 
         [Target(
-            nameof(PublishTargets.PublishVersionBadge),
-            nameof(PublishTargets.PublishCombinedFrameworkSDKHostInstallerFile),
+            nameof(PublishTargets.PublishInstallerFilesToAzure),
+            nameof(PublishTargets.PublishArchivesToAzure),
             nameof(PublishTargets.PublishDebFilesToDebianRepo),
-            nameof(PublishTargets.PublishCombinedFrameworkSDKHostFile),
-            nameof(PublishTargets.PublishCombinedFrameworkHostFile),
-            nameof(PublishTargets.PublishLatestVersionTextFile))]
-        public static BuildTargetResult PublishArtifacts(BuildTargetContext c)
-        {
-            return c.Success();
-        }
+            nameof(PublishTargets.PublishLatestCliVersionTextFile),
+            nameof(PublishTargets.PublishLatestSharedFrameworkVersionTextFile),
+            nameof(PublishTargets.PublishCliVersionBadge))]
+        public static BuildTargetResult PublishArtifacts(BuildTargetContext c) => c.Success();
 
-        [Target]
-        public static BuildTargetResult PublishVersionBadge(BuildTargetContext c)
-        {
-            var versionBadge = c.BuildContext.Get<string>("VersionBadge");
-            var latestVersionBadgeBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(versionBadge)}";
-            var versionBadgeBlob = $"{Channel}/Binaries/{Version}/{Path.GetFileName(versionBadge)}";
+        [Target(
+            nameof(PublishTargets.PublishSharedHostInstallerFileToAzure),
+            nameof(PublishTargets.PublishSharedFrameworkInstallerFileToAzure),
+            nameof(PublishTargets.PublishSdkInstallerFileToAzure),
+            nameof(PublishTargets.PublishCombinedFrameworkSDKHostInstallerFileToAzure),
+            nameof(PublishTargets.PublishCombinedFrameworkHostInstallerFileToAzure))]
+        public static BuildTargetResult PublishInstallerFilesToAzure(BuildTargetContext c) => c.Success();
 
-            PublishFileAzure(versionBadgeBlob, versionBadge);
-            PublishFileAzure(latestVersionBadgeBlob, versionBadge);
-            return c.Success();
-        }
-
-        [Target]
-        [BuildPlatforms(BuildPlatform.Windows, BuildPlatform.OSX)]
-        public static BuildTargetResult PublishCombinedFrameworkSDKHostInstallerFile(BuildTargetContext c)
-        {
-            var installerFile = c.BuildContext.Get<string>("CombinedFrameworkSDKHostInstallerFile");
-            var installerFileBlob = $"{Channel}/Installers/{Version}/{Path.GetFileName(installerFile)}";
-            var latestInstallerFile = installerFile.Replace(Version, "latest");
-            var latestInstallerFileBlob = $"{Channel}/Installers/Latest/{Path.GetFileName(latestInstallerFile)}";
-
-            PublishFileAzure(installerFileBlob, installerFile);
-            PublishFileAzure(latestInstallerFileBlob, installerFile);
-            return c.Success();
-        }
-
-        [Target]
-        public static BuildTargetResult PublishLatestVersionTextFile(BuildTargetContext c)
-        {
-            var osname = Monikers.GetOSShortName();
-            var latestVersionBlob = $"{Channel}/dnvm/latest.{osname}.{CurrentArchitecture.Current}.version";
-            var latestVersionFile = Path.Combine(Dirs.Stage2, "sdk", NuGetVersion, ".version");
-
-            PublishFileAzure(latestVersionBlob, latestVersionFile);
-            return c.Success();
-        }
+        [Target(
+            nameof(PublishTargets.PublishCombinedHostFrameworkArchiveToAzure),
+            nameof(PublishTargets.PublishCombinedHostFrameworkSdkArchiveToAzure))]
+        public static BuildTargetResult PublishArchivesToAzure(BuildTargetContext c) => c.Success();
 
         [Target(
             nameof(PublishSdkDebToDebianRepo),
@@ -104,13 +80,143 @@ namespace Microsoft.DotNet.Cli.Build
         }
 
         [Target]
+        public static BuildTargetResult PublishCliVersionBadge(BuildTargetContext c)
+        {
+            var CliversionBadge = c.BuildContext.Get<string>("CliVersionBadge");
+            var latestCliVersionBadgeBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(CliversionBadge)}";
+            var CliversionBadgeBlob = $"{Channel}/Binaries/{CliVersion}/{Path.GetFileName(CliversionBadge)}";
+
+            AzurePublisherTool.PublishFile(CliversionBadgeBlob, CliversionBadge);
+            AzurePublisherTool.PublishFile(latestCliVersionBadgeBlob, CliversionBadge);
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
+        public static BuildTargetResult PublishSharedHostInstallerFileToAzure(BuildTargetContext c)
+        {
+            var version = CliNuGetVersion;
+            var installerFile = c.BuildContext.Get<string>("SharedHostInstallerFile");
+
+            AzurePublisherTool.PublishInstallerFileAndLatest(installerFile, Channel, version);
+            
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
+        public static BuildTargetResult PublishSharedFrameworkInstallerFileToAzure(BuildTargetContext c)
+        {
+            var version = SharedFrameworkNugetVersion;
+            var installerFile = c.BuildContext.Get<string>("SharedFrameworkInstallerFile");
+
+            AzurePublisherTool.PublishInstallerFileAndLatest(installerFile, Channel, version);
+            
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.Ubuntu)]
+        public static BuildTargetResult PublishSdkInstallerFileToAzure(BuildTargetContext c)
+        {
+            var version = CliNuGetVersion;
+            var installerFile = c.BuildContext.Get<string>("SDKInstallerFile");
+
+            AzurePublisherTool.PublishInstallerFileAndLatest(installerFile, Channel, version);
+
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.Windows, BuildPlatform.OSX)]
+        public static BuildTargetResult PublishCombinedFrameworkHostInstallerFileToAzure(BuildTargetContext c)
+        {
+            var version = SharedFrameworkNugetVersion;
+            var installerFile = c.BuildContext.Get<string>("CombinedFrameworkHostInstallerFile");
+
+            AzurePublisherTool.PublishInstallerFileAndLatest(installerFile, Channel, version);
+
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.Windows, BuildPlatform.OSX)]
+        public static BuildTargetResult PublishCombinedFrameworkSDKHostInstallerFileToAzure(BuildTargetContext c)
+        {
+            var version = CliNuGetVersion;
+            var installerFile = c.BuildContext.Get<string>("CombinedFrameworkSDKHostInstallerFile");
+
+            AzurePublisherTool.PublishInstallerFileAndLatest(installerFile, Channel, version);
+
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult PublishCombinedHostFrameworkSdkArchiveToAzure(BuildTargetContext c)
+        {
+            var version = CliNuGetVersion;
+            var archiveFile = c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile");
+
+            AzurePublisherTool.PublishInstallerFileAndLatest(archiveFile, Channel, version);
+
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult PublishCombinedHostFrameworkArchiveToAzure(BuildTargetContext c)
+        {
+            var version = SharedFrameworkNugetVersion;
+            var archiveFile = c.BuildContext.Get<string>("CombinedFrameworkHostCompressedFile");
+
+            AzurePublisherTool.PublishInstallerFileAndLatest(archiveFile, Channel, version);
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult PublishLatestCliVersionTextFile(BuildTargetContext c)
+        {
+            var version = CliNuGetVersion;
+
+            var osname = Monikers.GetOSShortName();
+            var latestCliVersionBlob = $"{Channel}/dnvm/latest.{osname}.{CurrentArchitecture.Current}.version";
+            var latestCliVersionFile = Path.Combine(Dirs.Stage2, "sdk", version, ".version");
+
+            AzurePublisherTool.PublishFile(latestCliVersionBlob, latestCliVersionFile);
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult PublishLatestSharedFrameworkVersionTextFile(BuildTargetContext c)
+        {
+            var version = SharedFrameworkNugetVersion;
+
+            var osname = Monikers.GetOSShortName();
+            var latestSharedFXVersionBlob = $"{Channel}/dnvm/latest.sharedfx.{osname}.{CurrentArchitecture.Current}.version";
+            var latestSharedFXVersionFile = Path.Combine(
+                Dirs.Stage2, 
+                "shared", 
+                CompileTargets.SharedFrameworkName, 
+                version, 
+                ".version");
+
+            AzurePublisherTool.PublishFile(latestSharedFXVersionBlob, latestSharedFXVersionFile);
+            return c.Success();
+        }
+
+        [Target]
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult PublishSdkDebToDebianRepo(BuildTargetContext c)
         {
+            var version = CliNuGetVersion;
+
             var packageName = Monikers.GetSdkDebianPackageName(c);
             var installerFile = c.BuildContext.Get<string>("SdkInstallerFile");
+            var uploadUrl = AzurePublisherTool.CalculateInstallerUploadUrl(installerFile, Channel, version);
 
-            PublishDebFileToDebianRepo(packageName, installerFile);
+            DebRepoPublisherTool.PublishDebFileToDebianRepo(
+                packageName, 
+                version, 
+                uploadUrl);
 
             return c.Success();
         }
@@ -119,10 +225,16 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult PublishSharedFrameworkDebToDebianRepo(BuildTargetContext c)
         {
-            var packageName = Monikers.GetDebianSharedFrameworkPackageName(c);
+            var version = SharedFrameworkNugetVersion;
+
+            var packageName = Monikers.GetSdkDebianPackageName(c);
             var installerFile = c.BuildContext.Get<string>("SharedFrameworkInstallerFile");
-            
-            PublishDebFileToDebianRepo(packageName, installerFile);
+            var uploadUrl = AzurePublisherTool.CalculateInstallerUploadUrl(installerFile, Channel, version);
+
+            DebRepoPublisherTool.PublishDebFileToDebianRepo(
+                packageName, 
+                version, 
+                uploadUrl);
 
             return c.Success();
         }
@@ -131,10 +243,16 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Ubuntu)]
         public static BuildTargetResult PublishSharedHostDebToDebianRepo(BuildTargetContext c)
         {
-            var packageName = Monikers.GetDebianSharedHostPackageName(c);
-            var installerFile = c.BuildContext.Get<string>("SharedHostInstallerFile");
+            var version = CliNuGetVersion;
 
-            PublishDebFileToDebianRepo(packageName, installerFile);
+            var packageName = Monikers.GetSdkDebianPackageName(c);
+            var installerFile = c.BuildContext.Get<string>("SharedHostInstallerFile");
+            var uploadUrl = AzurePublisherTool.CalculateInstallerUploadUrl(installerFile, Channel, version);
+
+            DebRepoPublisherTool.PublishDebFileToDebianRepo(
+                packageName, 
+                version, 
+                uploadUrl);
 
             return c.Success();
         }
@@ -176,88 +294,6 @@ namespace Microsoft.DotNet.Cli.Build
                 }
             }
             return c.Success();
-        }
-
-        private static string GenerateUploadJsonFile(string packageName, string version, string uploadUrl)
-        {
-            var repoID = Environment.GetEnvironmentVariable("REPO_ID");
-            var uploadJson = Path.Combine(Dirs.Packages, "package_upload.json");
-            File.Delete(uploadJson);
-
-            using (var fileStream = File.Create(uploadJson))
-            {
-                using (StreamWriter sw = new StreamWriter(fileStream))
-                {
-                    sw.WriteLine("{");
-                    sw.WriteLine($"  \"name\":\"{packageName}\",");
-                    sw.WriteLine($"  \"version\":\"{version}\",");
-                    sw.WriteLine($"  \"repositoryId\":\"{repoID}\",");
-                    sw.WriteLine($"  \"sourceUrl\":\"{uploadUrl}\"");
-                    sw.WriteLine("}");
-                }
-            }
-
-            return uploadJson;
-        }
-
-        [Target]
-        public static BuildTargetResult PublishCombinedFrameworkSDKHostFile(BuildTargetContext c)
-        {
-            var compressedFile = c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile");
-            var compressedFileBlob = $"{Channel}/Binaries/{Version}/{Path.GetFileName(compressedFile)}";
-            var latestCompressedFile = compressedFile.Replace(Version, "latest");
-            var latestCompressedFileBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(latestCompressedFile)}";
-
-            PublishFileAzure(compressedFileBlob, compressedFile);
-            PublishFileAzure(latestCompressedFileBlob, compressedFile);
-            return c.Success();
-        }
-
-        [Target]
-        public static BuildTargetResult PublishCombinedFrameworkHostFile(BuildTargetContext c)
-        {
-            var compressedFile = c.BuildContext.Get<string>("CombinedFrameworkHostCompressedFile");
-            var compressedFileBlob = $"{Channel}/Binaries/{Version}/{Path.GetFileName(compressedFile)}";
-            var latestCompressedFile = compressedFile.Replace(Version, "latest");
-            var latestCompressedFileBlob = $"{Channel}/Binaries/Latest/{Path.GetFileName(latestCompressedFile)}";
-
-            PublishFileAzure(compressedFileBlob, compressedFile);
-            PublishFileAzure(latestCompressedFileBlob, compressedFile);
-            return c.Success();
-        }
-
-        private static BuildTargetResult PublishFile(BuildTargetContext c, string file)
-        {
-            var env = PackageTargets.GetCommonEnvVars(c);
-            Cmd("powershell", "-NoProfile", "-NoLogo",
-                Path.Combine(Dirs.RepoRoot, "scripts", "publish", "publish.ps1"), file)
-                    .Environment(env)
-                    .Execute()
-                    .EnsureSuccessful();
-            return c.Success();
-        }
-
-        private static void PublishDebFileToDebianRepo(string packageName, string installerFile)
-        {
-            var uploadUrl = $"https://dotnetcli.blob.core.windows.net/dotnet/{Channel}/Installers/{Version}/{Path.GetFileName(installerFile)}";
-            var uploadJson = GenerateUploadJsonFile(packageName, Version, uploadUrl);
-
-            Cmd(Path.Combine(Dirs.RepoRoot, "scripts", "publish", "repoapi_client.sh"), "-addpkg", uploadJson)
-                    .Execute()
-                    .EnsureSuccessful();
-        }
-
-        private static void PublishFileAzure(string blob, string file)
-        {
-            CloudBlockBlob blockBlob = BlobContainer.GetBlockBlobReference(blob);
-            blockBlob.UploadFromFileAsync(file, FileMode.Open).Wait();
-
-            if (Path.GetExtension(blockBlob.Uri.AbsolutePath.ToLower()) == ".svg")
-            {
-                blockBlob.Properties.ContentType = "image/svg+xml";
-                blockBlob.Properties.CacheControl = "no-cache";
-                blockBlob.SetPropertiesAsync().Wait();
-            }
         }
     }
 }

--- a/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
+++ b/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+using static Microsoft.DotNet.Cli.Build.Framework.BuildHelpers;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class AzurePublisher
+    {
+        private static readonly string s_dotnetBlobRootUrl = "https://dotnetcli.blob.core.windows.net/dotnet/";
+        private static readonly string s_dotnetBlobContainerName = "dotnet";
+
+        private string _connectionString { get; set; }
+        private CloudBlobContainer _blobContainer { get; set; }
+
+        public AzurePublisher()
+        {
+            _connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING").Trim('"');
+
+            _blobContainer = GetDotnetBlobContainer(_connectionString);
+        }
+
+        private CloudBlobContainer GetDotnetBlobContainer(string connectionString)
+        {
+            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connectionString);
+            CloudBlobClient blobClient = storageAccount.CreateCloudBlobClient();
+            
+            return blobClient.GetContainerReference(s_dotnetBlobContainerName);
+        }
+
+        public void PublishInstallerFileAndLatest(string installerFile, string channel, string version)
+        {
+            var installerFileBlob = CalculateInstallerBlob(installerFile, channel, version);
+
+            var latestInstallerFileName = installerFile.Replace(version, "latest");
+            var latestInstallerFileBlob = CalculateInstallerBlob(latestInstallerFileName, channel, "Latest");
+
+            PublishFile(installerFileBlob, installerFile);
+            PublishFile(latestInstallerFileBlob, installerFile);
+        }
+
+        public void PublishArchiveAndLatest(string archiveFile, string channel, string version)
+        {
+            var archiveFileBlob = CalculateArchiveBlob(archiveFile, channel, version);
+
+            var latestArchiveFileName = archiveFile.Replace(version, "latest");
+            var latestArchiveFileBlob = CalculateArchiveBlob(latestArchiveFileName, channel, "Latest");
+
+            PublishFile(archiveFileBlob, archiveFile);
+            PublishFile(latestArchiveFileBlob, archiveFile);
+        }
+
+        public void PublishFile(string blob, string file)
+        {
+            CloudBlockBlob blockBlob = _blobContainer.GetBlockBlobReference(blob);
+            blockBlob.UploadFromFileAsync(file, FileMode.Open).Wait();
+
+            SetBlobPropertiesBasedOnFileType(blockBlob);
+        }
+
+        private void SetBlobPropertiesBasedOnFileType(CloudBlockBlob blockBlob)
+        {
+            if (Path.GetExtension(blockBlob.Uri.AbsolutePath.ToLower()) == ".svg")
+            {
+                blockBlob.Properties.ContentType = "image/svg+xml";
+                blockBlob.Properties.CacheControl = "no-cache";
+                blockBlob.SetPropertiesAsync().Wait();
+            }
+        }
+
+        public string CalculateInstallerUploadUrl(string installerFile, string channel, string version)
+        {
+            return $"{s_dotnetBlobRootUrl}{CalculateInstallerBlob(installerFile, channel, version)}";
+        }
+
+        public string CalculateInstallerBlob(string installerFile, string channel, string version)
+        {
+            return $"{channel}/Installers/{version}/{Path.GetFileName(installerFile)}";
+        }
+
+        public string CalculateArchiveUploadUrl(string archiveFile, string channel, string version)
+        {
+            return $"{s_dotnetBlobRootUrl}{CalculateArchiveBlob(archiveFile, channel, version)}";
+        }
+
+        public string CalculateArchiveBlob(string archiveFile, string channel, string version)
+        {
+            return $"{channel}/Binaries/{version}/{Path.GetFileName(archiveFile)}";
+        }
+    }
+}

--- a/scripts/dotnet-cli-build/Publishing/DebRepoPublisher.cs
+++ b/scripts/dotnet-cli-build/Publishing/DebRepoPublisher.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+using static Microsoft.DotNet.Cli.Build.Framework.BuildHelpers;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class DebRepoPublisher
+    {
+        private string _repoID;
+        private string _uploadJsonDirectory;
+
+        public DebRepoPublisher(string uploadJsonDirectory)
+        {
+            _uploadJsonDirectory = uploadJsonDirectory;
+            _repoID = Environment.GetEnvironmentVariable("REPO_ID");
+        }
+
+        public void PublishDebFileToDebianRepo(string packageName, string packageVersion, string uploadUrl)
+        {
+            var uploadJson = GenerateUploadJsonFile(packageName, packageVersion, uploadUrl);
+
+            Cmd(Path.Combine(Dirs.RepoRoot, "scripts", "publish", "repoapi_client.sh"), "-addpkg", uploadJson)
+                    .Execute()
+                    .EnsureSuccessful();
+        }
+
+        private string GenerateUploadJsonFile(string packageName, string packageVersion, string uploadUrl)
+        {
+            var uploadJson = Path.Combine(_uploadJsonDirectory, "package_upload.json");
+            File.Delete(uploadJson);
+
+            using (var fileStream = File.Create(uploadJson))
+            {
+                using (StreamWriter sw = new StreamWriter(fileStream))
+                {
+                    sw.WriteLine("{");
+                    sw.WriteLine($"  \"name\":\"{packageName}\",");
+                    sw.WriteLine($"  \"version\":\"{packageVersion}\",");
+                    sw.WriteLine($"  \"repositoryId\":\"{_repoID}\",");
+                    sw.WriteLine($"  \"sourceUrl\":\"{uploadUrl}\"");
+                    sw.WriteLine("}");
+                }
+            }
+
+            return uploadJson;
+        }
+    }
+}

--- a/scripts/dotnet-cli-build/Utils/Monikers.cs
+++ b/scripts/dotnet-cli-build/Utils/Monikers.cs
@@ -10,11 +10,10 @@ namespace Microsoft.DotNet.Cli.Build
     {
         public const string SharedFrameworkName = "Microsoft.NETCore.App";
 
-        public static string GetProductMoniker(BuildTargetContext c, string artifactPrefix)
+        public static string GetProductMoniker(BuildTargetContext c, string artifactPrefix, string version)
         {
             string osname = GetOSShortName();
             var arch = CurrentArchitecture.Current.ToString();
-            var version = c.BuildContext.Get<BuildVersion>("BuildVersion").SimpleVersion;
             return $"{artifactPrefix}-{osname}-{arch}.{version}";
         }
 


### PR DESCRIPTION
Publishing for debs, pkgs, msis, with appropriate versions dependent on the package type (host, sdk, sharedfx)

Also unify versions of all installers to the semantic version.

Fixes #2007 

Worked with @krwq to get this tested and ready.

cc @Sridhar-MS @piotrpMSFT 