### PR TITLE
Move telemetry dependency out of Utils and into dotnet

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -5,7 +5,6 @@
     "warningsAsErrors": true
   },
   "dependencies": {
-    "Microsoft.ApplicationInsights": "2.0.0-rc1",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20100",
     "NuGet.Versioning": "3.5.0-beta-1130",

--- a/src/dotnet/ITelemetry.cs
+++ b/src/dotnet/ITelemetry.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.DotNet.Cli.Utils
+namespace Microsoft.DotNet.Cli
 {
     public interface ITelemetry
     {

--- a/src/dotnet/Telemetry.cs
+++ b/src/dotnet/Telemetry.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.ApplicationInsights;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.Extensions.PlatformAbstractions;
 using System.Diagnostics;
 
-namespace Microsoft.DotNet.Cli.Utils
+namespace Microsoft.DotNet.Cli
 {
     public class Telemetry : ITelemetry
     {

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -25,6 +25,7 @@
     "System.Text.Encoding.CodePages": "4.0.1-rc2-23931",
     "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23931",
     "System.CommandLine": "0.1.0-e160323-1",
+    "Microsoft.ApplicationInsights": "2.0.0",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",


### PR DESCRIPTION
Nothing fancy, just moving all the telemetry code into dotnet so that other packages which use Utils and do not need AppInsights do not have a dependency on AppInsights.

Fixes https://github.com/dotnet/cli/issues/2314

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2328)
<!-- Reviewable:end -->
