### PR TITLE
Alow type platform to be in target dependencies

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -145,8 +145,9 @@ namespace Microsoft.DotNet.ProjectModel
             {
                 return this;
             }
-            
-            var standalone = !ProjectFile.Dependencies.Any(d => d.Type.Equals(LibraryDependencyType.Platform));
+
+            var standalone = !RootProject.Dependencies
+                .Any(d => d.Type.Equals(LibraryDependencyType.Platform));
 
             var context = CreateBuilder(ProjectFile.ProjectFilePath, TargetFramework)
                 .WithRuntimeIdentifiers(standalone ? runtimeIdentifiers : Enumerable.Empty<string>())


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/2307
Alows:
```
{
  "dependencies": {
    "Microsoft.AspNetCore.Testing": "1.0.0-*",
    "Microsoft.Extensions.DependencyInjection": "1.0.0-*",
    "Microsoft.Extensions.DependencyInjection.Specification.Tests": "1.0.0-*",
    "xunit": "2.1.0"
  },
  "frameworks": {
    "netcoreapp1.0": {
      "imports": [
        "dnxcore50",
        "portable-net451+win8"
      ],
      "dependencies": {
        "Microsoft.NETCore.App": {
          "type": "platform",
          "version":"1.0.0-*"
        },
        "dotnet-test-xunit": "1.0.0-dev-*"
      }
    },
    "net451": {
      "frameworkAssemblies": {
         "System.Runtime": { "type": "build"}
      },
      "dependencies": {
        "xunit.runner.console": "2.1.0"
      }
    }
  },
  "runtimes":
  {
    "win7-x64": {},
    "win7-x86": {},
  },
  "testRunner": "xunit"
}
```
@anurse @davidfowl

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2306)
<!-- Reviewable:end -->
