### PR TITLE
Updating dotnet-test-xunit to the lastest version in hopes that it wi…

### DIFF
--- a/TestAssets/TestProjects/ProjectWithTests/project.json
+++ b/TestAssets/TestProjects/ProjectWithTests/project.json
@@ -5,7 +5,7 @@
     "System.Linq.Expressions": "4.0.11-rc2-23929",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23929",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -16,7 +16,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -17,7 +17,7 @@
     },
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -21,7 +21,7 @@
     },
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -10,7 +10,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -10,7 +10,7 @@
     "System.Collections.Immutable": "1.2.0-rc2-23929",
     "FluentAssertions": "4.0.0",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12",
+    "dotnet-test-xunit": "1.0.0-dev-128011-22",
     "Microsoft.DotNet.TestFramework": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",

--- a/test/Microsoft.Extensions.DependencyModel.Tests/project.json
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/project.json
@@ -12,7 +12,7 @@
     "FluentAssertions": "4.0.0",
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
@@ -16,7 +16,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12",
+    "dotnet-test-xunit": "1.0.0-dev-128011-22",
     "FluentAssertions": "4.2.2"
   },
   "frameworks": {

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
@@ -11,7 +11,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12",
+    "dotnet-test-xunit": "1.0.0-dev-128011-22",
     "FluentAssertions": "4.2.2",
     "moq.netcore": "4.4.0-beta8"
   },

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -10,7 +10,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -10,7 +10,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -15,7 +15,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12",
+    "dotnet-test-xunit": "1.0.0-dev-128011-22",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -11,7 +11,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -15,7 +15,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12",
+    "dotnet-test-xunit": "1.0.0-dev-128011-22",
     "System.Net.NameResolution": "4.0.0-rc2-23929"
   },
   "frameworks": {

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -12,7 +12,7 @@
     },
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -11,7 +11,7 @@
     },
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -10,7 +10,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -16,7 +16,7 @@
     "System.Net.Sockets": "4.1.0-rc2-23929",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23929",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -11,7 +11,7 @@
       "exclude": "Compile"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12",
+    "dotnet-test-xunit": "1.0.0-dev-128011-22",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -11,7 +11,7 @@
       "type": "build"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-91790-12"
+    "dotnet-test-xunit": "1.0.0-dev-128011-22"
   },
   "frameworks": {
     "netstandardapp1.5": {


### PR DESCRIPTION
…ll fix the inconsistent build break we are seeing in Jenkins and VSO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2131)
<!-- Reviewable:end -->