### PR TITLE
Update ISSUE_TEMPLATE to use dotnet --info

### DIFF
--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -8,7 +8,7 @@
 
 
 ## Environment data
-`dotnet --version` output:
+`dotnet --info` output:
 
 
 


### PR DESCRIPTION
Now that --version only prints out the version, change the issue template to tell users to use dotnet --info.

skip ci please

@piotrpMSFT @livarcocc @Sridhar-MS @brthor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2171)
<!-- Reviewable:end -->