### PR TITLE
Fix incorrect link to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Compiling to IL is done using:
 
 This will drop a binary in `./bin/[configuration]/[framework]/[rid]/[binary name]` that you can just run.
 
-For more details, please refer to the [documentation](https://github.com/dotnet/corert/tree/master/Documentation).
+For more details, please refer to the [documentation](Documentation).
 
 Building from source
 --------------------


### PR DESCRIPTION
I noticed that the link to documentation in README.md was pointing to the CoreRT repo's documentation. Changed it to point to dotnet/cli documentation and also made it a relative link so that it shows the documentation in whatever branch you're on.

cc: @schellap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2447)
<!-- Reviewable:end -->