### PR TITLE
StreamForwarder shouldn't ignore empty lines

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/BuiltInCommand.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/BuiltInCommand.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            _stdOut.ForwardTo(writeLine: handler);
+            _stdOut.ForwardTo(write: handler);
 
             return this;
         }
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            _stdErr.ForwardTo(writeLine: handler);
+            _stdErr.ForwardTo(write: handler);
 
             return this;
         }

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -199,12 +199,12 @@ namespace Microsoft.DotNet.Cli.Utils
 
                 if (to == null)
                 {
-                    _stdOut.ForwardTo(writeLine: Reporter.Output.WriteLine);
+                    _stdOut.ForwardTo(write: Reporter.Output.Write);
                     EnvironmentVariable(CommandContext.Variables.AnsiPassThru, ansiPassThrough.ToString());
                 }
                 else
                 {
-                    _stdOut.ForwardTo(writeLine: to.WriteLine);
+                    _stdOut.ForwardTo(write: to.Write);
                 }
             }
             return this;
@@ -219,12 +219,12 @@ namespace Microsoft.DotNet.Cli.Utils
 
                 if (to == null)
                 {
-                    _stdErr.ForwardTo(writeLine: Reporter.Error.WriteLine);
+                    _stdErr.ForwardTo(write: Reporter.Error.Write);
                     EnvironmentVariable(CommandContext.Variables.AnsiPassThru, ansiPassThrough.ToString());
                 }
                 else
                 {
-                    _stdErr.ForwardTo(writeLine: to.WriteLine);
+                    _stdErr.ForwardTo(write: to.Write);
                 }
             }
             return this;
@@ -235,7 +235,7 @@ namespace Microsoft.DotNet.Cli.Utils
             ThrowIfRunning();
             EnsureStdOut();
 
-            _stdOut.ForwardTo(writeLine: handler);
+            _stdOut.ForwardTo(write: handler);
             return this;
         }
 
@@ -244,7 +244,7 @@ namespace Microsoft.DotNet.Cli.Utils
             ThrowIfRunning();
             EnsureStdErr();
 
-            _stdErr.ForwardTo(writeLine: handler);
+            _stdErr.ForwardTo(write: handler);
             return this;
         }
 

--- a/src/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private StringBuilder _builder;
         private StringWriter _capture;
-        private Action<string> _writeLine;
+        private Action<string> _write;
 
         public string CapturedOutput
         {
@@ -35,13 +35,13 @@ namespace Microsoft.DotNet.Cli.Utils
             return this;
         }
 
-        public StreamForwarder ForwardTo(Action<string> writeLine)
+        public StreamForwarder ForwardTo(Action<string> write)
         {
-            ThrowIfNull(writeLine);
+            ThrowIfNull(write);
 
             ThrowIfForwarderSet();
 
-            _writeLine = writeLine;
+            _write = write;
 
             return this;
         }
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
                 if (currentCharacter == s_flushBuilderCharacter)
                 {
-                    WriteBuilder();
+                    WriteBuilder(true);
                 }
                 else if (! s_ignoreCharacters.Contains(currentCharacter))
                 {
@@ -79,31 +79,30 @@ namespace Microsoft.DotNet.Cli.Utils
 
             // Flush anything else when the stream is closed
             // Which should only happen if someone used console.Write
-            WriteBuilder();
+            WriteBuilder(false);
         }
 
-        private void WriteBuilder()
+        private void WriteBuilder(bool includeNewLine)
         {
-            if (_builder.Length == 0)
+            if (_builder.Length == 0 && !includeNewLine)
             {
                 return;
             }
 
-            WriteLine(_builder.ToString());
+            if (includeNewLine)
+            {
+                _builder.Append(Environment.NewLine);
+            }
+
+            Write(_builder.ToString());
             _builder.Clear();
         }
 
-        private void WriteLine(string str)
+        private void Write(string str)
         {
-            if (_capture != null)
-            {
-                _capture.WriteLine(str);
-            }
+            _capture?.Write(str);
 
-            if (_writeLine != null)
-            {
-                _writeLine(str);
-            }
+            _write?.Invoke(str);
         }
 
         private void ThrowIfNull(object obj)
@@ -116,7 +115,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private void ThrowIfForwarderSet()
         {
-            if (_writeLine != null)
+            if (_write != null)
             {
                 throw new InvalidOperationException("WriteLine forwarder set previously");
             }

--- a/src/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
@@ -11,7 +11,6 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public sealed class StreamForwarder
     {
-        private static readonly char[] s_ignoreCharacters = new char[] { '\r' };
         private static readonly char s_flushBuilderCharacter = '\n';
 
         private StringBuilder _builder;
@@ -67,31 +66,24 @@ namespace Microsoft.DotNet.Cli.Utils
             {
                 currentCharacter = buffer[0];
 
+                _builder.Append(currentCharacter);
+
                 if (currentCharacter == s_flushBuilderCharacter)
                 {
-                    WriteBuilder(true);
-                }
-                else if (! s_ignoreCharacters.Contains(currentCharacter))
-                {
-                    _builder.Append(currentCharacter);
+                    WriteBuilder();
                 }
             }
 
             // Flush anything else when the stream is closed
             // Which should only happen if someone used console.Write
-            WriteBuilder(false);
+            WriteBuilder();
         }
 
-        private void WriteBuilder(bool includeNewLine)
+        private void WriteBuilder()
         {
-            if (_builder.Length == 0 && !includeNewLine)
+            if (_builder.Length == 0)
             {
                 return;
-            }
-
-            if (includeNewLine)
-            {
-                _builder.Append(Environment.NewLine);
             }
 
             Write(_builder.ToString());

--- a/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
+++ b/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
@@ -229,7 +229,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             }
             else
             {
-                reporter.WriteLine(line);
+                reporter.Write(line);
             }
         }
     }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/BuiltInCommandTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/BuiltInCommandTests.cs
@@ -64,11 +64,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
                     if (onOutputLineCallCount == 1)
                     {
-                        Assert.Equal($"firstsecond", line);
+                        Assert.Equal($"firstsecond" + Environment.NewLine, line);
                     }
                     else
                     {
-                        Assert.Equal($"third", line);
+                        Assert.Equal($"third" + Environment.NewLine, line);
                     }
                 })
                 .OnErrorLine(line =>
@@ -77,11 +77,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
                     if (onErrorLineCallCount == 1)
                     {
-                        Assert.Equal($"fourth", line);
+                        Assert.Equal($"fourth" + Environment.NewLine, line);
                     }
                     else
                     {
-                        Assert.Equal($"fifth", line);
+                        Assert.Equal($"fifth" + Environment.NewLine, line);
                     }
                 })
                 .Execute();

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             {
                 return new[]
                 {
+                    new object[] { "\n\n\n", new string[]{"", "", Environment.NewLine} },
+                    new object[] { "\r\n\r\n\r\n", new string[]{"", "", Environment.NewLine} },
                     new object[] { "123", new string[]{"123"} },
                     new object[] { "123\n", new string[] {"123" + Environment.NewLine} },
                     new object[] { "123\r\n", new string[] {"123" + Environment.NewLine} },

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
@@ -34,21 +34,21 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             {
                 return new[]
                 {
-                    new object[] { "\n\n\n", new string[]{"", "", Environment.NewLine} },
-                    new object[] { "\r\n\r\n\r\n", new string[]{"", "", Environment.NewLine} },
+                    new object[] { "\n\n\n", new string[]{"\n", "\n", "\n"} },
+                    new object[] { "\r\n\r\n\r\n", new string[]{"\r\n", "\r\n", "\r\n"} },
                     new object[] { "123", new string[]{"123"} },
-                    new object[] { "123\n", new string[] {"123" + Environment.NewLine} },
-                    new object[] { "123\r\n", new string[] {"123" + Environment.NewLine} },
-                    new object[] { "1234\n5678", new string[] {"1234", "5678"} },
-                    new object[] { "1234\r\n5678", new string[] {"1234", "5678"} },
-                    new object[] { "1234\n\n5678", new string[] {"1234", "", "5678"} },
-                    new object[] { "1234\r\n\r\n5678", new string[] {"1234", "", "5678"} },
-                    new object[] { "1234\n5678\n", new string[] {"1234", "5678" + Environment.NewLine} },
-                    new object[] { "1234\r\n5678\r\n", new string[] {"1234", "5678" + Environment.NewLine} },
-                    new object[] { "1234\n5678\nabcdefghijklmnopqrstuvwxyz", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz"} },
-                    new object[] { "1234\r\n5678\r\nabcdefghijklmnopqrstuvwxyz", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz"} },
-                    new object[] { "1234\n5678\nabcdefghijklmnopqrstuvwxyz\n", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz" + Environment.NewLine} },
-                    new object[] { "1234\r\n5678\r\nabcdefghijklmnopqrstuvwxyz\r\n", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz" + Environment.NewLine} }
+                    new object[] { "123\n", new string[] {"123\n"} },
+                    new object[] { "123\r\n", new string[] {"123\r\n"} },
+                    new object[] { "1234\n5678", new string[] {"1234\n", "5678"} },
+                    new object[] { "1234\r\n5678", new string[] {"1234\r\n", "5678"} },
+                    new object[] { "1234\n\n5678", new string[] {"1234\n", "\n", "5678"} },
+                    new object[] { "1234\r\n\r\n5678", new string[] {"1234\r\n", "\r\n", "5678"} },
+                    new object[] { "1234\n5678\n", new string[] {"1234\n", "5678\n"} },
+                    new object[] { "1234\r\n5678\r\n", new string[] {"1234\r\n", "5678\r\n"} },
+                    new object[] { "1234\n5678\nabcdefghijklmnopqrstuvwxyz", new string[] {"1234\n", "5678\n", "abcdefghijklmnopqrstuvwxyz"} },
+                    new object[] { "1234\r\n5678\r\nabcdefghijklmnopqrstuvwxyz", new string[] {"1234\r\n", "5678\r\n", "abcdefghijklmnopqrstuvwxyz"} },
+                    new object[] { "1234\n5678\nabcdefghijklmnopqrstuvwxyz\n", new string[] {"1234\n", "5678\n", "abcdefghijklmnopqrstuvwxyz\n"} },
+                    new object[] { "1234\r\n5678\r\nabcdefghijklmnopqrstuvwxyz\r\n", new string[] {"1234\r\n", "5678\r\n", "abcdefghijklmnopqrstuvwxyz\r\n"} }
                 };
             }
         }
@@ -65,11 +65,6 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [MemberData("ForwardingTheoryVariations")]
         public void TestForwardingOnly(string inputStr, string[] expectedWrites)
         {
-            for (int i = 0; i < expectedWrites.Length - 1; ++i)
-            {
-                expectedWrites[i] += Environment.NewLine;
-            }
-
             TestCapturingAndForwardingHelper(ForwardOptions.Write, inputStr, null, expectedWrites);
         }
 
@@ -77,11 +72,6 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [MemberData("ForwardingTheoryVariations")]
         public void TestCaptureOnly(string inputStr, string[] expectedWrites)
         {
-            for (int i = 0; i < expectedWrites.Length - 1; ++i)
-            {
-                expectedWrites[i] += Environment.NewLine;
-            }
-
             var expectedCaptured = string.Join("", expectedWrites);
 
             TestCapturingAndForwardingHelper(ForwardOptions.Capture, inputStr, expectedCaptured, new string[0]);
@@ -91,11 +81,6 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [MemberData("ForwardingTheoryVariations")]
         public void TestCaptureAndForwardingTogether(string inputStr, string[] expectedWrites)
         {
-            for (int i = 0; i < expectedWrites.Length - 1; ++i)
-            {
-                expectedWrites[i] += Environment.NewLine;
-            }
-
             var expectedCaptured = string.Join("", expectedWrites);
 
             TestCapturingAndForwardingHelper(ForwardOptions.Write | ForwardOptions.Capture, inputStr, expectedCaptured, expectedWrites);

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
@@ -35,16 +35,18 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 return new[]
                 {
                     new object[] { "123", new string[]{"123"} },
-                    new object[] { "123\n", new string[] {"123"} },
-                    new object[] { "123\r\n", new string[] {"123"} },
+                    new object[] { "123\n", new string[] {"123" + Environment.NewLine} },
+                    new object[] { "123\r\n", new string[] {"123" + Environment.NewLine} },
                     new object[] { "1234\n5678", new string[] {"1234", "5678"} },
                     new object[] { "1234\r\n5678", new string[] {"1234", "5678"} },
-                    new object[] { "1234\n5678\n", new string[] {"1234", "5678"} },
-                    new object[] { "1234\r\n5678\r\n", new string[] {"1234", "5678"} },
+                    new object[] { "1234\n\n5678", new string[] {"1234", "", "5678"} },
+                    new object[] { "1234\r\n\r\n5678", new string[] {"1234", "", "5678"} },
+                    new object[] { "1234\n5678\n", new string[] {"1234", "5678" + Environment.NewLine} },
+                    new object[] { "1234\r\n5678\r\n", new string[] {"1234", "5678" + Environment.NewLine} },
                     new object[] { "1234\n5678\nabcdefghijklmnopqrstuvwxyz", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz"} },
                     new object[] { "1234\r\n5678\r\nabcdefghijklmnopqrstuvwxyz", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz"} },
-                    new object[] { "1234\n5678\nabcdefghijklmnopqrstuvwxyz\n", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz"} },
-                    new object[] { "1234\r\n5678\r\nabcdefghijklmnopqrstuvwxyz\r\n", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz"} }
+                    new object[] { "1234\n5678\nabcdefghijklmnopqrstuvwxyz\n", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz" + Environment.NewLine} },
+                    new object[] { "1234\r\n5678\r\nabcdefghijklmnopqrstuvwxyz\r\n", new string[] {"1234", "5678", "abcdefghijklmnopqrstuvwxyz" + Environment.NewLine} }
                 };
             }
         }
@@ -61,19 +63,19 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [MemberData("ForwardingTheoryVariations")]
         public void TestForwardingOnly(string inputStr, string[] expectedWrites)
         {
-            for (int i = 0; i < expectedWrites.Length; ++i)
+            for (int i = 0; i < expectedWrites.Length - 1; ++i)
             {
                 expectedWrites[i] += Environment.NewLine;
             }
 
-            TestCapturingAndForwardingHelper(ForwardOptions.WriteLine, inputStr, null, expectedWrites);
+            TestCapturingAndForwardingHelper(ForwardOptions.Write, inputStr, null, expectedWrites);
         }
 
         [Theory]
         [MemberData("ForwardingTheoryVariations")]
         public void TestCaptureOnly(string inputStr, string[] expectedWrites)
         {
-            for (int i = 0; i < expectedWrites.Length; ++i)
+            for (int i = 0; i < expectedWrites.Length - 1; ++i)
             {
                 expectedWrites[i] += Environment.NewLine;
             }
@@ -87,14 +89,14 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [MemberData("ForwardingTheoryVariations")]
         public void TestCaptureAndForwardingTogether(string inputStr, string[] expectedWrites)
         {
-            for (int i = 0; i < expectedWrites.Length; ++i)
+            for (int i = 0; i < expectedWrites.Length - 1; ++i)
             {
                 expectedWrites[i] += Environment.NewLine;
             }
 
             var expectedCaptured = string.Join("", expectedWrites);
 
-            TestCapturingAndForwardingHelper(ForwardOptions.WriteLine | ForwardOptions.Capture, inputStr, expectedCaptured, expectedWrites);
+            TestCapturingAndForwardingHelper(ForwardOptions.Write | ForwardOptions.Capture, inputStr, expectedCaptured, expectedWrites);
         }
 
         [Flags]
@@ -102,7 +104,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         {
             None = 0x0,
             Capture = 0x1,
-            WriteLine = 0x02,
+            Write = 0x02,
         }
 
         private void TestCapturingAndForwardingHelper(ForwardOptions options, string str, string expectedCaptured, string[] expectedWrites)
@@ -110,9 +112,9 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             var forwarder = new StreamForwarder();
             var writes = new List<string>();
 
-            if ((options & ForwardOptions.WriteLine) != 0)
+            if ((options & ForwardOptions.Write) != 0)
             {
-                forwarder.ForwardTo(writeLine: s => writes.Add(s + Environment.NewLine));
+                forwarder.ForwardTo(write: s => writes.Add(s));
             }
             if ((options & ForwardOptions.Capture) != 0)
             {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
@@ -9,14 +9,14 @@ using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 
-namespace StreamForwarderTests
+namespace Microsoft.DotNet.Cli.Utils.Tests
 {
     public class StreamForwarderTests : TestBase
     {
         private static readonly string s_rid = RuntimeEnvironmentRidExtensions.GetLegacyRestoreRuntimeIdentifier();
         private static readonly string s_testProjectRoot = Path.Combine(AppContext.BaseDirectory, "TestAssets", "TestProjects");
 
-        private TempDirectory _root;
+        private readonly TempDirectory _root;
 
         public static void Main()
         {
@@ -97,6 +97,7 @@ namespace StreamForwarderTests
             TestCapturingAndForwardingHelper(ForwardOptions.WriteLine | ForwardOptions.Capture, inputStr, expectedCaptured, expectedWrites);
         }
 
+        [Flags]
         private enum ForwardOptions
         {
             None = 0x0,

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -65,8 +65,8 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             var stdOut = new StreamForwarder();
             var stdErr = new StreamForwarder();
 
-            stdOut.ForwardTo(writeLine: Reporter.Output.WriteLine);
-            stdErr.ForwardTo(writeLine: Reporter.Output.WriteLine);
+            stdOut.ForwardTo(write: Reporter.Output.Write);
+            stdErr.ForwardTo(write: Reporter.Output.Write);
 
             return RunProcessAsync(commandPath, args, stdOut, stdErr);
         }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -49,8 +49,8 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             var stdOut = new StreamForwarder();
             var stdErr = new StreamForwarder();
 
-            stdOut.ForwardTo(writeLine: Reporter.Output.WriteLine);
-            stdErr.ForwardTo(writeLine: Reporter.Output.WriteLine);
+            stdOut.ForwardTo(write: Reporter.Output.Write);
+            stdErr.ForwardTo(write: Reporter.Output.Write);
 
             return RunProcess(commandPath, args, stdOut, stdErr);
         }


### PR DESCRIPTION
This also ensures StreamForwarder doesn't add newline
at the end of a stream where there isn't one in the original.

Also performed minor cleanup of `StreamForwarderTests`.

This is an alternative to #2235.

Fixes  #2234.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2244)
<!-- Reviewable:end -->