### PR TITLE
Added a Help property to DotnetTestParams that indicates when the par…

### DIFF
--- a/src/dotnet/commands/dotnet-test/DotnetTestParams.cs
+++ b/src/dotnet/commands/dotnet-test/DotnetTestParams.cs
@@ -47,6 +47,8 @@ namespace Microsoft.DotNet.Tools.Test
 
         public bool NoBuild { get; set; }
 
+        public bool Help { get; set; }
+
         public DotnetTestParams()
         {
             _app = new CommandLineApplication(false)
@@ -57,6 +59,8 @@ namespace Microsoft.DotNet.Tools.Test
             };
 
             AddDotnetTestParameters();
+
+            Help = true;
         }
 
         public void Parse(string[] args)
@@ -108,6 +112,8 @@ namespace Microsoft.DotNet.Tools.Test
 
                 RemainingArguments = _app.RemainingArguments;
 
+                Help = false;
+
                 return 0;
             });
 
@@ -150,7 +156,7 @@ namespace Microsoft.DotNet.Tools.Test
                 _app.Option("--no-build", "Do not build project before testing", CommandOptionType.NoValue);
             _projectPath = _app.Argument(
                 "<PROJECT>",
-                "The project to test, defaults to the current directory. Can be a path to a project.json or a project directory.");            
+                "The project to test, defaults to the current directory. Can be a path to a project.json or a project directory.");
         }
     }
 }

--- a/src/dotnet/commands/dotnet-test/DotnetTestRunnerFactory.cs
+++ b/src/dotnet/commands/dotnet-test/DotnetTestRunnerFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Tools.Test
+{
+    public class DotnetTestRunnerFactory : IDotnetTestRunnerFactory
+    {
+        public IDotnetTestRunner Create(int? port)
+        {
+            IDotnetTestRunner dotnetTestRunner = new ConsoleTestRunner();
+            if (port.HasValue)
+            {
+                dotnetTestRunner = new DesignTimeRunner();
+            }
+
+            return dotnetTestRunner;
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-test/IDotnetTestRunnerFactory.cs
+++ b/src/dotnet/commands/dotnet-test/IDotnetTestRunnerFactory.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Tools.Test
+{
+    public interface IDotnetTestRunnerFactory
+    {
+        IDotnetTestRunner Create(int? port);
+    }
+}

--- a/test/dotnet-test.UnitTests/GivenATestCommand.cs
+++ b/test/dotnet-test.UnitTests/GivenATestCommand.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test;
+using Moq;
+using Xunit;
+using Microsoft.DotNet.ProjectModel;
+
+namespace Microsoft.Dotnet.Tools.Test.Tests
+{
+    public class GivenATestCommand
+    {
+        private static readonly string ProjectJsonPath = Path.Combine(
+                AppContext.BaseDirectory,
+                "TestAssets",
+                "TestProjects",
+                "ProjectWithTests",
+                "project.json");
+
+        private TestCommand _testCommand;
+        private Mock<IDotnetTestRunnerFactory> _dotnetTestRunnerFactoryMock;
+        private Mock<IDotnetTestRunner> _dotnetTestRunnerMock;
+
+        public GivenATestCommand()
+        {
+            _dotnetTestRunnerMock = new Mock<IDotnetTestRunner>();
+            _dotnetTestRunnerMock
+                .Setup(d => d.RunTests(It.IsAny<ProjectContext>(), It.IsAny<DotnetTestParams>()))
+                .Returns(0);
+
+            _dotnetTestRunnerFactoryMock = new Mock<IDotnetTestRunnerFactory>();
+            _dotnetTestRunnerFactoryMock.Setup(d => d.Create(null)).Returns(_dotnetTestRunnerMock.Object);
+
+            _testCommand = new TestCommand(_dotnetTestRunnerFactoryMock.Object);
+        }
+
+        [Fact]
+        public void It_does_not_create_a_runner_if_the_args_include_help()
+        {
+            var result = _testCommand.DoRun(new[] {"--help"});
+
+            result.Should().Be(0);
+            _dotnetTestRunnerFactoryMock.Verify(d => d.Create(It.IsAny<int?>()), Times.Never);
+        }
+
+        [Fact]
+        public void It_creates_a_runner_if_the_args_do_no_include_help()
+        {
+            var result = _testCommand.DoRun(new[] { ProjectJsonPath });
+
+            result.Should().Be(0);
+            _dotnetTestRunnerFactoryMock.Verify(d => d.Create(It.IsAny<int?>()), Times.Once);
+        }
+
+        [Fact]
+        public void It_runs_the_tests_through_the_DotnetTestRunner()
+        {
+            var result = _testCommand.DoRun(new[] { ProjectJsonPath });
+
+            _dotnetTestRunnerMock.Verify(
+                d => d.RunTests(It.IsAny<ProjectContext>(), It.IsAny<DotnetTestParams>()),
+                Times.Once);
+        }
+    }
+}

--- a/test/dotnet-test.UnitTests/GivenThatWeWantToParseArgumentsForDotnetTest.cs
+++ b/test/dotnet-test.UnitTests/GivenThatWeWantToParseArgumentsForDotnetTest.cs
@@ -192,5 +192,20 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         {
             _emptyDotnetTestParams.NoBuild.Should().BeFalse();
         }
+
+        [Fact]
+        public void It_sets_Help_to_false_when_help_is_not_passed_in()
+        {
+            _dotnetTestFullParams.Help.Should().BeFalse();
+        }
+
+        [Fact]
+        public void It_sets_Help_to_true_when_help_is_passed_in()
+        {
+            var dotnetTestParams = new DotnetTestParams();
+            dotnetTestParams.Parse(new[] { "--help" });
+
+            dotnetTestParams.Help.Should().BeTrue();
+        }
     }
 }

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -23,5 +23,8 @@
       ]
     }
   },
+  "content": [
+    "../../TestAssets/TestProjects/ProjectWithTests/project.json"
+  ],
   "testRunner": "xunit"
 }


### PR DESCRIPTION
…sed arguments included the help param. The TestCommand then uses this property of the params to decide whether to continue with the execution or just return. Also added unit tests around this as well as introduced a DotnetTestRunnerFactory to make these unit tests possible and also push the responsibility to figure out which runner to use to the factory.

cc @brthor @piotrpMSFT 

Fixes https://github.com/dotnet/cli/issues/2063.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2078)
<!-- Reviewable:end -->