### PR TITLE
Move ASP.NET package references to rc2-20581 from the aspnetrelease feed.

### DIFF
--- a/scripts/Microsoft.DotNet.Cli.Build.Framework/project.json
+++ b/scripts/Microsoft.DotNet.Cli.Build.Framework/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "NETStandard.Library": "1.5.0-rc2-24018",
     "System.Diagnostics.Process": "4.1.0-rc2-24018",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20100"
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20581"
   },
   "frameworks": {
     "netstandard1.3": {

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -6,7 +6,6 @@
   },
   "dependencies": {
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20459",
     "NuGet.Versioning": "3.5.0-beta-1178",
     "NuGet.Packaging": "3.5.0-beta-1178",
     "NuGet.Frameworks": "3.5.0-beta-1178",

--- a/src/Microsoft.DotNet.InternalAbstractions/project.json
+++ b/src/Microsoft.DotNet.InternalAbstractions/project.json
@@ -10,7 +10,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20459"
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20581"
   },
   "frameworks": {
     "net451": {},

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -6,7 +6,7 @@
   "description": "Types to model a .NET Project",
   "dependencies": {
     "Microsoft.Extensions.DependencyModel": "1.0.0-*",
-    "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-20459",
+    "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-rc2-20581",
     "Microsoft.Extensions.HashCodeCombiner.Sources": {
       "type": "build",
       "version": "1.0.0-rc2-20459"

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -18,7 +18,6 @@
       "type": "build",
       "version": "1.0.0-rc2-20459"
     },
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20459",
     "Newtonsoft.Json": "7.0.1"
   },
   "frameworks": {

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "Newtonsoft.Json": "7.0.1",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-20459",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-20581",
     "Microsoft.DiaSymReader": "1.0.6",
     "Microsoft.DiaSymReader.Native": "1.3.3"
   },

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -30,9 +30,8 @@
     "Microsoft.DotNet.Compiler.Common": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.DotNet.ILCompiler.SDK": "1.0.6-prerelease-00003",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20459",
-    "Microsoft.Extensions.Logging": "1.0.0-rc2-20459",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20459",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-20581",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20581",
     "Microsoft.Extensions.CommandLineUtils.Sources": {
       "type": "build",
       "version": "1.0.0-rc2-20221"

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -18,7 +18,6 @@
     "Microsoft.DotNet.TestFramework": "1.0.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-*",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20100",
     "Microsoft.DotNet.InternalAbstractions": {
       "target": "project",
       "version": "1.0.0-*"


### PR DESCRIPTION
The places where I removed a dependency is because a lower package (InternalAbstrations) was already bringing in that dependency.

Fix #2567

@Sridhar-MS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2606)
<!-- Reviewable:end -->