### PR TITLE
fix build numbers in ResourcesTests

### DIFF
--- a/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
+++ b/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
@@ -7,7 +7,7 @@
     "Microsoft.Data.OData": "5.6.4",
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-24008"
+      "version": "1.0.0-rc2-*"
     },
     "TestLibraryWithResources": { "target": "project" }
   },


### PR DESCRIPTION
Going to merge as soon as I get a green light, this should've been part of the (already Ask-approved) resources bug

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2539)
<!-- Reviewable:end -->
