### PR TITLE
Fix example runtimeconfig.json.

### DIFF
--- a/Documentation/specs/runtime-configuration-file.md
+++ b/Documentation/specs/runtime-configuration-file.md
@@ -30,14 +30,13 @@ The files are both JSON files stored in UTF-8 encoding. Below are sample files. 
             "System.GC.Server": true,
             "System.GC.Concurrent": true,
             "System.Threading.ThreadPool.MinThreads": 4,
-            "System.Threading.ThreadPool.MaxThreads": 8,
-            "System.Threading.Thread.UseAllCpuGroups": true,
+            "System.Threading.ThreadPool.MaxThreads": 8
         },
 
         "framework": {
             "name": "Microsoft.DotNetCore",
             "version": "1.0.1",
-            "rollForward": false,
+            "rollForward": false
         }
     }
 }


### PR DESCRIPTION
The current example runtimeconfig.json in the documentation is invalid because it has trailing commas in the JSON objects. It fails to parse at run time with an error.

This change removes those commas and also removes the `UseAllCpuGroups` property which isn't supported for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2075)
<!-- Reviewable:end -->