### PR TITLE
Telemetry notification on installation of debian package

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 echo "This software may collect information about you and your use of the software, and send that to Microsoft."
 echo "Please visit http://aka.ms/dotnet-cli-eula for more information."

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "This software may collect information about you and your use of the software, and send that to Microsoft."
+echo "Please visit http://aka.ms/dotnet-cli-eula for more information."

--- a/scripts/package/package-debian.sh
+++ b/scripts/package/package-debian.sh
@@ -158,6 +158,7 @@ create_empty_debian_layout(){
     mkdir "$PACKAGE_LAYOUT_DIR/package_root"
     mkdir "$PACKAGE_LAYOUT_DIR/samples"
     mkdir "$PACKAGE_LAYOUT_DIR/docs"
+    mkdir "$PACKAGE_LAYOUT_DIR/debian"
 }
 
 copy_files_to_debian_layout(){
@@ -177,7 +178,7 @@ copy_files_to_debian_layout(){
     for manpage in "$PACKAGE_LAYOUT_DIR/docs/"*; do mv "$manpage" "${manpage}-${DOTNET_CLI_VERSION}.1"; done
 
     # Copy postinstall
-    cp "$PACKAGING_ROOT/postinst" "$PACKAGE_LAYOUT_DIR/$"
+    cp "$PACKAGING_ROOT/postinst" "$PACKAGE_LAYOUT_DIR/debian/postinst"
 }
 
 create_debian_package(){

--- a/scripts/package/package-debian.sh
+++ b/scripts/package/package-debian.sh
@@ -158,6 +158,7 @@ create_empty_debian_layout(){
     mkdir "$PACKAGE_LAYOUT_DIR/package_root"
     mkdir "$PACKAGE_LAYOUT_DIR/samples"
     mkdir "$PACKAGE_LAYOUT_DIR/docs"
+    mkdir "$PACKAGE_LAYOUT_DIR/DEBIAN"
 }
 
 copy_files_to_debian_layout(){
@@ -175,6 +176,11 @@ copy_files_to_debian_layout(){
     # Append Version to all manpage files
     for manpage in "$PACKAGE_LAYOUT_DIR/docs/"*.1; do mv "$manpage" "${manpage%.1}"; done
     for manpage in "$PACKAGE_LAYOUT_DIR/docs/"*; do mv "$manpage" "${manpage}-${DOTNET_CLI_VERSION}.1"; done
+
+    # Copy postinstall
+    cp "$PACKAGING_ROOT/postinst" "$PACKAGE_LAYOUT_DIR/$"
+    #cp "$PACKAGING_ROOT/postinst" "PACKAGE_LAYOUT_DIR/package_root"
+    #cp "$PACKAGING_ROOT/postinst" "$PACKAGE_LAYOUT_DIR/DEBIAN/postinst"
 }
 
 create_debian_package(){

--- a/scripts/package/package-debian.sh
+++ b/scripts/package/package-debian.sh
@@ -158,7 +158,6 @@ create_empty_debian_layout(){
     mkdir "$PACKAGE_LAYOUT_DIR/package_root"
     mkdir "$PACKAGE_LAYOUT_DIR/samples"
     mkdir "$PACKAGE_LAYOUT_DIR/docs"
-    mkdir "$PACKAGE_LAYOUT_DIR/DEBIAN"
 }
 
 copy_files_to_debian_layout(){
@@ -179,8 +178,6 @@ copy_files_to_debian_layout(){
 
     # Copy postinstall
     cp "$PACKAGING_ROOT/postinst" "$PACKAGE_LAYOUT_DIR/$"
-    #cp "$PACKAGING_ROOT/postinst" "PACKAGE_LAYOUT_DIR/package_root"
-    #cp "$PACKAGING_ROOT/postinst" "$PACKAGE_LAYOUT_DIR/DEBIAN/postinst"
 }
 
 create_debian_package(){

--- a/tools/DebianPackageTool/package_tool
+++ b/tools/DebianPackageTool/package_tool
@@ -152,7 +152,9 @@ package_all(){
     package_absolute_placement
     package_samples
     package_docs
-    package_debian
+    if [[ $PACKAGE_NAME == "dotnet-dev-"* ]]; then
+        package_debian
+    fi
 }
 
 generate_all(){

--- a/tools/DebianPackageTool/package_tool
+++ b/tools/DebianPackageTool/package_tool
@@ -152,9 +152,7 @@ package_all(){
     package_absolute_placement
     package_samples
     package_docs
-    if [[ $PACKAGE_NAME == "dotnet-dev-"* ]]; then
-        package_debian
-    fi
+    package_install_scripts 
 }
 
 generate_all(){
@@ -219,9 +217,10 @@ package_docs(){
     fi
 }
 
-package_debian(){
-    if [[ -d "$ABSOLUTE_PLACEMENT_DIR" ]]; then
-        cp "$ABSOLUTE_PLACEMENT_DIR/postinst" $DEBIAN_DIR/postinst
+package_install_scripts(){
+    # copy scripts for the package's control section like preinst, postint, etc
+    if [[ -d "$INPUT_DIR/debian" ]]; then
+        cp -a "$INPUT_DIR/debian/." $DEBIAN_DIR
     fi
 }
 

--- a/tools/DebianPackageTool/package_tool
+++ b/tools/DebianPackageTool/package_tool
@@ -152,6 +152,7 @@ package_all(){
     package_absolute_placement
     package_samples
     package_docs
+    package_debian
 }
 
 generate_all(){
@@ -213,6 +214,12 @@ package_docs(){
     if [[ -d "$INPUT_DOCS_DIR" ]]; then
         mkdir -p $DOCS_DIR
         cp -a $INPUT_DOCS_DIR/. $DOCS_DIR
+    fi
+}
+
+package_debian(){
+    if [[ -d "$ABSOLUTE_PLACEMENT_DIR" ]]; then
+        cp "$ABSOLUTE_PLACEMENT_DIR/postinst" $DEBIAN_DIR/postinst
     fi
 }
 


### PR DESCRIPTION
To go along with https://github.com/dotnet/cli/pull/2149 we want to notify on install for the debian packages which otherwise don't show the EULA. This adds a simple postinstall script to the package which direct users to the GitHub copy of the ENU EULA like so:
![image](https://cloud.githubusercontent.com/assets/7121557/14224257/4c978368-f84b-11e5-9554-e34f68b4a218.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2223)
<!-- Reviewable:end -->