### PR TITLE
Windows Installer changes

### DIFF
--- a/packaging/windows/clisdk/bundle.wxs
+++ b/packaging/windows/clisdk/bundle.wxs
@@ -8,9 +8,7 @@
   <Bundle Name="$(var.ProductName)" Manufacturer="$(var.Manufacturer)"
           Version="$(var.DisplayVersion)" UpgradeCode="$(var.UpgradeCode)"
           AboutUrl="http://dotnet.github.io/"
-          Compressed="yes"
-          DisableModify="yes"
-          DisableRemove="yes">
+          Compressed="yes">
 
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.Foundation">
       <bal:WixStandardBootstrapperApplication
@@ -34,13 +32,13 @@
     <util:DirectorySearch Path="[PreviousInstallFolder]" Variable="DOTNETHOME" After="PreviousInstallFolderSearch" Condition="PreviousInstallFolder" />
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
-      <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)" Visible="yes">
+      <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
-      <MsiPackage SourceFile="$(var.SharedFXMsiSourcePath)" Visible="yes">
+      <MsiPackage SourceFile="$(var.SharedFXMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
-      <MsiPackage SourceFile="$(var.SharedHostMsiSourcePath)" Visible="yes">
+      <MsiPackage SourceFile="$(var.SharedHostMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
     </Chain>

--- a/packaging/windows/clisdk/bundle.wxs
+++ b/packaging/windows/clisdk/bundle.wxs
@@ -6,9 +6,11 @@
   <?include "Variables.wxi" ?>
 
   <Bundle Name="$(var.ProductName)" Manufacturer="$(var.Manufacturer)"
-          Version="$(var.DisplayVersion)" UpgradeCode="70A1576F-63B6-4659-9E39-25C7B769DDE5"
+          Version="$(var.DisplayVersion)" UpgradeCode="$(var.UpgradeCode)"
           AboutUrl="http://dotnet.github.io/"
-          Compressed="yes">
+          Compressed="yes"
+          DisableModify="yes"
+          DisableRemove="yes">
 
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.Foundation">
       <bal:WixStandardBootstrapperApplication
@@ -32,13 +34,13 @@
     <util:DirectorySearch Path="[PreviousInstallFolder]" Variable="DOTNETHOME" After="PreviousInstallFolderSearch" Condition="PreviousInstallFolder" />
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
-      <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
+      <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)" Visible="yes">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
-      <MsiPackage SourceFile="$(var.SharedFXMsiSourcePath)">
+      <MsiPackage SourceFile="$(var.SharedFXMsiSourcePath)" Visible="yes">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
-      <MsiPackage SourceFile="$(var.SharedHostMsiSourcePath)">
+      <MsiPackage SourceFile="$(var.SharedHostMsiSourcePath)" Visible="yes">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
     </Chain>

--- a/packaging/windows/clisdk/generatebundle.ps1
+++ b/packaging/windows/clisdk/generatebundle.ps1
@@ -9,6 +9,7 @@ param(
     [Parameter(Mandatory=$true)][string]$WixRoot,
     [Parameter(Mandatory=$true)][string]$DotnetMSIVersion,
     [Parameter(Mandatory=$true)][string]$DotnetCLIVersion,
+    [Parameter(Mandatory=$true)][string]$UpgradeCode,
     [Parameter(Mandatory=$true)][string]$Architecture,
     [Parameter(Mandatory=$true)][string]$ReleaseSuffix
 )
@@ -31,6 +32,7 @@ function RunCandleForBundle
         -dDisplayVersion="$DotnetCLIVersion" `
         -dReleaseSuffix="$ReleaseSuffix" `
         -dCLISDKMsiSourcePath="$CLISDKMSIFile" `
+        -dUpgradeCode="$UpgradeCode" `
         -dSharedFXMsiSourcePath="$SharedFxMSIFile" `
         -dSharedHostMsiSourcePath="$SharedHostMSIFile" `
         -arch "$Architecture" `

--- a/packaging/windows/clisdk/generatemsi.ps1
+++ b/packaging/windows/clisdk/generatemsi.ps1
@@ -7,6 +7,7 @@ param(
     [Parameter(Mandatory=$true)][string]$WixRoot,
     [Parameter(Mandatory=$true)][string]$DotnetMSIVersion,
     [Parameter(Mandatory=$true)][string]$DotnetCLIVersion,
+    [Parameter(Mandatory=$true)][string]$UpgradeCode,
     [Parameter(Mandatory=$true)][string]$Architecture,
     [Parameter(Mandatory=$true)][string]$ReleaseSuffix
 )
@@ -49,6 +50,7 @@ function RunCandle
         -dMicrosoftEula="$RepoRoot\packaging\osx\resources\en.lproj\eula.rtf" `
         -dBuildVersion="$DotnetMSIVersion" `
         -dDisplayVersion="$DotnetCLIVersion" `
+        -dUpgradeCode="$UpgradeCode" `
         -dReleaseSuffix="$ReleaseSuffix" `
         -arch "$Architecture" `
         -ext WixDependencyExtension.dll `

--- a/packaging/windows/clisdk/variables.wxi
+++ b/packaging/windows/clisdk/variables.wxi
@@ -26,11 +26,9 @@
   <?if $(var.Platform)=x86?>
   <?define Program_Files="ProgramFilesFolder"?>
   <?define Win64AttributeValue=no?>
-  <?define UpgradeCode="25CAE344-22A6-422D-942E-942687C56A45"?>
   <?elseif $(var.Platform)=x64?>
   <?define Program_Files="ProgramFiles64Folder"?>
   <?define Win64AttributeValue=yes?>
-  <?define UpgradeCode="7D73E4F7-71E2-4236-8CF5-1C499BA3FF50"?>
   <?else?>
   <?error Invalid Platform ($(var.Platform))?>
   <?endif?>

--- a/scripts/dotnet-cli-build/MsiTargets.cs
+++ b/scripts/dotnet-cli-build/MsiTargets.cs
@@ -107,9 +107,11 @@ namespace Microsoft.DotNet.Cli.Build
         public static BuildTargetResult GenerateCliSdkMsi(BuildTargetContext c)
         {
             var cliSdkRoot = c.BuildContext.Get<string>("CLISDKRoot");
+            var upgradeCode = Utils.GenerateGuidFromName(SdkMsi).ToString().ToUpper();
+
             Cmd("powershell", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "clisdk", "generatemsi.ps1"),
-                cliSdkRoot, SdkMsi, WixRoot, MsiVersion, CliVersion, Arch, Channel)
+                cliSdkRoot, SdkMsi, WixRoot, MsiVersion, CliVersion, upgradeCode, Arch, Channel)
                     .Execute()
                     .EnsureSuccessful();
             return c.Success();
@@ -143,7 +145,8 @@ namespace Microsoft.DotNet.Cli.Build
             var inputDir = c.BuildContext.Get<string>("SharedFrameworkPublishRoot");
             var sharedFrameworkNuGetName = Monikers.SharedFrameworkName;
             var sharedFrameworkNuGetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
-            var upgradeCode = Utils.GenerateGuidFromName($"{sharedFrameworkNuGetName}-{sharedFrameworkNuGetVersion}-{Arch}").ToString().ToUpper();
+            var msiVerison = sharedFrameworkNuGetVersion.Split('-')[0];
+            var upgradeCode = Utils.GenerateGuidFromName(SharedFrameworkMsi).ToString().ToUpper();
             var wixObjRoot = Path.Combine(Dirs.Output, "obj", "wix", "sharedframework");
 
             if (Directory.Exists(wixObjRoot))
@@ -154,7 +157,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             Cmd("powershell", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "sharedframework", "generatemsi.ps1"),
-                inputDir, SharedFrameworkMsi, WixRoot, MsiVersion, sharedFrameworkNuGetName, sharedFrameworkNuGetVersion, upgradeCode, Arch, wixObjRoot)
+                inputDir, SharedFrameworkMsi, WixRoot, msiVerison, sharedFrameworkNuGetName, sharedFrameworkNuGetVersion, upgradeCode, Arch, wixObjRoot)
                     .Execute()
                     .EnsureSuccessful();
             return c.Success();
@@ -165,9 +168,11 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Windows)]
         public static BuildTargetResult GenerateCliSdkBundle(BuildTargetContext c)
         {
+            var upgradeCode = Utils.GenerateGuidFromName(SdkBundle).ToString().ToUpper();
+
             Cmd("powershell", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "clisdk", "generatebundle.ps1"),
-                SdkMsi, SharedFrameworkMsi, SharedHostMsi, SdkBundle, WixRoot, MsiVersion, CliVersion, Arch, Channel)
+                SdkMsi, SharedFrameworkMsi, SharedHostMsi, SdkBundle, WixRoot, MsiVersion, CliVersion, upgradeCode, Arch, Channel)
                     .EnvironmentVariable("Stage2Dir", Dirs.Stage2)
                     .Execute()
                     .EnsureSuccessful();
@@ -180,7 +185,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var sharedFrameworkNuGetName = Monikers.SharedFrameworkName;
             var sharedFrameworkNuGetVersion = c.BuildContext.Get<string>("SharedFrameworkNugetVersion");
-            var upgradeCode = Utils.GenerateGuidFromName($"{sharedFrameworkNuGetName}-{sharedFrameworkNuGetVersion}-{Arch}-bundle").ToString().ToUpper();
+            var upgradeCode = Utils.GenerateGuidFromName(SharedFrameworkBundle).ToString().ToUpper();
 
             Cmd("powershell", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "sharedframework", "generatebundle.ps1"),

--- a/test/Installer/Microsoft.DotNet.Cli.Msi.Tests/InstallationTests.cs
+++ b/test/Installer/Microsoft.DotNet.Cli.Msi.Tests/InstallationTests.cs
@@ -22,21 +22,16 @@ namespace Dotnet.Cli.Msi.Tests
             _msiMgr = new MsiManager(msiFile);
         }
 
-        [Theory]
-        [InlineData("")]
-        [InlineData(@"%SystemDrive%\dotnet")]
-        public void InstallTest(string installLocation)
+        [Fact]
+        public void InstallTest()
         {
-            installLocation = Environment.ExpandEnvironmentVariables(installLocation);
-            string expectedInstallLocation = string.IsNullOrEmpty(installLocation) ?
-                Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\dotnet") :
-                installLocation;
+            string expectedInstallLocation = Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\dotnet");
 
             // make sure that the msi is not already installed, if so the machine is in a bad state
             Assert.False(_msiMgr.IsInstalled, "The dotnet CLI msi is already installed");
             Assert.False(Directory.Exists(expectedInstallLocation));
 
-            _msiMgr.Install(installLocation);
+            _msiMgr.Install();
             Assert.True(_msiMgr.IsInstalled);
             Assert.True(Directory.Exists(expectedInstallLocation));
 

--- a/test/Installer/Microsoft.DotNet.Cli.Msi.Tests/PostInstallTests.cs
+++ b/test/Installer/Microsoft.DotNet.Cli.Msi.Tests/PostInstallTests.cs
@@ -45,12 +45,5 @@ namespace Dotnet.Cli.Msi.Tests
             Assert.Equal(_fixture.InstallLocation, regKey.GetValue("InstallDir"));
             Assert.NotNull(regKey.GetValue("Version"));
         }
-
-        [Fact]
-        public void UpgradeCodeTest()
-        {
-            // magic number found in https://github.com/dotnet/cli/blob/master/packaging/windows/variables.wxi
-            Assert.Equal("{7D73E4F7-71E2-4236-8CF5-1C499BA3FF50}", _msiMgr.UpgradeCode);
-        }
     }
 }

--- a/test/Installer/Microsoft.DotNet.Cli.Msi.Tests/PostUninstallTests.cs
+++ b/test/Installer/Microsoft.DotNet.Cli.Msi.Tests/PostUninstallTests.cs
@@ -23,7 +23,7 @@ namespace Dotnet.Cli.Msi.Tests
             Assert.False(Utils.ExistsOnPath("dotnet.exe"), "After uninstallation dotnet tools must not be on path");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/cli/issues/2073")]
         public void DotnetRegKeysTest()
         {
             Assert.True(_msiMgr.IsInstalled);


### PR DESCRIPTION
- Make CLI SDK MSI non-upgradable. It must alwasy be installed SxS.
- The CLI bundle and SharedFx bundle are non-upgradeable. They are also installed SxS.
- Make host\muxer upgradeable. It will be upgradeable till v1.0.0 RTM. Post RTM will be installed SxS with v.1.0.0.
- SharedFx MSI was using the CLI MSI version. Fixing it to use the SharedFx version.
- Do not allow bundles to uninstall. User will be able to uninstall the  individual MSIs.

cc: @piotrpMSFT @Petermarcu @ellismg @joeloff

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2048)
<!-- Reviewable:end -->