### PR TITLE
Use default version for unresolved MSBuild reference

### DIFF
--- a/src/dotnet/commands/dotnet-projectmodel-server/Models/DependencyDescription.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/Models/DependencyDescription.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.ProjectModel.Compilation;
 using Microsoft.DotNet.ProjectModel.Graph;
+using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ProjectModel.Server.Models
 {
@@ -23,7 +24,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Models
         public string Type { get; private set; }
 
         public bool Resolved { get; private set; }
-        
+
         public IEnumerable<DependencyItem> Dependencies { get; private set; }
 
         public IEnumerable<DiagnosticMessageView> Errors { get; private set; }
@@ -60,7 +61,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Models
             {
                 Name = library.Identity.Name,
                 DisplayName = library.Identity.Name,
-                Version = library.Identity.Version?.ToNormalizedString(),
+                Version = (library.Identity.Version ?? new NuGetVersion("1.0.0")).ToNormalizedString(),
                 Type = library.Identity.Type.Value,
                 Resolved = library.Resolved,
                 Path = library.Path,

--- a/test/dotnet-projectmodel-server.Tests/DthTests.cs
+++ b/test/dotnet-projectmodel-server.Tests/DthTests.cs
@@ -438,12 +438,13 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
                 client.Initialize(projectPath);
                 var messages = client.DrainAllMessages();
                 messages.AssertDoesNotContain(MessageTypes.Error);
+                // PrintAllMessages(new[] { messages.RetrieveSingleMessage(MessageTypes.Dependencies) });
                 messages.RetrieveSingleMessage(MessageTypes.Dependencies)
                         .RetrieveDependency("ClassLibrary4")
                         .AssertProperty<object>(
                             "Version",
                             v => !string.IsNullOrEmpty(v.ToString()),
-                            v => "Version string shouldn't be empty.");
+                            v => $"Version string shouldn't be empty. Value [{v.ToString()}]");
             }
         }
 


### PR DESCRIPTION
Issue #2200 

/cc @davidfowl @abpiskunov @piotrpMSFT 

Note: The fix is made a project model server. It is a conservative approach because the root cause is in the `ProjectReader` ([this line](https://github.com/dotnet/cli/blob/rel/1.0.0/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs#L271)). Here an unresolved `project` type dependencies is added the `null` version leak into the project model.

Now I bank my fix high on the stack just to ensure the impact will be limited to project model server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2249)
<!-- Reviewable:end -->