### PR TITLE
make all packages serviceable by default

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
@@ -115,7 +115,9 @@ namespace Microsoft.Extensions.DependencyModel
         {
             var type = export.Library.Identity.Type;
 
-            var serviceable = (export.Library as PackageDescription)?.PackageLibrary.IsServiceable ?? false;
+            // TEMPORARY: All packages are serviceable in RC2
+            // See https://github.com/dotnet/cli/issues/2569
+            var serviceable = (export.Library as PackageDescription) != null;
             var libraryDependencies = new HashSet<Dependency>();
 
             foreach (var libraryDependency in export.Library.Dependencies)

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextBuilderTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextBuilderTests.cs
@@ -96,6 +96,18 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void SetsServiceableToTrueForPackageDescriptions()
+        {
+            var context = Build(runtimeExports: new[]
+            {
+                Export(PackageDescription("Pack.Age", servicable: false))
+            });
+
+            var lib = context.RuntimeLibraries.Single();
+            lib.Serviceable.Should().BeTrue();
+        }
+
+        [Fact]
         public void TakesServicableFromPackageDescription()
         {
             var context = Build(runtimeExports: new[]


### PR DESCRIPTION
fixes https://github.com/dotnet/cli/issues/2569

/cc @pakrym @davidfowl @ericstj

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2575)
<!-- Reviewable:end -->