### PR TITLE
Enable parallel for NuGet restore

### DIFF
--- a/scripts/common/_common.sh
+++ b/scripts/common/_common.sh
@@ -23,7 +23,7 @@ export CHANNEL=$RELEASE_SUFFIX
 
 #TODO this is a workaround for a nuget bug on ubuntu. Remove
 export DISABLE_PARALLEL=""
-[[ "$RID" =~ "ubuntu" ]] && export DISABLE_PARALLEL="--disable-parallel"
+[[ "$RID" =~ "ubuntu" ]] && export DISABLE_PARALLEL=""
 
 unset COMMONSOURCE
 unset COMMONDIR

--- a/scripts/dotnet-cli-build/PrepareTargets.cs
+++ b/scripts/dotnet-cli-build/PrepareTargets.cs
@@ -205,8 +205,8 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var dotnet = DotNetCli.Stage0;
 
-            dotnet.Restore("--verbosity", "verbose", "--disable-parallel").WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "src")).Execute().EnsureSuccessful();
-            dotnet.Restore("--verbosity", "verbose", "--disable-parallel", "--infer-runtimes").WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "tools")).Execute().EnsureSuccessful();
+            dotnet.Restore("--verbosity", "verbose").WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "src")).Execute().EnsureSuccessful();
+            dotnet.Restore("--verbosity", "verbose", "--infer-runtimes").WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "tools")).Execute().EnsureSuccessful();
 
             return c.Success();
         }

--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Build
             CleanNuGetTempCache();
 
             var dotnet = DotNetCli.Stage2;
-            dotnet.Restore("--verbosity", "verbose", "--infer-runtimes", "--disable-parallel")
+            dotnet.Restore("--verbosity", "verbose", "--infer-runtimes")
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "TestPackages"))
                 .Execute()
                 .EnsureSuccessful();
@@ -87,8 +87,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             var dotnet = DotNetCli.Stage2;
             dotnet.Restore(
-                "--verbosity", "verbose", 
-                "--disable-parallel", 
+                "--verbosity", "verbose",
                 "--infer-runtimes",
                 "--fallbacksource", Dirs.TestPackages)
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "TestProjects"))
@@ -96,15 +95,13 @@ namespace Microsoft.DotNet.Cli.Build
 
             // The 'ProjectModelServer' directory contains intentionally-unresolved dependencies, so don't check for success. Also, suppress the output
             dotnet.Restore(
-                "--verbosity", "verbose", 
-                "--disable-parallel", 
+                "--verbosity", "verbose",
                 "--infer-runtimes")
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "ProjectModelServer", "DthTestProjects"))
                 .Execute();
 
             dotnet.Restore(
-                "--verbosity", "verbose", 
-                "--disable-parallel", 
+                "--verbosity", "verbose",
                 "--infer-runtimes")
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "ProjectModelServer", "DthUpdateSearchPathSample"))
                 .Execute();
@@ -119,7 +116,7 @@ namespace Microsoft.DotNet.Cli.Build
             var dotnet = DotNetCli.Stage2;
 
             dotnet.Restore("--verbosity", "verbose", 
-                "--disable-parallel", "--infer-runtimes",
+                "--infer-runtimes",
                 "--fallbacksource", Dirs.TestPackages)
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "DesktopTestProjects"))
                 .Execute().EnsureSuccessful();
@@ -257,7 +254,7 @@ namespace Microsoft.DotNet.Cli.Build
             CleanBinObj(c, Path.Combine(c.BuildContext.BuildDirectory, "test"));
 
             CleanNuGetTempCache();
-            DotNetCli.Stage2.Restore("--verbosity", "verbose", "--disable-parallel", "--infer-runtimes","--fallbacksource", Dirs.TestPackages)
+            DotNetCli.Stage2.Restore("--verbosity", "verbose", "--infer-runtimes", "--fallbacksource", Dirs.TestPackages)
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "test"))
                 .Execute()
                 .EnsureSuccessful();

--- a/scripts/run-build.ps1
+++ b/scripts/run-build.ps1
@@ -72,7 +72,7 @@ $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
 # Restore the build scripts
 Write-Host "Restoring Build Script projects..."
 pushd $PSScriptRoot
-dotnet restore --disable-parallel --infer-runtimes
+dotnet restore --infer-runtimes
 if($LASTEXITCODE -ne 0) { throw "Failed to restore" }
 popd
 

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -103,7 +103,7 @@ fi
 echo "Restoring Build Script projects..."
 (
     cd $DIR
-    dotnet restore --disable-parallel --infer-runtimes
+    dotnet restore --infer-runtimes
 )
 
 # Build the builder


### PR DESCRIPTION
We've made some parallelism improvements for Mac and Linux. This PR re-enables parallel restore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2181)
<!-- Reviewable:end -->