### PR TITLE
Fixes #2512

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/ProjectDependenciesCommandFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ProjectDependenciesCommandFactory.cs
@@ -27,13 +27,18 @@ namespace Microsoft.DotNet.Cli.Utils
             _outputPath = outputPath;
             _buildBasePath = buildBasePath;
             _projectDirectory = projectDirectory;
+
+            if (_configuration == null)
+            {
+                _configuration = Constants.DefaultConfiguration;
+            }
         }
 
         public ICommand Create(
             string commandName,
             IEnumerable<string> args,
             NuGetFramework framework = null,
-            string configuration = Constants.DefaultConfiguration)
+            string configuration = null)
         {
             if (string.IsNullOrEmpty(configuration))
             {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
@@ -1,0 +1,151 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Linq;
+using Xunit;
+using Moq;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.Extensions.PlatformAbstractions;
+using Microsoft.DotNet.TestFramework;
+using System.Threading;
+using FluentAssertions;
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    public class GivenAProjectDependenciesCommandFactory : TestBase
+    {
+        private static readonly NuGetFramework s_desktopTestFramework = FrameworkConstants.CommonFrameworks.Net451;  
+        
+        [WindowsOnlyFact]
+        public void It_resolves_desktop_apps_from_the_output_directory_using_Debug_configuration_when_configuration_is_null()
+        {
+            var configuration = "Debug";
+
+            var testAssetManager = new TestAssetsManager(Path.Combine(RepoRoot, "TestAssets", "DesktopTestProjects"));
+            var testInstance = testAssetManager.CreateTestInstance("AppWithDirectDependencyDesktopAndPortable")
+                .WithLockFiles();
+
+            var buildCommand = new BuildCommand(
+                Path.Combine(testInstance.TestRoot, "project.json"), 
+                configuration: configuration)
+                    .ExecuteWithCapturedOutput()
+                    .Should()
+                    .Pass();
+
+            var context = ProjectContext.Create(testInstance.TestRoot, s_desktopTestFramework);
+
+            var factory = new ProjectDependenciesCommandFactory(
+                s_desktopTestFramework,
+                null,
+                null,
+                null,
+                testInstance.TestRoot);
+
+            var command = factory.Create("dotnet-desktop-and-portable", null);
+
+            command.CommandName.Should().Contain(Path.Combine(testInstance.TestRoot, "bin", configuration));
+            Path.GetFileName(command.CommandName).Should().Be("dotnet-desktop-and-portable.exe");
+        }
+
+        [WindowsOnlyFact]
+        public void It_resolves_desktop_apps_from_the_output_directory_when_configuration_is_Debug()
+        {
+            var configuration = "Debug";
+
+            var testAssetManager = new TestAssetsManager(Path.Combine(RepoRoot, "TestAssets", "DesktopTestProjects"));
+            var testInstance = testAssetManager.CreateTestInstance("AppWithDirectDependencyDesktopAndPortable")
+                .WithLockFiles();
+
+            var buildCommand = new BuildCommand(
+                Path.Combine(testInstance.TestRoot, "project.json"), 
+                configuration: configuration)
+                    .ExecuteWithCapturedOutput()
+                    .Should()
+                    .Pass();
+
+            var context = ProjectContext.Create(testInstance.TestRoot, s_desktopTestFramework);
+
+            var factory = new ProjectDependenciesCommandFactory(
+                s_desktopTestFramework,
+                configuration,
+                null,
+                null,
+                testInstance.TestRoot);
+
+            var command = factory.Create("dotnet-desktop-and-portable", null);
+
+            command.CommandName.Should().Contain(Path.Combine(testInstance.TestRoot, "bin", configuration));
+            Path.GetFileName(command.CommandName).Should().Be("dotnet-desktop-and-portable.exe");
+        }
+
+        [WindowsOnlyFact]
+        public void It_resolves_desktop_apps_from_the_output_directory_when_configuration_is_Release()
+        {
+            var configuration = "Release";
+
+            var testAssetManager = new TestAssetsManager(Path.Combine(RepoRoot, "TestAssets", "DesktopTestProjects"));
+            var testInstance = testAssetManager.CreateTestInstance("AppWithDirectDependencyDesktopAndPortable")
+                .WithLockFiles();
+
+            var buildCommand = new BuildCommand(
+                Path.Combine(testInstance.TestRoot, "project.json"), 
+                configuration: configuration)
+                    .ExecuteWithCapturedOutput()
+                    .Should()
+                    .Pass();
+
+            var context = ProjectContext.Create(testInstance.TestRoot, s_desktopTestFramework);
+
+            var factory = new ProjectDependenciesCommandFactory(
+                s_desktopTestFramework,
+                configuration,
+                null,
+                null,
+                testInstance.TestRoot);
+
+            var command = factory.Create("dotnet-desktop-and-portable", null);
+
+            command.CommandName.Should().Contain(Path.Combine(testInstance.TestRoot, "bin", configuration));
+            Path.GetFileName(command.CommandName).Should().Be("dotnet-desktop-and-portable.exe");
+        }
+
+        [WindowsOnlyFact]
+        public void It_resolves_desktop_apps_from_the_output_directory_using_configuration_passed_to_create_over_configuration_passed_to_the_constructor()
+        {
+            var configuration = "Release";
+
+            var testAssetManager = new TestAssetsManager(Path.Combine(RepoRoot, "TestAssets", "DesktopTestProjects"));
+            var testInstance = testAssetManager.CreateTestInstance("AppWithDirectDependencyDesktopAndPortable")
+                .WithLockFiles();
+
+            var buildCommand = new BuildCommand(
+                Path.Combine(testInstance.TestRoot, "project.json"), 
+                configuration: configuration)
+                    .ExecuteWithCapturedOutput()
+                    .Should()
+                    .Pass();
+
+            var context = ProjectContext.Create(testInstance.TestRoot, s_desktopTestFramework);
+
+            var factory = new ProjectDependenciesCommandFactory(
+                s_desktopTestFramework,
+                "Debug",
+                null,
+                null,
+                testInstance.TestRoot);
+
+            var command = factory.Create("dotnet-desktop-and-portable", null, configuration: configuration);
+
+            command.CommandName.Should().Contain(Path.Combine(testInstance.TestRoot, "bin", configuration));
+            Path.GetFileName(command.CommandName).Should().Be("dotnet-desktop-and-portable.exe");
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the behavior of the `ProjectDependenciesCommandFactory` to not always use the default configuration. 

I think the pattern of passing in the configuration should change to one place instead of two, but to minimize code changes this will fix the issue we are seeing.

@NTaylorMullen PTAL

cc @livarcocc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2559)
<!-- Reviewable:end -->