### PR TITLE
Resolve hostpolicy from deps file in exec mode

### DIFF
--- a/src/corehost/cli/deps_format.cpp
+++ b/src/corehost/cli/deps_format.cpp
@@ -97,6 +97,16 @@ void deps_json_t::reconcile_libraries_with_targets(
                         entry.relative_path.c_str());
                 }
 
+                if (i == deps_entry_t::asset_types::native &&
+                        entry.asset_name == LIBHOSTPOLICY_FILENAME)
+                {
+                    m_hostpolicy_index = m_deps_entries[i].size() - 1;
+                    trace::verbose(_X("Found hostpolicy from deps %d [%s, %s, %s]"),
+                        m_hostpolicy_index,
+                        entry.library_name.c_str(),
+                        entry.library_version.c_str(),
+                        entry.relative_path.c_str());
+                }
             }
         }
     }

--- a/src/corehost/cli/deps_format.h
+++ b/src/corehost/cli/deps_format.h
@@ -26,6 +26,7 @@ public:
     deps_json_t()
         : m_valid(false)
         , m_coreclr_index(-1)
+        , m_hostpolicy_index(-1)
     {
     }
 
@@ -51,10 +52,21 @@ public:
         return m_coreclr_index >= 0;
     }
 
+    bool has_hostpolicy_entry()
+    {
+        return m_hostpolicy_index >= 0;
+    }
+
     const deps_entry_t& get_coreclr_entry()
     {
         assert(has_coreclr_entry());
         return m_deps_entries[deps_entry_t::asset_types::native][m_coreclr_index];
+    }
+
+    const deps_entry_t& get_hostpolicy_entry()
+    {
+        assert(has_hostpolicy_entry());
+        return m_deps_entries[deps_entry_t::asset_types::native][m_hostpolicy_index];
     }
 
     bool is_valid()
@@ -90,6 +102,7 @@ private:
 	std::unordered_map<pal::string_t, int> m_ni_entries;
     rid_fallback_graph_t m_rid_fallback_graph;
     int m_coreclr_index;
+    int m_hostpolicy_index;
     bool m_valid;
 };
 

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -20,6 +20,8 @@ set(SOURCES
     ../../common/trace.cpp
     ../../common/utils.cpp
     ../libhost.cpp
+    ../deps_format.cpp
+    ../deps_entry.cpp
     ../runtime_config.cpp
     ../json/casablanca/src/json/json.cpp
     ../json/casablanca/src/json/json_parsing.cpp

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -21,7 +21,7 @@ int load_host_library(
     corehost_unload_fn* unload_fn)
 {
     pal::string_t host_path;
-    if (!library_exists_in_dir(lib_dir, LIBHOST_NAME, &host_path))
+    if (!library_exists_in_dir(lib_dir, LIBHOSTPOLICY_NAME, &host_path))
     {
         return StatusCode::CoreHostLibMissingFailure;
     }
@@ -86,7 +86,7 @@ bool hostpolicy_exists_in_svc(pal::string_t* resolved_dir)
     append_path(&path, COREHOST_PACKAGE_NAME);
     append_path(&path, COREHOST_PACKAGE_VERSION);
     append_path(&path, COREHOST_PACKAGE_COREHOST_RELATIVE_DIR);
-    if (library_exists_in_dir(path, LIBHOST_NAME))
+    if (library_exists_in_dir(path, LIBHOSTPOLICY_NAME))
     {
         resolved_dir->assign(path);
     }

--- a/src/corehost/cli/libhost.h
+++ b/src/corehost/cli/libhost.h
@@ -4,8 +4,6 @@
 #ifndef __LIBHOST_H__
 #define __LIBHOST_H__
 
-#define LIBHOST_NAME MAKE_LIBNAME("hostpolicy")
-
 enum host_mode_t
 {
     invalid = 0,

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -65,6 +65,10 @@
 #define LIBCORECLR_FILENAME (LIB_PREFIX _X("coreclr"))
 #define LIBCORECLR_NAME MAKE_LIBNAME("coreclr")
 
+
+#define LIBHOSTPOLICY_FILENAME (LIB_PREFIX _X("hostpolicy"))
+#define LIBHOSTPOLICY_NAME MAKE_LIBNAME("hostpolicy")
+
 #if !defined(PATH_MAX) && !defined(_WIN32)
 #define PATH_MAX    4096
 #endif


### PR DESCRIPTION
@gkhanna79 PTAL.

For the `dotnet run` scenario, `hostpolicy.dll` itself has to be loaded from the additional probing path (nuget cache).

This PR can go in post #2080 and a new host package is uploaded.

Cc @brthor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2083)
<!-- Reviewable:end -->
