### PR TITLE
Generate binding redirects for all executable package dependencies.

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,7 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
+    <add key="coreclr-xunit" value="https://www.myget.org/F/coreclr-xunit/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,7 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
-    <add key="coreclr-xunit" value="https://www.myget.org/F/coreclr-xunit/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsAndConfig/app.config
+++ b/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsAndConfig/app.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>  
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="3.5.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="4.5.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Some.Foo.Assembly" publicKeyToken="814f48568d36eed5" culture="neutral" />
+        <bindingRedirect oldVersion="3.0.0.0" newVersion="5.5.5.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+  <appSettings>
+    <add key="Setting1" value="Hello"/>
+    <add key="Setting2" value="World"/>
+  </appSettings>
+</configuration>

--- a/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsAndConfig/project.json
+++ b/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsAndConfig/project.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "compile": [
+    "../src/*.cs"
+  ],
+  "dependencies": {
+    "Newtonsoft.Json": "8.0.3",    
+    "Microsoft.AspNet.Mvc": "3.0.50813.1",
+    "Unity.Mvc": "3.0.1304",
+    "dotnet-desktop-binding-redirects": "1.0.0-*"
+  },
+  "frameworks": {
+    "net451": {}
+  }
+}

--- a/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsAndConfig/project.json
+++ b/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsAndConfig/project.json
@@ -14,5 +14,14 @@
   },
   "frameworks": {
     "net451": {}
+  },
+  "tools": {
+    "dotnet-dependency-tool-invoker": {
+      "version": "1.0.0-*",
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
   }
 }

--- a/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsNoConfig/project.json
+++ b/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsNoConfig/project.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "compile": [
+    "../src/*.cs"
+  ],
+  "dependencies": {
+    "Newtonsoft.Json": "8.0.3",    
+    "Microsoft.AspNet.Mvc": "3.0.50813.1",
+    "Unity.Mvc": "3.0.1304",
+    "dotnet-desktop-binding-redirects": "1.0.0-*"
+  },
+  "frameworks": {
+    "net451": {}
+  }
+}

--- a/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsNoConfig/project.json
+++ b/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsNoConfig/project.json
@@ -14,5 +14,14 @@
   },
   "frameworks": {
     "net451": {}
+  },
+  "tools": {
+    "dotnet-dependency-tool-invoker": {
+      "version": "1.0.0-*",
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
   }
 }

--- a/TestAssets/DesktopTestProjects/BindingRedirectSample/src/Program.cs
+++ b/TestAssets/DesktopTestProjects/BindingRedirectSample/src/Program.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace BindingRedirects
+{
+    public class Program
+    {
+        private const string ExpectedNewtonSoftVersion = "8.0.0.0";
+
+        public static int Main(string[] args)
+        {
+            return VerifyJsonLoad();
+        }
+
+        private static int VerifyJsonLoad()
+        {
+            WriteLine("=======Verifying Redirected Newtonsoft.Json assembly load=======");
+
+            int result = 0;
+
+            try
+            {
+                var jsonAsm = typeof(Newtonsoft.Json.JsonConvert).Assembly;
+                var version = jsonAsm.GetName().Version.ToString();
+                if (version != ExpectedNewtonSoftVersion)
+                {
+                    WriteLine($"Failure - Newtonsoft.Json: ExpectedVersion - {ExpectedNewtonSoftVersion}, ActualVersion - {version}");
+                    result = -1;
+                }
+            }
+            catch (Exception ex)
+            {
+                WriteLine($"Failed to load type 'Newtonsoft.Json.JsonConvert'");
+                throw ex;
+            }
+
+            return result;
+        }
+
+        private static void WriteLine(string str)
+        {
+            var currentAssembly = Assembly.GetExecutingAssembly().GetName().Name;
+            Console.WriteLine($"{currentAssembly}: {str}");
+        }
+    }
+}

--- a/TestAssets/TestPackages/dotnet-desktop-binding-redirects/Program.cs
+++ b/TestAssets/TestPackages/dotnet-desktop-binding-redirects/Program.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace BindingRedirects
+{
+    public class Program
+    {
+        private const string ExpectedNewtonSoftVersion = "8.0.0.0";
+
+        public static int Main(string[] args)
+        {
+            return VerifyJsonLoad();
+        }
+
+        private static int VerifyJsonLoad()
+        {
+            WriteLine("=======Verifying Redirected Newtonsoft.Json assembly load=======");
+
+            int result = 0;
+
+            try
+            {
+                var jsonAsm = typeof(Newtonsoft.Json.JsonConvert).Assembly;
+                var version = jsonAsm.GetName().Version.ToString();
+                if (version != ExpectedNewtonSoftVersion)
+                {
+                    WriteLine($"Failure - Newtonsoft.Json: ExpectedVersion - {ExpectedNewtonSoftVersion}, ActualVersion - {version}");
+                    result = -1;
+                }
+            }
+            catch (Exception ex)
+            {
+                WriteLine($"Failed to load type 'Newtonsoft.Json.JsonConvert'");
+                throw ex;
+            }
+
+            return result;
+        }
+
+        private static void WriteLine(string str)
+        {
+            var currentAssembly = Assembly.GetExecutingAssembly().GetName().Name;
+            Console.WriteLine($"{currentAssembly}: {str}");
+        }
+    }
+}

--- a/TestAssets/TestPackages/dotnet-desktop-binding-redirects/dotnet-desktop-binding-redirects.xproj
+++ b/TestAssets/TestPackages/dotnet-desktop-binding-redirects/dotnet-desktop-binding-redirects.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>281f1cdb-8627-47c7-9bb1-cde8d30d93d1</ProjectGuid>
+    <RootNamespace>dotnet-desktop-binding-redirects</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/TestAssets/TestPackages/dotnet-desktop-binding-redirects/project.json
+++ b/TestAssets/TestPackages/dotnet-desktop-binding-redirects/project.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "5.0.0",
+    "NuGet.Protocol.Core.v3": "3.3.0"
+  },
+  "frameworks": {
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Configuration": ""
+      }
+    }
+  }
+}
+

--- a/scripts/dotnet-cli-build/TestPackageProjects.cs
+++ b/scripts/dotnet-cli-build/TestPackageProjects.cs
@@ -78,6 +78,16 @@ namespace Microsoft.DotNet.Cli.Build
             },
             new TestPackageProject()
             {
+                Name = "dotnet-desktop-binding-redirects",
+                IsTool = true,
+                Path = "TestAssets/TestPackages/dotnet-desktop-binding-redirects",
+                IsApplicable = CurrentPlatform.IsWindows,
+                VersionSuffix = s_testPackageBuildVersionSuffix,
+                Clean = true,
+                Frameworks = new [] { "net451" }
+            },
+            new TestPackageProject()
+            {
                 Name = "dotnet-hello",
                 IsTool = true,
                 Path = "TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello",

--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -362,7 +362,7 @@ namespace Microsoft.DotNet.Cli.Build
         private static IEnumerable<string> GetTestProjects()
         {
             List<string> testProjects = new List<string>();
-            testProjects.AddRange(testProjects);
+            testProjects.AddRange(TestProjects);
 
             if (CurrentPlatform.IsWindows)
             {

--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -39,6 +39,11 @@ namespace Microsoft.DotNet.Cli.Build
             "Microsoft.Extensions.DependencyModel.Tests"
         };
 
+        public static readonly string[] WindowsTestProjects = new[]
+        {
+            "binding-redirects.Tests"
+        };
+
         public static readonly dynamic[] ConditionalTestAssets = new[]
         {
             new { Path = "AppWithDirectDependencyDesktopAndPortable", Skip = new Func<bool>(() => !CurrentPlatform.IsWindows) }
@@ -59,9 +64,9 @@ namespace Microsoft.DotNet.Cli.Build
         [Target(nameof(RestoreTestAssetPackages), nameof(BuildTestAssetPackages))]
         public static BuildTargetResult SetupTestPackages(BuildTargetContext c) => c.Success();
 
-        [Target(nameof(RestoreTestAssetProjects), 
-            nameof(RestoreDesktopTestAssetProjects), 
-            nameof(BuildTestAssetProjects), 
+        [Target(nameof(RestoreTestAssetProjects),
+            nameof(RestoreDesktopTestAssetProjects),
+            nameof(BuildTestAssetProjects),
             nameof(BuildDesktopTestAssetProjects))]
         public static BuildTargetResult SetupTestProjects(BuildTargetContext c) => c.Success();
 
@@ -223,7 +228,7 @@ namespace Microsoft.DotNet.Cli.Build
             foreach (var packageProject in TestPackageProjects.Projects.Where(p => p.IsApplicable && p.Clean))
             {
                 Rmdir(Path.Combine(Dirs.NuGetPackages, packageProject.Name));
-                if(packageProject.IsTool)
+                if (packageProject.IsTool)
                 {
                     Rmdir(Path.Combine(Dirs.NuGetPackages, ".tools", packageProject.Name));
                 }
@@ -276,7 +281,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             var configuration = c.BuildContext.Get<string>("Configuration");
 
-            foreach (var testProject in TestProjects)
+            foreach (var testProject in GetTestProjects())
             {
                 c.Info($"Building tests: {testProject}");
                 dotnet.Build("--configuration", configuration)
@@ -307,7 +312,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             // Run the tests and set the VS vars in the environment when running them
             var failingTests = new List<string>();
-            foreach (var project in TestProjects)
+            foreach (var project in GetTestProjects())
             {
                 c.Info($"Running tests in: {project}");
                 var result = dotnet.Test("--configuration", configuration, "-xml", $"{project}-testResults.xml", "-notrait", "category=failing")
@@ -352,6 +357,19 @@ namespace Microsoft.DotNet.Cli.Build
                 .Execute();
 
             return c.Success();
+        }
+
+        private static IEnumerable<string> GetTestProjects()
+        {
+            List<string> testProjects = new List<string>();
+            testProjects.AddRange(testProjects);
+
+            if (CurrentPlatform.IsWindows)
+            {
+                testProjects.AddRange(WindowsTestProjects);
+            }
+
+            return testProjects;
         }
 
         private static BuildTargetResult BuildTestAssets(BuildTargetContext c, string testAssetsRoot, DotNetCli dotnet, string framework)

--- a/src/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public static readonly string ProjectFileName = "project.json";
         public static readonly string ExeSuffix = CurrentPlatform == Platform.Windows ? ".exe" : string.Empty;
+        public static readonly string ConfigSuffix = ".config";
 
         // Priority order of runnable suffixes to look for and run
         public static readonly string[] RunnableSuffixes = CurrentPlatform == Platform.Windows

--- a/src/Microsoft.DotNet.Compiler.Common/Executable.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/Executable.cs
@@ -254,7 +254,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
         public void GenerateBindingRedirects(LibraryExporter exporter)
         {
             var outputName = _outputPaths.RuntimeFiles.Assembly;
-            var configFile = outputName + ".config";
+            var configFile = outputName + Constants.ConfigSuffix;
 
             var existingConfig = new DirectoryInfo(_context.ProjectDirectory)
                 .EnumerateFiles()
@@ -271,12 +271,12 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             foreach (var export in exporter.GetDependencies())
             {
                 var dependencyExecutables = export.RuntimeAssemblyGroups.GetDefaultAssets()
-                                                .Where(asset => asset.FileName.ToLower().EndsWith(".exe"))
+                                                .Where(asset => asset.FileName.ToLower().EndsWith(FileNameSuffixes.DotNet.Exe))
                                                 .Select(asset => Path.Combine(_runtimeOutputPath, asset.FileName));
 
                 foreach (var executable in dependencyExecutables)
                 {
-                    configFile = executable + ".config";
+                    configFile = executable + Constants.ConfigSuffix;
                     configFiles.Add(configFile);
                 }
             }

--- a/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.TestAssetsManager.cs
+++ b/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.TestAssetsManager.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.TestFramework
                                        .CaptureStdOut()
                                        .CaptureStdErr()
                                        .Execute();
-            
+
             int exitCode = commandResult.ExitCode;
 
             if (exitCode != 0)
@@ -93,7 +93,12 @@ namespace Microsoft.DotNet.TestFramework
                 throw new Exception($"Cannot find '{testProjectName}' at '{AssetsRoot}'");
             }
 
-            string testDestination = Path.Combine(AppContext.BaseDirectory, callingMethod + identifier, testProjectName);
+#if NET451
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+#else
+            string baseDirectory = AppContext.BaseDirectory;
+#endif
+            string testDestination = Path.Combine(baseDirectory, callingMethod + identifier, testProjectName);
             var testInstance = new TestInstance(testProjectDir, testDestination);
             return testInstance;
         }

--- a/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.TestInstance.cs
+++ b/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.TestInstance.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.TestFramework
                                   {
                                       file = file.ToLower();
                                       return !file.EndsWith("project.lock.json")
-                                            && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") 
+                                            && !file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
                                             && !file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}");
                                   });
 
@@ -71,7 +71,6 @@ namespace Microsoft.DotNet.TestFramework
             {
                 string destFile = srcFile.Replace(_testAssetRoot, _testDestination);
                 File.Copy(srcFile, destFile, true);
-                FixTimeStamp(srcFile, destFile);
             }
         }
 
@@ -81,7 +80,6 @@ namespace Microsoft.DotNet.TestFramework
             {
                 string destinationLockFile = lockFile.Replace(_testAssetRoot, _testDestination);
                 File.Copy(lockFile, destinationLockFile, true);
-                FixTimeStamp(lockFile, destinationLockFile);
             }
 
             return this;
@@ -93,9 +91,9 @@ namespace Microsoft.DotNet.TestFramework
                                  .Where(dir =>
                                  {
                                      dir = dir.ToLower();
-                                     return dir.EndsWith($"{Path.DirectorySeparatorChar}bin") 
+                                     return dir.EndsWith($"{Path.DirectorySeparatorChar}bin")
                                             || dir.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
-                                            || dir.EndsWith($"{Path.DirectorySeparatorChar}obj") 
+                                            || dir.EndsWith($"{Path.DirectorySeparatorChar}obj")
                                             || dir.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}");
                                  });
 
@@ -109,7 +107,7 @@ namespace Microsoft.DotNet.TestFramework
                                  {
                                      file = file.ToLower();
 
-                                     var isArtifact = file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") 
+                                     var isArtifact = file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
                                             || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}");
 
                                      var isBlackListed = BuildArtifactBlackList.Any(b => file.Contains(b));
@@ -121,7 +119,6 @@ namespace Microsoft.DotNet.TestFramework
             {
                 string destFile = binFile.Replace(_testAssetRoot, _testDestination);
                 File.Copy(binFile, destFile, true);
-                FixTimeStamp(binFile, destFile);
             }
 
             return this;
@@ -130,16 +127,6 @@ namespace Microsoft.DotNet.TestFramework
         public string TestRoot
         {
             get { return _testDestination; }
-        }
-
-        private static void FixTimeStamp(string originalFile, string newFile)
-        {
-            // workaround for https://github.com/dotnet/corefx/issues/6083
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                var originalTime = File.GetLastWriteTime(originalFile);
-                File.SetLastWriteTime(newFile, originalTime);
-            }
         }
     }
 }

--- a/src/Microsoft.DotNet.TestFramework/project.json
+++ b/src/Microsoft.DotNet.TestFramework/project.json
@@ -4,6 +4,9 @@
   "tags": [
     ""
   ],
+  "compilationOptions": {
+    "keyFile": "../../tools/Key.snk"
+  },
   "projectUrl": "",
   "licenseUrl": "",
   "dependencies": {
@@ -14,6 +17,7 @@
       "imports": [
         "portable-net45+wp80+win8+wpa81+dnxcore50"
       ]
-    }
+    },
+    "net451": { }
   }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
@@ -266,7 +266,11 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         public string GetExecutableExtension()
         {
+#if NET451
+            return ".exe";
+#else
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
+#endif
         }
 
         private string BuildArgs()

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/DependencyToolInvokerCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/DependencyToolInvokerCommand.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.DotNet.Cli.Utils;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.ProjectModel;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public class DependencyToolInvokerCommand : TestCommand
+    {
+        public DependencyToolInvokerCommand()
+            : base("dotnet")
+        {
+        }
+
+        public CommandResult Execute(string commandName, string framework, string additionalArgs)
+        {
+            var args = $"dependency-tool-invoker {commandName} --framework {framework} {additionalArgs}";
+            return base.Execute(args);
+        }
+
+        public CommandResult ExecuteWithCapturedOutput(string commandName, string framework, string additionalArgs)
+        {
+            var args = $"dependency-tool-invoker {commandName} --framework {framework} {additionalArgs}";
+            return base.ExecuteWithCapturedOutput(args);
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
@@ -104,7 +104,11 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         public string GetExecutableExtension()
         {
+#if NET451
+            return ".exe";
+#else
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : "";
+#endif
         }
 
         private string BuildArgs()

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/ProcessExtensions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/ProcessExtensions.cs
@@ -8,7 +8,11 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 {
     internal static class ProcessExtensions
     {
+#if NET451
+        private static readonly bool _isWindows = true;
+#else
         private static readonly bool _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
         private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
 
         public static void KillTree(this Process process)

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/TestBase.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/TestBase.cs
@@ -33,7 +33,11 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                     return s_repoRoot;
                 }
 
-                string directory = AppContext.BaseDirectory;
+#if NET451
+            string directory = AppDomain.CurrentDomain.BaseDirectory;
+#else
+            string directory = AppContext.BaseDirectory;
+#endif
 
                 while (!Directory.Exists(Path.Combine(directory, ".git")) && directory != null)
                 {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -5,13 +5,6 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0-rc2-*"
-    },
-    "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24022",
-    "System.Collections.Immutable": "1.2.0-rc2-24022",
-    "System.Net.NetworkInformation": "4.1.0-rc2-24022",
     "FluentAssertions": "4.0.0",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-162081-13",
@@ -27,8 +20,22 @@
     "netcoreapp1.0": {
       "imports": [
         "dotnet5.4",
-        "portable-net451+win8"
-      ]
+        "portable-net451+win8"      
+      ],
+      "Microsoft.NETCore.App": {
+        "type": "platform",
+        "version": "1.0.0-rc2-*"
+      },
+      "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24022",
+      "System.Collections.Immutable": "1.2.0-rc2-24022",
+      "System.Net.NetworkInformation": "4.1.0-rc2-24022"
+    },
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Runtime": {
+          "type": "build"
+        }
+      }
     }
   }
 }

--- a/test/binding-redirects.Tests/BindingRedirectTests.cs
+++ b/test/binding-redirects.Tests/BindingRedirectTests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.DotNet.Tests
             }
         }
 
-        [WindowsOnlyFact]
+        [Fact]
         public void Build_Generates_Redirects_For_App_Without_Config()
         {
             var redirects = GetRedirects(_appWithoutConfigBuildOutput);
@@ -227,7 +227,7 @@ namespace Microsoft.DotNet.Tests
             commandResult.Should().Pass();
         }
 
-        [WindowsOnlyFact]
+        [Fact]
         public void Publish_Generates_Redirects_For_App_Without_Config()
         {
             var redirects = GetRedirects(_appWithoutConfigPublishOutput);
@@ -238,7 +238,7 @@ namespace Microsoft.DotNet.Tests
             commandResult.Should().Pass();
         }
 
-        [WindowsOnlyFact]
+        [Fact]
         public void Build_Generates_Redirects_For_Executable_Dependency()
         {
             var redirects = GetRedirects(_executableDependencyBuildOutput);
@@ -249,7 +249,7 @@ namespace Microsoft.DotNet.Tests
             commandResult.Should().Pass();
         }
 
-        //[WindowsOnlyFact]
+        [Fact(Skip = "https://github.com/dotnet/cli/issues/2632")]
         public void Publish_Generates_Redirects_For_Executable_Dependency()
         {
             var redirects = GetRedirects(_executableDependencyPublishOutput);
@@ -260,7 +260,7 @@ namespace Microsoft.DotNet.Tests
             commandResult.Should().Pass();
         }
 
-        [WindowsOnlyFact]
+        [Fact]
         public void Build_Generates_Redirects_For_App_With_Config()
         {
             var redirects = GetRedirects(_appWithConfigBuildOutput);
@@ -272,7 +272,7 @@ namespace Microsoft.DotNet.Tests
             commandResult.Should().Pass();
         }
 
-        [WindowsOnlyFact]
+        [Fact]
         public void Publish_Generates_Redirects_For_App_With_Config()
         {
             var redirects = GetRedirects(_appWithConfigPublishOutput);

--- a/test/binding-redirects.Tests/BindingRedirectTests.cs
+++ b/test/binding-redirects.Tests/BindingRedirectTests.cs
@@ -1,0 +1,287 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.Extensions.PlatformAbstractions;
+using Xunit;
+using FluentAssertions;
+
+namespace Microsoft.DotNet.Tests
+{
+    public class TestSetupFixture : TestBase
+    {
+        private const string Framework = "net451";
+        private const string Config = "Debug";
+        private const string AppWithConfig = "AppWithRedirectsAndConfig";
+        private const string AppWithoutConfig = "AppWithRedirectsNoConfig";
+
+        private string _Runtime = PlatformServices.Default.Runtime.GetLegacyRestoreRuntimeIdentifier();
+        private string _desktopProjectsRoot = Path.Combine(RepoRoot, "TestAssets", "DesktopTestProjects");
+        private string _buildRelativePath;
+        private string _appWithConfigBuildDir;
+        private string _appWithConfigPublishDir;
+        private string _appWithoutConfigBuildDir;
+        private string _appWithoutConfigPublishDir;
+        private TestInstance _testInstance;
+
+
+        public string AppWithConfigBuildOutput { get; }
+        public string AppWithConfigPublishOutput { get; }
+        public string AppWithoutConfigBuildOutput { get; }
+        public string AppWithoutConfigPublishOutput { get; }
+
+        public TestSetupFixture()
+        {
+            _buildRelativePath = Path.Combine("bin", Config, Framework, _Runtime);
+            var testAssetsMgr = new TestAssetsManager(_desktopProjectsRoot);
+            _testInstance = testAssetsMgr.CreateTestInstance("BindingRedirectSample")
+                                         .WithLockFiles();
+
+            Setup(AppWithConfig, ref _appWithConfigBuildDir, ref _appWithConfigPublishDir);
+            Setup(AppWithoutConfig, ref _appWithoutConfigBuildDir, ref _appWithoutConfigPublishDir);
+
+            AppWithConfigBuildOutput = Path.Combine(_appWithConfigBuildDir, AppWithConfig + ".exe");
+            AppWithConfigPublishOutput = Path.Combine(_appWithConfigPublishDir, AppWithConfig + ".exe");
+            AppWithoutConfigBuildOutput = Path.Combine(_appWithoutConfigBuildDir, AppWithoutConfig + ".exe");
+            AppWithoutConfigPublishOutput = Path.Combine(_appWithoutConfigPublishDir, AppWithoutConfig + ".exe");
+        }
+
+        private void Setup(string project, ref string buildDir, ref string publishDir)
+        {
+            string projectRoot = Path.Combine(_testInstance.TestRoot, project);
+            buildDir = Path.Combine(projectRoot, _buildRelativePath);
+            publishDir = Path.Combine(projectRoot, "publish");
+
+            var buildCommand = new BuildCommand(projectRoot, framework: Framework, runtime: _Runtime);
+            buildCommand.Execute().Should().Pass();
+
+            var publishCommand = new PublishCommand(projectRoot, output: publishDir, framework: Framework, runtime: _Runtime);
+            publishCommand.Execute().Should().Pass();
+        }
+    }
+
+    public class GivenAnAppWithRedirectsAndExecutableDependency : TestBase, IClassFixture<TestSetupFixture>
+    {
+        private const string ExecutableDependency = "dotnet-desktop-binding-redirects.exe";
+        private TestSetupFixture _testSetup;
+        private string _appWithConfigBuildOutput;
+        private string _appWithoutConfigBuildOutput;
+        private string _appWithConfigPublishOutput;
+        private string _appWithoutConfigPublishOutput;
+        private string _executableDependencyBuildOutput;
+        private string _executableDependencyPublishOutput;
+
+        public GivenAnAppWithRedirectsAndExecutableDependency(TestSetupFixture testSetup)
+        {
+            _testSetup = testSetup;
+            _appWithConfigBuildOutput = _testSetup.AppWithConfigBuildOutput;
+            _appWithConfigPublishOutput = _testSetup.AppWithConfigPublishOutput;
+            _appWithoutConfigBuildOutput = _testSetup.AppWithoutConfigBuildOutput;
+            _appWithoutConfigPublishOutput = _testSetup.AppWithoutConfigPublishOutput;
+            _executableDependencyBuildOutput = Path.Combine(Path.GetDirectoryName(_appWithConfigBuildOutput), ExecutableDependency);
+            _executableDependencyPublishOutput = Path.Combine(Path.GetDirectoryName(_appWithConfigPublishOutput), ExecutableDependency);
+        }
+
+        private static List<string> BindingsAppNoConfig
+        {
+            get
+            {
+                List<string> bindings = new List<string>()
+                {
+                    @"<dependentAssembly xmlns=""urn:schemas-microsoft-com:asm.v1"">
+                        <assemblyIdentity name=""Newtonsoft.Json"" publicKeyToken=""30ad4fe6b2a6aeed"" culture=""neutral"" />
+                        <bindingRedirect oldVersion=""4.5.0.0"" newVersion=""8.0.0.0"" />
+                        <bindingRedirect oldVersion=""6.0.0.0"" newVersion=""8.0.0.0"" />
+                      </dependentAssembly>",
+                    @"<dependentAssembly xmlns=""urn:schemas-microsoft-com:asm.v1"">
+                        <assemblyIdentity name=""System.Web.Mvc"" publicKeyToken=""31bf3856ad364e35"" culture=""neutral"" />
+                        <bindingRedirect oldVersion=""4.0.0.0"" newVersion=""3.0.0.1"" />
+                      </dependentAssembly>"
+                };
+
+                return bindings;
+            }
+        }
+
+        private static List<string> BindingsAppWithConfig
+        {
+            get
+            {
+                List<string> bindings = new List<string>()
+                {
+                    @"<dependentAssembly xmlns=""urn:schemas-microsoft-com:asm.v1"">
+                        <assemblyIdentity name=""Newtonsoft.Json"" publicKeyToken=""30ad4fe6b2a6aeed"" culture=""neutral"" />
+                        <bindingRedirect oldVersion=""3.5.0.0"" newVersion=""8.0.0.0"" />
+                        <bindingRedirect oldVersion=""4.5.0.0"" newVersion=""8.0.0.0"" />
+                        <bindingRedirect oldVersion=""6.0.0.0"" newVersion=""8.0.0.0"" />
+                      </dependentAssembly>",
+                    @"<dependentAssembly xmlns=""urn:schemas-microsoft-com:asm.v1"">
+                        <assemblyIdentity name=""Some.Foo.Assembly"" publicKeyToken=""814f48568d36eed5"" culture=""neutral"" />
+                        <bindingRedirect oldVersion=""3.0.0.0"" newVersion=""5.5.5.1"" />
+                      </dependentAssembly>",
+                    @"<dependentAssembly xmlns=""urn:schemas-microsoft-com:asm.v1"">
+                        <assemblyIdentity name=""System.Web.Mvc"" publicKeyToken=""31bf3856ad364e35"" culture=""neutral"" />
+                        <bindingRedirect oldVersion=""4.0.0.0"" newVersion=""3.0.0.1"" />
+                      </dependentAssembly>"
+                };
+
+                return bindings;
+            }
+        }
+
+        private static List<XElement> ExpectedBindingsAppNoConfig
+        {
+            get
+            {
+                List<XElement> bindingElements = new List<XElement>();
+
+                foreach (var binding in BindingsAppNoConfig)
+                {
+                    bindingElements.Add(XElement.Parse(binding));
+                }
+
+                return bindingElements;
+            }
+        }
+
+        private static List<XElement> ExpectedBindingsAppWithConfig
+        {
+            get
+            {
+                List<XElement> bindingElements = new List<XElement>();
+
+                foreach (var binding in BindingsAppWithConfig)
+                {
+                    bindingElements.Add(XElement.Parse(binding));
+                }
+
+                return bindingElements;
+            }
+        }
+
+        private static Dictionary<string, string> ExpectedAppSettings
+        {
+            get
+            {
+                Dictionary<string, string> appSettings = new Dictionary<string, string>()
+                {
+                    {"Setting1", "Hello"},
+                    {"Setting2", "World"}
+                };
+
+                return appSettings;
+            }
+        }
+
+        private IEnumerable<XElement> GetRedirects(string exePath)
+        {
+            var configFile = exePath + ".config";
+            File.Exists(configFile).Should().BeTrue($"Config file not found - {configFile}");
+            var config = ConfigurationManager.OpenExeConfiguration(exePath);
+            var runtimeSectionXml = config.Sections["runtime"].SectionInformation.GetRawXml();
+            var runtimeSectionElement = XElement.Parse(runtimeSectionXml);
+            var redirects = runtimeSectionElement.Elements()
+                                .Where(e => e.Name.LocalName == "assemblyBinding").Elements()
+                                .Where(e => e.Name.LocalName == "dependentAssembly");
+            return redirects;
+        }
+
+        private void VerifyRedirects(IEnumerable<XElement> redirects, IEnumerable<XElement> generatedBindings)
+        {
+            foreach (var binding in generatedBindings)
+            {
+                var redirect = redirects.SingleOrDefault(r => /*XNode.DeepEquals(r, binding)*/ r.ToString() == binding.ToString());
+
+                redirect.Should().NotBeNull($"Binding not found in runtime section : {Environment.NewLine}{binding}");
+            }
+        }
+
+        private void VerifyAppSettings(string exePath)
+        {
+            var configFile = ConfigurationManager.OpenExeConfiguration(exePath);
+            foreach (var appSetting in ExpectedAppSettings)
+            {
+                var value = configFile.AppSettings.Settings[appSetting.Key];
+                value.Should().NotBeNull($"AppSetting with key '{appSetting.Key}' not found in config file.");
+                value.Value.Should().Be(appSetting.Value, $"For AppSetting '{appSetting.Key}' - Expected Value '{appSetting.Value}', Actual '{ value.Value}'");
+            }
+        }
+
+        [WindowsOnlyFact]
+        public void Build_Generates_Redirects_For_App_Without_Config()
+        {
+            var redirects = GetRedirects(_appWithoutConfigBuildOutput);
+            VerifyRedirects(redirects, ExpectedBindingsAppNoConfig);
+
+            var commandResult = new TestCommand(_appWithoutConfigBuildOutput)
+                                    .Execute();
+            commandResult.Should().Pass();
+        }
+
+        [WindowsOnlyFact]
+        public void Publish_Generates_Redirects_For_App_Without_Config()
+        {
+            var redirects = GetRedirects(_appWithoutConfigPublishOutput);
+            VerifyRedirects(redirects, ExpectedBindingsAppNoConfig);
+
+            var commandResult = new TestCommand(_appWithoutConfigPublishOutput)
+                                    .Execute();
+            commandResult.Should().Pass();
+        }
+
+        [WindowsOnlyFact]
+        public void Build_Generates_Redirects_For_Executable_Dependency()
+        {
+            var redirects = GetRedirects(_executableDependencyBuildOutput);
+            VerifyRedirects(redirects, ExpectedBindingsAppNoConfig);
+
+            var commandResult = new TestCommand(_executableDependencyBuildOutput)
+                                    .Execute();
+            commandResult.Should().Pass();
+        }
+
+        //[WindowsOnlyFact]
+        public void Publish_Generates_Redirects_For_Executable_Dependency()
+        {
+            var redirects = GetRedirects(_executableDependencyPublishOutput);
+            VerifyRedirects(redirects, ExpectedBindingsAppNoConfig);
+
+            var commandResult = new TestCommand(_executableDependencyPublishOutput)
+                                    .Execute();
+            commandResult.Should().Pass();
+        }
+
+        [WindowsOnlyFact]
+        public void Build_Generates_Redirects_For_App_With_Config()
+        {
+            var redirects = GetRedirects(_appWithConfigBuildOutput);
+            VerifyRedirects(redirects, ExpectedBindingsAppWithConfig);
+            VerifyAppSettings(_appWithConfigBuildOutput);
+
+            var commandResult = new TestCommand(_appWithConfigBuildOutput)
+                                    .Execute();
+            commandResult.Should().Pass();
+        }
+
+        [WindowsOnlyFact]
+        public void Publish_Generates_Redirects_For_App_With_Config()
+        {
+            var redirects = GetRedirects(_appWithConfigPublishOutput);
+            VerifyRedirects(redirects, ExpectedBindingsAppWithConfig);
+            VerifyAppSettings(_appWithConfigPublishOutput);
+
+            var commandResult = new TestCommand(_appWithConfigPublishOutput)
+                                    .Execute();
+            commandResult.Should().Pass();
+        }
+    }
+}

--- a/test/binding-redirects.Tests/TestSetupFixture.cs
+++ b/test/binding-redirects.Tests/TestSetupFixture.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.Extensions.PlatformAbstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.Tests
+{
+    public class TestSetupFixture : TestBase
+    {
+        private const string Framework = "net451";
+        private const string Config = "Debug";
+        private const string AppWithConfig = "AppWithRedirectsAndConfig";
+        private const string AppWithoutConfig = "AppWithRedirectsNoConfig";
+
+        private string _Runtime = PlatformServices.Default.Runtime.GetLegacyRestoreRuntimeIdentifier();
+        private string _desktopProjectsRoot = Path.Combine(RepoRoot, "TestAssets", "DesktopTestProjects");
+        private string _buildRelativePath;
+        private string _appWithConfigProjectRoot;
+        private string _appWithConfigBuildDir;
+        private string _appWithConfigPublishDir;
+        private string _appWithoutConfigProjectRoot;
+        private string _appWithoutConfigBuildDir;
+        private string _appWithoutConfigPublishDir;
+        private TestInstance _testInstance;
+
+        public string AppWithConfigProjectRoot { get { return _appWithConfigProjectRoot; } }
+        public string AppWithConfigBuildOutput { get; }
+        public string AppWithConfigPublishOutput { get; }
+        public string AppWithoutConfigProjectRoot { get { return _appWithoutConfigProjectRoot; } }
+        public string AppWithoutConfigBuildOutput { get; }
+        public string AppWithoutConfigPublishOutput { get; }
+
+        public TestSetupFixture()
+        {
+            _buildRelativePath = Path.Combine("bin", Config, Framework, _Runtime);
+            var testAssetsMgr = new TestAssetsManager(_desktopProjectsRoot);
+            _testInstance = testAssetsMgr.CreateTestInstance("BindingRedirectSample")
+                                         .WithLockFiles();
+
+            Setup(AppWithConfig, ref _appWithConfigProjectRoot, ref _appWithConfigBuildDir, ref _appWithConfigPublishDir);
+            Setup(AppWithoutConfig, ref _appWithoutConfigProjectRoot, ref _appWithoutConfigBuildDir, ref _appWithoutConfigPublishDir);
+
+            AppWithConfigBuildOutput = Path.Combine(_appWithConfigBuildDir, AppWithConfig + ".exe");
+            AppWithConfigPublishOutput = Path.Combine(_appWithConfigPublishDir, AppWithConfig + ".exe");
+            AppWithoutConfigBuildOutput = Path.Combine(_appWithoutConfigBuildDir, AppWithoutConfig + ".exe");
+            AppWithoutConfigPublishOutput = Path.Combine(_appWithoutConfigPublishDir, AppWithoutConfig + ".exe");
+        }
+
+        private void Setup(string project, ref string projectDir, ref string buildDir, ref string publishDir)
+        {
+            projectDir = Path.Combine(_testInstance.TestRoot, project);
+            buildDir = Path.Combine(projectDir, _buildRelativePath);
+            publishDir = Path.Combine(projectDir, "publish");
+
+            var buildCommand = new BuildCommand(projectDir, framework: Framework, runtime: _Runtime);
+            buildCommand.Execute().Should().Pass();
+
+            var publishCommand = new PublishCommand(projectDir, output: publishDir, framework: Framework, runtime: _Runtime);
+            publishCommand.Execute().Should().Pass();
+        }
+    }
+}

--- a/test/binding-redirects.Tests/binding-redirects.Tests.xproj
+++ b/test/binding-redirects.Tests/binding-redirects.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.23107" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.23107</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>27dbf851-f2e3-4fd5-bf4d-a73c81933283</ProjectGuid>
+    <RootNamespace>binding-redirects.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{9b56c4a1-b027-48c1-8050-e344f0630b98}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/binding-redirects.Tests/project.json
+++ b/test/binding-redirects.Tests/project.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc2-157751-46",
+    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    }
+  },
+  "frameworks": {
+    "net451": {
+       "frameworkAssemblies": {
+        "System.Configuration": ""
+      }
+     }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {}   
+  },
+  "testRunner": "xunit"
+}

--- a/test/binding-redirects.Tests/project.json
+++ b/test/binding-redirects.Tests/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-157751-46",
+    "dotnet-test-xunit": "1.0.0-rc2-162081-13",
     "Microsoft.NETCore.Platforms": "1.0.1-*",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -242,25 +242,5 @@ namespace Microsoft.DotNet.Tests
                 return base.ExecuteWithCapturedOutput(args);
             }
         }
-
-        class DependencyToolInvokerCommand : TestCommand
-        {
-            public DependencyToolInvokerCommand()
-                : base("dotnet")
-            {
-            }
-
-            public CommandResult Execute(string commandName, string framework, string additionalArgs)
-            {
-                var args = $"dependency-tool-invoker {commandName} --framework {framework} {additionalArgs}";
-                return base.Execute(args);
-            }
-
-            public CommandResult ExecuteWithCapturedOutput(string commandName, string framework, string additionalArgs)
-            {
-                var args = $"dependency-tool-invoker {commandName} --framework {framework} {additionalArgs}";
-                return base.ExecuteWithCapturedOutput(args);
-            }
-        }
     }
 }


### PR DESCRIPTION
Binding redirects are already generated for the current project. This
change is to add these same binding redirects to all executable package
dependencies.

Fixes - #2505


Meanwhile @piotrpMSFT @anurse @pakrym, can you guys please take a look?
I still need to do some more testing but I like to get some feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2586)
<!-- Reviewable:end -->