### PR TITLE
Fix bug in dependency context adding assets to wrong groups

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextJsonReader.cs
@@ -195,7 +195,8 @@ namespace Microsoft.Extensions.DependencyModel
                 var nativeLibraryGroups = new List<RuntimeAssetGroup>();
                 foreach (var ridGroup in entries.GroupBy(e => e.Rid))
                 {
-                    var groupRuntimeAssemblies = entries.Where(e => e.Type == DependencyContextStrings.RuntimeAssetType)
+                    var groupRuntimeAssemblies = ridGroup
+                        .Where(e => e.Type == DependencyContextStrings.RuntimeAssetType)
                         .Select(e => e.Path)
                         .ToArray();
 
@@ -206,7 +207,8 @@ namespace Microsoft.Extensions.DependencyModel
                             groupRuntimeAssemblies.Where(a => Path.GetFileName(a) != "_._")));
                     }
 
-                    var groupNativeLibraries = entries.Where(e => e.Type == DependencyContextStrings.NativeAssetType)
+                    var groupNativeLibraries = ridGroup
+                        .Where(e => e.Type == DependencyContextStrings.NativeAssetType)
                         .Select(e => e.Path)
                         .ToArray();
 

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
@@ -38,6 +38,41 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void GroupsRuntimeAssets()
+        {
+            var context = Read(@"
+ {
+     ""targets"": {
+         "".NETStandard,Version=v1.5"": {
+             ""System.Banana/1.0.0"": {
+                 ""runtimeTargets"": {
+                     ""runtimes/unix/Banana.dll"": { ""rid"": ""unix"", ""assetType"": ""runtime"" },
+                     ""runtimes/win7/Banana.dll"": { ""rid"": ""win7"",  ""assetType"": ""runtime"" },
+
+                     ""runtimes/native/win7/Apple.dll"": { ""rid"": ""win7"",  ""assetType"": ""native"" },
+                     ""runtimes/native/unix/libapple.so"": { ""rid"": ""unix"",  ""assetType"": ""native"" }
+                 }
+             }
+         }
+     },
+     ""libraries"": {
+         ""System.Banana/1.0.0"": {
+             ""type"": ""package"",
+             ""serviceable"": false,
+             ""sha512"": ""HASH-System.Banana""
+         },
+     }
+ }");
+            context.RuntimeLibraries.Should().HaveCount(1);
+            var runtimeLib = context.RuntimeLibraries.Single();
+            runtimeLib.RuntimeAssemblyGroups.Should().HaveCount(2);
+            runtimeLib.RuntimeAssemblyGroups.All(g => g.AssetPaths.Count == 1).Should().BeTrue();
+
+            runtimeLib.NativeLibraryGroups.Should().HaveCount(2);
+            runtimeLib.NativeLibraryGroups.All(g => g.AssetPaths.Count == 1).Should().BeTrue();
+        }
+
+        [Fact]
         public void SetsPortableIfRuntimeTargetHasNoRid()
         {
             var context = Read(


### PR DESCRIPTION
Fix #2327.

Without this fix, these groups can contain asset paths to native/runtime libraries with the wrong RID.

cc @pakrym

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2329)
<!-- Reviewable:end -->
