### PR TITLE
Increasing timeout to check Kestrel Server is up.

### DIFF
--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/NetworkUtils/NetworkHelper.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/NetworkUtils/NetworkHelper.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
     public class NetworkHelper
     {
         // in milliseconds
-        private const int Timeout = 20000;
+        private const int Timeout = 50000;
 
         public static string Localhost { get; } = "http://localhost";
 


### PR DESCRIPTION
KestrelSample app compilation time on CI machines is 16-20s and the test timeouts even before the kestrel server is up, which I suspect is the reason why kestrel tests are flaky.

cc @piotrpMSFT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2378)
<!-- Reviewable:end -->
