### PR TITLE
Execute project dependency command from output directory for Desktop.

### DIFF
--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/Program.cs
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 
 namespace ConsoleApplication
 {
@@ -11,7 +12,8 @@ namespace ConsoleApplication
 #elif NETSTANDARD1_5
             Console.WriteLine($"Hello {string.Join(" ", args)} From .NETStandardApp,Version=v1.5");
 #endif
-            Console.WriteLine($"Base Directory - {AppContext.BaseDirectory}");
+            var currentAssemblyPath = typeof(ConsoleApplication.Program).GetTypeInfo().Assembly.Location;
+            Console.WriteLine($"Current Assembly Directory - {currentAssemblyPath}");
         }
     }
 }

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/Program.cs
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/Program.cs
@@ -11,6 +11,7 @@ namespace ConsoleApplication
 #elif NETSTANDARD1_5
             Console.WriteLine($"Hello {string.Join(" ", args)} From .NETStandardApp,Version=v1.5");
 #endif
+            Console.WriteLine($"Base Directory - {AppContext.BaseDirectory}");
         }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/CommandResolutionStrategy.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/CommandResolutionStrategy.cs
@@ -23,6 +23,9 @@
         // command loaded from rooted path
         RootedPath,
 
+        // command loaded from project build output path
+        OutputPath,
+
         // command not found
         None
     }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/OutputPathCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/OutputPathCommandResolver.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.ProjectModel.Graph;
+using Microsoft.Extensions.PlatformAbstractions;
+using NuGet.Frameworks;
+using NuGet.Packaging;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public class OutputPathCommandResolver : AbstractPathBasedCommandResolver
+    {
+        public OutputPathCommandResolver(IEnvironmentProvider environment,
+            IPlatformCommandSpecFactory commandSpecFactory) : base(environment, commandSpecFactory)
+        { }
+
+
+        internal override string ResolveCommandPath(CommandResolverArguments commandResolverArguments)
+        {
+            if (commandResolverArguments.Framework == null
+                || commandResolverArguments.ProjectDirectory == null
+                || commandResolverArguments.Configuration == null
+                || commandResolverArguments.CommandName == null)
+            {
+                return null;
+            }
+
+            return ResolveFromProjectOutput(
+                commandResolverArguments.ProjectDirectory,
+                commandResolverArguments.Framework,
+                commandResolverArguments.Configuration,
+                commandResolverArguments.CommandName,
+                commandResolverArguments.CommandArguments.OrEmptyIfNull(),
+                commandResolverArguments.OutputPath,
+                commandResolverArguments.BuildBasePath);
+        }
+
+        private string ResolveFromProjectOutput(
+            string projectDirectory,
+            NuGetFramework framework,
+            string configuration,
+            string commandName,
+            IEnumerable<string> commandArguments,
+            string outputPath,
+            string buildBasePath)
+        {
+            var projectContext = GetProjectContextFromDirectory(
+                projectDirectory,
+                framework);
+
+            if (projectContext == null)
+            {
+                return null;
+            }
+
+            var buildOutputPath = projectContext.GetOutputPaths(configuration, buildBasePath, outputPath).RuntimeFiles.BasePath;
+
+            return _environment.GetCommandPathFromRootPath(buildOutputPath, commandName);
+        }
+
+        private ProjectContext GetProjectContextFromDirectory(string directory, NuGetFramework framework)
+        {
+            if (directory == null || framework == null)
+            {
+                return null;
+            }
+
+            var projectRootPath = directory;
+
+            if (!File.Exists(Path.Combine(projectRootPath, Project.FileName)))
+            {
+                return null;
+            }
+
+            var projectContext = ProjectContext.Create(
+                projectRootPath,
+                framework,
+                PlatformServices.Default.Runtime.GetAllCandidateRuntimeIdentifiers());
+
+            if (projectContext.RuntimeIdentifier == null)
+            {
+                return null;
+            }
+
+            return projectContext;
+        }
+
+        internal override CommandResolutionStrategy GetCommandResolutionStrategy()
+        {
+            return CommandResolutionStrategy.OutputPath;
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/ProjectDependenciesCommandFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ProjectDependenciesCommandFactory.cs
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
             if (framework.IsDesktop())
             {
-                var platformCommandSpecFactory = default(IPlatformCommandSpecFactory);
+                IPlatformCommandSpecFactory platformCommandSpecFactory = null;
                 if (PlatformServices.Default.Runtime.OperatingSystemPlatform == Platform.Windows)
                 {
                     platformCommandSpecFactory = new WindowsExePreferredCommandSpecFactory();

--- a/src/Microsoft.DotNet.Cli.Utils/ProjectDependenciesCommandFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ProjectDependenciesCommandFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using Microsoft.Extensions.PlatformAbstractions;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli.Utils
@@ -76,7 +77,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 ProjectDirectory = projectDirectory
             };
 
-            var commandResolver = GetProjectDependenciesCommandResolver();
+            var commandResolver = GetProjectDependenciesCommandResolver(framework);
 
             var commandSpec = commandResolver.Resolve(commandResolverArguments);
             if (commandSpec == null)
@@ -87,12 +88,29 @@ namespace Microsoft.DotNet.Cli.Utils
             return commandSpec;
         }
 
-        private ICommandResolver GetProjectDependenciesCommandResolver()
+        private ICommandResolver GetProjectDependenciesCommandResolver(NuGetFramework framework)
         {
             var environment = new EnvironmentProvider();
-            var packagedCommandSpecFactory = new PackagedCommandSpecFactory();
 
-            return new ProjectDependenciesCommandResolver(environment, packagedCommandSpecFactory);
+            if (framework.IsDesktop())
+            {
+                var platformCommandSpecFactory = default(IPlatformCommandSpecFactory);
+                if (PlatformServices.Default.Runtime.OperatingSystemPlatform == Platform.Windows)
+                {
+                    platformCommandSpecFactory = new WindowsExePreferredCommandSpecFactory();
+                }
+                else
+                {
+                    platformCommandSpecFactory = new GenericPlatformCommandSpecFactory();
+                }
+
+                return new OutputPathCommandResolver(environment, platformCommandSpecFactory);
+            }
+            else
+            {
+                var packagedCommandSpecFactory = new PackagedCommandSpecFactory();
+                return new ProjectDependenciesCommandResolver(environment, packagedCommandSpecFactory);
+            }
         }
     }
 }

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -44,9 +44,9 @@ namespace Microsoft.DotNet.Tests
 
         // need conditional theories so we can skip on non-Windows
         [Theory]
-        [InlineData(".NETStandardApp,Version=v1.5", "CoreFX")]
-        [InlineData(".NETFramework,Version=v4.5.1", "NetFX")]
-        public void TestFrameworkSpecificDependencyToolsCanBeInvoked(string framework, string args)
+        [InlineData(".NETStandardApp,Version=v1.5", "CoreFX", @"lib\netstandard1.5\dotnet-desktop-and-portable.dll")]
+        [InlineData(".NETFramework,Version=v4.5.1", "NetFX", @"AppWithDirectDependencyDesktopAndPortable\bin\Debug\net451\win7-x64\dotnet-desktop-and-portable.exe")]
+        public void TestFrameworkSpecificDependencyToolsCanBeInvoked(string framework, string args, string expectedDependencyToolPath)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -65,6 +65,7 @@ namespace Microsoft.DotNet.Tests
 
                 result.Should().HaveStdOutContaining(framework);
                 result.Should().HaveStdOutContaining(args);
+                result.Should().HaveStdOutContaining(expectedDependencyToolPath);
                 result.Should().NotHaveStdErr();
                 result.Should().Pass();
         }


### PR DESCRIPTION
Created a new command resolver called OutputPathCommandResolver which
reolves a command from the project build output directory.

Made changes ProjectDependenciesCommandFactory to use
OutputPathCommandResolver if the target framework is Desktop.

Fixes - #2126

Still need to add tests.

cc @piotrpMSFT @brthor @bricelam

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2297)
<!-- Reviewable:end -->