### PR TITLE
Update developer-guide.md to include openssl

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -29,6 +29,9 @@ developer@linux:~$ sudo apt-get install cmake llvm-3.5 clang-3.5 git
 1. Xcode
 2. CMake (available from https://cmake.org/) on the PATH.
 3. git (available from http://www.git-scm.com/) on the PATH.
+4. Install OpenSSL (a .NET Core requirement)
+  - brew install openssl
+  - brew link --force openssl
 
 ## Building/Running
 


### PR DESCRIPTION
In order to use Crypto on .NET Core (which NuGet needs when talking https), you need to install openssl on OSX.

@piotrpMSFT @blackdwarf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2030)
<!-- Reviewable:end -->