### PR TITLE
Update project.json template to be netcoreapp1.0

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
@@ -10,6 +10,6 @@
     }
   },
   "frameworks": {
-    "netstandard1.5": {}
+    "netcoreapp1.0": {}
   }
 }

--- a/test/EndToEnd/EndToEndTest.cs
+++ b/test/EndToEnd/EndToEndTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
 {
     public class EndToEndTest : TestBase
     {
-        private static readonly string NetStandardTfm = "netstandard1.5";
+        private static readonly string NetCoreAppTfm = "netcoreapp1.0";
         private static readonly string s_expectedOutput = "Hello World!" + Environment.NewLine;
         private static readonly string s_testdirName = "e2etestroot";
         private static readonly string s_outputdirName = "test space/bin";
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         [Fact]
         public void TestDotnetBuild()
         {
-            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, framework: NetStandardTfm);
+            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, framework: NetCoreAppTfm);
 
             buildCommand.Execute().Should().Pass();
 
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         public void TestDotnetIncrementalBuild()
         {
             // first build
-            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, framework: NetStandardTfm);
+            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, framework: NetCoreAppTfm);
             buildCommand.Execute().Should().Pass();
             TestOutputExecutable(OutputDirectory, buildCommand.GetPortableOutputName(), s_expectedOutput);
 
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
                 return;
             }
 
-            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true, framework: NetStandardTfm);
+            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true, framework: NetCoreAppTfm);
 
             buildCommand.Execute().Should().Pass();
 
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
                 return;
             }
 
-            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true, nativeCppMode: true, framework: NetStandardTfm);
+            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true, nativeCppMode: true, framework: NetCoreAppTfm);
 
             buildCommand.Execute().Should().Pass();
 
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             }
 
             // first build
-            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true, nativeCppMode: true, framework: NetStandardTfm);
+            var buildCommand = new BuildCommand(TestProject, output: OutputDirectory, native: true, nativeCppMode: true, framework: NetCoreAppTfm);
             var binariesOutputDirectory = GetCompilationOutputPath(OutputDirectory, false);
 
             buildCommand.Execute().Should().Pass();

--- a/test/EndToEnd/EndToEndTest.cs
+++ b/test/EndToEnd/EndToEndTest.cs
@@ -142,6 +142,10 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         [Fact]
         public void TestDotnetRun()
         {
+            var restoreCommand = new TestCommand("dotnet");
+            restoreCommand.Execute($"restore {TestProject}")
+                .Should()
+                .Pass();
             var runCommand = new RunCommand(TestProject);
 
             runCommand.Execute()


### PR DESCRIPTION
It should be time, now that RID inference is off, to update dotnet new to finally use netcoreapp1.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2198)
<!-- Reviewable:end -->
