### PR TITLE
Update Roslyn to 1.3.0-beta1-20160405-05

### DIFF
--- a/pkg/projects/Microsoft.NETCore.App/project.json
+++ b/pkg/projects/Microsoft.NETCore.App/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160321-04",
-    "Microsoft.CodeAnalysis.VisualBasic": "1.3.0-beta1-20160321-04",
+    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160405-05",
+    "Microsoft.CodeAnalysis.VisualBasic": "1.3.0-beta1-20160405-05",
     "Microsoft.CSharp": "4.0.1-rc2-23931",
     "Microsoft.VisualBasic": "10.0.1-rc2-23931",
     "NETStandard.Library": "1.5.0-rc2-23931",

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "NETStandard.Library": "1.5.0-rc2-23931",
     "System.CommandLine": "0.1.0-e160323-1",
-    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160329-01",
+    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160405-05",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.DotNet.Files": "1.0.0-*"

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -7,7 +7,7 @@
     "NETStandard.Library": "1.5.0-rc2-23931",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
-    "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.0-beta1-20160329-01"
+    "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.0-beta1-20160405-05"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/src/compilers/project.json
+++ b/src/compilers/project.json
@@ -8,8 +8,8 @@
       "type": "platform",
       "version": "1.0.0-rc2-23931"
     },
-    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160329-01",
-    "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160329-01",
+    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160405-05",
+    "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160405-05",
     "Microsoft.DiaSymReader.Native": "1.3.3"
   },
   "frameworks": {


### PR DESCRIPTION
@weshaggard @piotrpMSFT 

Tomas says there may be a few more changes.  But I wanted to get this version in now to make sure tests pass with the newest Roslyn.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2320)
<!-- Reviewable:end -->
