### PR TITLE
Changing --version in the CLI

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -61,7 +61,12 @@ namespace Microsoft.DotNet.Cli
                 }
                 else if (IsArg(args[lastArg], "version"))
                 {
-                    PrintVersionInfo();
+                    PrintVersion();
+                    return 0;
+                }
+                else if (IsArg(args[lastArg], "info"))
+                {
+                    PrintInfo();
                     return 0;
                 }
                 else if (IsArg(args[lastArg], "h", "help"))
@@ -129,7 +134,12 @@ namespace Microsoft.DotNet.Cli
                 .ExitCode;
         }
 
-        private static void PrintVersionInfo()
+        private static void PrintVersion()
+        {
+            Reporter.Output.WriteLine(HelpCommand.ProductVersion);
+        }
+
+        private static void PrintInfo()
         {
             HelpCommand.PrintVersionHeader();
 
@@ -144,7 +154,7 @@ namespace Microsoft.DotNet.Cli
             Reporter.Output.WriteLine($" OS Name:     {runtimeEnvironment.OperatingSystem}");
             Reporter.Output.WriteLine($" OS Version:  {runtimeEnvironment.OperatingSystemVersion}");
             Reporter.Output.WriteLine($" OS Platform: {runtimeEnvironment.OperatingSystemPlatform}");
-            Reporter.Output.WriteLine($" Runtime Id:  {runtimeEnvironment.GetRuntimeIdentifier()}");
+            Reporter.Output.WriteLine($" RID:         {runtimeEnvironment.GetRuntimeIdentifier()}");
         }
 
         private static bool IsArg(string candidate, string longName)

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -8,7 +8,7 @@ dotnet -- general driver for running the command-line commands
 
 # SYNOPSIS
 
-dotnet [--version] [--help] [--verbose] < command > [< args >]
+dotnet [--version] [--info] [--help] [--verbose] < command > [< args >]
 
 # DESCRIPTION
 dotnet is a generic driver for the CLI toolchain. Invoked on its own, it will give out brief usage instructions. 
@@ -24,6 +24,10 @@ Each specific feature is implemented as a command. In order to use the feature, 
 `--version`
 
     Print out the version of the CLI tooling
+
+`--info`
+
+    Print out information about the CLI tooling
 
 `-h, --help`
 

--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -17,7 +17,8 @@ Arguments:
 
 Common Options (passed before the command):
   -v|--verbose  Enable verbose output
-  --version     Display .NET CLI Version Info
+  --version     Display .NET CLI Version Number
+  --info        Display .NET CLI Info
 
 Common Commands:
   new           Initialize a basic .NET project


### PR DESCRIPTION
`dotnet --version` returns just the version number. This helps tools get this information without having to parse the full info.
Introduce a new argument `--info` that returns the current "long form". With this, we also change the long form to say "RID" instead of "Runtime ID" simply because that would avoid any future localization issues and thus make the parsing easier.

Fix #1607 #1882 

@blackdwarf @piotrpMSFT @davidfowl @anurse

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2035)
<!-- Reviewable:end -->
