### PR TITLE
fix the name of debian packages in packageUpload.json

### DIFF
--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -253,7 +253,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var version = SharedFrameworkNugetVersion;
 
-            var packageName = Monikers.GetSdkDebianPackageName(c);
+            var packageName = Monikers.GetDebianSharedFrameworkPackageName(c);
             var installerFile = c.BuildContext.Get<string>("SharedFrameworkInstallerFile");
             var uploadUrl = AzurePublisherTool.CalculateInstallerUploadUrl(installerFile, Channel, version);
 
@@ -271,7 +271,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var version = CliNuGetVersion;
 
-            var packageName = Monikers.GetSdkDebianPackageName(c);
+            var packageName = Monikers.GetDebianSharedHostPackageName(c);
             var installerFile = c.BuildContext.Get<string>("SharedHostInstallerFile");
             var uploadUrl = AzurePublisherTool.CalculateInstallerUploadUrl(installerFile, Channel, version);
 


### PR DESCRIPTION
Fixes #2293

@Sridhar-MS please take a quick look

This change doesn't impact the observable behavior of our products or installers, it only makes the metadata used to manage the feed correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2294)
<!-- Reviewable:end -->