### PR TITLE
Clean Microsoft.NETCore.* nuget packages from the cache during the build.

### DIFF
--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -67,9 +67,9 @@ namespace Microsoft.DotNet.Cli.Build
             return c.Success();
         }
 
-        // Moving PrepareTargets.RestorePackages after PackagePkgProjects because managed code depends on the
-        // Microsoft.NETCore.App package that is created during PackagePkgProjects.
-        [Target(nameof(PrepareTargets.Init), nameof(CompileCoreHost), nameof(PackagePkgProjects), nameof(RestoreLockedCoreHost), nameof(PrepareTargets.RestorePackages), nameof(CompileStage1), nameof(CompileStage2))]
+        // Moving PrepareTargets.RestorePackages after BuildCoreHost because managed code depends on the
+        // Microsoft.NETCore.App package that is created during BuildCoreHost.
+        [Target(nameof(PrepareTargets.Init), nameof(BuildCoreHost), nameof(PrepareTargets.RestorePackages), nameof(CompileStage1), nameof(CompileStage2))]
         public static BuildTargetResult Compile(BuildTargetContext c)
         {
             return c.Success();
@@ -145,6 +145,11 @@ namespace Microsoft.DotNet.Cli.Build
 
             return c.Success();
         }
+
+        [Target(
+            nameof(CompileCoreHost),
+            nameof(BuildCoreHostPackages))]
+        public static BuildTargetResult BuildCoreHost(BuildTargetContext c) => c.Success();
 
         [Target(nameof(PrepareTargets.Init))]
         public static BuildTargetResult CompileCoreHost(BuildTargetContext c)
@@ -229,8 +234,15 @@ namespace Microsoft.DotNet.Cli.Build
             return c.Success();
         }
 
-        [Target(nameof(CompileTargets.GenerateStubHostPackages))]
-        public static BuildTargetResult PackagePkgProjects(BuildTargetContext c)
+        [Target(
+            nameof(GenerateStubHostPackages),
+            nameof(PackageHostPackages),
+            nameof(CleanHostPackagesFromCache),
+            nameof(RestoreLockedCoreHost))]
+        public static BuildTargetResult BuildCoreHostPackages(BuildTargetContext c) => c.Success();
+
+        [Target]
+        public static BuildTargetResult PackageHostPackages(BuildTargetContext c)
         {
             var arch = IsWinx86 ? "x86" : "x64";
             
@@ -289,6 +301,18 @@ namespace Microsoft.DotNet.Cli.Build
                     throw new BuildFailureException($"Nupkg for {fileFilter} was not created.");
                 }
             }
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult CleanHostPackagesFromCache(BuildTargetContext c)
+        {
+            IEnumerable<string> packagesToClean = NuGetUtils.GetPackageIds(
+                Dirs.CorehostLocalPackages, 
+                Dirs.CorehostDummyPackages);
+
+            NuGetUtils.CleanPackagesFromCache(packagesToClean);
+
             return c.Success();
         }
 

--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -217,7 +217,6 @@ namespace Microsoft.DotNet.Cli.Build
             var versionSuffix = c.BuildContext.Get<BuildVersion>("BuildVersion").CommitCountString;
             var configuration = c.BuildContext.Get<string>("Configuration");
 
-            var env = GetCommonEnvVars(c);
             var dotnet = DotNetCli.Stage2;
 
             var packagingBuildBasePath = Path.Combine(Dirs.Stage2Compilation, "forPackaging");
@@ -252,43 +251,6 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             return c.Success();
-        }
-
-        internal static Dictionary<string, string> GetCommonEnvVars(BuildTargetContext c)
-        {
-            // Set up the environment variables previously defined by common.sh/ps1
-            // This is overkill, but I want to cover all the variables used in all OSes (including where some have the same names)
-            var buildVersion = c.BuildContext.Get<BuildVersion>("BuildVersion");
-            var configuration = c.BuildContext.Get<string>("Configuration");
-            var architecture = RuntimeEnvironment.RuntimeArchitecture;
-            var env = new Dictionary<string, string>()
-            {
-                { "RID", RuntimeEnvironment.GetRuntimeIdentifier() },
-                { "OSNAME", RuntimeEnvironment.OperatingSystem },
-                { "TFM", "dnxcore50" },
-                { "REPOROOT", Dirs.RepoRoot },
-                { "OutputDir", Dirs.Output },
-                { "Stage1Dir", Dirs.Stage1 },
-                { "Stage1CompilationDir", Dirs.Stage1Compilation },
-                { "Stage2Dir", Dirs.Stage2 },
-                { "STAGE2_DIR", Dirs.Stage2 },
-                { "Stage2CompilationDir", Dirs.Stage2Compilation },
-                { "PackageDir", Path.Combine(Dirs.Packages) }, // Legacy name
-                { "TestBinRoot", Dirs.TestOutput },
-                { "TestPackageDir", Dirs.TestPackages },
-                { "MajorVersion", buildVersion.Major.ToString() },
-                { "MinorVersion", buildVersion.Minor.ToString() },
-                { "PatchVersion", buildVersion.Patch.ToString() },
-                { "CommitCountVersion", buildVersion.CommitCountString },
-                { "COMMIT_COUNT_VERSION", buildVersion.CommitCountString },
-                { "DOTNET_CLI_VERSION", buildVersion.SimpleVersion },
-                { "DOTNET_MSI_VERSION", buildVersion.GenerateMsiVersion() },
-                { "VersionSuffix", buildVersion.VersionSuffix },
-                { "CONFIGURATION", configuration },
-                { "ARCHITECTURE", architecture }
-            };
-
-            return env;
         }
 
         private static void CreateZipFromDirectory(string directory, string artifactPath)

--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -145,8 +145,14 @@ namespace Microsoft.DotNet.Cli.Build
             return c.Success();
         }
 
-        [Target(nameof(CleanTestPackages), nameof(CleanProductPackages))]
-        public static BuildTargetResult BuildTestAssetPackages(BuildTargetContext c)
+        [Target(
+            nameof(CleanProductPackagesFromCache),
+            nameof(PackageTestPackages),
+            nameof(CleanTestPackagesFromCache))]
+        public static BuildTargetResult BuildTestAssetPackages(BuildTargetContext c) => c.Success();
+
+        [Target]
+        public static BuildTargetResult PackageTestPackages(BuildTargetContext c)
         {
             CleanBinObj(c, Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "TestPackages"));
 
@@ -213,7 +219,7 @@ namespace Microsoft.DotNet.Cli.Build
         }
 
         [Target]
-        public static BuildTargetResult CleanProductPackages(BuildTargetContext c)
+        public static BuildTargetResult CleanProductPackagesFromCache(BuildTargetContext c)
         {
             foreach (var packageName in PackageTargets.ProjectsToPack)
             {
@@ -224,16 +230,12 @@ namespace Microsoft.DotNet.Cli.Build
         }
 
         [Target]
-        public static BuildTargetResult CleanTestPackages(BuildTargetContext c)
+        public static BuildTargetResult CleanTestPackagesFromCache(BuildTargetContext c)
         {
-            foreach (var packageProject in TestPackageProjects.Projects.Where(p => p.IsApplicable && p.Clean))
-            {
-                Rmdir(Path.Combine(Dirs.NuGetPackages, packageProject.Name));
-                if (packageProject.IsTool)
-                {
-                    Rmdir(Path.Combine(Dirs.NuGetPackages, ".tools", packageProject.Name));
-                }
-            }
+            NuGetUtils.CleanPackagesFromCache(
+                NuGetUtils.GetPackageIds(Dirs.TestPackages),
+                cleanTools: true);
+
             return c.Success();
         }
 

--- a/scripts/dotnet-cli-build/Utils/NuGetUtils.cs
+++ b/scripts/dotnet-cli-build/Utils/NuGetUtils.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using static Microsoft.DotNet.Cli.Build.FS;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    internal static class NuGetUtils
+    {
+        public static void CleanPackagesFromCache(IEnumerable<string> packageIds, bool cleanTools = false)
+        {
+            foreach (string package in packageIds)
+            {
+                Rmdir(Path.Combine(Dirs.NuGetPackages, package));
+
+                if (cleanTools)
+                {
+                    Rmdir(Path.Combine(Dirs.NuGetPackages, ".tools", package));
+                }
+            }
+        }
+
+        public static IEnumerable<string> GetPackageIds(params string[] sourceDirectories)
+        {
+            Regex nugetFileRegex = new Regex("^(.*?)\\.(([0-9]+\\.)?[0-9]+\\.[0-9]+(-([A-z0-9-]+))?)\\.nupkg$");
+
+            IEnumerable<string> nugetFiles = sourceDirectories
+                .SelectMany(d => Directory.GetFiles(d, "*.nupkg"));
+
+            // There may be multiple versions of each package in the source folders, but we
+            // only need to return distinct ids.
+            HashSet<string> packages = new HashSet<string>();
+
+            foreach (string filePath in nugetFiles)
+            {
+                Match match = nugetFileRegex.Match(Path.GetFileName(filePath));
+                if (match.Success)
+                {
+                    string packageId = match.Groups[1].Value;
+                    packages.Add(packageId);
+                }
+            }
+
+            return packages;
+        }
+    }
+}

--- a/scripts/dotnet-cli-build/Utils/Utils.cs
+++ b/scripts/dotnet-cli-build/Utils/Utils.cs
@@ -106,7 +106,7 @@ namespace Microsoft.DotNet.Cli.Build
                         Directory.Delete(path, true);
                         return;
                     }
-                    catch (IOException ex)
+                    catch (IOException)
                     {
                         if (retry == 0)
                         {


### PR DESCRIPTION
This ensures the rest of the product will only use the packages it currently built, since it uses * versions.

@brthor @weshaggard @piotrpMSFT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2410)
<!-- Reviewable:end -->
