### PR TITLE
Add C# Lib and xunittest templates

### DIFF
--- a/build_projects/dotnet-cli-build/PrepareTargets.cs
+++ b/build_projects/dotnet-cli-build/PrepareTargets.cs
@@ -487,8 +487,8 @@ cmake is required to build the native host 'corehost'";
         }
 
         private static void AddInstallerArtifactToContext(
-            BuildTargetContext c, 
-            string artifactPrefix, 
+            BuildTargetContext c,
+            string artifactPrefix,
             string contextPrefix,
             string version)
         {

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/Library.cs
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/Library.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace ClassLibrary
+{
+    public class Class1
+    {
+        public void Method1()
+        {    
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
@@ -1,9 +1,10 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc3-24126-00"
   },
   "frameworks": {
-    "netstandard1.5": {}
+    "netstandard1.6": {
+        "NETStandard.Library": "1.5.0-rc3-24126-00"
+    }
   }
 }

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc3-24126-00"
+  },
+  "frameworks": {
+    "netstandard1.5": {}
+  }
+}

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/Tests.cs
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/Tests.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Xunit;
+
+namespace Tests
+{
+    public class Tests
+    {
+        [Fact]
+        public void Test1() 
+        {
+            Assert.True(true);
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -2,9 +2,9 @@
     "version": "1.0.0-*",
 
     "dependencies": {
-        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24008",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24127-01",
         "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-140469-38"
+        "dotnet-test-xunit": "1.0.0-rc2-192208-24"
     },
 
     "testRunner":  "xunit",

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+
+    "dependencies": {
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24008",
+        "xunit": "2.1.0",
+        "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    },
+
+    "testRunner":  "xunit",
+
+    "frameworks": {
+        "netcoreapp1.0": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0-rc3-004312"
+                }
+            },
+            "imports": [
+                "dotnet5.4",
+                "portable-net451+win8"
+            ]
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-new/Program.cs
+++ b/src/dotnet/commands/dotnet-new/Program.cs
@@ -88,8 +88,18 @@ namespace Microsoft.DotNet.Tools.New
             var dotnetNew = new NewCommand();
             app.OnExecute(() => {
 
-                var csharp = new { Name = "C#", Alias = new[] { "c#", "cs", "csharp" }, TemplatePrefix = "CSharp", Templates = new[] { "Console" } };
-                var fsharp = new { Name = "F#", Alias = new[] { "f#", "fs", "fsharp" }, TemplatePrefix = "FSharp", Templates = new[] { "Console" } };
+                var csharp = new { 
+                    Name = "C#", 
+                    Alias = new[] { "c#", "cs", "csharp" }, 
+                    TemplatePrefix = "CSharp", 
+                    Templates = new[] { "Console", "Lib", "xunittest" } 
+                };
+                var fsharp = new { 
+                    Name = "F#", 
+                    Alias = new[] { "f#", "fs", "fsharp" }, 
+                    TemplatePrefix = "FSharp", 
+                    Templates = new[] { "Console" } 
+                };
 
                 string languageValue = lang.Value() ?? csharp.Name;
 

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -9,13 +9,23 @@
         "commands/dotnet-new/CSharp_Console/project.json.template",
         "commands/dotnet-new/FSharp_Console/NuGet.config",
         "commands/dotnet-new/FSharp_Console/Program.fs",
-        "commands/dotnet-new/FSharp_Console/project.json.template"
+        "commands/dotnet-new/FSharp_Console/project.json.template",
+        "commands/dotnet-new/CSharp_Console/Program.cs",
+        "commands/dotnet-new/CSharp_Console/project.json.template",
+        "commands/dotnet-new/FSharp_Console/Program.fs",
+        "commands/dotnet-new/FSharp_Console/project.json.template",
+        "commands/dotnet-new/CSharp_Lib/Library.cs",
+        "commands/dotnet-new/CSharp_Lib/project.json.template",
+        "commands/dotnet-new/CSharp_xunittest/Tests.cs",
+        "commands/dotnet-new/CSharp_xunittest/project.json.template"
       ]
     },
     "compile": {
       "exclude": [
         "commands/dotnet-new/CSharp_Console/**",
-        "commands/dotnet-new/FSharp_Console/**"
+        "commands/dotnet-new/FSharp_Console/**",
+        "commands/dotnet-new/CSharp_Lib/**",
+        "commands/dotnet-new/CSharp_xunittest/**"
       ]
     }
   },

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -4,20 +4,15 @@
     "emitEntryPoint": true,
     "embed": {
       "include": [
-        "commands/dotnet-new/CSharp_Console/NuGet.Config",
         "commands/dotnet-new/CSharp_Console/Program.cs",
         "commands/dotnet-new/CSharp_Console/project.json.template",
-        "commands/dotnet-new/FSharp_Console/NuGet.config",
-        "commands/dotnet-new/FSharp_Console/Program.fs",
-        "commands/dotnet-new/FSharp_Console/project.json.template",
-        "commands/dotnet-new/CSharp_Console/Program.cs",
-        "commands/dotnet-new/CSharp_Console/project.json.template",
-        "commands/dotnet-new/FSharp_Console/Program.fs",
-        "commands/dotnet-new/FSharp_Console/project.json.template",
         "commands/dotnet-new/CSharp_Lib/Library.cs",
         "commands/dotnet-new/CSharp_Lib/project.json.template",
         "commands/dotnet-new/CSharp_xunittest/Tests.cs",
-        "commands/dotnet-new/CSharp_xunittest/project.json.template"
+        "commands/dotnet-new/CSharp_xunittest/project.json.template",
+        "commands/dotnet-new/FSharp_Console/NuGet.config",
+        "commands/dotnet-new/FSharp_Console/Program.fs",
+        "commands/dotnet-new/FSharp_Console/project.json.template"
       ]
     },
     "compile": {


### PR DESCRIPTION
Adding the C# lib and xunittest templates to `dotnet new`. These need
to be invoked with the `dotnet new -t lib` and `dotnet new -t
xunittest` keywords respectively.

Fix #2014 

/cc @piotrpMSFT @livarcocc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2106)
<!-- Reviewable:end -->