### PR TITLE
Fix for #2236

### DIFF
--- a/scripts/obtain/install.ps1
+++ b/scripts/obtain/install.ps1
@@ -62,6 +62,9 @@ $ErrorActionPreference="Stop"
 $ProgressPreference="SilentlyContinue"
 
 $BinFolderRelativePath=""
+if($Channel.Equals('future',[System.StringComparison]::OrdinalIgnoreCase)){
+    $BinFolderRelativePath = 'bin'
+}
 
 # example path with regex: shared/1.0.0-beta-12345/somepath
 $VersionRegEx="/\d+\.\d+[^/]+/"
@@ -153,8 +156,11 @@ function Get-Download-Links([string]$AzureFeed, [string]$AzureChannel, [string]$
     Say-Invocation $MyInvocation
     
     $ret = @()
-    $files = @("dotnet-dev")
-    
+    $files = @('dotnet')
+    if($AzureChannel.Equals('beta',[System.StringComparison]::OrdinalIgnoreCase)){
+        $files = @('dotnet-dev')
+    }
+
     foreach ($file in $files) {
         $PayloadURL = "$AzureFeed/$AzureChannel/Binaries/$SpecificVersion/$file-win-$CLIArchitecture.$SpecificVersion.zip"
         Say-Verbose "Constructed payload URL: $PayloadURL"


### PR DESCRIPTION
I had to modify the script in two places to fix #2236. The two spots were

 - Add bin path of 'bin' for future (dev)
 - Update url from 'dotnet' to 'dotnet-dev' for preview (beta)

It looks like there are some inconsistencies between preview/future in these ways.

I tested with preview/future and it looks to work on my machine. Whoever owns this script should test it more thoroughly to ensure there are noissues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2239)
<!-- Reviewable:end -->