### PR TITLE
Remove Logging from Testing.Abstractions

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,8 +5,9 @@
     <clear />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetvnext/api/v3/index.json" />
   </packageSources>
   <activePackageSource>
-    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+   
   </activePackageSource>
 </configuration>

--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
@@ -13,14 +13,14 @@
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.Extensions.CommandLineUtils.Sources": {
       "type": "build",
-      "version": "1.0.0-rc2-16453"
+      "version": "1.0.0-rc2-20221"
     },
     "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
-      "version": "1.0.0-rc2-16453",
+      "version": "1.0.0-rc2-20221",
       "type": "build"
     },
     "Microsoft.Dnx.Runtime.Sources": {
-      "version": "1.0.0-rc2-16453",
+      "version": "1.0.0-rc2-20221",
       "type": "build"
     },
     "System.CommandLine": "0.1.0-e160323-1"

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20100",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20459",
     "NuGet.Versioning": "3.5.0-beta-1130",
     "NuGet.Packaging": "3.5.0-beta-1130",
     "NuGet.Frameworks": "3.5.0-beta-1130",
@@ -21,9 +21,8 @@
       }
     },
     "netstandard1.5": {
-      "imports": "dnxcore50",
+      "imports": "portable-net45+wp80+win8+wpa81+dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-23931",
         "System.Diagnostics.Process": "4.1.0-rc2-23931"
       }
     }

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -4,20 +4,16 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2-23931",
-    "System.CommandLine": "0.1.0-e160323-1",
     "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160329-01",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-    "Microsoft.DotNet.Files": "1.0.0-*"
+    "Microsoft.DotNet.Files": "1.0.0-*",
+    "System.CommandLine": "0.1.0-e160323-1"
   },
   "frameworks": {
     "netstandard1.5": {
-      "imports": [
-        "dnxcore50",
-        "portable-net45+win8"
-      ]
+      "imports": "portable-net45+wp80+win8+wpa81+dnxcore50"
     }
   },
-  "scripts": {}
+  "scripts": { }
 }

--- a/src/Microsoft.DotNet.Files/project.json
+++ b/src/Microsoft.DotNet.Files/project.json
@@ -5,15 +5,13 @@
   },
   "description": "Abstraction to interact with the file system and file paths.",
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2-23931",
-    "System.Linq.Expressions": "4.0.11-rc2-23931",
-    "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15996",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-    "Microsoft.DotNet.ProjectModel": "1.0.0-*"
+    "Microsoft.DotNet.ProjectModel": "1.0.0-*",
+    "System.Linq.Expressions": "4.0.11-rc2-23931"
   },
   "frameworks": {
     "netstandard1.5": {
-      "imports": "dnxcore50"
+      "imports": "portable-net45+wp80+win8+wpa81+dnxcore50"
     }
   },
   "scripts": {}

--- a/src/Microsoft.DotNet.InternalAbstractions/project.json
+++ b/src/Microsoft.DotNet.InternalAbstractions/project.json
@@ -10,16 +10,11 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20100"
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20459"
   },
   "frameworks": {
     "net451": {},
-    "netstandard1.3": {
-      "imports": "dnxcore50",
-      "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-23931"
-      }
-    }
+    "netstandard1.3": {}
   },
   "scripts": {}
 }

--- a/src/Microsoft.DotNet.ProjectModel.Loader/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/project.json
@@ -4,13 +4,12 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2-23931",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "System.Runtime.Loader": "4.0.0-rc2-23931"
   },
   "frameworks": {
     "netstandard1.5": {
-      "imports": "dnxcore50"
+      "imports": "portable-net45+wp80+win8+wpa81+dnxcore50"
     }
   }
 }

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -4,7 +4,6 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2-23931",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.0-beta1-20160329-01"
@@ -12,7 +11,7 @@
   "frameworks": {
     "netstandard1.5": {
       "imports": [
-        "dnxcore50",
+        "portable-net45+wp80+win8+wpa81+dnxcore50",
         "portable-net45+win8"
       ]
     }

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -5,20 +5,19 @@
   },
   "description": "Types to model a .NET Project",
   "dependencies": {
-    "System.Reflection.Metadata": "1.3.0-rc2-23931",
-    "NuGet.Packaging": "3.5.0-beta-1130",
-    "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-15996",
-    "Microsoft.Extensions.JsonParser.Sources": {
-      "type": "build",
-      "version": "1.0.0-rc2-16453"
-    },
-    "Newtonsoft.Json": "7.0.1",
-    "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23931",
+    "Microsoft.Extensions.DependencyModel": "1.0.0-*",
+    "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-20459",
     "Microsoft.Extensions.HashCodeCombiner.Sources": {
       "type": "build",
-      "version": "1.0.0-rc2-16054"
+      "version": "1.0.0-rc2-20459"
     },
-    "Microsoft.Extensions.DependencyModel": "1.0.0-*"
+    "Microsoft.Extensions.JsonParser.Sources": {
+      "type": "build",
+      "version": "1.0.0-rc2-20221"
+    },
+    "Newtonsoft.Json": "7.0.1",
+    "NuGet.Packaging": "3.5.0-beta-1130",
+    "System.Reflection.Metadata": "1.3.0-rc2-23931"
   },
   "frameworks": {
     "net451": {
@@ -35,14 +34,17 @@
       }
     },
     "netstandard1.5": {
-      "imports": "dnxcore50",
+      "imports": [
+        "portable-net45+wp80+win8+wpa81+dnxcore50",
+        "dotnet5.4"
+      ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-23931",
-        "System.Dynamic.Runtime": "4.0.11-rc2-23931",
-        "System.Threading.Thread": "4.0.0-rc2-23931",
-        "System.Runtime.Loader": "4.0.0-rc2-23931",
-        "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23931",
         "Microsoft.CSharp": "4.0.1-rc2-23931",
+        "System.Dynamic.Runtime": "4.0.11-rc2-23931",
+        "System.Runtime.Loader": "4.0.0-rc2-23931",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-23931",
+        "System.Security.Cryptography.Algorithms": "4.1.0-rc2-23931",
+        "System.Threading.Thread": "4.0.0-rc2-23931",
         "System.Xml.XDocument": "4.0.11-rc2-23931"
       }
     }

--- a/src/Microsoft.DotNet.TestFramework/project.json
+++ b/src/Microsoft.DotNet.TestFramework/project.json
@@ -1,21 +1,17 @@
 {
   "version": "1.0.0-*",
   "description": "Microsoft.DotNet.TestFramework Class Library",
-  "authors": [
-    "sridhper"
-  ],
   "tags": [
     ""
   ],
   "projectUrl": "",
   "licenseUrl": "",
   "dependencies": {
-    "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
-    "NETStandard.Library": "1.5.0-rc2-23931"
+    "Microsoft.DotNet.Cli.Utils": "1.0.0-*"
   },
   "frameworks": {
     "netstandard1.5": {
-      "imports": "dnxcore50"
+      "imports": "portable-net45+wp80+win8+wpa81+dnxcore50"
     }
   }
 }

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -10,23 +10,23 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.Extensions.HashCodeCombiner.Sources": {
-      "type": "build",
-      "version": "1.0.0-rc2-16054"
-    },
     "Microsoft.DotNet.InternalAbstractions": {
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Newtonsoft.Json": "7.0.1",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20100"
+    "Microsoft.Extensions.HashCodeCombiner.Sources": {
+      "type": "build",
+      "version": "1.0.0-rc2-20459"
+    },
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20459",
+    "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {
     "net451": {},
     "netstandard1.5": {
-      "imports": "dnxcore50",
+      "imports": "portable-net45+wp80+win8+wpa81+dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-23931",
+        "System.Diagnostics.Debug": "4.0.11-rc2-23931",
         "System.Dynamic.Runtime": "4.0.11-rc2-23931"
       }
     }

--- a/src/Microsoft.Extensions.Testing.Abstractions/SourceInformationProvider.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/SourceInformationProvider.cs
@@ -5,22 +5,20 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Extensions.Testing.Abstractions
 {
     public class SourceInformationProvider : ISourceInformationProvider
     {
         private readonly string _pdbPath;
-        private readonly ILogger _logger;
         private readonly IPdbReader _pdbReader;
 
-        public SourceInformationProvider(string pdbPath, ILogger logger) :
-            this(pdbPath, logger, new PdbReaderFactory())
+        public SourceInformationProvider(string pdbPath) :
+            this(pdbPath, new PdbReaderFactory())
         {
         }
 
-        public SourceInformationProvider(string pdbPath, ILogger logger, IPdbReaderFactory pdbReaderFactory)
+        public SourceInformationProvider(string pdbPath, IPdbReaderFactory pdbReaderFactory)
         {
             if (string.IsNullOrWhiteSpace(pdbPath) || !File.Exists(pdbPath))
             {
@@ -28,7 +26,6 @@ namespace Microsoft.Extensions.Testing.Abstractions
             }
 
             _pdbPath = pdbPath;
-            _logger = logger;
 
             _pdbReader = pdbReaderFactory.Create(pdbPath);
         }
@@ -57,7 +54,7 @@ namespace Microsoft.Extensions.Testing.Abstractions
             }
             catch (Exception ex)
             {
-                _logger?.LogWarning("Failed to access source information in symbol.", ex);
+                Console.WriteLine("Failed to access source information in symbol.", ex);
                 return null;
             }
         }

--- a/src/Microsoft.Extensions.Testing.Abstractions/TestHostServices.cs
+++ b/src/Microsoft.Extensions.Testing.Abstractions/TestHostServices.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Extensions.Logging;
-
 namespace Microsoft.Extensions.Testing.Abstractions
 {
     public abstract class TestHostServices
@@ -12,7 +10,5 @@ namespace Microsoft.Extensions.Testing.Abstractions
         public abstract ITestExecutionSink TestExecutionSink { get; }
 
         public abstract ISourceInformationProvider SourceInformationProvider { get; }
-
-        public abstract ILoggerFactory LoggerFactory { get; }
     }
 }

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-16040",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-20459",
     "Microsoft.DiaSymReader": "1.0.6",
     "Microsoft.DiaSymReader.Native": "1.3.3"
   },
@@ -21,11 +21,10 @@
     "net451": {},
     "netstandard1.5": {
       "imports": [
-        "dnxcore50",
+        "portable-net45+wp80+win8+wpa81+dnxcore50",
         "portable-net45+win8"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-23931",
         "System.Resources.ResourceManager": "4.0.1-rc2-23931",
         "System.Reflection.TypeExtensions": "4.1.0-rc2-23931"
       }

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-20459",
     "Microsoft.DiaSymReader": "1.0.6",
     "Microsoft.DiaSymReader.Native": "1.3.3"
   },

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -29,20 +29,12 @@
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.DotNet.ILCompiler.SDK": "1.0.6-prerelease-00003",
-    "Microsoft.Extensions.Logging": "1.0.0-rc2-16040",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-16040",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20100",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20459",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-20459",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20459",
     "Microsoft.Extensions.CommandLineUtils.Sources": {
       "type": "build",
-      "version": "1.0.0-rc2-16453"
-    },
-    "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
-      "version": "1.0.0-rc2-16453",
-      "type": "build"
-    },
-    "Microsoft.Dnx.Runtime.Sources": {
-      "version": "1.0.0-rc2-16453",
-      "type": "build"
+      "version": "1.0.0-rc2-20221"
     },
     "Microsoft.Extensions.Testing.Abstractions": "1.0.0-*",
     "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23931",
@@ -66,9 +58,9 @@
       "imports": [
         "dnxcore50",
         "netstandardapp1.5",
-        "portable-net45+win8"
+        "portable-net45+win8",
+        "portable-net45+wp80+win8+wpa81+dnxcore50"
       ]
     }
-  },
-  "scripts": {}
+  }
 }


### PR DESCRIPTION
Following up on https://github.com/dotnet/cli/pull/2296 to remove Extensions.Logging from Testing.Abstractions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2298)
<!-- Reviewable:end -->
