### PR TITLE
Remove OOB Commands and Pdbs from stage2

### DIFF
--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -20,9 +20,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public static readonly string[] BinariesForCoreHost = new[]
         {
-            "csi",
-            "csc",
-            "vbc"
+            "csc"
         };
 
         public static readonly string[] ProjectsToPublish = new[]
@@ -32,7 +30,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public static readonly string[] FilesToClean = new[]
         {
-            "README.md"
+            "vbc.exe"
         };
 
         public static readonly string[] ProjectsToPack = new[]
@@ -165,9 +163,13 @@ namespace Microsoft.DotNet.Cli.Build
 
             CopySharedHost(Dirs.Stage1);
             PublishSharedFramework(c, Dirs.Stage1, DotNetCli.Stage0);
-            return CompileCliSdk(c,
+            var result = CompileCliSdk(c,
                 dotnet: DotNetCli.Stage0,
                 outputDir: Dirs.Stage1);
+
+            CleanOutputDir(Path.Combine(Dirs.Stage1, "sdk"));
+
+            return result;
         }
 
         [Target]
@@ -214,7 +216,15 @@ namespace Microsoft.DotNet.Cli.Build
                 }
             }
 
+            CleanOutputDir(Path.Combine(Dirs.Stage2, "sdk"));
+
             return c.Success();
+        }
+
+        private static void CleanOutputDir(string directory)
+        {
+            FS.RmFilesInDirRecursive(directory, "vbc.exe");
+            FS.RmFilesInDirRecursive(directory, "*.pdb");
         }
 
         private static void CopySharedHost(string outputDir)

--- a/scripts/dotnet-cli-build/Utils/FS.cs
+++ b/scripts/dotnet-cli-build/Utils/FS.cs
@@ -34,6 +34,15 @@ namespace Microsoft.DotNet.Cli.Build
             }
         }
 
+        public static void RmFilesInDirRecursive(string dir, string filePattern)
+        {
+            var files = Directory.EnumerateFiles(dir, filePattern, SearchOption.AllDirectories);
+            foreach (var file in files)
+            {
+                FS.Rm(file);
+            }
+        }
+
         public static void Chmod(string file, string mode, bool recursive = false)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/compilers/project.json
+++ b/src/compilers/project.json
@@ -10,8 +10,6 @@
     },
     "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160321-04",
     "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160321-04",
-    "Microsoft.Net.CSharp.Interactive.netcore": "1.3.0-beta1-20160321-04",
-    "Microsoft.FSharp.Compiler.netcore": "1.0.0-alpha-160318",
     "Microsoft.DiaSymReader.Native": "1.3.3"
   },
   "frameworks": {

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -108,14 +108,11 @@ namespace Microsoft.DotNet.Cli
             {
                 ["build"] = BuildCommand.Run,
                 ["compile-csc"] = CompileCscCommand.Run,
-                ["compile-fsc"] = CompileFscCommand.Run,
-                ["compile-native"] = CompileNativeCommand.Run,
                 ["help"] = HelpCommand.Run,
                 ["new"] = NewCommand.Run,
                 ["pack"] = PackCommand.Run,
                 ["projectmodel-server"] = ProjectModelServerCommand.Run,
                 ["publish"] = PublishCommand.Run,
-                ["repl"] = ReplCommand.Run,
                 ["restore"] = RestoreCommand.Run,
                 ["run"] = RunCommand.Run,
                 ["test"] = TestCommand.Run


### PR DESCRIPTION
remove out of box commands and all pdbs from stage2 so they will not be included in our installers.

cc @Petermarcu @Sridhar-MS @piotrpMSFT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2151)
<!-- Reviewable:end -->
