### PR TITLE
Updating nuget to 3.5.0.1083

### DIFF
--- a/scripts/update-dependencies/project.json
+++ b/scripts/update-dependencies/project.json
@@ -9,7 +9,7 @@
     "Microsoft.CSharp": "4.0.1-rc2-23925",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23925",
     "Microsoft.DotNet.Cli.Build.Framework": "1.0.0-*",
-    "NuGet.Versioning": "3.5.0-beta-1068",
+    "NuGet.Versioning": "3.5.0-beta-1083",
     "Newtonsoft.Json": "7.0.1",
     "Octokit": "0.18.0",
     "Microsoft.Net.Http": "2.2.29"

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -7,10 +7,10 @@
   "dependencies": {
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-16537",
-    "NuGet.Versioning": "3.5.0-beta-1068",
-    "NuGet.Packaging": "3.5.0-beta-1068",
-    "NuGet.Frameworks": "3.5.0-beta-1068",
-    "NuGet.ProjectModel": "3.5.0-beta-1068"
+    "NuGet.Versioning": "3.5.0-beta-1083",
+    "NuGet.Packaging": "3.5.0-beta-1083",
+    "NuGet.Frameworks": "3.5.0-beta-1083",
+    "NuGet.ProjectModel": "3.5.0-beta-1083"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -6,7 +6,7 @@
   "description": "Types to model a .NET Project",
   "dependencies": {
     "System.Reflection.Metadata": "1.3.0-rc2-23925",
-    "NuGet.Packaging": "3.5.0-beta-1068",
+    "NuGet.Packaging": "3.5.0-beta-1083",
     "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15996",
     "Microsoft.Extensions.JsonParser.Sources": {
       "type": "build",

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -17,10 +17,10 @@
   ],
   "dependencies": {
     "NuGet.Commands": {
-      "version": "3.5.0-beta-1068",
+      "version": "3.5.0-beta-1083",
       "exclude": "compile"
     },
-    "NuGet.CommandLine.XPlat": "3.5.0-beta-1068",
+    "NuGet.CommandLine.XPlat": "3.5.0-beta-1083",
     "Newtonsoft.Json": "7.0.1",
     "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160321-04",
     "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160321-04",

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -6,10 +6,10 @@
   "dependencies": {
     "NETStandard.Library": "1.5.0-rc2-23925",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23925",
-    "NuGet.Versioning": "3.5.0-beta-1068",
-    "NuGet.Packaging": "3.5.0-beta-1068",
-    "NuGet.Frameworks": "3.5.0-beta-1068",
-    "NuGet.ProjectModel": "3.5.0-beta-1068",
+    "NuGet.Versioning": "3.5.0-beta-1083",
+    "NuGet.Packaging": "3.5.0-beta-1083",
+    "NuGet.Frameworks": "3.5.0-beta-1083",
+    "NuGet.ProjectModel": "3.5.0-beta-1083",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/tools/RuntimeGraphGenerator/project.json
+++ b/tools/RuntimeGraphGenerator/project.json
@@ -4,8 +4,8 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NuGet.RuntimeModel": "3.5.0-beta-1068",
-    "NuGet.Versioning": "3.5.0-beta-1068",
+    "NuGet.RuntimeModel": "3.5.0-beta-1083",
+    "NuGet.Versioning": "3.5.0-beta-1083",
     "System.CommandLine": "0.1.0-e160119-1",
     "System.Runtime.Serialization.Json": "4.0.2-rc2-23925",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",


### PR DESCRIPTION
Updates to NuGet 1083. 

* Project to project framework compatibility checks
* Proxy support
* Updates to NETStandard.Library 1.5.0-rc2-23925

//cc @piotrpMSFT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2074)
<!-- Reviewable:end -->