### PR TITLE
Add dotnet-compile-native linker script for Linux / OSX

### DIFF
--- a/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
+++ b/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Linux/LinuxRyuJitCompileStep.cs
@@ -70,6 +70,13 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var ilcSdkLibPath = Path.Combine(config.IlcSdkPath, "sdk");
             argsList.AddRange(_ilcSdkLibs.Select(lib => Path.Combine(ilcSdkLibPath, lib)));
 
+            // Optional linker script
+            var linkerScriptFile = Path.Combine(ilcSdkLibPath, "linkerscript");
+            if (File.Exists(linkerScriptFile))
+            {
+                argsList.Add(linkerScriptFile);
+            }
+
             // AppDep Libs
             var baseAppDepLibPath = Path.Combine(config.AppDepSDKPath, "CPPSdk/ubuntu.14.04", config.Architecture.ToString());
             argsList.AddRange(_appdeplibs.Select(lib => Path.Combine(baseAppDepLibPath, lib)));

--- a/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
+++ b/src/dotnet/commands/dotnet-compile-native/IntermediateCompilation/Mac/MacRyuJitCompileStep.cs
@@ -72,6 +72,13 @@ namespace Microsoft.DotNet.Tools.Compiler.Native
             var ilcSdkLibPath = Path.Combine(config.IlcSdkPath, "sdk");
             argsList.AddRange(_ilcSdkLibs.Select(lib => Path.Combine(ilcSdkLibPath, lib)));
 
+            // Optional linker script
+            var linkerScriptFile = Path.Combine(ilcSdkLibPath, "linkerscript");
+            if (File.Exists(linkerScriptFile))
+            {
+                argsList.Add(linkerScriptFile);
+            }
+
             // AppDep Libs
             var baseAppDepLibPath = Path.Combine(config.AppDepSDKPath, "CPPSdk/osx.10.10", config.Architecture.ToString());
             argsList.AddRange(appdeplibs.Select(lib => Path.Combine(baseAppDepLibPath, lib)));


### PR DESCRIPTION
Add CoreRT SDK linkerscript to linker options if the file is present. It
is used for controlling section merging for multi-file compilation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2101)
<!-- Reviewable:end -->