### PR TITLE
Enable Cross Platform Publishing and add tests

### DIFF
--- a/TestAssets/CrossPublishTestProjects/StandaloneAppCrossPublish/Program.cs
+++ b/TestAssets/CrossPublishTestProjects/StandaloneAppCrossPublish/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace StandaloneApp
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}

--- a/TestAssets/CrossPublishTestProjects/StandaloneAppCrossPublish/project.json
+++ b/TestAssets/CrossPublishTestProjects/StandaloneAppCrossPublish/project.json
@@ -1,0 +1,35 @@
+{
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": "1.0.0-rc2-*"
+      }
+    }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {},
+    "osx.10.10-x64": {},
+    "osx.10.11-x64": {},
+    "ubuntu.14.04-x64": {},
+    "centos.7-x64": {},
+    "rhel.7.2-x64": {},
+    "debian.8.2-x64": {}
+  },
+
+  "runtimeOptions": {
+    "somethingString": "anything",
+    "somethingBoolean": true,
+    "someArray": ["one", "two"],
+    "someObject": {
+      "someProperty": "someValue"
+    }
+  }
+}

--- a/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
@@ -12,9 +12,9 @@
     "../src/*.cs"
   ],
   "frameworks": {
-    "netstandardapp1.5": {
+    "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.0-rc2-24008"
+        "Microsoft.NETCore.App": "1.0.0-rc2-3002306"
       },
       "imports": [
         "dnxcore50",

--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -422,6 +422,9 @@ namespace Microsoft.DotNet.Cli.Build
             File.Copy(
                 Path.Combine(Dirs.Corehost, HostPolicyBaseName),
                 Path.Combine(SharedFrameworkNameAndVersionRoot, HostPolicyBaseName), true);
+            File.Copy(
+                Path.Combine(Dirs.Corehost, DotnetHostFxrBaseName),
+                Path.Combine(SharedFrameworkNameAndVersionRoot, DotnetHostFxrBaseName), true);
 
             if (File.Exists(Path.Combine(SharedFrameworkNameAndVersionRoot, "mscorlib.ni.dll")))
             {

--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.Cli.Build
         [Target(nameof(RestoreTestAssetPackages), nameof(BuildTestAssetPackages))]
         public static BuildTargetResult SetupTestPackages(BuildTargetContext c) => c.Success();
 
-        [Target(nameof(RestoreTestAssetProjects), nameof(RestoreDesktopTestAssetProjects), nameof(BuildTestAssetProjects))]
+        [Target(nameof(RestoreTestAssetProjects), nameof(RestoreDesktopTestAssetProjects), nameof(RestoreCrossPublishTestAssetProjects), nameof(BuildTestAssetProjects))]
         public static BuildTargetResult SetupTestProjects(BuildTargetContext c) => c.Success();
 
         [Target]
@@ -135,6 +135,18 @@ namespace Microsoft.DotNet.Cli.Build
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "DesktopTestProjects"))
                 .Execute().EnsureSuccessful();
 
+            return c.Success();
+        }
+        
+        [Target]
+        public static BuildTargetResult RestoreCrossPublishTestAssetProjects(BuildTargetContext c)
+        {
+            var dotnet = DotNetCli.Stage2;
+
+            dotnet.Restore("--verbosity", "verbose")
+                .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "CrossPublishTestProjects"))
+                .Execute().EnsureSuccessful();
+                
             return c.Success();
         }
 

--- a/src/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public static readonly string ResponseFileSuffix = ".rsp";
 
+        public static readonly string PublishedHostExecutableName = "dotnet";
         public static readonly string HostExecutableName = "corehost" + ExeSuffix;
         public static readonly string[] HostBinaryNames = new string[] {
             HostExecutableName,

--- a/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System;
 using System.Linq;
 using Microsoft.DotNet.ProjectModel;
 using Microsoft.DotNet.ProjectModel.Compilation;

--- a/src/dotnet/commands/dotnet-publish/PublishCommand.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommand.cs
@@ -139,11 +139,10 @@ namespace Microsoft.DotNet.Tools.Publish
             var exports = exporter.GetAllExports();
             foreach (var export in exports.Where(e => !collectExclusionList.Contains(e.Library.Identity.Name)))
             {
-                Reporter.Verbose.WriteLine($"Publishing {export.Library.Identity.ToString().Green().Bold()} ...");
+                Reporter.Verbose.WriteLine($"publish: Publishing {export.Library.Identity.ToString().Green().Bold()} ...");
 
                 PublishAssetGroups(export.RuntimeAssemblyGroups, outputPath, nativeSubdirectories: false, includeRuntimeGroups: isPortable);
                 PublishAssetGroups(export.NativeLibraryGroups, outputPath, nativeSubdirectories, includeRuntimeGroups: isPortable);
-                export.RuntimeAssets.StructuredCopyTo(outputPath, outputPaths.IntermediateOutputDirectoryPath);
             }
 
             if (options.PreserveCompilationContext.GetValueOrDefault())
@@ -153,19 +152,9 @@ namespace Microsoft.DotNet.Tools.Publish
                     PublishRefs(export, outputPath, !collectExclusionList.Contains(export.Library.Identity.Name));
                 }
             }
-
-            if (context.ProjectFile.HasRuntimeOutput(configuration) && !context.TargetFramework.IsDesktop())
-            {
-                // Get the output paths used by the call to `dotnet build` above (since we didn't pass `--output`, they will be different from
-                // our current output paths)
-                var buildOutputPaths = context.GetOutputPaths(configuration, buildBasePath);
-                PublishFiles(
-                    new[] {
-                        buildOutputPaths.RuntimeFiles.DepsJson,
-                        buildOutputPaths.RuntimeFiles.RuntimeConfigJson
-                    },
-                    outputPath);
-            }
+            
+            var buildOutputPaths = context.GetOutputPaths(configuration, buildBasePath, null);
+            PublishBuildOutputFiles(buildOutputPaths, context, outputPath, Configuration);
 
             var contentFiles = new ContentFiles(context);
             contentFiles.StructuredCopyTo(outputPath);
@@ -173,15 +162,70 @@ namespace Microsoft.DotNet.Tools.Publish
             // Publish a host if this is an application
             if (options.EmitEntryPoint.GetValueOrDefault() && !string.IsNullOrEmpty(context.RuntimeIdentifier))
             {
-                Reporter.Verbose.WriteLine($"Copying native host to output to create fully standalone output.");
-                PublishHost(context, outputPath, options);
+                Reporter.Verbose.WriteLine($"publish: Renaming native host in output to create fully standalone output.");
+                RenamePublishedHost(context, outputPath, options);
             }
 
             RunScripts(context, ScriptNames.PostPublish, contextVariables);
 
-            Reporter.Output.WriteLine($"Published to {outputPath}".Green().Bold());
+            Reporter.Output.WriteLine($"publish: Published to {outputPath}".Green().Bold());
 
             return true;
+        }
+
+        private void PublishBuildOutputFiles(OutputPaths buildOutputPaths, ProjectContext context, string outputPath, string configuration)
+        {
+            List<string> filesToPublish = new List<string>();
+
+            string[]  buildOutputFiles = null;
+
+            if (context.ProjectFile.HasRuntimeOutput(configuration))
+            {
+                Reporter.Verbose.WriteLine($"publish: using runtime build output files");
+
+                buildOutputFiles = new string[] 
+                {
+                    buildOutputPaths.RuntimeFiles.DepsJson,
+                    buildOutputPaths.RuntimeFiles.RuntimeConfigJson,
+                    buildOutputPaths.RuntimeFiles.Config,
+                    buildOutputPaths.RuntimeFiles.Assembly,
+                    buildOutputPaths.RuntimeFiles.PdbPath,
+                    Path.ChangeExtension(buildOutputPaths.RuntimeFiles.Assembly, "xml")
+                };
+
+                filesToPublish.AddRange(buildOutputPaths.RuntimeFiles.Resources());
+            }
+            else
+            {
+                Reporter.Verbose.WriteLine($"publish: using compilation build output files");
+
+                buildOutputFiles = new string[] 
+                {
+                    buildOutputPaths.CompilationFiles.Assembly,
+                    buildOutputPaths.CompilationFiles.PdbPath,
+                    Path.ChangeExtension(buildOutputPaths.CompilationFiles.Assembly, "xml")
+                };
+
+                filesToPublish.AddRange(buildOutputPaths.CompilationFiles.Resources());
+            }
+
+            foreach (var buildOutputFile in buildOutputFiles)
+            {
+                if (File.Exists(buildOutputFile))
+                {
+                    filesToPublish.Add(buildOutputFile);
+                }
+                else
+                {
+                    Reporter.Verbose.WriteLine($"publish: build output file not found {buildOutputFile} ");
+                }
+            }
+            
+            Reporter.Verbose.WriteLine($"publish: Copying build output files:\n {string.Join("\n", filesToPublish)}");
+
+            PublishFiles(
+                filesToPublish,
+                outputPath);
         }
 
         private bool InvokeBuildOnProject(ProjectContext context, string buildBasePath, string configuration)
@@ -272,31 +316,58 @@ namespace Microsoft.DotNet.Tools.Publish
             }
         }
 
-        private static int PublishHost(ProjectContext context, string outputPath, CommonCompilerOptions compilationOptions)
+        private static int RenamePublishedHost(ProjectContext context, string outputPath, CommonCompilerOptions compilationOptions)
         {
             if (context.TargetFramework.IsDesktop())
             {
                 return 0;
             }
 
-            foreach (var binaryName in Constants.HostBinaryNames)
+            var publishedHostFile = ResolvePublishedHostFile(outputPath);
+            if (publishedHostFile == null)
             {
-                var hostBinaryPath = Path.Combine(AppContext.BaseDirectory, binaryName);
-                if (!File.Exists(hostBinaryPath))
-                {
-                    Reporter.Error.WriteLine($"Cannot find {binaryName} in the dotnet directory.".Red());
-                    return 1;
-                }
+                Reporter.Output.WriteLine($"publish: warning: host executable not available in dependencies, using host for current platform");
+                // TODO should this be an error?
 
-                var outputBinaryName = binaryName.Equals(Constants.HostExecutableName)
-                    ? compilationOptions.OutputName + Constants.ExeSuffix
-                    : binaryName;
-                var outputBinaryPath = Path.Combine(outputPath, outputBinaryName);
+                CoreHost.CopyTo(outputPath, compilationOptions.OutputName + Constants.ExeSuffix);
+                return 0;
+            }
 
-                File.Copy(hostBinaryPath, outputBinaryPath, overwrite: true);
+            var publishedHostExtension = Path.GetExtension(publishedHostFile);
+            var renamedHostName = compilationOptions.OutputName + publishedHostExtension;
+            var renamedHostFile = Path.Combine(outputPath, renamedHostName);
+
+            try
+            {
+                Reporter.Verbose.WriteLine($"publish: renaming published host {publishedHostFile} to {renamedHostFile}");
+                File.Copy(publishedHostFile, renamedHostFile, true);
+                File.Delete(publishedHostFile);
+            }
+            catch (Exception e)
+            {
+                Reporter.Error.WriteLine($"publish: Failed to rename {publishedHostFile} to {renamedHostFile}: {e.Message}");
+                return 1;
             }
 
             return 0;
+        }
+
+        private static string ResolvePublishedHostFile(string outputPath)
+        {
+            var tryExtensions = new string[] { "", ".exe" };
+
+            foreach (var extension in tryExtensions)
+            {
+                var hostFile = Path.Combine(outputPath, Constants.PublishedHostExecutableName + extension);
+                if (File.Exists(hostFile))
+                {
+                    Reporter.Verbose.WriteLine($"resolved published host: {hostFile}");
+                    return hostFile;
+                }
+            }
+            
+            Reporter.Verbose.WriteLine($"failed to resolve published host in: {outputPath}");
+            return null;
         }
 
         private static void PublishFiles(IEnumerable<string> files, string outputPath)
@@ -326,6 +397,7 @@ namespace Microsoft.DotNet.Tools.Publish
                         Directory.CreateDirectory(destinationDirectory);
                     }
 
+                    Reporter.Verbose.WriteLine($"Publishing file {Path.GetFileName(file.RelativePath)} to {destinationDirectory}");
                     File.Copy(file.ResolvedPath, Path.Combine(destinationDirectory, file.FileName), overwrite: true);
                 }
             }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -218,6 +218,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             projectToolsCommandResolver.GenerateDepsJsonFile(lockFile, depsJsonFile);
 
             File.ReadAllText(depsJsonFile).Should().Be("temp");
+            File.Delete(depsJsonFile);
         }
 
         private ProjectToolsCommandResolver SetupProjectToolsCommandResolver(

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/TestBase.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/TestBase.cs
@@ -55,12 +55,19 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             {
                 if (s_testsAssetsMgr == null)
                 {
-                    string assetsRoot = Path.Combine(RepoRoot, "TestAssets", "TestProjects");
-                    s_testsAssetsMgr = new TestAssetsManager(assetsRoot);
+                    s_testsAssetsMgr = GetTestGroupTestAssetsManager("TestProjects");
                 }
 
                 return s_testsAssetsMgr;
             }
+        }
+        
+        protected static TestAssetsManager GetTestGroupTestAssetsManager(string testGroup)
+        {
+            string assetsRoot = Path.Combine(RepoRoot, "TestAssets", testGroup);
+            var testAssetsMgr = new TestAssetsManager(assetsRoot);
+            
+            return testAssetsMgr;
         }
 
         protected TestBase()

--- a/test/dotnet-publish.Tests/PublishTests.cs
+++ b/test/dotnet-publish.Tests/PublishTests.cs
@@ -92,6 +92,46 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             publishCommand.Execute().Should().Fail();
         }
 
+        [Theory]
+        [InlineData("centos.7-x64", "", new string[] { "libhostfxr.so", "libcoreclr.so", "libhostpolicy.so" })]
+        [InlineData("rhel.7.2-x64", "", new string[] { "libhostfxr.so", "libcoreclr.so", "libhostpolicy.so" })]
+        [InlineData("ubuntu.14.04-x64", "", new string[] { "libhostfxr.so", "libcoreclr.so", "libhostpolicy.so" })]
+        [InlineData("win7-x64", ".exe", new string[] { "hostfxr.dll", "coreclr.dll", "hostpolicy.dll" })]
+        [InlineData("osx.10.11-x64", "", new string[] { "libhostfxr.dylib", "libcoreclr.dylib", "libhostpolicy.dylib" })]
+        public void CrossPublishingSucceedsAndHasExpectedArtifacts(string rid, string hostExtension, string[] expectedArtifacts)
+        {
+            var testNugetCache = "packages_cross_publish_test";
+            TestInstance instance = GetTestGroupTestAssetsManager("CrossPublishTestProjects")
+                .CreateTestInstance("StandaloneAppCrossPublish");
+                
+            var testProject = Path.Combine(instance.TestRoot, "project.json");
+
+            var restoreCommand = new RestoreCommand();
+
+            restoreCommand.WorkingDirectory = Path.GetDirectoryName(testProject);
+            restoreCommand.Environment["NUGET_PACKAGES"] = testNugetCache;
+            restoreCommand.Execute().Should().Pass();
+
+            var buildCommand = new BuildCommand(testProject, runtime: rid);
+
+            buildCommand.WorkingDirectory = Path.GetDirectoryName(testProject);
+            buildCommand.Environment["NUGET_PACKAGES"] = testNugetCache;
+            buildCommand.Execute().Should().Pass();
+
+            var publishCommand = new PublishCommand(testProject, runtime: rid, noBuild: true);
+            publishCommand.Environment["NUGET_PACKAGES"] = testNugetCache;
+            publishCommand.WorkingDirectory = Path.GetDirectoryName(testProject);
+            publishCommand.Execute().Should().Pass();
+
+            var publishedDir = publishCommand.GetOutputDirectory();
+            publishedDir.Should().HaveFile("StandaloneAppCrossPublish"+ hostExtension);
+
+            foreach (var artifact in expectedArtifacts)
+            {
+                publishedDir.Should().HaveFile(artifact);
+            }
+        }
+
         [Fact]
         public void LibraryPublishTest()
         {


### PR DESCRIPTION
Fixes #317
Fixes #2141
Fixes #2217 

This enables Cross Publishing but is currently blocked on getting an updated host in the `Microsoft.NETCore.App` metapackage. (tests will fail) ( @schellap @weshaggard ) 

I was able to verify the changes locally by patching the dropped host with a recently built one, and also verified that appropriate files are dropped when publishing for a different platform.

After the metapackage is published we'll need to update the package references.

cc @gkhanna79 @piotrpMSFT @Sridhar-MS 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2220)
<!-- Reviewable:end -->