### PR TITLE
Fix version badges to display Nuget Version of cli.

### DIFF
--- a/resources/images/version_badge.svg
+++ b/resources/images/version_badge.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="150" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="20">
     <mask id="a">
-        <rect width="150" height="20" rx="0" fill="#fff" />
+        <rect width="180" height="20" rx="0" fill="#fff" />
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h52v20H0z" />
-        <path fill="#007ec6" d="M52 0h100v20H52z" />
+        <path fill="#007ec6" d="M52 0h115v20H52z" />
         <path fill="url(#b)" d="M0 0h150v20H0z" />
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="26" y="15" fill="#010101" fill-opacity=".3">version</text>
         <text x="26" y="14">version</text>
-        <text x="100" y="15" fill="#010101" fill-opacity=".3">ver_number</text>
-        <text x="100" y="14">ver_number</text>
+        <text x="110" y="15" fill="#010101" fill-opacity=".3">ver_number</text>
+        <text x="110" y="14">ver_number</text>
     </g>
 </svg>

--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Cli.Build
             var outputVersionSvg = c.BuildContext.Get<string>("VersionBadge");
 
             var versionSvgContent = File.ReadAllText(versionSvg);
-            versionSvgContent = versionSvgContent.Replace("ver_number", buildVersion.SimpleVersion);
+            versionSvgContent = versionSvgContent.Replace("ver_number", buildVersion.NuGetVersion);
             File.WriteAllText(outputVersionSvg, versionSvgContent);
 
             return c.Success();


### PR DESCRIPTION
We started using the nuget version in rest of our build scripts.
Fixes - #2099

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2102)
<!-- Reviewable:end -->
