### PR TITLE
Optimize dependency context memory usage

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/IDependencyContextReader.cs
+++ b/src/Microsoft.Extensions.DependencyModel/IDependencyContextReader.cs
@@ -1,8 +1,9 @@
+using System;
 using System.IO;
 
 namespace Microsoft.Extensions.DependencyModel
 {
-    public interface IDependencyContextReader
+    public interface IDependencyContextReader: IDisposable
     {
         DependencyContext Read(Stream stream);
     }


### PR DESCRIPTION
1. Pool strings
2. Do not hold onto `DependencyContextJsonReader` in `DependencyContextLoader`
3. Use same reader with same string pool to load multiple contexts in case of portable app.

Brings `DependencyContext` size in ASP.NET app to ~250kb.

/cc @davidfowl

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2264)
<!-- Reviewable:end -->