### PR TITLE
Perform prerelease roll forward for FX and servicing

### DIFF
--- a/src/corehost/cli/args.h
+++ b/src/corehost/cli/args.h
@@ -14,7 +14,8 @@ struct probe_config_t
 {
     pal::string_t probe_dir;
     bool match_hash;
-    bool roll_forward;
+    bool patch_roll_fwd;
+    bool prerelease_roll_fwd;
     const deps_json_t* probe_deps_json;
 
     bool only_runtime_assets;
@@ -22,60 +23,66 @@ struct probe_config_t
 
     void print() const
     {
-        trace::verbose(_X("probe_config_t: probe=[%s] match-hash=[%d] roll-forward=[%d] deps-json=[%p]"),
-            probe_dir.c_str(), match_hash, roll_forward, probe_deps_json);
+        trace::verbose(_X("probe_config_t: probe=[%s] match-hash=[%d] patch-roll-forward=[%d] prerelease-roll-forward=[%d] deps-json=[%p]"),
+            probe_dir.c_str(), match_hash, patch_roll_fwd, prerelease_roll_fwd, probe_deps_json);
+    }
+    bool is_roll_fwd_set() const
+    {
+        return patch_roll_fwd || prerelease_roll_fwd;
     }
 
     probe_config_t(
         const pal::string_t& probe_dir,
         bool match_hash,
-        bool roll_forward,
+        bool patch_roll_fwd,
+        bool prerelease_roll_fwd,
         const deps_json_t* probe_deps_json,
         bool only_serviceable_assets,
         bool only_runtime_assets)
         : probe_dir(probe_dir)
         , match_hash(match_hash)
-        , roll_forward(roll_forward)
+        , patch_roll_fwd(patch_roll_fwd)
+        , prerelease_roll_fwd(prerelease_roll_fwd)
         , probe_deps_json(probe_deps_json)
         , only_serviceable_assets(only_serviceable_assets)
         , only_runtime_assets(only_runtime_assets)
     {
         // Cannot roll forward and also match hash.
-        assert(!roll_forward || !match_hash);
+        assert(!is_roll_fwd_set() || !match_hash);
         // Will not roll forward within a deps json.
-        assert(!roll_forward || probe_deps_json == nullptr);
+        assert(!is_roll_fwd_set() || probe_deps_json == nullptr);
         // Will not do hash match when probing a deps json.
         assert(!match_hash || probe_deps_json == nullptr);
     }
 
-    static probe_config_t svc_ni(const pal::string_t dir, bool roll_fwd)
+    static probe_config_t svc_ni(const pal::string_t dir, bool patch_roll_fwd, bool prerelease_roll_fwd)
     {
-        return probe_config_t(dir, false, roll_fwd, nullptr, true, true);
+        return probe_config_t(dir, false, patch_roll_fwd, prerelease_roll_fwd, nullptr, true, true);
     }
 
-    static probe_config_t svc(const pal::string_t dir, bool roll_fwd)
+    static probe_config_t svc(const pal::string_t dir, bool patch_roll_fwd, bool prerelease_roll_fwd)
     {
-        return probe_config_t(dir, false, roll_fwd, nullptr, true, false);
+        return probe_config_t(dir, false, patch_roll_fwd, prerelease_roll_fwd, nullptr, true, false);
     }
 
     static probe_config_t cache_ni(const pal::string_t dir)
     {
-        return probe_config_t(dir, true, false, nullptr, false, true);
+        return probe_config_t(dir, true, false, false, nullptr, false, true);
     }
     
     static probe_config_t cache(const pal::string_t dir)
     {
-        return probe_config_t(dir, true, false, nullptr, false, false);
+        return probe_config_t(dir, true, false, false, nullptr, false, false);
     }
 
     static probe_config_t fx(const pal::string_t dir, const deps_json_t* deps)
     {
-        return probe_config_t(dir, false, false, deps, false, false);
+        return probe_config_t(dir, false, false, false, deps, false, false);
     }
 
-    static probe_config_t additional(const pal::string_t dir, bool roll_fwd)
+    static probe_config_t additional(const pal::string_t dir, bool patch_roll_fwd, bool prerelease_roll_fwd)
     {
-        return probe_config_t(dir, false, roll_fwd, nullptr, false, false);
+        return probe_config_t(dir, false, patch_roll_fwd, prerelease_roll_fwd, nullptr, false, false);
     }
 };
 

--- a/src/corehost/cli/deps_resolver.h
+++ b/src/corehost/cli/deps_resolver.h
@@ -112,6 +112,8 @@ private:
     bool try_roll_forward(
         const deps_entry_t& entry,
         const pal::string_t& probe_dir,
+        bool patch_roll_fwd,
+        bool prerelease_roll_fwd,
         pal::string_t* candidate);
 
     // Framework deps file.
@@ -125,7 +127,8 @@ private:
     dir_assemblies_t m_local_assemblies;
     dir_assemblies_t m_fx_assemblies;
 
-    std::unordered_map<pal::string_t, pal::string_t> m_roll_forward_cache;
+    std::unordered_map<pal::string_t, pal::string_t> m_patch_roll_forward_cache;
+    std::unordered_map<pal::string_t, pal::string_t> m_prerelease_roll_forward_cache;
 
     pal::string_t m_package_cache;
 

--- a/src/corehost/cli/fxr/fx_ver.cpp
+++ b/src/corehost/cli/fxr/fx_ver.cpp
@@ -59,6 +59,20 @@ pal::string_t fx_ver_t::as_str() const
     return stream.str();
 }
 
+pal::string_t fx_ver_t::prerelease_glob() const
+{
+    pal::stringstream_t stream;
+    stream << m_major << _X(".") << m_minor << _X(".") << m_patch << _X("-*");
+    return stream.str();
+}
+
+pal::string_t fx_ver_t::patch_glob() const
+{
+    pal::stringstream_t stream;
+    stream << m_major << _X(".") << m_minor << _X(".*");
+    return stream.str();
+}
+
 /* static */
 int fx_ver_t::compare(const fx_ver_t&a, const fx_ver_t& b)
 {

--- a/src/corehost/cli/fxr/fx_ver.h
+++ b/src/corehost/cli/fxr/fx_ver.h
@@ -25,6 +25,8 @@ struct fx_ver_t
     bool is_prerelease() const { return !m_pre.empty(); }
 
     pal::string_t as_str() const;
+    pal::string_t prerelease_glob() const;
+    pal::string_t patch_glob() const;
 
     bool operator ==(const fx_ver_t& b) const;
     bool operator !=(const fx_ver_t& b) const;

--- a/src/corehost/cli/fxr/hostfxr.cpp
+++ b/src/corehost/cli/fxr/hostfxr.cpp
@@ -97,7 +97,15 @@ bool hostpolicy_exists_in_svc(pal::string_t* resolved_dir)
     append_path(&path, _STRINGIFY(HOST_POLICY_PKG_NAME));
 
     pal::string_t max_ver;
-    try_patch_roll_forward_in_dir(path, lib_ver, &max_ver, false);
+    if (lib_ver.is_prerelease())
+    {
+        try_prerelease_roll_forward_in_dir(path, lib_ver, &max_ver);
+    }
+    else
+    {
+        try_patch_roll_forward_in_dir(path, lib_ver, &max_ver);
+    }
+    
     
     append_path(&path, max_ver.c_str());
     append_path(&path, rel_dir.c_str());

--- a/src/corehost/cli/libhost.h
+++ b/src/corehost/cli/libhost.h
@@ -25,7 +25,7 @@ class corehost_init_t
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 public:
-    static const int s_version = 0x8002;
+    static const int s_version = 0x8003;
 private:
     int m_version;
     std::vector<pal::string_t> m_probe_paths;
@@ -83,6 +83,7 @@ public:
 pal::string_t get_runtime_config_from_file(const pal::string_t& file, pal::string_t* dev_config_file);
 host_mode_t detect_operating_mode(const int argc, const pal::char_t* argv[], pal::string_t* own_dir = nullptr);
 
-void try_patch_roll_forward_in_dir(const pal::string_t& cur_dir, const fx_ver_t& start_ver, pal::string_t* max_str, bool only_production);
+void try_patch_roll_forward_in_dir(const pal::string_t& cur_dir, const fx_ver_t& start_ver, pal::string_t* max_str);
+void try_prerelease_roll_forward_in_dir(const pal::string_t& cur_dir, const fx_ver_t& start_ver, pal::string_t* max_str);
 
 #endif // __LIBHOST_H__

--- a/src/corehost/cli/runtime_config.cpp
+++ b/src/corehost/cli/runtime_config.cpp
@@ -9,7 +9,8 @@
 #include <cassert>
 
 runtime_config_t::runtime_config_t(const pal::string_t& path, const pal::string_t& dev_path)
-    : m_fx_roll_fwd(true)
+    : m_patch_roll_fwd(true)
+    , m_prerelease_roll_fwd(false)
     , m_path(path)
     , m_dev_path(dev_path)
     , m_portable(false)
@@ -58,10 +59,16 @@ bool runtime_config_t::parse_opts(const json_value& opts)
         }
     }
 
-    auto roll_fwd = opts_obj.find(_X("applyPatches"));
-    if (roll_fwd != opts_obj.end())
+    auto patch_roll_fwd = opts_obj.find(_X("applyPatches"));
+    if (patch_roll_fwd != opts_obj.end())
     {
-        m_fx_roll_fwd = roll_fwd->second.as_bool();
+        m_patch_roll_fwd = patch_roll_fwd->second.as_bool();
+    }
+
+    auto prerelease_roll_fwd = opts_obj.find(_X("preReleaseRollForward"));
+    if (prerelease_roll_fwd != opts_obj.end())
+    {
+        m_prerelease_roll_fwd = prerelease_roll_fwd->second.as_bool();
     }
 
     auto framework =  opts_obj.find(_X("framework"));
@@ -90,7 +97,7 @@ bool runtime_config_t::ensure_dev_config_parsed()
     }
 
     // Set dev mode default values, if the file exists.
-    m_fx_roll_fwd = false;
+    m_patch_roll_fwd = false;
 
     pal::ifstream_t file(m_dev_path);
     if (!file.good())
@@ -120,6 +127,7 @@ bool runtime_config_t::ensure_dev_config_parsed()
         trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), m_dev_path.c_str(), jes.c_str());
         return false;
     }
+
     return true;
 }
 
@@ -181,10 +189,16 @@ const pal::string_t& runtime_config_t::get_fx_version() const
     return m_fx_ver;
 }
 
-bool runtime_config_t::get_fx_roll_fwd() const
+bool runtime_config_t::get_patch_roll_fwd() const
 {
     assert(m_valid);
-    return m_fx_roll_fwd;
+    return m_patch_roll_fwd;
+}
+
+bool runtime_config_t::get_prerelease_roll_fwd() const
+{
+    assert(m_valid);
+    return m_prerelease_roll_fwd;
 }
 
 bool runtime_config_t::get_portable() const

--- a/src/corehost/cli/runtime_config.h
+++ b/src/corehost/cli/runtime_config.h
@@ -10,6 +10,11 @@ typedef web::json::value json_value;
 
 class runtime_config_t
 {
+    // // WARNING // WARNING // WARNING // WARNING // WARNING // WARNING //
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // !! If you change this class layout increment the                  !!
+    // !!        corehost_init_t::s_version field;                       !!
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 public:
     runtime_config_t(const pal::string_t& path, const pal::string_t& dev_path);
     bool is_valid() { return m_valid; }
@@ -19,7 +24,8 @@ public:
     const pal::string_t& get_fx_version() const;
     const pal::string_t& get_fx_name() const;
     const std::list<pal::string_t>& get_probe_paths() const;
-    bool get_fx_roll_fwd() const;
+    bool get_patch_roll_fwd() const;
+    bool get_prerelease_roll_fwd() const;
     bool get_portable() const;
     bool parse_opts(const json_value& opts);
     void config_kv(std::vector<std::string>*, std::vector<std::string>*) const;
@@ -34,7 +40,8 @@ private:
     std::list<pal::string_t> m_probe_paths;
     pal::string_t m_fx_name;
     pal::string_t m_fx_ver;
-    bool m_fx_roll_fwd;
+    bool m_patch_roll_fwd;
+    bool m_prerelease_roll_fwd;
 
     pal::string_t m_dev_path;
     pal::string_t m_path;


### PR DESCRIPTION
**NOTE:** This is opt-in for packages. Default for SharedFX.

WIP for manual testing the scenarios

Pre-Release -> Pre-Release but doesn't step over to production `max(x.y.z-*)`
Production -> Patch, but doesn't step over minor. `max(V = x.y.*) V not prerelease`

@gkhanna79 PTAL.

Cc @muratg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2316)
<!-- Reviewable:end -->
