### PR TITLE
Get Executable name properly

### DIFF
--- a/src/corehost/cli/libhost.cpp
+++ b/src/corehost/cli/libhost.cpp
@@ -36,7 +36,7 @@ host_mode_t detect_operating_mode(const int argc, const pal::char_t* argv[], pal
         p_own_dir->assign(own_dir);
     }
 
-    pal::string_t own_dll_filename = strip_file_ext(own_name) + _X(".dll");
+    pal::string_t own_dll_filename = get_executable(own_name) + _X(".dll");
     pal::string_t own_dll = own_dir;
     append_path(&own_dll, own_dll_filename.c_str());
     trace::info(_X("Own DLL path=[%s]"), own_dll.c_str());

--- a/src/corehost/common/pal.h
+++ b/src/corehost/common/pal.h
@@ -99,6 +99,8 @@ namespace pal
     typedef HMODULE dll_t;
     typedef FARPROC proc_t;
 
+    inline string_t exe_suffix() { return _X(".exe"); }
+
     pal::string_t to_string(int value);
 
     bool getcwd(pal::string_t* recv);
@@ -138,6 +140,8 @@ namespace pal
     typedef void* dll_t;
     typedef void* proc_t;
 
+    inline string_t exe_suffix() { return _X(""); }
+
     pal::string_t to_string(int value);
 
     bool getcwd(pal::string_t* recv);
@@ -156,6 +160,7 @@ namespace pal
     inline void to_palstring(const char* str, pal::string_t* out) { out->assign(str); }
     inline void to_stdstring(const char_t* str, std::string* out) { out->assign(str); }
 #endif
+
     bool realpath(string_t* path);
     bool file_exists(const string_t& path);
     inline bool directory_exists(const string_t& path) { return file_exists(path); }

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -60,15 +60,21 @@ void append_path(pal::string_t* path1, const pal::char_t* path2)
 
 pal::string_t get_executable(const pal::string_t& filename)
 {
-    pal::string_t result(filename);
-
-    if (ends_with(result, _X(".exe"), false))
+    pal::string_t exe_suffix = pal::exe_suffix();
+    if (exe_suffix.empty())
     {
-        // We need to strip off the old extension
-        result.erase(result.size() - 4);
+        return filename;
     }
 
-    return result;
+    if (ends_with(filename, exe_suffix, false))
+    {
+        // We need to strip off the old extension
+        pal::string_t result(filename);
+        result.erase(result.size() - exe_suffix.size());
+        return result;
+    }
+
+    return filename;
 }
 
 pal::string_t strip_file_ext(const pal::string_t& path)


### PR DESCRIPTION
For OSX and Unix we shouldn't strip file ext to obtain DLL name.

Cc @pakrym 

Fixes https://github.com/dotnet/cli/issues/2125

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2128)
<!-- Reviewable:end -->
