### PR TITLE
Publish an Archive with the SDK Pdbs

### DIFF
--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -243,6 +243,9 @@ namespace Microsoft.DotNet.Cli.Build
                 outputDir: Dirs.Stage1);
 
             CleanOutputDir(Path.Combine(Dirs.Stage1, "sdk"));
+            FS.CopyRecursive(Dirs.Stage1, Dirs.Stage1Symbols);
+
+            RemovePdbsFromDir(Path.Combine(Dirs.Stage1, "sdk"));
 
             return result;
         }
@@ -293,13 +296,23 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             CleanOutputDir(Path.Combine(Dirs.Stage2, "sdk"));
+            FS.CopyRecursive(Dirs.Stage2, Dirs.Stage2Symbols);
+
+            RemovePdbsFromDir(Path.Combine(Dirs.Stage2, "sdk"));
 
             return c.Success();
         }
 
         private static void CleanOutputDir(string directory)
         {
-            FS.RmFilesInDirRecursive(directory, "vbc.exe");
+            foreach (var file in FilesToClean)
+            {
+                FS.RmFilesInDirRecursive(directory, file);
+            }
+        }
+
+        private static void RemovePdbsFromDir(string directory)
+        {
             FS.RmFilesInDirRecursive(directory, "*.pdb");
         }
 

--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -175,6 +175,8 @@ namespace Microsoft.DotNet.Cli.Build
             CreateZipFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkSDKHostRoot"), c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile"));
             CreateZipFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkHostRoot"), c.BuildContext.Get<string>("CombinedFrameworkHostCompressedFile"));
 
+            CreateZipFromDirectory(Path.Combine(Dirs.Stage2Symbols, "sdk"), c.BuildContext.Get<string>("SdkSymbolsCompressedFile"));
+
             return c.Success();
         }
 
@@ -184,6 +186,8 @@ namespace Microsoft.DotNet.Cli.Build
         {
             CreateTarBallFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkSDKHostRoot"), c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile"));
             CreateTarBallFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkHostRoot"), c.BuildContext.Get<string>("CombinedFrameworkHostCompressedFile"));
+
+            CreateTarBallFromDirectory(Path.Combine(Dirs.Stage2Symbols, "sdk"), c.BuildContext.Get<string>("SdkSymbolsCompressedFile"));
 
             return c.Success();
         }

--- a/scripts/dotnet-cli-build/PrepareTargets.cs
+++ b/scripts/dotnet-cli-build/PrepareTargets.cs
@@ -130,6 +130,7 @@ namespace Microsoft.DotNet.Cli.Build
             AddInstallerArtifactToContext(c, "dotnet-sharedframework", "SharedFramework", sharedFrameworkVersion);
             AddInstallerArtifactToContext(c, "dotnet-dev", "CombinedFrameworkSDKHost", cliVersion);
             AddInstallerArtifactToContext(c, "dotnet", "CombinedFrameworkHost", sharedFrameworkVersion);
+            AddInstallerArtifactToContext(c, "dotnet-sdk-debug", "SdkSymbols", cliVersion);
 
             return c.Success();
         }

--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -68,7 +68,8 @@ namespace Microsoft.DotNet.Cli.Build
 
         [Target(
             nameof(PublishTargets.PublishCombinedHostFrameworkArchiveToAzure),
-            nameof(PublishTargets.PublishCombinedHostFrameworkSdkArchiveToAzure))]
+            nameof(PublishTargets.PublishCombinedHostFrameworkSdkArchiveToAzure),
+            nameof(PublishTargets.PublishSDKSymbolsArchiveToAzure))]
         public static BuildTargetResult PublishArchivesToAzure(BuildTargetContext c) => c.Success();
 
         [Target(
@@ -170,6 +171,17 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var version = CliNuGetVersion;
             var archiveFile = c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile");
+
+            AzurePublisherTool.PublishArchiveAndLatest(archiveFile, Channel, version);
+
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult PublishSDKSymbolsArchiveToAzure(BuildTargetContext c)
+        {
+            var version = CliNuGetVersion;
+            var archiveFile = c.BuildContext.Get<string>("SdkSymbolsCompressedFile");
 
             AzurePublisherTool.PublishArchiveAndLatest(archiveFile, Channel, version);
 

--- a/scripts/dotnet-cli-build/Utils/Dirs.cs
+++ b/scripts/dotnet-cli-build/Utils/Dirs.cs
@@ -17,8 +17,10 @@ namespace Microsoft.DotNet.Cli.Build
         public static readonly string Packages = Path.Combine(Output, "packages");
         public static readonly string Stage1 = Path.Combine(Output, "stage1");
         public static readonly string Stage1Compilation = Path.Combine(Output, "stage1compilation");
+        public static readonly string Stage1Symbols = Path.Combine(Output, "stage1symbols");
         public static readonly string Stage2 = Path.Combine(Output, "stage2");
         public static readonly string Stage2Compilation = Path.Combine(Output, "stage2compilation");
+        public static readonly string Stage2Symbols = Path.Combine(Output, "stage2symbols");
         public static readonly string Corehost = Path.Combine(Output, "corehost");
         public static readonly string TestOutput = Path.Combine(Output, "tests");
         public static readonly string TestArtifacts = Path.Combine(TestOutput, "artifacts");


### PR DESCRIPTION
* Creates `stage1symbols`, `stage2symbols` directories in the build, with pdbs inside
* Publishes an archive of the `sdk` directory in `stage2symbols` with name `dotnet-sdk-debug`

Fixes #2260

PTAL @Sridhar-MS @piotrpMSFT @eerhardt 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2272)
<!-- Reviewable:end -->
