### PR TITLE
Add crossgen tests

### DIFF
--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Cli.Build
         public static readonly string[] TestProjects = new[]
         {
             "ArgumentForwardingTests",
+            "crossgen.Tests",
             "EndToEnd",
             "dotnet.Tests",
             "dotnet-build.Tests",

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/PeReaderUtils.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/PeReaderUtils.cs
@@ -11,6 +11,19 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 {
     public static class PeReaderUtils
     {
+        public static bool IsCrossgened(this PEReader peReader)
+        {
+            bool isCrossgened = false;
+
+            if (peReader.HasMetadata)
+            {
+                // 4 is the magic numbers that is set in the CLR header's flags when crossgened.
+                isCrossgened = (int)peReader.PEHeaders.CorHeader.Flags == 4;
+            }
+
+            return isCrossgened;
+        }
+
         public static string GetAssemblyAttributeValue(string assemblyPath, string attributeName)
         {
             if (!File.Exists(assemblyPath))

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/PeReaderUtils.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/PeReaderUtils.cs
@@ -13,12 +13,13 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
     {
         public static bool IsCrossgened(this PEReader peReader)
         {
+            const int CROSSGEN_FLAG = 4;
             bool isCrossgened = false;
 
             if (peReader.HasMetadata)
             {
                 // 4 is the magic numbers that is set in the CLR header's flags when crossgened.
-                isCrossgened = (int)peReader.PEHeaders.CorHeader.Flags == 4;
+                isCrossgened = ((int)peReader.PEHeaders.CorHeader.Flags & CROSSGEN_FLAG) == CROSSGEN_FLAG;
             }
 
             return isCrossgened;

--- a/test/crossgen.Tests/crossgen.Tests.cs
+++ b/test/crossgen.Tests/crossgen.Tests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection.PortableExecutable;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.DotNet.Tests
+{
+    /// <summary>
+    /// Static analysis of assemblies to make sure that they are crossgened.
+    /// </summary>
+    public class CrossgenTests : TestBase
+    {
+        [Fact]
+        public void CLI_SDK_assemblies_must_be_crossgened()
+        {
+            string dotnetDir = FindDotnetDirInPath();
+            string cliPath = Directory.EnumerateFiles(dotnetDir, "dotnet.dll", SearchOption.AllDirectories).First();
+            cliPath = Path.GetDirectoryName(cliPath);
+            CheckDirectoryIsCrossgened(cliPath);
+        }
+
+        [Fact]
+        public void Shared_Fx_assemblies_must_be_crossgened()
+        {
+            string dotnetDir = FindDotnetDirInPath();
+            string sharedFxPath = Directory.EnumerateFiles(dotnetDir, "mscorlib*.dll", SearchOption.AllDirectories).First();
+            sharedFxPath = Path.GetDirectoryName(sharedFxPath);
+            CheckDirectoryIsCrossgened(sharedFxPath);
+        }
+
+        private static void CheckDirectoryIsCrossgened(string pathToAssemblies)
+        {
+            Console.WriteLine($"Checking directory '{pathToAssemblies}' for crossgened assemblies");
+
+            var dlls = Directory.EnumerateFiles(pathToAssemblies, "*.dll", SearchOption.TopDirectoryOnly);
+            var exes = Directory.EnumerateFiles(pathToAssemblies, "*.exe", SearchOption.TopDirectoryOnly);
+            var assemblies = dlls.Concat(exes);
+            assemblies.Count().Should().NotBe(0, $"No assemblies found at directory '{pathToAssemblies}'");
+
+            foreach (var assembly in assemblies)
+            {
+                using (var asmStream = File.OpenRead(assembly))
+                {
+                    using (var peReader = new PEReader(asmStream))
+                    {
+                        if (peReader.HasMetadata)
+                        {
+                            peReader.IsCrossgened().Should().BeTrue($"Managed assembly '{assembly}' is not crossgened.");
+                        }
+                    }
+                }
+            }
+        }
+
+        private static string FindDotnetDirInPath()
+        {
+            string dotnetExecutable = $"dotnet{FileNameSuffixes.CurrentPlatform.Exe}";
+            foreach (string path in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
+            {
+                string dotnetPath = Path.Combine(path, dotnetExecutable);
+                if (File.Exists(dotnetPath))
+                {
+                    return Path.GetDirectoryName(dotnetPath);
+                }
+            }
+
+            throw new FileNotFoundException($"Unable to find '{dotnetExecutable}' in the $PATH");
+        }
+    }
+}

--- a/test/crossgen.Tests/crossgen.Tests.xproj
+++ b/test/crossgen.Tests/crossgen.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.23107" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.23107</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>414afbf1-b501-40e5-bf68-8c7d921c4e5d</ProjectGuid>
+    <RootNamespace>crossgen.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{57f03957-7b34-4fc5-a575-1ff41accaaf4}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/crossgen.Tests/project.json
+++ b/test/crossgen.Tests/project.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0-rc2-*"
+    },    
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.Cli.Utils": {
+      "target": "project"
+    },
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00206",
+    "dotnet-test-xunit": "1.0.0-dev-140469-38"    
+  },
+  "frameworks": {
+     "netcoreapp1.0": {
+        "imports": [
+          "netstandardapp1.5",
+          "dnxcore50",
+          "portable-net45+win8"
+        ]
+      }
+  },
+  "testRunner": "xunit"
+}

--- a/test/crossgen.Tests/project.json
+++ b/test/crossgen.Tests/project.json
@@ -12,17 +12,15 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"    
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
-     "netcoreapp1.0": {
-        "imports": [
-          "netstandardapp1.5",
-          "dnxcore50",
-          "portable-net45+win8"
-        ]
-      }
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net451+win8"
+      ]
+    }
   },
   "testRunner": "xunit"
 }


### PR DESCRIPTION
Simple tests which does static analysis of managed assemblies metadata to
make sure that they are crossgened. Currently it verifies that all the
assemblies in CLI SDK and SharedFx directory are crossgened.

cc @brianrob @JohnChen0 @piotrpMSFT 

I am not sure if there is a way to make sure that the assemblies are not partially crossgened. @brianrob @JohnChen0 do you guys know of a reliable way to do that?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2560)
<!-- Reviewable:end -->
