### PR TITLE
Telemetry PR

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandContext.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandContext.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.Cli.Utils
             public static readonly string AnsiPassThru = Prefix + "ANSI_PASS_THRU";
         }
 
-        private static Lazy<bool> _verbose = new Lazy<bool>(() => Env.GetBool(Variables.Verbose));
-        private static Lazy<bool> _ansiPassThru = new Lazy<bool>(() => Env.GetBool(Variables.AnsiPassThru));
+        private static Lazy<bool> _verbose = new Lazy<bool>(() => Env.GetEnvironmentVariableAsBool(Variables.Verbose));
+        private static Lazy<bool> _ansiPassThru = new Lazy<bool>(() => Env.GetEnvironmentVariableAsBool(Variables.AnsiPassThru));
 
         public static bool IsVerbose()
         {

--- a/src/Microsoft.DotNet.Cli.Utils/CommandContext.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandContext.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.Cli.Utils
             public static readonly string AnsiPassThru = Prefix + "ANSI_PASS_THRU";
         }
 
-        private static Lazy<bool> _verbose = new Lazy<bool>(() => GetBool(Variables.Verbose));
-        private static Lazy<bool> _ansiPassThru = new Lazy<bool>(() => GetBool(Variables.AnsiPassThru));
+        private static Lazy<bool> _verbose = new Lazy<bool>(() => Env.GetBool(Variables.Verbose));
+        private static Lazy<bool> _ansiPassThru = new Lazy<bool>(() => Env.GetBool(Variables.AnsiPassThru));
 
         public static bool IsVerbose()
         {
@@ -25,29 +25,6 @@ namespace Microsoft.DotNet.Cli.Utils
         public static bool ShouldPassAnsiCodesThrough()
         {
             return _ansiPassThru.Value;
-        }
-        
-        private static bool GetBool(string name, bool defaultValue = false)
-        {
-            var str = Environment.GetEnvironmentVariable(name);
-            if (string.IsNullOrEmpty(str))
-            {
-                return defaultValue;
-            }
-
-            switch (str.ToLowerInvariant())
-            {
-                case "true":
-                case "1":
-                case "yes":
-                    return true;
-                case "false":
-                case "0":
-                case "no":
-                    return false;
-                default:
-                    return defaultValue;
-            }
-        }
+        }        
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Env.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Env.cs
@@ -34,28 +34,9 @@ namespace Microsoft.DotNet.Cli.Utils
             return _environment.GetCommandPathFromRootPath(rootPath, commandName, extensions);
         }
 
-        public static bool GetBool(string name, bool defaultValue = false)
+        public static bool GetEnvironmentVariableAsBool(string name, bool defaultValue = false)
         {
-            var str = Environment.GetEnvironmentVariable(name);
-            if (string.IsNullOrEmpty(str))
-            {
-                return defaultValue;
-            }
-
-            switch (str.ToLowerInvariant())
-            {
-                case "true":
-                case "1":
-                case "yes":
-                    return true;
-                case "false":
-                case "0":
-                case "no":
-                    return false;
-                default:
-                    return defaultValue;
-            }
+            return _environment.GetEnvironmentVariableAsBool(name, defaultValue);
         }
-
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Env.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Env.cs
@@ -33,5 +33,29 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             return _environment.GetCommandPathFromRootPath(rootPath, commandName, extensions);
         }
+
+        public static bool GetBool(string name, bool defaultValue = false)
+        {
+            var str = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(str))
+            {
+                return defaultValue;
+            }
+
+            switch (str.ToLowerInvariant())
+            {
+                case "true":
+                case "1":
+                case "yes":
+                    return true;
+                case "false":
+                case "0":
+                case "no":
+                    return false;
+                default:
+                    return defaultValue;
+            }
+        }
+
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
@@ -93,5 +93,29 @@ namespace Microsoft.DotNet.Cli.Utils
 
             return GetCommandPathFromRootPath(rootPath, commandName, extensionsArr);
         }
+
+        public bool GetEnvironmentVariableAsBool(string name, bool defaultValue)
+        {
+            var str = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(str))
+            {
+                return defaultValue;
+            }
+
+            switch (str.ToLowerInvariant())
+            {
+                case "true":
+                case "1":
+                case "yes":
+                    return true;
+                case "false":
+                case "0":
+                case "no":
+                    return false;
+                default:
+                    return defaultValue;
+            }
+        }
+
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/IEnvironmentProvider.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/IEnvironmentProvider.cs
@@ -16,5 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils
         string GetCommandPathFromRootPath(string rootPath, string commandName, params string[] extensions);
 
         string GetCommandPathFromRootPath(string rootPath, string commandName, IEnumerable<string> extensions);
+
+        bool GetEnvironmentVariableAsBool(string name, bool defaultValue);
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Product.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Product.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public class Product
+    {
+        public static readonly string LongName = ".NET Command Line Tools";
+        public static readonly string Version = GetProductVersion();
+
+        private static string GetProductVersion()
+        {
+            var attr = typeof(Product).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return attr?.InformationalVersion;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
@@ -7,51 +7,44 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class Telemetry
     {
-        private class Variables
-        {
-            public static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
-            private static readonly string Prefix = "DOTNET_CLI_TELEMETRY_";
-            public static readonly string Optout = Prefix + "OPTOUT";
-        }
-
-        private class Properties
-        {
-            public static readonly string OSVersion = "OS Version";
-            public static readonly string OSPlatform = "OS Platform";
-            public static readonly string RuntimeId = "Runtime Id";
-            public static readonly string ProductVersion = "Product Version";
-        }
-
         private static bool _isInitialized = false;
         private static TelemetryClient _client = null;
 
         private static Dictionary<string, string> _commonProperties = null;
         private static Dictionary<string, double> _commonMeasurements = null;
 
-        static Telemetry()
+        private static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
+
+        private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";
+        private const string OSVersion = "OS Version";
+        private const string OSPlatform = "OS Platform";
+        private const string RuntimeId = "Runtime Id";
+        private const string ProductVersion = "Product Version";
+
+        public Telemetry()
         {
             if (_isInitialized)
                 return;
 
-            bool Optout = Env.GetBool(Variables.Optout);
+            bool optout = Env.GetEnvironmentVariableAsBool(TelemetryOptout);
 
-            if (Optout)
+            if (optout)
                 return;
 
             try
             {
                 _client = new TelemetryClient();
-                _client.InstrumentationKey = Variables.InstrumentationKey;
+                _client.InstrumentationKey = InstrumentationKey;
                 _client.Context.Session.Id = Guid.NewGuid().ToString();
 
                 var runtimeEnvironment = PlatformServices.Default.Runtime;
                 _client.Context.Device.OperatingSystem = runtimeEnvironment.OperatingSystem;
 
                 _commonProperties = new Dictionary<string, string>();
-                _commonProperties.Add(Properties.OSVersion, runtimeEnvironment.OperatingSystemVersion);
-                _commonProperties.Add(Properties.OSPlatform, runtimeEnvironment.OperatingSystemPlatform.ToString());
-                _commonProperties.Add(Properties.RuntimeId, runtimeEnvironment.GetRuntimeIdentifier());
-                _commonProperties.Add(Properties.ProductVersion, Product.Version);
+                _commonProperties.Add(OSVersion, runtimeEnvironment.OperatingSystemVersion);
+                _commonProperties.Add(OSPlatform, runtimeEnvironment.OperatingSystemPlatform.ToString());
+                _commonProperties.Add(RuntimeId, runtimeEnvironment.GetRuntimeIdentifier());
+                _commonProperties.Add(ProductVersion, Product.Version);
                 _commonMeasurements = new Dictionary<string, double>();
 
                 _isInitialized = true;
@@ -59,23 +52,24 @@ namespace Microsoft.DotNet.Cli.Utils
             catch (Exception) { }
         }
 
-        public static void TrackCommand(string command, IDictionary<string, string> properties = null, IDictionary<string, double> measurements = null)
+        public void TrackCommand(string command, IDictionary<string, string> properties = null, IDictionary<string, double> measurements = null)
         {
             if (!_isInitialized)
                 return;
 
-            Dictionary<string, string> eventProperties = new Dictionary<string, string>(_commonProperties);
-            if (properties != null)
-            {
-                foreach (var p in properties)
-                {
-                    if (eventProperties.ContainsKey(p.Key))
-                        eventProperties[p.Key] = p.Value;
-                    else
-                        eventProperties.Add(p.Key, p.Value);
-                }
-            }
+            Dictionary<string, double> eventMeasurements = GetEventMeasures(measurements);
+            Dictionary<string, string> eventProperties = GetEventProperties(properties);
 
+            try
+            {
+                _client.TrackEvent(command, eventProperties, eventMeasurements);
+                _client.Flush();
+            }
+            catch (Exception) { }
+        }
+
+        private Dictionary<string, double> GetEventMeasures(IDictionary<string, double> measurements)
+        {
             Dictionary<string, double> eventMeasurements = new Dictionary<string, double>(_commonMeasurements);
             if (measurements != null)
             {
@@ -87,13 +81,23 @@ namespace Microsoft.DotNet.Cli.Utils
                         eventMeasurements.Add(m.Key, m.Value);
                 }
             }
+            return eventMeasurements;
+        }
 
-            try
+        private Dictionary<string, string> GetEventProperties(IDictionary<string, string> properties)
+        {
+            Dictionary<string, string> eventProperties = new Dictionary<string, string>(_commonProperties);
+            if (properties != null)
             {
-                _client.TrackEvent(command, eventProperties, eventMeasurements);
-                _client.Flush();
+                foreach (var p in properties)
+                {
+                    if (eventProperties.ContainsKey(p.Key))
+                        eventProperties[p.Key] = p.Value;
+                    else
+                        eventProperties.Add(p.Key, p.Value);
+                }
             }
-            catch (Exception) { }
+            return eventProperties;
         }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.PlatformAbstractions;
+using System.Diagnostics;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -13,9 +14,7 @@ namespace Microsoft.DotNet.Cli.Utils
         private static Dictionary<string, string> _commonProperties = null;
         private static Dictionary<string, double> _commonMeasurements = null;
 
-        //readonly instead of const to to avoid inlining in case we need to change the instrumentation key
-        private static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
-
+        private const string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";
         private const string OSVersion = "OS Version";
         private const string OSPlatform = "OS Platform";
@@ -50,7 +49,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
                 _isInitialized = true;
             }
-            catch (Exception) { }
+            catch (Exception)
+            {
+                // we dont want to fail the tool if telemetry fais. We should be able to detect abnormalities from data 
+                // at the server end
+            }
         }
 
         public void TrackCommand(string command, IDictionary<string, string> properties = null, IDictionary<string, double> measurements = null)
@@ -68,6 +71,7 @@ namespace Microsoft.DotNet.Cli.Utils
             }
             catch (Exception) { }
         }
+
 
         private Dictionary<string, double> GetEventMeasures(IDictionary<string, double> measurements)
         {

--- a/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.Cli.Utils
         private static Dictionary<string, string> _commonProperties = null;
         private static Dictionary<string, double> _commonMeasurements = null;
 
+        //readonly instead of const to to avoid inlining in case we need to change the instrumentation key
         private static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
 
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";

--- a/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights;
+using Microsoft.Extensions.PlatformAbstractions;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public class Telemetry
+    {
+        private class Variables
+        {
+            public static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
+            private static readonly string Prefix = "DOTNET_CLI_TELEMETRY_";
+            public static readonly string Optout = Prefix + "OPTOUT";
+        }
+
+        private class Properties
+        {
+            public static readonly string OSVersion = "OS Version";
+            public static readonly string OSPlatform = "OS Platform";
+            public static readonly string RuntimeId = "Runtime Id";
+            public static readonly string ProductVersion = "Product Version";
+        }
+
+        private static bool _isInitialized = false;
+        private static TelemetryClient _client = null;
+
+        private static Dictionary<string, string> _commonProperties = null;
+        private static Dictionary<string, double> _commonMeasurements = null;
+
+        static Telemetry()
+        {
+            if (_isInitialized)
+                return;
+
+            bool Optout = Env.GetBool(Variables.Optout);
+
+            if (Optout)
+                return;
+
+            try
+            {
+                _client = new TelemetryClient();
+                _client.InstrumentationKey = Variables.InstrumentationKey;
+                _client.Context.Session.Id = Guid.NewGuid().ToString();
+
+                var runtimeEnvironment = PlatformServices.Default.Runtime;
+                _client.Context.Device.OperatingSystem = runtimeEnvironment.OperatingSystem;
+
+                _commonProperties = new Dictionary<string, string>();
+                _commonProperties.Add(Properties.OSVersion, runtimeEnvironment.OperatingSystemVersion);
+                _commonProperties.Add(Properties.OSPlatform, runtimeEnvironment.OperatingSystemPlatform.ToString());
+                _commonProperties.Add(Properties.RuntimeId, runtimeEnvironment.GetRuntimeIdentifier());
+                _commonProperties.Add(Properties.ProductVersion, Product.Version);
+                _commonMeasurements = new Dictionary<string, double>();
+
+                _isInitialized = true;
+            }
+            catch (Exception) { }
+        }
+
+        public static void TrackCommand(string command, IDictionary<string, string> properties = null, IDictionary<string, double> measurements = null)
+        {
+            if (!_isInitialized)
+                return;
+
+            Dictionary<string, string> eventProperties = new Dictionary<string, string>(_commonProperties);
+            if (properties != null)
+            {
+                foreach (var p in properties)
+                {
+                    if (eventProperties.ContainsKey(p.Key))
+                        eventProperties[p.Key] = p.Value;
+                    else
+                        eventProperties.Add(p.Key, p.Value);
+                }
+            }
+
+            Dictionary<string, double> eventMeasurements = new Dictionary<string, double>(_commonMeasurements);
+            if (measurements != null)
+            {
+                foreach (var m in measurements)
+                {
+                    if (eventMeasurements.ContainsKey(m.Key))
+                        eventMeasurements[m.Key] = m.Value;
+                    else
+                        eventMeasurements.Add(m.Key, m.Value);
+                }
+            }
+
+            try
+            {
+                _client.TrackEvent(command, eventProperties, eventMeasurements);
+                _client.Flush();
+            }
+            catch (Exception) { }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -5,6 +5,7 @@
     "warningsAsErrors": true
   },
   "dependencies": {
+    "Microsoft.ApplicationInsights": "2.0.0-rc1",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
     "NuGet.Versioning": "3.5.0-beta-1068",

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -143,10 +143,6 @@ namespace Microsoft.DotNet.Cli
 
             telemetryClient.TrackCommand(
                 command,
-                new Dictionary<string, string>
-                {
-                    ["Arguments"] = arguments
-                },
                 new Dictionary<string, double>
                 {
                     ["ExitCode"] = exitCode

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -121,18 +121,13 @@ namespace Microsoft.DotNet.Cli
                 ["test"] = TestCommand.Run
             };
 
-            int exitCode = 100;
-            
-            string arguments = string.Empty;
-
-
+            int exitCode;            
+            var arguments = string.Empty;
             Func<string[], int> builtIn;
             if (builtIns.TryGetValue(command, out builtIn))
             {
                 exitCode = builtIn(appArgs.ToArray());
-                
-                appArgs.ToList().ForEach(a => { arguments += a + " "; });
-
+                arguments = string.Join(" ", appArgs);
             }
             else
             {
@@ -144,7 +139,9 @@ namespace Microsoft.DotNet.Cli
                 exitCode = result.ExitCode;
             }
 
-            Telemetry.TrackCommand(
+            Telemetry telemetryClient = new Telemetry();
+
+            telemetryClient.TrackCommand(
                 command,
                 new Dictionary<string, string>
                 {
@@ -159,7 +156,7 @@ namespace Microsoft.DotNet.Cli
 
         }
 
-private static void PrintVersion()
+        private static void PrintVersion()
         {
             Reporter.Output.WriteLine(Product.Version);
         }

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -121,22 +121,47 @@ namespace Microsoft.DotNet.Cli
                 ["test"] = TestCommand.Run
             };
 
+            int exitCode = 100;
+            
+            string arguments = string.Empty;
+
+
             Func<string[], int> builtIn;
             if (builtIns.TryGetValue(command, out builtIn))
             {
-                return builtIn(appArgs.ToArray());
+                exitCode = builtIn(appArgs.ToArray());
+                
+                appArgs.ToList().ForEach(a => { arguments += a + " "; });
+
+            }
+            else
+            {
+                CommandResult result = Command.Create("dotnet-" + command, appArgs, FrameworkConstants.CommonFrameworks.NetStandardApp15)
+                    .ForwardStdErr()
+                    .ForwardStdOut()
+                    .Execute();
+                arguments = result.StartInfo.Arguments;
+                exitCode = result.ExitCode;
             }
 
-            return Command.Create("dotnet-" + command, appArgs, FrameworkConstants.CommonFrameworks.NetStandardApp15)
-                .ForwardStdErr()
-                .ForwardStdOut()
-                .Execute()
-                .ExitCode;
+            Telemetry.TrackCommand(
+                command,
+                new Dictionary<string, string>
+                {
+                    ["Arguments"] = arguments
+                },
+                new Dictionary<string, double>
+                {
+                    ["ExitCode"] = exitCode
+                });
+
+            return exitCode;
+
         }
 
-        private static void PrintVersion()
+private static void PrintVersion()
         {
-            Reporter.Output.WriteLine(HelpCommand.ProductVersion);
+            Reporter.Output.WriteLine(Product.Version);
         }
 
         private static void PrintInfo()
@@ -146,7 +171,7 @@ namespace Microsoft.DotNet.Cli
             var commitSha = GetCommitSha() ?? "N/A";
             Reporter.Output.WriteLine();
             Reporter.Output.WriteLine("Product Information:");
-            Reporter.Output.WriteLine($" Version:     {HelpCommand.ProductVersion}");
+            Reporter.Output.WriteLine($" Version:     {Product.Version}");
             Reporter.Output.WriteLine($" Commit Sha:  {commitSha}");
             Reporter.Output.WriteLine();
             var runtimeEnvironment = PlatformServices.Default.Runtime;

--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -8,7 +8,6 @@ namespace Microsoft.DotNet.Tools.Help
 {
     public class HelpCommand
     {
-        private const string ProductLongName = ".NET Command Line Tools";
         private const string UsageText = @"Usage: dotnet [common-options] [command] [arguments]
 
 Arguments:
@@ -28,13 +27,6 @@ Common Commands:
   run           Compiles and immediately executes a .NET project
   repl          Launch an interactive session (read, eval, print, loop)
   pack          Creates a NuGet package";
-        public static readonly string ProductVersion = GetProductVersion();
-
-        private static string GetProductVersion()
-        {
-            var attr = typeof(HelpCommand).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            return attr?.InformationalVersion;
-        }
 
         public static int Run(string[] args)
         {
@@ -57,10 +49,10 @@ Common Commands:
 
         public static void PrintVersionHeader()
         {
-            var versionString = string.IsNullOrEmpty(ProductVersion) ?
+            var versionString = string.IsNullOrEmpty(Product.Version) ?
                 string.Empty :
-                $" ({ProductVersion})";
-            Reporter.Output.WriteLine(ProductLongName + versionString);
+                $" ({Product.Version})";
+            Reporter.Output.WriteLine(Product.LongName + versionString);
         }
     }
 }


### PR DESCRIPTION
.NET Core Tools Telemetry collection
====================================

## Overview
In RC2 of the command line tools, we've started collecting usage telemetry. We've made this choice in order to help us better understand the usage patterns of the CLI tools, and will thus allow us to see which parts of the CLI should be improved.

The data collected will not have any personal data, such as usernames or emails or anything that can be used to identify the actual user. We will also not scan the code and we will not extract any project-level data that can be considered sensitive, such as name, repo or author (if you set those in your `project.json`). 

The data that we collect will be shown publicly in due time. Due time here means when we have enough data to show and when we figure out how to make it accessible. 

## Behavior
The telemetry tracking is "on" by default.

There is a way to opt-out of the telemetry gathering process by setting an environment variable DOTNET_CLI_TELEMETRY_OPTOUT. Doing this will stop the collection process from running. In order to set the environment variable, please use the existing operating system mechanisms for this (e.g. `export` on OS X/Linux).  

## What do we collect?
We collect the following pieces of data: 

* The command being used (e.g. "build", "restore")
* Arguments passed to the command 
* ExitCode of the command
* For test projects, the test runner being used
* Timestamp of invocation
* Details about the project commands are invoked on 
    * Framework used 
    * If RIDs are present in the "runtimes" node
* The CLI version being used

## Questions, feedback, comments
If you have any questions, feedback or comment, please feel free to leave them either on [our issues](), in our [Gitter channel](). If you do file an issue for this, please be sure to tag @blackdwarf and @piotrMSFT so we would get notified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2066)
<!-- Reviewable:end -->