### PR TITLE
fix framework assembly resolution for net35

### DIFF
--- a/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/Program.cs
+++ b/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Xml;
 
 namespace ConsoleApplication
 {
@@ -7,6 +8,10 @@ namespace ConsoleApplication
         public static void Main()
         {
             Console.WriteLine("Hello World!");
+#if NET20 || NET35 || NET45 || NET461
+            // Force XmlDocument to be used
+            var doc = new XmlDocument();
+#endif
         }
     }
 }

--- a/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
@@ -5,11 +5,28 @@
   },
   "dependencies": {},
   "frameworks": {
-    "net20": {},
-    "net35": {},
-    "net40": {},
-    "net461": {},
+    "net20": {
+        "frameworkAssemblies": {
+            "System.Xml": {}
+        }
+    },
+    "net35": {
+        "frameworkAssemblies": {
+            "System.Xml": {}
+        }
+    },
+    "net40": {
+        "frameworkAssemblies": {
+            "System.Xml": {}
+        }
+    },
+    "net461": {
+        "frameworkAssemblies": {
+            "System.Xml": {}
+        }
+    },
     "netstandard1.5": {
+      "imports": "dnxcore50",
       "dependencies": {
         "NETStandard.Library": "1.5.0-rc2-24018"
       }

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/FrameworkReferenceResolver.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/FrameworkReferenceResolver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
         private static readonly NuGetFramework Dnx46 = new NuGetFramework(
             FrameworkConstants.FrameworkIdentifiers.Dnx,
             new Version(4, 6));
-            
+
         private static FrameworkReferenceResolver _default;
 
         private readonly IDictionary<NuGetFramework, FrameworkInformation> _cache = new Dictionary<NuGetFramework, FrameworkInformation>();
@@ -30,14 +30,14 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
             { FrameworkConstants.CommonFrameworks.Dnx451, new [] { FrameworkConstants.CommonFrameworks.Net451 } },
             { Dnx46, new [] { FrameworkConstants.CommonFrameworks.Net46 } }
         };
-        
+
         public FrameworkReferenceResolver(string referenceAssembliesPath)
         {
             ReferenceAssembliesPath = referenceAssembliesPath;
         }
-        
+
         public string ReferenceAssembliesPath { get; }
-        
+
         public static FrameworkReferenceResolver Default
         {
             get
@@ -46,11 +46,11 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
                 {
                     _default = new FrameworkReferenceResolver(GetDefaultReferenceAssembliesPath());
                 }
-                
+
                 return _default;
             }
         }
-        
+
         public static string GetDefaultReferenceAssembliesPath()
         {
             // Allow setting the reference assemblies path via an environment variable
@@ -210,7 +210,7 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
             // Check for legacy frameworks
             if (PlatformServices.Default.Runtime.OperatingSystemPlatform == Platform.Windows &&
                 targetFramework.IsDesktop() &&
-                targetFramework.Version <= new Version(3, 5))
+                targetFramework.Version <= new Version(3, 5, 0, 0))
             {
                 return GetLegacyFrameworkInformation(targetFramework, referenceAssembliesPath);
             }


### PR DESCRIPTION
Fixes #2525 

Turns out in System.Version land `3.5.0.0` is **not** less than or equal to `3.5`.

/cc @davidfowl @pakrym

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2557)
<!-- Reviewable:end -->
