### PR TITLE
updating Get-Download-Links to resolve #2236

### DIFF
--- a/scripts/obtain/install.ps1
+++ b/scripts/obtain/install.ps1
@@ -153,7 +153,7 @@ function Get-Download-Links([string]$AzureFeed, [string]$AzureChannel, [string]$
     Say-Invocation $MyInvocation
     
     $ret = @()
-    $files = @("dotnet-dev")
+    $files = @("dotnet")
     
     foreach ($file in $files) {
         $PayloadURL = "$AzureFeed/$AzureChannel/Binaries/$SpecificVersion/$file-win-$CLIArchitecture.$SpecificVersion.zip"


### PR DESCRIPTION
To address #2236, it looks like there was a typo in the install script.

Note: I tested with the `preview` channel, I didn't test with the other channels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2238)
<!-- Reviewable:end -->