### PR TITLE
add trimming of published output based on sharedfx

### DIFF
--- a/TestAssets/TestProjects/PortableTests/PortableAppWithIntentionalManagedDowngrade/Program.cs
+++ b/TestAssets/TestProjects/PortableTests/PortableAppWithIntentionalManagedDowngrade/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace PortableApp
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/PortableTests/PortableAppWithIntentionalManagedDowngrade/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppWithIntentionalManagedDowngrade/project.json
@@ -1,0 +1,21 @@
+{
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {},
+  "frameworks": {
+    "netstandard1.5": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-rc2-23925"
+        },
+        "System.Linq": "4.0.0"
+      }
+    }
+  }
+}

--- a/test/dotnet-publish.Tests/PublishPortableTests.cs
+++ b/test/dotnet-publish.Tests/PublishPortableTests.cs
@@ -36,6 +36,9 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
                 "PortableAppWithNative.deps.json"
             });
 
+            // Prior to `type:platform` trimming, this would have been published.
+            publishDir.Should().NotHaveFile("System.Linq.dll");
+
             var runtimesOutput = publishDir.Sub("runtimes");
 
             runtimesOutput.Should().Exist();
@@ -49,6 +52,27 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
                 nativeDir.Should().Exist();
                 nativeDir.Should().HaveFile(output.Item2);
             }
+        }
+
+        [Fact]
+        public void PortableAppWithIntentionalDowngradePublishesDowngradedManagedCode()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests")
+                .WithLockFiles();
+
+            var publishCommand = new PublishCommand(Path.Combine(testInstance.TestRoot, "PortableAppWithIntentionalManagedDowngrade"));
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            var publishDir = publishCommand.GetOutputDirectory(portable: true);
+            publishDir.Should().HaveFiles(new[]
+            {
+                "PortableAppWithIntentionalManagedDowngrade.dll",
+                "PortableAppWithIntentionalManagedDowngrade.deps",
+                "PortableAppWithIntentionalManagedDowngrade.deps.json",
+                "System.Linq.dll"
+            });
         }
     }
 }


### PR DESCRIPTION
Any dependencies which **exactly** match the version requested in the
graph originating at the `type: platform` dependency (if any) are
trimmed from the publish output

/cc @davidfowl @piotrpMSFT @pakrym

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2097)
<!-- Reviewable:end -->
