### PR TITLE
Lakshanf/issue2066/telemetry

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandContext.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandContext.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.Cli.Utils
             public static readonly string AnsiPassThru = Prefix + "ANSI_PASS_THRU";
         }
 
-        private static Lazy<bool> _verbose = new Lazy<bool>(() => Env.GetBool(Variables.Verbose));
-        private static Lazy<bool> _ansiPassThru = new Lazy<bool>(() => Env.GetBool(Variables.AnsiPassThru));
+        private static Lazy<bool> _verbose = new Lazy<bool>(() => Env.GetEnvironmentVariableAsBool(Variables.Verbose));
+        private static Lazy<bool> _ansiPassThru = new Lazy<bool>(() => Env.GetEnvironmentVariableAsBool(Variables.AnsiPassThru));
 
         public static bool IsVerbose()
         {

--- a/src/Microsoft.DotNet.Cli.Utils/CommandContext.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandContext.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.Cli.Utils
             public static readonly string AnsiPassThru = Prefix + "ANSI_PASS_THRU";
         }
 
-        private static Lazy<bool> _verbose = new Lazy<bool>(() => GetBool(Variables.Verbose));
-        private static Lazy<bool> _ansiPassThru = new Lazy<bool>(() => GetBool(Variables.AnsiPassThru));
+        private static Lazy<bool> _verbose = new Lazy<bool>(() => Env.GetBool(Variables.Verbose));
+        private static Lazy<bool> _ansiPassThru = new Lazy<bool>(() => Env.GetBool(Variables.AnsiPassThru));
 
         public static bool IsVerbose()
         {
@@ -25,29 +25,6 @@ namespace Microsoft.DotNet.Cli.Utils
         public static bool ShouldPassAnsiCodesThrough()
         {
             return _ansiPassThru.Value;
-        }
-
-        private static bool GetBool(string name, bool defaultValue = false)
-        {
-            var str = Environment.GetEnvironmentVariable(name);
-            if (string.IsNullOrEmpty(str))
-            {
-                return defaultValue;
-            }
-
-            switch (str.ToLowerInvariant())
-            {
-                case "true":
-                case "1":
-                case "yes":
-                    return true;
-                case "false":
-                case "0":
-                case "no":
-                    return false;
-                default:
-                    return defaultValue;
-            }
-        }
+        }        
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Env.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Env.cs
@@ -34,28 +34,9 @@ namespace Microsoft.DotNet.Cli.Utils
             return _environment.GetCommandPathFromRootPath(rootPath, commandName, extensions);
         }
 
-        public static bool GetBool(string name, bool defaultValue = false)
+        public static bool GetEnvironmentVariableAsBool(string name, bool defaultValue = false)
         {
-            var str = Environment.GetEnvironmentVariable(name);
-            if (string.IsNullOrEmpty(str))
-            {
-                return defaultValue;
-            }
-
-            switch (str.ToLowerInvariant())
-            {
-                case "true":
-                case "1":
-                case "yes":
-                    return true;
-                case "false":
-                case "0":
-                case "no":
-                    return false;
-                default:
-                    return defaultValue;
-            }
+            return _environment.GetEnvironmentVariableAsBool(name, defaultValue);
         }
-
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Env.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Env.cs
@@ -33,5 +33,29 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             return _environment.GetCommandPathFromRootPath(rootPath, commandName, extensions);
         }
+
+        public static bool GetBool(string name, bool defaultValue = false)
+        {
+            var str = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(str))
+            {
+                return defaultValue;
+            }
+
+            switch (str.ToLowerInvariant())
+            {
+                case "true":
+                case "1":
+                case "yes":
+                    return true;
+                case "false":
+                case "0":
+                case "no":
+                    return false;
+                default:
+                    return defaultValue;
+            }
+        }
+
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
@@ -93,5 +93,29 @@ namespace Microsoft.DotNet.Cli.Utils
 
             return GetCommandPathFromRootPath(rootPath, commandName, extensionsArr);
         }
+
+        public bool GetEnvironmentVariableAsBool(string name, bool defaultValue)
+        {
+            var str = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(str))
+            {
+                return defaultValue;
+            }
+
+            switch (str.ToLowerInvariant())
+            {
+                case "true":
+                case "1":
+                case "yes":
+                    return true;
+                case "false":
+                case "0":
+                case "no":
+                    return false;
+                default:
+                    return defaultValue;
+            }
+        }
+
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/IEnvironmentProvider.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/IEnvironmentProvider.cs
@@ -16,5 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils
         string GetCommandPathFromRootPath(string rootPath, string commandName, params string[] extensions);
 
         string GetCommandPathFromRootPath(string rootPath, string commandName, IEnumerable<string> extensions);
+
+        bool GetEnvironmentVariableAsBool(string name, bool defaultValue);
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/ITelemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ITelemetry.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public interface ITelemetry
+    {
+        void TrackEvent(string eventName, IDictionary<string, string> properties, IDictionary<string, double> measurements);
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/Product.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Product.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Reflection;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public class Product
+    {
+        public static readonly string LongName = ".NET Command Line Tools";
+        public static readonly string Version = GetProductVersion();
+
+        private static string GetProductVersion()
+        {
+            var attr = typeof(Product).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return attr?.InformationalVersion;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
@@ -7,51 +7,44 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class Telemetry
     {
-        private class Variables
-        {
-            public static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
-            private static readonly string Prefix = "DOTNET_CLI_TELEMETRY_";
-            public static readonly string Optout = Prefix + "OPTOUT";
-        }
-
-        private class Properties
-        {
-            public static readonly string OSVersion = "OS Version";
-            public static readonly string OSPlatform = "OS Platform";
-            public static readonly string RuntimeId = "Runtime Id";
-            public static readonly string ProductVersion = "Product Version";
-        }
-
         private static bool _isInitialized = false;
         private static TelemetryClient _client = null;
 
         private static Dictionary<string, string> _commonProperties = null;
         private static Dictionary<string, double> _commonMeasurements = null;
 
-        static Telemetry()
+        private static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
+
+        private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";
+        private const string OSVersion = "OS Version";
+        private const string OSPlatform = "OS Platform";
+        private const string RuntimeId = "Runtime Id";
+        private const string ProductVersion = "Product Version";
+
+        public Telemetry()
         {
             if (_isInitialized)
                 return;
 
-            bool Optout = Env.GetBool(Variables.Optout);
+            bool optout = Env.GetEnvironmentVariableAsBool(TelemetryOptout);
 
-            if (Optout)
+            if (optout)
                 return;
 
             try
             {
                 _client = new TelemetryClient();
-                _client.InstrumentationKey = Variables.InstrumentationKey;
+                _client.InstrumentationKey = InstrumentationKey;
                 _client.Context.Session.Id = Guid.NewGuid().ToString();
 
                 var runtimeEnvironment = PlatformServices.Default.Runtime;
                 _client.Context.Device.OperatingSystem = runtimeEnvironment.OperatingSystem;
 
                 _commonProperties = new Dictionary<string, string>();
-                _commonProperties.Add(Properties.OSVersion, runtimeEnvironment.OperatingSystemVersion);
-                _commonProperties.Add(Properties.OSPlatform, runtimeEnvironment.OperatingSystemPlatform.ToString());
-                _commonProperties.Add(Properties.RuntimeId, runtimeEnvironment.GetRuntimeIdentifier());
-                _commonProperties.Add(Properties.ProductVersion, Product.Version);
+                _commonProperties.Add(OSVersion, runtimeEnvironment.OperatingSystemVersion);
+                _commonProperties.Add(OSPlatform, runtimeEnvironment.OperatingSystemPlatform.ToString());
+                _commonProperties.Add(RuntimeId, runtimeEnvironment.GetRuntimeIdentifier());
+                _commonProperties.Add(ProductVersion, Product.Version);
                 _commonMeasurements = new Dictionary<string, double>();
 
                 _isInitialized = true;
@@ -59,23 +52,24 @@ namespace Microsoft.DotNet.Cli.Utils
             catch (Exception) { }
         }
 
-        public static void TrackCommand(string command, IDictionary<string, string> properties = null, IDictionary<string, double> measurements = null)
+        public void TrackCommand(string command, IDictionary<string, string> properties = null, IDictionary<string, double> measurements = null)
         {
             if (!_isInitialized)
                 return;
 
-            Dictionary<string, string> eventProperties = new Dictionary<string, string>(_commonProperties);
-            if (properties != null)
-            {
-                foreach (var p in properties)
-                {
-                    if (eventProperties.ContainsKey(p.Key))
-                        eventProperties[p.Key] = p.Value;
-                    else
-                        eventProperties.Add(p.Key, p.Value);
-                }
-            }
+            Dictionary<string, double> eventMeasurements = GetEventMeasures(measurements);
+            Dictionary<string, string> eventProperties = GetEventProperties(properties);
 
+            try
+            {
+                _client.TrackEvent(command, eventProperties, eventMeasurements);
+                _client.Flush();
+            }
+            catch (Exception) { }
+        }
+
+        private Dictionary<string, double> GetEventMeasures(IDictionary<string, double> measurements)
+        {
             Dictionary<string, double> eventMeasurements = new Dictionary<string, double>(_commonMeasurements);
             if (measurements != null)
             {
@@ -87,13 +81,23 @@ namespace Microsoft.DotNet.Cli.Utils
                         eventMeasurements.Add(m.Key, m.Value);
                 }
             }
+            return eventMeasurements;
+        }
 
-            try
+        private Dictionary<string, string> GetEventProperties(IDictionary<string, string> properties)
+        {
+            Dictionary<string, string> eventProperties = new Dictionary<string, string>(_commonProperties);
+            if (properties != null)
             {
-                _client.TrackEvent(command, eventProperties, eventMeasurements);
-                _client.Flush();
+                foreach (var p in properties)
+                {
+                    if (eventProperties.ContainsKey(p.Key))
+                        eventProperties[p.Key] = p.Value;
+                    else
+                        eventProperties.Add(p.Key, p.Value);
+                }
             }
-            catch (Exception) { }
+            return eventProperties;
         }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.PlatformAbstractions;
+using System.Diagnostics;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -13,9 +14,7 @@ namespace Microsoft.DotNet.Cli.Utils
         private static Dictionary<string, string> _commonProperties = null;
         private static Dictionary<string, double> _commonMeasurements = null;
 
-        //readonly instead of const to to avoid inlining in case we need to change the instrumentation key
-        private static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
-
+        private const string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";
         private const string OSVersion = "OS Version";
         private const string OSPlatform = "OS Platform";
@@ -50,7 +49,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
                 _isInitialized = true;
             }
-            catch (Exception) { }
+            catch (Exception)
+            {
+                // we dont want to fail the tool if telemetry fais. We should be able to detect abnormalities from data 
+                // at the server end
+            }
         }
 
         public void TrackCommand(string command, IDictionary<string, string> properties = null, IDictionary<string, double> measurements = null)
@@ -68,6 +71,7 @@ namespace Microsoft.DotNet.Cli.Utils
             }
             catch (Exception) { }
         }
+
 
         private Dictionary<string, double> GetEventMeasures(IDictionary<string, double> measurements)
         {

--- a/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.Cli.Utils
         private static Dictionary<string, string> _commonProperties = null;
         private static Dictionary<string, double> _commonMeasurements = null;
 
+        //readonly instead of const to to avoid inlining in case we need to change the instrumentation key
         private static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
 
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";

--- a/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.ApplicationInsights;
+using Microsoft.Extensions.PlatformAbstractions;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public class Telemetry
+    {
+        private class Variables
+        {
+            public static readonly string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
+            private static readonly string Prefix = "DOTNET_CLI_TELEMETRY_";
+            public static readonly string Optout = Prefix + "OPTOUT";
+        }
+
+        private class Properties
+        {
+            public static readonly string OSVersion = "OS Version";
+            public static readonly string OSPlatform = "OS Platform";
+            public static readonly string RuntimeId = "Runtime Id";
+            public static readonly string ProductVersion = "Product Version";
+        }
+
+        private static bool _isInitialized = false;
+        private static TelemetryClient _client = null;
+
+        private static Dictionary<string, string> _commonProperties = null;
+        private static Dictionary<string, double> _commonMeasurements = null;
+
+        static Telemetry()
+        {
+            if (_isInitialized)
+                return;
+
+            bool Optout = Env.GetBool(Variables.Optout);
+
+            if (Optout)
+                return;
+
+            try
+            {
+                _client = new TelemetryClient();
+                _client.InstrumentationKey = Variables.InstrumentationKey;
+                _client.Context.Session.Id = Guid.NewGuid().ToString();
+
+                var runtimeEnvironment = PlatformServices.Default.Runtime;
+                _client.Context.Device.OperatingSystem = runtimeEnvironment.OperatingSystem;
+
+                _commonProperties = new Dictionary<string, string>();
+                _commonProperties.Add(Properties.OSVersion, runtimeEnvironment.OperatingSystemVersion);
+                _commonProperties.Add(Properties.OSPlatform, runtimeEnvironment.OperatingSystemPlatform.ToString());
+                _commonProperties.Add(Properties.RuntimeId, runtimeEnvironment.GetRuntimeIdentifier());
+                _commonProperties.Add(Properties.ProductVersion, Product.Version);
+                _commonMeasurements = new Dictionary<string, double>();
+
+                _isInitialized = true;
+            }
+            catch (Exception) { }
+        }
+
+        public static void TrackCommand(string command, IDictionary<string, string> properties = null, IDictionary<string, double> measurements = null)
+        {
+            if (!_isInitialized)
+                return;
+
+            Dictionary<string, string> eventProperties = new Dictionary<string, string>(_commonProperties);
+            if (properties != null)
+            {
+                foreach (var p in properties)
+                {
+                    if (eventProperties.ContainsKey(p.Key))
+                        eventProperties[p.Key] = p.Value;
+                    else
+                        eventProperties.Add(p.Key, p.Value);
+                }
+            }
+
+            Dictionary<string, double> eventMeasurements = new Dictionary<string, double>(_commonMeasurements);
+            if (measurements != null)
+            {
+                foreach (var m in measurements)
+                {
+                    if (eventMeasurements.ContainsKey(m.Key))
+                        eventMeasurements[m.Key] = m.Value;
+                    else
+                        eventMeasurements.Add(m.Key, m.Value);
+                }
+            }
+
+            try
+            {
+                _client.TrackEvent(command, eventProperties, eventMeasurements);
+                _client.Flush();
+            }
+            catch (Exception) { }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Telemetry.cs
@@ -8,11 +8,11 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class Telemetry : ITelemetry
     {
-        private static bool _isInitialized = false;
-        private static TelemetryClient _client = null;
+        private bool _isInitialized = false;
+        private TelemetryClient _client = null;
 
-        private static Dictionary<string, string> _commonProperties = null;
-        private static Dictionary<string, double> _commonMeasurements = null;
+        private Dictionary<string, string> _commonProperties = null;
+        private Dictionary<string, double> _commonMeasurements = null;
 
         private const string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";
@@ -52,6 +52,7 @@ namespace Microsoft.DotNet.Cli.Utils
             {
                 // we dont want to fail the tool if telemetry fais. We should be able to detect abnormalities from data 
                 // at the server end
+                Debug.Fail("Exception during telemetry initialization");
             }
         }
 
@@ -70,7 +71,10 @@ namespace Microsoft.DotNet.Cli.Utils
                 _client.TrackEvent(eventName, eventProperties, eventMeasurements);
                 _client.Flush();
             }
-            catch (Exception) { }
+            catch (Exception) 
+            {
+                Debug.Fail("Exception during TrackEvent");
+            }
         }
 
 
@@ -96,9 +100,9 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private Dictionary<string, string> GetEventProperties(IDictionary<string, string> properties)
         {
-            Dictionary<string, string> eventProperties = new Dictionary<string, string>(_commonProperties);
             if (properties != null)
             {
+                var eventProperties = new Dictionary<string, string>(_commonProperties);
                 foreach (var property in properties)
                 {
                     if (eventProperties.ContainsKey(property.Key))
@@ -110,8 +114,12 @@ namespace Microsoft.DotNet.Cli.Utils
                         eventProperties.Add(property.Key, property.Value);
                     }
                 }
+                return eventProperties;
             }
-            return eventProperties;
+            else 
+            {
+                return _commonProperties;    
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -5,6 +5,7 @@
     "warningsAsErrors": true
   },
   "dependencies": {
+    "Microsoft.ApplicationInsights": "2.0.0-rc1",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20100",
     "NuGet.Versioning": "3.5.0-beta-1123",

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli
 
         }
 
-        public int ProcessArgs(string[] args, ITelemetry telemetryClient)
+        internal int ProcessArgs(string[] args, ITelemetry telemetryClient)
         {
             // CommandLineApplication is a bit restrictive, so we parse things ourselves here. Individual apps should use CLA.
 

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Cli
 
             try
             {
-                return new Program().ProcessArgs(args, new Telemetry());
+                return Program.ProcessArgs(args, new Telemetry());
             }
             catch (CommandUnknownException e)
             {
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli
 
         }
 
-        internal int ProcessArgs(string[] args, ITelemetry telemetryClient)
+        internal static int ProcessArgs(string[] args, ITelemetry telemetryClient)
         {
             // CommandLineApplication is a bit restrictive, so we parse things ourselves here. Individual apps should use CLA.
 

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -117,12 +117,10 @@ namespace Microsoft.DotNet.Cli
             };
 
             int exitCode;            
-            var arguments = string.Empty;
             Func<string[], int> builtIn;
             if (builtIns.TryGetValue(command, out builtIn))
             {
                 exitCode = builtIn(appArgs.ToArray());
-                arguments = string.Join(" ", appArgs);
             }
             else
             {
@@ -130,7 +128,6 @@ namespace Microsoft.DotNet.Cli
                     .ForwardStdErr()
                     .ForwardStdOut()
                     .Execute();
-                arguments = result.StartInfo.Arguments;
                 exitCode = result.ExitCode;
             }
 

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -139,10 +139,6 @@ namespace Microsoft.DotNet.Cli
 
             telemetryClient.TrackCommand(
                 command,
-                new Dictionary<string, string>
-                {
-                    ["Arguments"] = arguments
-                },
                 new Dictionary<string, double>
                 {
                     ["ExitCode"] = exitCode

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -26,14 +26,13 @@ namespace Microsoft.DotNet.Cli
 {
     public class Program
     {
-
         public static int Main(string[] args)
         {
             DebugHelper.HandleDebugSwitch(ref args);
 
             try
             {
-                return ProcessArgs(args);
+                return new Program().ProcessArgs(args, new Telemetry());
             }
             catch (CommandUnknownException e)
             {
@@ -44,7 +43,7 @@ namespace Microsoft.DotNet.Cli
 
         }
 
-        private static int ProcessArgs(string[] args)
+        public int ProcessArgs(string[] args, ITelemetry telemetryClient)
         {
             // CommandLineApplication is a bit restrictive, so we parse things ourselves here. Individual apps should use CLA.
 
@@ -135,10 +134,9 @@ namespace Microsoft.DotNet.Cli
                 exitCode = result.ExitCode;
             }
 
-            Telemetry telemetryClient = new Telemetry();
-
-            telemetryClient.TrackCommand(
+            telemetryClient.TrackEvent(
                 command,
+                null,
                 new Dictionary<string, double>
                 {
                     ["ExitCode"] = exitCode

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -117,18 +117,13 @@ namespace Microsoft.DotNet.Cli
                 ["test"] = TestCommand.Run
             };
 
-            int exitCode = 100;
-            
-            string arguments = string.Empty;
-
-
+            int exitCode;            
+            var arguments = string.Empty;
             Func<string[], int> builtIn;
             if (builtIns.TryGetValue(command, out builtIn))
             {
                 exitCode = builtIn(appArgs.ToArray());
-                
-                appArgs.ToList().ForEach(a => { arguments += a + " "; });
-
+                arguments = string.Join(" ", appArgs);
             }
             else
             {
@@ -140,7 +135,9 @@ namespace Microsoft.DotNet.Cli
                 exitCode = result.ExitCode;
             }
 
-            Telemetry.TrackCommand(
+            Telemetry telemetryClient = new Telemetry();
+
+            telemetryClient.TrackCommand(
                 command,
                 new Dictionary<string, string>
                 {
@@ -155,7 +152,7 @@ namespace Microsoft.DotNet.Cli
 
         }
 
-private static void PrintVersion()
+        private static void PrintVersion()
         {
             Reporter.Output.WriteLine(Product.Version);
         }

--- a/src/dotnet/Properties/AssemblyInfo.cs
+++ b/src/dotnet/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("dotnet.Tests")]

--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -8,7 +8,6 @@ namespace Microsoft.DotNet.Tools.Help
 {
     public class HelpCommand
     {
-        private const string ProductLongName = ".NET Command Line Tools";
         private const string UsageText = @"Usage: dotnet [common-options] [command] [arguments]
 
 Arguments:
@@ -29,13 +28,6 @@ Common Commands:
   test          Executes tests in a test project
   repl          Launch an interactive session (read, eval, print, loop)
   pack          Creates a NuGet package";
-        public static readonly string ProductVersion = GetProductVersion();
-
-        private static string GetProductVersion()
-        {
-            var attr = typeof(HelpCommand).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            return attr?.InformationalVersion;
-        }
 
         public static int Run(string[] args)
         {
@@ -58,10 +50,10 @@ Common Commands:
 
         public static void PrintVersionHeader()
         {
-            var versionString = string.IsNullOrEmpty(ProductVersion) ?
+            var versionString = string.IsNullOrEmpty(Product.Version) ?
                 string.Empty :
-                $" ({ProductVersion})";
-            Reporter.Output.WriteLine(ProductLongName + versionString);
+                $" ({Product.Version})";
+            Reporter.Output.WriteLine(Product.LongName + versionString);
         }
     }
 }

--- a/test/dotnet.Tests/TelemetryCommandTest.cs
+++ b/test/dotnet.Tests/TelemetryCommandTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 using FluentAssertions;

--- a/test/dotnet.Tests/TelemetryCommandTest.cs
+++ b/test/dotnet.Tests/TelemetryCommandTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Collections.Generic;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;

--- a/test/dotnet.Tests/TelemetryCommandTest.cs
+++ b/test/dotnet.Tests/TelemetryCommandTest.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+using FluentAssertions;
+
+namespace Microsoft.DotNet.Tests
+{
+    public class MockTelemetry : ITelemetry
+    {
+        public string EventName{get;set;}
+        public void TrackEvent(string eventName, IDictionary<string, string> properties, IDictionary<string, double> measurements)
+        {
+            EventName = eventName;
+        }
+    }
+
+
+    public class TelemetryCommandTests : TestBase
+    {
+        [Fact]
+        public void TestProjectDependencyIsNotAvailableThroughDriver()
+        {
+            Program program = new Program();
+            MockTelemetry mockTelemetry = new MockTelemetry();
+            string[] args = { "help" };
+            program.ProcessArgs(args, mockTelemetry);
+            Assert.Equal(mockTelemetry.EventName, args[0]);
+        }
+    }
+}

--- a/test/dotnet.Tests/TelemetryCommandTest.cs
+++ b/test/dotnet.Tests/TelemetryCommandTest.cs
@@ -27,10 +27,9 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void TestProjectDependencyIsNotAvailableThroughDriver()
         {
-            Program program = new Program();
             MockTelemetry mockTelemetry = new MockTelemetry();
             string[] args = { "help" };
-            program.ProcessArgs(args, mockTelemetry);
+            Program.ProcessArgs(args, mockTelemetry);
             Assert.Equal(mockTelemetry.EventName, args[0]);
         }
     }

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -6,6 +6,9 @@
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
+    "dotnet": {
+      "target": "project"
+    },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project",
       "type": "build"


### PR DESCRIPTION
.NET Core Tools Telemetry collection
====================================

## Overview
In RC2 of the command line tools, we've started collecting usage telemetry. We've made this choice in order to help us better understand the usage patterns of the CLI tools, and will thus allow us to see which parts of the CLI should be improved first

The data collected will not have any personal data, such as usernames or emails or anything that can be used to identify the actual user. We will also not scan the code and we will not extract any project-level data that can be considered sensitive, such as name, repo or author (if you set those in your `project.json`). 

The data that we collect will be shown publicly in due time. Due time here means when we have enough data to show and when we figure out how to make it accessible. 

## Behavior
The telemetry tracking is "on" by default.

There is a way to opt-out of the telemetry gathering process by setting an environment variable DOTNET_CLI_TELEMETRY_OPTOUT. Doing this will stop the collection process from running. In order to set the environment variable, please use the existing operating system mechanisms for this (e.g. `export` on OS X/Linux).  

## What do we collect?
We collect the following pieces of data: 

* The command being used (e.g. "build", "restore")
* Arguments passed to the command
* ExitCode of the command
* For test projects, the test runner being used
* Timestamp of invocation
* Details about the project commands are invoked on 
    * Framework used 
    * If RIDs are present in the "runtimes" node
* The CLI version being used

## Questions, feedback, comments
If you have any questions, feedback or comment, please feel free to leave them either on [our issues](), in our [Gitter channel](). If you do file an issue for this, please be sure to tag @blackdwarf and @piotrMSFT so we would get notified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2145)
<!-- Reviewable:end -->