### PR TITLE
Fix test project imports to be consistent.

### DIFF
--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -24,9 +24,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/ArgumentsReflector/project.json
+++ b/test/ArgumentsReflector/project.json
@@ -10,12 +10,7 @@
     },
   },
   "frameworks": {
-    "netcoreapp1.0": {
-      "imports": [
-        "netstandardapp1.5",
-        "dnxcore50"
-      ]
-    }
+    "netcoreapp1.0": { }
   },
   "content": [
     "reflector_cmd.cmd"

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -25,9 +25,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/Kestrel.Tests/project.json
+++ b/test/Kestrel.Tests/project.json
@@ -18,9 +18,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -31,8 +31,8 @@
     "netcoreapp1.0": {
       "imports": [
         "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -21,9 +21,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -21,9 +21,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -26,9 +26,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   }

--- a/test/Microsoft.Extensions.DependencyModel.Tests/project.json
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/project.json
@@ -24,9 +24,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -20,9 +20,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
@@ -25,10 +25,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "netstandard1.3",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
@@ -21,10 +21,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "netstandard1.3",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/TestingAbstractions/TestAppWithFullPdbs/project.json
+++ b/test/TestingAbstractions/TestAppWithFullPdbs/project.json
@@ -7,11 +7,6 @@
     "NETStandard.Library": "1.5.0-rc2-24018"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": [
-        "portable-net45+win8",
-        "dnxcore50"
-      ]
-    }
+    "netstandard1.5": { }
   }
 }

--- a/test/TestingAbstractions/TestAppWithPortablePdbs/project.json
+++ b/test/TestingAbstractions/TestAppWithPortablePdbs/project.json
@@ -7,11 +7,6 @@
     "NETStandard.Library": "1.5.0-rc2-24018"
   },
   "frameworks": {
-    "netstandard1.5": {
-      "imports": [
-        "portable-net45+win8",
-        "dnxcore50"
-      ]
-    }
+    "netstandard1.5": { }
   }
 }

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -19,8 +19,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net451+win8"
       ]
     }

--- a/test/dotnet-compile-fsc.Tests/project.json
+++ b/test/dotnet-compile-fsc.Tests/project.json
@@ -17,8 +17,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net451+win8"
       ]
     }

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -18,8 +18,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net451+win8"
       ]
     }

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -33,7 +33,7 @@
     "netcoreapp1.0": {
       "imports": [
         "netstandardapp1.5",
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net451+win8"
       ]
     }

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -19,8 +19,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
+        "dotnet5.4",
         "portable-net451+win8"
       ]
     }

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -25,8 +25,8 @@
     "netcoreapp1.0": {
       "imports": [
         "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -18,9 +18,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -19,9 +19,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -18,9 +18,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -24,9 +24,8 @@
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
-        "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -22,8 +22,8 @@
     "netcoreapp1.0": {
       "imports": [
         "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -23,8 +23,8 @@
     "netcoreapp1.0": {
       "imports": [
         "netstandardapp1.5",
-        "dnxcore50",
-        "portable-net45+win8"
+        "dotnet5.4",
+        "portable-net451+win8"
       ]
     }
   },


### PR DESCRIPTION
- Every test project.json needs portable-net451+win8 and dotnet5.4 imports (required by dotnet-test-xunit).
- If a test references NuGet, it also needs "netstandardapp1.5", because that the TFM NuGet uses currently.

@brthor @Sridhar-MS @piotrpMSFT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2415)
<!-- Reviewable:end -->
