### PR TITLE
Bring has runtime output check back

### DIFF
--- a/src/dotnet/commands/dotnet-build/CompileContext.cs
+++ b/src/dotnet/commands/dotnet-build/CompileContext.cs
@@ -489,7 +489,10 @@ namespace Microsoft.DotNet.Tools.Build
 
         private void MakeRunnable()
         {
-            var runtimeContext = _rootProject.CreateRuntimeContext(_args.GetRuntimes());
+            var runtimeContext = _rootProject.ProjectFile.HasRuntimeOutput(_args.ConfigValue) ?
+                _rootProject.CreateRuntimeContext(_args.GetRuntimes()) :
+                _rootProject;
+
             var outputPaths = runtimeContext.GetOutputPaths(_args.ConfigValue, _args.BuildBasePathValue, _args.OutputValue);
             var libraryExporter = runtimeContext.CreateExporter(_args.ConfigValue, _args.BuildBasePathValue);
 


### PR DESCRIPTION
`MakeRunnable` tries to create runtime project context even for class library projects which fails for net451 class libraries restored without rids and is totally unnecessary

@anurse @davidfowl

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2337)
<!-- Reviewable:end -->