### PR TITLE
Use StringComparison.Ordinal with IndexOf in AnsiConsole

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Cli.Utils
             var escapeScan = 0;
             for (;;)
             {
-                var escapeIndex = message.IndexOf("\x1b[", escapeScan);
+                var escapeIndex = message.IndexOf("\x1b[", escapeScan, StringComparison.Ordinal);
                 if (escapeIndex == -1)
                 {
                     var text = message.Substring(escapeScan);


### PR DESCRIPTION
Fixes #https://github.com/dotnet/cli/issues/2042
cc: @ellismg, @brthor 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2096)
<!-- Reviewable:end -->
