### PR TITLE
Update netci.groovy

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -9,7 +9,7 @@ def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
 
-def platformList = ['Ubuntu:x64:Debug', 'Ubuntu:x64:Release', 'OSX:x64:Release', 'Windows_NT:x64:Release', 'Windows_2016:x64:Release', 'Windows_2016:x86:Debug', 'RHEL7.2:x64:Release', 'CentOS7.1:x64:Debug']
+def platformList = ['Ubuntu:x64:Debug', 'Ubuntu:x64:Release', 'OSX:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'RHEL7.2:x64:Release', 'CentOS7.1:x64:Debug']
 
 def static getBuildJobName(def configuration, def os, def architecture) {
     return configuration.toLowerCase() + '_' + os.toLowerCase() + '_' + architecture.toLowerCase()


### PR DESCRIPTION
Remove Windows Server 2016 from the PR CIs. This was slowing down our builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2034)
<!-- Reviewable:end -->
