### PR TITLE
Changing the name of two tests that conflict with each other and fail…

### DIFF
--- a/test/dotnet-build.Tests/BuildPortableTests.cs
+++ b/test/dotnet-build.Tests/BuildPortableTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
         }
 
         [Fact]
-        public void TheRuntimeOptionsGetsCopiedFromProjectJsonToRuntimeConfigJson()
+        public void RuntimeOptionsGetsCopiedToRuntimeConfigJsonForAPortableApp()
         {
             var testInstance = TestAssetsManager.CreateTestInstance("PortableTests")
                 .WithLockFiles();

--- a/test/dotnet-build.Tests/BuildStandAloneTests.cs
+++ b/test/dotnet-build.Tests/BuildStandAloneTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
         }
 
         [Fact]
-        public void TheRuntimeOptionsGetsCopiedFromProjectJsonToRuntimeConfigJson()
+        public void RuntimeOptionsGetsCopiedToRuntimeConfigJsonForAStandaloneApp()
         {
             var testInstance = TestAssetsManager.CreateTestInstance("PortableTests")
                 .WithLockFiles();


### PR DESCRIPTION
… inconsistently when the tests run in parallel because they stomp on each other.

cc @brthor @Sridhar-MS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2284)
<!-- Reviewable:end -->
