### PR TITLE
compile-fsc, support debugType and fix

### DIFF
--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -129,6 +129,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
             allArgs.Add("--noframework");
             allArgs.Add("--nologo");
             allArgs.Add("--simpleresolution");
+            allArgs.Add("--nocopyfsharpcore");
 
             // project.json compilationOptions
             if (commonOptions.Defines != null)

--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -104,15 +104,26 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 allArgs.Add($"--out:{outputName}");
             }
 
-            //debug info (only windows pdb supported, not portablepdb)
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            //let's pass debugging type only if options.DebugType is specified, until 
+            //portablepdb are confirmed to work.
+            //so it's possibile to test portable pdb without breaking existing build
+            if (string.IsNullOrEmpty(commonOptions.DebugType))
             {
-                allArgs.Add("--debug");
-                //TODO check if full or pdbonly
-                allArgs.Add("--debug:pdbonly");
+                //debug info (only windows pdb supported, not portablepdb)
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    allArgs.Add("--debug");
+                    //TODO check if full or pdbonly
+                    allArgs.Add("--debug:pdbonly");
+                }
+                else
+                    allArgs.Add("--debug-");
             }
             else
-                allArgs.Add("--debug-");
+            {
+                allArgs.Add("--debug");
+                allArgs.Add($"--debug:{commonOptions.DebugType}");
+            }
 
             // Default options
             allArgs.Add("--noframework");


### PR DESCRIPTION
add to compile-fsc (f#):

- support property `compilationOptions.debugType` of `project.json`
    the <value> is passed as argument `--debug:<value>` to fsc
    like portablepdb ( ref Microsoft/visualfsharp#999 ). 
    if not specified, default is old behaviour (pdbonly on windows, none on osx/unix) 
- fix do not copy `FSharp.Core` to output dir ( ref Microsoft/visualfsharp#894 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2076)
<!-- Reviewable:end -->
