### PR TITLE
Account for packages not built with serviceable attribute

### DIFF
--- a/src/corehost/cli/args.h
+++ b/src/corehost/cli/args.h
@@ -57,12 +57,18 @@ struct probe_config_t
 
     static probe_config_t svc_ni(const pal::string_t& dir, bool patch_roll_fwd, bool prerelease_roll_fwd)
     {
-        return probe_config_t(dir, false, patch_roll_fwd, prerelease_roll_fwd, nullptr, true, true);
+        bool runtime_assets_only = true;  // Since this is ngen based package location, assets should be managed.
+        bool serviceable_only = false;    // Ignore deps specified "serviceable" flag since all packages
+                                          // are not expected to be authored with this attribute.
+        return probe_config_t(dir, false, patch_roll_fwd, prerelease_roll_fwd, nullptr, serviceable_only, runtime_assets_only);
     }
 
     static probe_config_t svc(const pal::string_t& dir, bool patch_roll_fwd, bool prerelease_roll_fwd)
     {
-        return probe_config_t(dir, false, patch_roll_fwd, prerelease_roll_fwd, nullptr, true, false);
+        bool runtime_assets_only = false; // Include both native and managed assemblies.
+        bool serviceable_only = false;    // Ignore deps specified "serviceable" flag since all packages
+                                          // are not expected to be authored with this attribute.
+        return probe_config_t(dir, false, patch_roll_fwd, prerelease_roll_fwd, nullptr, serviceable_only, runtime_assets_only);
     }
 
     static probe_config_t cache_ni(const pal::string_t& dir)

--- a/src/corehost/cli/deps_resolver.cpp
+++ b/src/corehost/cli/deps_resolver.cpp
@@ -427,7 +427,7 @@ void deps_resolver_t::resolve_tpa_list(
         else
         {
             // FIXME: Consider this error as a fail fast?
-            trace::verbose(_X("Error: Could not resolve path to assembly: [%s, %s, %s]"), entry.library_name.c_str(), entry.library_version.c_str(), entry.relative_path.c_str());
+            trace::verbose(_X("Warning: Could not resolve path to assembly: [%s, %s, %s]"), entry.library_name.c_str(), entry.library_version.c_str(), entry.relative_path.c_str());
         }
     };
     


### PR DESCRIPTION
@gkhanna79 @ericstj, CoreCLR packages are not authored with the "serviceable" attribute, the host optimizes a probe for anything that is not marked serviceable from the servicing location.

I realize that it might be too much to expect package authors to put this flag, so I made the host ignore this flag and not perform a probe optimization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2491)
<!-- Reviewable:end -->