### PR TITLE
Updating package publish for Debian

### DIFF
--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -386,6 +386,7 @@ namespace Microsoft.DotNet.Cli.Build
                 {"osx.10.10-x64", false },
                 {"rhel.7-x64", false },
                 {"ubuntu.14.04-x64", false },
+                {"debian.8-x64", false },
             };
 
             var buildFiles = AzurePublisherTool.ListBlobs(hostBlob + buildVersion);


### PR DESCRIPTION
With https://github.com/dotnet/cli/pull/2472, CLI is now building on Debian.  I updated the publish logic to verify the Debian runtime packages exist.

@weshaggard, @eerhardt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2553)
<!-- Reviewable:end -->