### PR TITLE
Fix fsharp corehostify

### DIFF
--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public static readonly string[] BinariesForCoreHost = new[]
         {
+            "fsc",
             "csi",
             "csc",
             "vbc"
@@ -372,12 +373,22 @@ namespace Microsoft.DotNet.Cli.Build
             File.Copy(Path.Combine(Dirs.Corehost, $"{Constants.DynamicLibPrefix}hostpolicy{Constants.DynamicLibSuffix}"), Path.Combine(outputDir, $"{Constants.DynamicLibPrefix}hostpolicy{Constants.DynamicLibSuffix}"), overwrite: true);
             File.Copy(Path.Combine(Dirs.Corehost, $"{Constants.DynamicLibPrefix}hostfxr{Constants.DynamicLibSuffix}"), Path.Combine(outputDir, $"{Constants.DynamicLibPrefix}hostfxr{Constants.DynamicLibSuffix}"), overwrite: true);
 
-            var binaryToCorehostifyOutDir = Path.Combine(outputDir, "runtimes", "any", "native");
             // Corehostify binaries
             foreach (var binaryToCorehostify in BinariesForCoreHost)
             {
                 try
                 {
+                    string binaryToCorehostifyOutDir;
+                    if (binaryToCorehostify == "fsc")
+                    {
+                        //fsc.exe is in the same directory, not in runtimes/any/native subdirectory
+                        binaryToCorehostifyOutDir = outputDir;
+                    }
+                    else
+                    {
+                        binaryToCorehostifyOutDir = Path.Combine(outputDir, "runtimes", "any", "native");
+                    }
+
                     // Yes, it is .exe even on Linux. This is the managed exe we're working with
                     File.Copy(Path.Combine(binaryToCorehostifyOutDir, $"{binaryToCorehostify}.exe"), Path.Combine(outputDir, $"{binaryToCorehostify}.dll"));
                     File.Delete(Path.Combine(binaryToCorehostifyOutDir, $"{binaryToCorehostify}.exe"));

--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 //HACK we need default.win32manifest for exe
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    var win32manifestPath = Path.Combine(AppContext.BaseDirectory, "runtimes", "any", "native", "default.win32manifest");
+                    var win32manifestPath = GetDefaultWin32ManifestPath();
                     allArgs.Add($"--win32manifest:{win32manifestPath}");
                 }
             }
@@ -257,10 +257,21 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
             return result.ExitCode;
         }
 
+        private static string GetFscPath()
+        {
+            return Environment.GetEnvironmentVariable("DOTNET_FSC_PATH")
+                   ?? Path.Combine(AppContext.BaseDirectory, "fsc.dll");
+        }
+
+        private static string GetDefaultWin32ManifestPath()
+        {
+            var baseDir = Path.GetDirectoryName(GetFscPath());
+            return Path.Combine(baseDir, "runtimes", "any", "native", "default.win32manifest");
+        }
+
         private static Command RunFsc(List<string> fscArgs)
         {
-            var fscExe = Environment.GetEnvironmentVariable("DOTNET_FSC_PATH")
-                      ?? Path.Combine(AppContext.BaseDirectory, "fsc.dll");
+            var fscExe = GetFscPath();
 
             var exec = Environment.GetEnvironmentVariable("DOTNET_FSC_EXEC")?.ToUpper() ?? "COREHOST";
 

--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
                 //HACK we need default.win32manifest for exe
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    var win32manifestPath = Path.Combine(AppContext.BaseDirectory, "default.win32manifest");
+                    var win32manifestPath = Path.Combine(AppContext.BaseDirectory, "runtimes", "any", "native", "default.win32manifest");
                     allArgs.Add($"--win32manifest:{win32manifestPath}");
                 }
             }

--- a/src/dotnet/commands/dotnet-compile-fsc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-fsc/Program.cs
@@ -260,7 +260,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
         private static Command RunFsc(List<string> fscArgs)
         {
             var fscExe = Environment.GetEnvironmentVariable("DOTNET_FSC_PATH")
-                      ?? Path.Combine(AppContext.BaseDirectory, "fsc.exe");
+                      ?? Path.Combine(AppContext.BaseDirectory, "fsc.dll");
 
             var exec = Environment.GetEnvironmentVariable("DOTNET_FSC_EXEC")?.ToUpper() ?? "COREHOST";
 
@@ -271,8 +271,9 @@ namespace Microsoft.DotNet.Tools.Compiler.Fsc
 
                 case "COREHOST":
                 default:
-                    var corehost = Path.Combine(AppContext.BaseDirectory, Constants.HostExecutableName);
-                    return Command.Create(corehost, new[] { fscExe }.Concat(fscArgs).ToArray());
+                    var muxer = new Muxer();
+                    var host = muxer.MuxerPath;
+                    return Command.Create(host, new[] { "exec", fscExe }.Concat(fscArgs).ToArray());
             }
 
         }


### PR DESCRIPTION
fix f# with latest changes of .NET CLI

- use muxer (`dotnet exec`)
- build script changes:
    - `fsc.exe` -> `fsc.dll` (like `csc`)
    - add `fsc.deps.json` ( like `csc.deps.json` )
    - add  `fsc.runtimeconfig.json` ( like `csc.runtimeconfig.json` )
- fix path of `default.win32manifest`



/cc @brthor @piotrpMSFT @pakrym

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2138)
<!-- Reviewable:end -->
