### PR TITLE
fix F# build, missing default.win32manifest

### DIFF
--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -25,7 +25,7 @@
     "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160321-04",
     "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160321-04",
     "Microsoft.Net.CSharp.Interactive.netcore": "1.3.0-beta1-20160321-04",
-    "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-160316",
+    "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-160318",
     "System.Text.Encoding.CodePages": "4.0.1-rc2-23925",
     "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23925",
     "Microsoft.DiaSymReader.Native": "1.3.3",


### PR DESCRIPTION
fix #2085

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2086)
<!-- Reviewable:end -->