### PR TITLE
update to new nuget and turn inference on

### DIFF
--- a/scripts/update-dependencies/project.json
+++ b/scripts/update-dependencies/project.json
@@ -9,7 +9,7 @@
     "Microsoft.CSharp": "4.0.1-rc2-23911",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23911",
     "Microsoft.DotNet.Cli.Build.Framework": "1.0.0-*",
-    "NuGet.Versioning": "3.4.0-rtm-0764",
+    "NuGet.Versioning": "3.5.0-beta-1068",
     "Newtonsoft.Json": "7.0.1",
     "Octokit": "0.18.0",
     "Microsoft.Net.Http": "2.2.29"

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -7,10 +7,10 @@
   "dependencies": {
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
-    "NuGet.Versioning": "3.5.0-beta-1034",
-    "NuGet.Packaging": "3.5.0-beta-1034",
-    "NuGet.Frameworks": "3.5.0-beta-1034",
-    "NuGet.ProjectModel": "3.5.0-beta-1034"
+    "NuGet.Versioning": "3.5.0-beta-1068",
+    "NuGet.Packaging": "3.5.0-beta-1068",
+    "NuGet.Frameworks": "3.5.0-beta-1068",
+    "NuGet.ProjectModel": "3.5.0-beta-1068"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -6,7 +6,7 @@
   "description": "Types to model a .NET Project",
   "dependencies": {
     "System.Reflection.Metadata": "1.2.0-rc2-23904",
-    "NuGet.Packaging": "3.5.0-beta-1034",
+    "NuGet.Packaging": "3.5.0-beta-1068",
     "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15996",
     "Microsoft.Extensions.JsonParser.Sources": {
       "type": "build",

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -36,6 +36,12 @@ namespace Microsoft.DotNet.Tools.Restore
             var quiet = args.Any(s => s.Equals("--quiet", StringComparison.OrdinalIgnoreCase));
             args = args.Where(s => !s.Equals("--quiet", StringComparison.OrdinalIgnoreCase)).ToArray();
 
+            // Always infer runtimes in dotnet-restore (for now).
+            if (!args.Any(s => s.Equals("--infer-runtimes", StringComparison.OrdinalIgnoreCase)))
+            {
+                args = Enumerable.Concat(new [] { "--infer-runtimes" }, args).ToArray();
+            }
+
             app.OnExecute(() =>
             {
                 try

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -17,10 +17,10 @@
   ],
   "dependencies": {
     "NuGet.Commands": {
-      "version": "3.5.0-beta-1034",
+      "version": "3.5.0-beta-1068",
       "exclude": "compile"
     },
-    "NuGet.CommandLine.XPlat": "3.5.0-beta-1034",
+    "NuGet.CommandLine.XPlat": "3.5.0-beta-1068",
 
     "Newtonsoft.Json": "7.0.1",
     "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160225-02",

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -5,10 +5,10 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.5.0-rc2-23911",
-    "NuGet.Versioning": "3.5.0-beta-1034",
-    "NuGet.Packaging": "3.5.0-beta-1034",
-    "NuGet.Frameworks": "3.5.0-beta-1034",
-    "NuGet.ProjectModel": "3.5.0-beta-1034",
+    "NuGet.Versioning": "3.5.0-beta-1068",
+    "NuGet.Packaging": "3.5.0-beta-1068",
+    "NuGet.Frameworks": "3.5.0-beta-1068",
+    "NuGet.ProjectModel": "3.5.0-beta-1068",
 
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"

--- a/tools/RuntimeGraphGenerator/project.json
+++ b/tools/RuntimeGraphGenerator/project.json
@@ -4,8 +4,8 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NuGet.RuntimeModel": "3.5.0-beta-1034",
-    "NuGet.Versioning": "3.5.0-beta-1034",
+    "NuGet.RuntimeModel": "3.5.0-beta-1068",
+    "NuGet.Versioning": "3.5.0-beta-1068",
     "System.CommandLine": "0.1.0-e160119-1",
     "System.Runtime.Serialization.Json": "1.0.0-rc2-23911",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",


### PR DESCRIPTION
Updates us to NuGet 1068, which disables RID inference by default. So, for now `dotnet restore` turns it back on explicitly (this is part of staging the changes). The next phase will be to remove the defaulting and ensure that the CLI can be a portable app (but still provide the switch for other CLI consumers to use while converting).

/cc @emgarten @pakrym @piotrpMSFT @eerhardt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2029)
<!-- Reviewable:end -->
