### PR TITLE
fix use latest version of fsc

### DIFF
--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -24,7 +24,7 @@
 
     "Newtonsoft.Json": "7.0.1",
     "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160225-02",
-    "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-151218",
+    "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-160316",
     "Microsoft.Net.CSharp.Interactive.netcore": "1.3.0-beta1-20160225-02",
     "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160225-02",
     "Microsoft.DiaSymReader.Native": "1.3.3",


### PR DESCRIPTION
This reverts to use latest version of fsc, downgraded by  43512b8973c89fa21a4236e4b250357c9fea767e

I think that was a merge conflict error right @anurse ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2053)
<!-- Reviewable:end -->
