### PR TITLE
Do not generate and pack runtime config for libraries

### DIFF
--- a/src/Microsoft.DotNet.Compiler.Common/Executable.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/Executable.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Dotnet.Cli.Compiler.Common
 
         private readonly LibraryExporter _exporter;
 
+        private readonly string _configuration;
+
         private readonly OutputPaths _outputPaths;
 
         private readonly string _runtimeOutputPath;
@@ -40,6 +42,7 @@ namespace Microsoft.Dotnet.Cli.Compiler.Common
             _runtimeOutputPath = outputPaths.RuntimeOutputPath;
             _intermediateOutputPath = outputPaths.IntermediateOutputDirectoryPath;
             _exporter = exporter;
+            _configuration = configuration;
             _compilerOptions = _context.ProjectFile.GetCompilerOptions(_context.TargetFramework, configuration);
         }
 
@@ -109,8 +112,11 @@ namespace Microsoft.Dotnet.Cli.Compiler.Common
         private void WriteDepsFileAndCopyProjectDependencies(LibraryExporter exporter)
         {
             WriteDeps(exporter);
-            WriteRuntimeConfig(exporter);
-            WriteDevRuntimeConfig(exporter);
+            if (_context.ProjectFile.HasRuntimeOutput(_configuration))
+            {
+                WriteRuntimeConfig(exporter);
+                WriteDevRuntimeConfig(exporter);
+            }
 
             var projectExports = exporter.GetDependencies(LibraryType.Project);
             CopyAssemblies(projectExports);

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/DirectoryInfoAssertions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/DirectoryInfoAssertions.cs
@@ -56,6 +56,16 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return new AndConstraint<DirectoryInfoAssertions>(this);
         }
 
+        public AndConstraint<DirectoryInfoAssertions> NotHaveFiles(IEnumerable<string> expectedFiles)
+        {
+            foreach (var expectedFile in expectedFiles)
+            {
+                NotHaveFile(expectedFile);
+            }
+
+            return new AndConstraint<DirectoryInfoAssertions>(this);
+        }
+
         public AndConstraint<DirectoryInfoAssertions> HaveDirectory(string expectedDir)
         {
             var dir = _dirInfo.EnumerateDirectories(expectedDir, SearchOption.TopDirectoryOnly).SingleOrDefault();

--- a/test/dotnet-build.Tests/BuildOutputTests.cs
+++ b/test/dotnet-build.Tests/BuildOutputTests.cs
@@ -27,19 +27,35 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             "TestApp" + FileNameSuffixes.DotNet.ProgramDatabase,
             "TestApp" + FileNameSuffixes.CurrentPlatform.Exe,
             "TestApp" + FileNameSuffixes.DepsJson,
+            "TestApp" + FileNameSuffixes.RuntimeConfigJson,
             "TestLibrary" + FileNameSuffixes.DotNet.DynamicLib,
             "TestLibrary" + FileNameSuffixes.DotNet.ProgramDatabase
         };
+
+        private readonly string[] _runtimeExcludeFiles =
+        {
+            "TestLibrary" + FileNameSuffixes.RuntimeConfigJson,
+            "TestLibrary" + FileNameSuffixes.RuntimeConfigDevJson
+        };
+
         private readonly string[] _appCompileFiles =
         {
             "TestApp" + FileNameSuffixes.DotNet.DynamicLib,
             "TestApp" + FileNameSuffixes.DotNet.ProgramDatabase
         };
+
         private readonly string[] _libCompileFiles =
         {
             "TestLibrary" + FileNameSuffixes.DotNet.DynamicLib,
             "TestLibrary" + FileNameSuffixes.DotNet.ProgramDatabase
         };
+
+        private readonly string[] _libCompileExcludeFiles =
+        {
+            "TestLibrary" + FileNameSuffixes.RuntimeConfigJson,
+            "TestLibrary" + FileNameSuffixes.RuntimeConfigDevJson
+        };
+
 
         private void GetProjectInfo(string testRoot)
         {
@@ -71,7 +87,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
         //[InlineData(false, "out", null, "TestLibrary/bin/debug/{fw}", "TestApp/bin/debug/{fw}", "out")]
         //[InlineData(false, null, "build", "build/TestLibrary/bin/debug/{fw}", "build/TestApp/bin/debug/{fw}", "build/TestApp/bin/debug/{fw}/{rid}")]
         //[InlineData(false, "out", "build", "build/TestLibrary/bin/debug/{fw}", "build/TestApp/bin/debug/{fw}", "out")]
-        public void DefaultPaths(string testIdentifer, bool global, string outputValue, string baseValue, string expectedLibCompile, string expectedAppCompile, string expectedAppRuntime)
+        public void AppDefaultPaths(string testIdentifer, bool global, string outputValue, string baseValue, string expectedLibCompile, string expectedAppCompile, string expectedAppRuntime)
         {
             var testInstance = TestAssetsManager.CreateTestInstance("TestAppWithLibrary", identifier: testIdentifer)
                                                 .WithLockFiles();
@@ -79,7 +95,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
             new BuildCommand(GetProjectPath(_testAppDirDirInfo),
                 output: outputValue != null ? Path.Combine(_testProjectsRoot, outputValue) : string.Empty,
-                buidBasePath: baseValue != null ? Path.Combine(_testProjectsRoot, baseValue) : string.Empty,
+                buildBasePath: baseValue != null ? Path.Combine(_testProjectsRoot, baseValue) : string.Empty,
                 framework: DefaultFramework)
                 .ExecuteWithCapturedOutput().Should().Pass();
 
@@ -87,9 +103,37 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             var appdebug = _rootDirInfo.Sub(FormatPath(expectedAppCompile, DefaultFramework, _runtime));
             var appruntime = _rootDirInfo.Sub(FormatPath(expectedAppRuntime, DefaultFramework, _runtime));
 
-            libdebug.Should().Exist().And.HaveFiles(_libCompileFiles);
+            libdebug.Should().Exist()
+                .And.HaveFiles(_libCompileFiles)
+                .And.NotHaveFiles(_libCompileExcludeFiles);
             appdebug.Should().Exist().And.HaveFiles(_appCompileFiles);
-            appruntime.Should().Exist().And.HaveFiles(_runtimeFiles);
+            appruntime.Should().Exist()
+                .And.HaveFiles(_runtimeFiles)
+                .And.NotHaveFiles(_runtimeExcludeFiles);
+        }
+
+        [Theory]
+        [InlineData("1", true, null, null, "TestLibrary/bin/Debug/{fw}", "TestLibrary/bin/Debug/{fw}/{rid}")]
+        [InlineData("2", true, "out", null, "TestLibrary/bin/Debug/{fw}", "out")]
+        [InlineData("3", true, null, "build", "build/TestLibrary/bin/Debug/{fw}", "build/TestLibrary/bin/Debug/{fw}/{rid}")]
+        [InlineData("4", true, "out", "build", "build/TestLibrary/bin/Debug/{fw}", "out")]
+        public void LibDefaultPaths(string testIdentifer, bool global, string outputValue, string baseValue, string expectedLibCompile, string expectedLibOutput)
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("TestAppWithLibrary", identifier: testIdentifer)
+                                                .WithLockFiles();
+            GetProjectInfo(testInstance.TestRoot);
+
+            new BuildCommand(GetProjectPath(_testLibDirInfo),
+                output: outputValue != null ? Path.Combine(_testProjectsRoot, outputValue) : string.Empty,
+                buildBasePath: baseValue != null ? Path.Combine(_testProjectsRoot, baseValue) : string.Empty,
+                framework: DefaultFramework)
+                .ExecuteWithCapturedOutput().Should().Pass();
+
+            var libdebug = _rootDirInfo.Sub(FormatPath(expectedLibCompile, DefaultFramework, _runtime));
+
+            libdebug.Should().Exist()
+                .And.HaveFiles(_libCompileFiles)
+                .And.NotHaveFiles(_libCompileExcludeFiles);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/cli/issues/2396

/cc @davidfowl

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2401)
<!-- Reviewable:end -->
