### PR TITLE
fix install.sh dry run to use exit instead of return

### DIFF
--- a/scripts/obtain/install.sh
+++ b/scripts/obtain/install.sh
@@ -619,7 +619,7 @@ calculate_vars
 if [ "$dry_run" = true ]; then
     say "Payload URL: $download_link"
     say "Repeatable invocation: ./$(basename $0) --version $specific_version --channel $channel --install-dir $install_dir"
-    return 0
+    exit 0
 fi
 
 check_pre_reqs


### PR DESCRIPTION
`--dry-run` is currently printing errors with some versions of bash

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2313)
<!-- Reviewable:end -->
