### PR TITLE
Adding a runtimeconfig.dev.json containing the additionalProbePaths when doing dotnet build.

### DIFF
--- a/src/Microsoft.DotNet.Compiler.Common/Executable.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/Executable.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Dotnet.Cli.Compiler.Common
         {
             WriteDeps(exporter);
             WriteRuntimeConfig(exporter);
+            WriteDevRuntimeConfig(exporter);
 
             var projectExports = exporter.GetDependencies(LibraryType.Project);
             CopyAssemblies(projectExports);
@@ -165,6 +166,35 @@ namespace Microsoft.Dotnet.Cli.Compiler.Common
                     json.WriteTo(writer);
                 }
             }
+        }
+
+        private void WriteDevRuntimeConfig(LibraryExporter exporter)
+        {
+            if (_context.TargetFramework.IsDesktop())
+            {
+                return;
+            }
+
+            var json = new JObject();
+            var runtimeOptions = new JObject();
+            json.Add("runtimeOptions", runtimeOptions);
+
+            AddAdditionalProbingPaths(runtimeOptions);
+
+            var runtimeConfigDevJsonFile =
+                    Path.Combine(_runtimeOutputPath, _compilerOptions.OutputName + FileNameSuffixes.RuntimeConfigDevJson);
+
+            using (var writer = new JsonTextWriter(new StreamWriter(File.Create(runtimeConfigDevJsonFile))))
+            {
+                writer.Formatting = Formatting.Indented;
+                json.WriteTo(writer);
+            }
+        }
+
+        private void AddAdditionalProbingPaths(JObject runtimeOptions)
+        {
+            var additionalProbingPaths = new JArray(_context.PackagesDirectory);
+            runtimeOptions.Add("additionalProbingPaths", additionalProbingPaths);
         }
 
         public void WriteDeps(LibraryExporter exporter)

--- a/src/Microsoft.DotNet.ProjectModel/FileNameSuffixes.cs
+++ b/src/Microsoft.DotNet.ProjectModel/FileNameSuffixes.cs
@@ -8,6 +8,7 @@ namespace Microsoft.DotNet.ProjectModel
         public const string Deps = ".deps";
         public const string DepsJson = ".deps.json";
         public const string RuntimeConfigJson = ".runtimeconfig.json";
+        public const string RuntimeConfigDevJson = ".runtimeconfig.dev.json";
 
         public static PlatformFileNameSuffixes CurrentPlatform
         {

--- a/test/dotnet-build.Tests/BuildPortableTests.cs
+++ b/test/dotnet-build.Tests/BuildPortableTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
+using Microsoft.DotNet.TestFramework;
 
 namespace Microsoft.DotNet.Tools.Builder.Tests
 {
@@ -9,9 +10,65 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
         [Fact]
         public void BuildingAPortableProjectProducesDepsFile()
         {
-            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests")
-                .WithLockFiles();
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests").WithLockFiles();
 
+            var netstandardappOutput = Build(testInstance);
+
+            netstandardappOutput.Should().Exist().And.HaveFile("PortableApp.deps");
+        }
+
+        [Fact]
+        public void BuildingAPortableProjectProducesDepsJsonFile()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests").WithLockFiles();
+
+            var netstandardappOutput = Build(testInstance);
+
+            netstandardappOutput.Should().Exist().And.HaveFile("PortableApp.deps.json");
+        }
+
+        [Fact]
+        public void BuildingAPortableProjectProducesADllFile()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests").WithLockFiles();
+
+            var netstandardappOutput = Build(testInstance);
+
+            netstandardappOutput.Should().Exist().And.HaveFile("PortableApp.dll");
+        }
+
+        [Fact]
+        public void BuildingAPortableProjectProducesAPdbFile()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests").WithLockFiles();
+
+            var netstandardappOutput = Build(testInstance);
+
+            netstandardappOutput.Should().Exist().And.HaveFile("PortableApp.pdb");
+        }
+
+        [Fact]
+        public void BuildingAPortableProjectProducesARuntimeConfigJsonFile()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests").WithLockFiles();
+
+            var netstandardappOutput = Build(testInstance);
+
+            netstandardappOutput.Should().Exist().And.HaveFile("PortableApp.runtimeconfig.json");
+        }
+
+        [Fact]
+        public void BuildingAPortableProjectProducesARuntimeConfigDevJsonFile()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests").WithLockFiles();
+
+            var netstandardappOutput = Build(testInstance);
+
+            netstandardappOutput.Should().Exist().And.HaveFile("PortableApp.runtimeconfig.dev.json");
+        }
+
+        private DirectoryInfo Build(TestInstance testInstance)
+        {
             var result = new BuildCommand(
                 projectPath: Path.Combine(testInstance.TestRoot, "PortableApp"))
                 .ExecuteWithCapturedOutput();
@@ -20,17 +77,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
             var outputBase = new DirectoryInfo(Path.Combine(testInstance.TestRoot, "PortableApp", "bin", "Debug"));
 
-            var netstandardappOutput = outputBase.Sub("netstandard1.5");
-
-            netstandardappOutput.Should()
-                .Exist().And
-                .HaveFiles(new[]
-                {
-                    "PortableApp.deps",
-                    "PortableApp.deps.json",
-                    "PortableApp.dll",
-                    "PortableApp.pdb"
-                });
+            return outputBase.Sub("netstandard1.5");
         }
     }
 }

--- a/test/dotnet-build.Tests/BuildStandAloneTests.cs
+++ b/test/dotnet-build.Tests/BuildStandAloneTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.Extensions.PlatformAbstractions;
+using Xunit;
+using System.Linq;
+using Microsoft.DotNet.TestFramework;
+
+namespace Microsoft.DotNet.Tools.Builder.Tests
+{
+    public class BuildStandAloneTests : TestBase
+    {
+        [Fact]
+        public void BuildingAStandAloneProjectProducesARuntimeConfigDevJsonFile()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests")
+                .WithLockFiles();
+
+            var netstandardappOutput = Build(testInstance);
+
+            netstandardappOutput.Should().Exist().And.HaveFile("StandaloneApp.runtimeconfig.dev.json");
+        }
+
+        public DirectoryInfo Build(TestInstance testInstance)
+        {
+            var projectPath = Path.Combine(testInstance.TestRoot, "StandaloneApp");
+
+            var result = new BuildCommand(
+                projectPath: projectPath)
+                .ExecuteWithCapturedOutput();
+
+            var contexts = ProjectContext.CreateContextForEachFramework(
+                projectPath,
+                null,
+                PlatformServices.Default.Runtime.GetAllCandidateRuntimeIdentifiers());
+
+            var runtime = contexts.FirstOrDefault(c => !string.IsNullOrEmpty(c.RuntimeIdentifier))?.RuntimeIdentifier;
+
+            result.Should().Pass();
+
+            var outputBase = new DirectoryInfo(
+                Path.Combine(testInstance.TestRoot, "StandaloneApp", "bin", "Debug", "netstandardapp1.5"));
+
+            return outputBase.Sub(runtime);
+        }
+    }
+}

--- a/test/dotnet-publish.Tests/PublishPortableTests.cs
+++ b/test/dotnet-publish.Tests/PublishPortableTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.DotNet.Tools.Test.Utilities;
+﻿using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Test.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,12 +24,8 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             var testInstance = TestAssetsManager.CreateTestInstance("PortableTests")
                 .WithLockFiles();
 
-            var publishCommand = new PublishCommand(Path.Combine(testInstance.TestRoot, "PortableAppWithNative"));
-            var publishResult = publishCommand.Execute();
+            var publishDir = Publish(testInstance);
 
-            publishResult.Should().Pass();
-
-            var publishDir = publishCommand.GetOutputDirectory(portable: true);
             publishDir.Should().HaveFiles(new[]
             {
                 "PortableAppWithNative.dll",
@@ -73,6 +70,27 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
                 "PortableAppWithIntentionalManagedDowngrade.deps.json",
                 "System.Linq.dll"
             });
+        }
+
+        [Fact]
+        public void PortableAppWithRuntimeTargetsDoesNotHaveRuntimeConfigDevJsonFile()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests")
+                .WithLockFiles();
+
+            var publishDir = Publish(testInstance);
+
+            publishDir.Should().NotHaveFile("PortableAppWithNative.runtimeconfig.dev.json");
+        }
+
+        private DirectoryInfo Publish(TestInstance testInstance)
+        {
+            var publishCommand = new PublishCommand(Path.Combine(testInstance.TestRoot, "PortableAppWithNative"));
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            return publishCommand.GetOutputDirectory(portable: true);
         }
     }
 }

--- a/test/dotnet-publish.Tests/PublishStandaloneTests.cs
+++ b/test/dotnet-publish.Tests/PublishStandaloneTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+using Microsoft.DotNet.TestFramework;
+
+namespace Microsoft.DotNet.Tools.Publish.Tests
+{
+    public class PublishStandaloneTests : TestBase
+    {
+        [Fact]
+        public void StandaloneAppDoesNotHaveRuntimeConfigDevJsonFile()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("PortableTests")
+                .WithLockFiles();
+
+            var publishDir = Publish(testInstance);
+
+            publishDir.Should().NotHaveFile("StandaloneApp.runtimeconfig.dev.json");
+        }
+
+        private DirectoryInfo Publish(TestInstance testInstance)
+        {
+            var publishCommand = new PublishCommand(Path.Combine(testInstance.TestRoot, "StandaloneApp"));
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            return publishCommand.GetOutputDirectory(portable: false);
+        }
+    }
+}


### PR DESCRIPTION
If I finish the project.json runtimeoptions work soon enough, I will put it here as well.

cc @anurse @pakrym @brthor @schellap @gkhanna79 @piotrpMSFT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2130)
<!-- Reviewable:end -->