### PR TITLE
Add back in copying of RuntimeAssets during publish.

### DIFF
--- a/test/dotnet-publish.Tests/PublishAppWithDependencies.cs
+++ b/test/dotnet-publish.Tests/PublishAppWithDependencies.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Publish.Tests
+{
+    public class PublishAppWithDependencies : TestBase
+    {
+        [Fact]
+        public void PublishTestAppWithContentPackage()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("TestAppWithContentPackage")
+                .WithLockFiles();
+
+            var publishDir = Publish(testInstance);
+
+            publishDir.Should().HaveFiles(new[]
+            {
+                "TestAppWithContentPackage.exe",
+                "TestAppWithContentPackage.dll",
+                "TestAppWithContentPackage.deps.json"
+            });
+
+            // these files come from the contentFiles of the SharedContentA dependency
+            publishDir
+                .Sub("scripts")
+                .Should()
+                .Exist()
+                .And
+                .HaveFile("run.cmd");
+
+            publishDir
+                .Should()
+                .HaveFile("config.xml");
+        }
+
+        private DirectoryInfo Publish(TestInstance testInstance)
+        {
+            var publishCommand = new PublishCommand(testInstance.TestRoot);
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            return publishCommand.GetOutputDirectory(portable: false);
+        }
+    }
+}

--- a/test/dotnet-publish.Tests/PublishAppWithDependencies.cs
+++ b/test/dotnet-publish.Tests/PublishAppWithDependencies.cs
@@ -16,13 +16,18 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             var testInstance = TestAssetsManager.CreateTestInstance("TestAppWithContentPackage")
                 .WithLockFiles();
 
-            var publishDir = Publish(testInstance);
+            var publishCommand = new PublishCommand(testInstance.TestRoot);
+            var publishResult = publishCommand.Execute();
+
+            publishResult.Should().Pass();
+
+            var publishDir = publishCommand.GetOutputDirectory(portable: false);
 
             publishDir.Should().HaveFiles(new[]
             {
-                "TestAppWithContentPackage.exe",
-                "TestAppWithContentPackage.dll",
-                "TestAppWithContentPackage.deps.json"
+                $"AppWithContentPackage{publishCommand.GetExecutableExtension()}",
+                "AppWithContentPackage.dll",
+                "AppWithContentPackage.deps.json"
             });
 
             // these files come from the contentFiles of the SharedContentA dependency
@@ -36,16 +41,6 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             publishDir
                 .Should()
                 .HaveFile("config.xml");
-        }
-
-        private DirectoryInfo Publish(TestInstance testInstance)
-        {
-            var publishCommand = new PublishCommand(testInstance.TestRoot);
-            var publishResult = publishCommand.Execute();
-
-            publishResult.Should().Pass();
-
-            return publishCommand.GetOutputDirectory(portable: false);
         }
     }
 }


### PR DESCRIPTION
Any NuGet packages that had contentFiles weren't getting the content files added to the published output directory.  This breaks things like debugging in VS Code.

Fix #2459

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2473)
<!-- Reviewable:end -->