### PR TITLE
Cache inputs for globbing change detection

### DIFF
--- a/TestAssets/TestProjects/TestSimpleIncrementalApp/Program2.cs
+++ b/TestAssets/TestProjects/TestSimpleIncrementalApp/Program2.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program2
+    {
+        public static void Foo(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Reflection;
+using Microsoft.Extensions.PlatformAbstractions;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -12,5 +14,16 @@ namespace Microsoft.DotNet.Cli.Utils
         /// The CLI ships with a .version file that stores the commit information and CLI version
         /// </summary>
         public static string VersionFile => Path.GetFullPath(Path.Combine(typeof(DotnetFiles).GetTypeInfo().Assembly.Location, "..", ".version"));
+
+        /// <summary>
+        /// Reads the version file and adds runtime specific information
+        /// </summary>
+        public static string ReadAndInterpretVersionFile()
+        {
+            var content = File.ReadAllText(DotnetFiles.VersionFile);
+            content += Environment.NewLine;
+            content += PlatformServices.Default.Runtime.GetRuntimeIdentifier();
+            return content;
+        }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Reporter.cs
@@ -37,11 +37,13 @@ namespace Microsoft.DotNet.Cli.Utils
             {
                 Output = new Reporter(AnsiConsole.GetOutput());
                 Error = new Reporter(AnsiConsole.GetError());
-                Verbose = CommandContext.IsVerbose() ?
+                Verbose = IsVerbose ?
                     new Reporter(AnsiConsole.GetOutput()) :
                     NullReporter;
             }
         }
+
+        public static bool IsVerbose => CommandContext.IsVerbose();
 
         public void WriteLine(string message)
         {

--- a/src/Microsoft.DotNet.Compiler.Common/ProjectContextExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/ProjectContextExtensions.cs
@@ -37,6 +37,12 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
             return Path.Combine(intermediatePath, ".SDKVersion");
         }
 
+        public static string IncrementalCacheFile(this ProjectContext context, string configuration, string buildBasePath, string outputPath)
+        {
+            var intermediatePath = context.GetOutputPaths(configuration, buildBasePath, outputPath).IntermediateOutputDirectoryPath;
+            return Path.Combine(intermediatePath, ".IncrementalCache");
+        }
+
         // used in incremental compilation for the key file
         public static CommonCompilerOptions ResolveCompilationOptions(this ProjectContext context, string configuration)
         {

--- a/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.TestInstance.cs
+++ b/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.TestInstance.cs
@@ -11,6 +11,9 @@ namespace Microsoft.DotNet.TestFramework
 {
     public class TestInstance
     {
+        // made tolower because the rest of the class works with normalized tolower strings
+        private static readonly IEnumerable<string> BuildArtifactBlackList = new List<string>() {".IncrementalCache", ".SDKVersion"}.Select(s => s.ToLower()).ToArray();
+
         private string _testDestination;
         private string _testAssetRoot;
 
@@ -105,8 +108,13 @@ namespace Microsoft.DotNet.TestFramework
                                  .Where(file =>
                                  {
                                      file = file.ToLower();
-                                     return file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") 
+
+                                     var isArtifact = file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}") 
                                             || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}");
+
+                                     var isBlackListed = BuildArtifactBlackList.Any(b => file.Contains(b));
+
+                                     return isArtifact && !isBlackListed;
                                  });
 
             foreach (string binFile in binFiles)

--- a/src/dotnet/commands/dotnet-build/CompilerIO.cs
+++ b/src/dotnet/commands/dotnet-build/CompilerIO.cs
@@ -2,18 +2,43 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.DotNet.Tools.Build
 {
-    internal struct CompilerIO
+    internal class CompilerIO
     {
-        public readonly List<string> Inputs;
-        public readonly List<string> Outputs;
+        public readonly IEnumerable<string> Inputs;
+        public readonly IEnumerable<string> Outputs;
 
-        public CompilerIO(List<string> inputs, List<string> outputs)
+        public CompilerIO(IEnumerable<string> inputs, IEnumerable<string> outputs)
         {
             Inputs = inputs;
             Outputs = outputs;
         }
+
+        public DiffResult DiffInputs(CompilerIO other)
+        {
+            var myInputSet = new HashSet<string>(Inputs);
+            var otherInputSet = new HashSet<string>(other.Inputs);
+
+            var additions = myInputSet.Except(otherInputSet);
+            var deletions = otherInputSet.Except(myInputSet);
+
+            return new DiffResult(additions, deletions);
+        }
+
+        internal class DiffResult
+        {
+            public IEnumerable<string> Additions { get; private set; }
+            public IEnumerable<string> Deletions { get; private set; }
+
+            public DiffResult(IEnumerable<string> additions, IEnumerable<string> deletions)
+            {
+                Additions = additions;
+                Deletions = deletions;
+            }
+        }
+
     }
 }

--- a/src/dotnet/commands/dotnet-build/IncrementalCache.cs
+++ b/src/dotnet/commands/dotnet-build/IncrementalCache.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.DotNet.Tools.Build
+{
+    internal class IncrementalCache
+    {
+        private const string InputsKeyName = "inputs";
+        private const string OutputsKeyNane = "outputs";
+
+        public CompilerIO CompilerIO { get; }
+
+        public IncrementalCache(CompilerIO compilerIO)
+        {
+            CompilerIO = compilerIO;
+        }
+
+        public void WriteToFile(string cacheFile)
+        {
+            try
+            {
+                CreatePathIfAbsent(cacheFile);
+
+                using (var streamWriter = new StreamWriter(new FileStream(cacheFile, FileMode.Create, FileAccess.Write, FileShare.None)))
+                {
+                    var rootObject = new JObject();
+                    rootObject[InputsKeyName] = new JArray(CompilerIO.Inputs);
+                    rootObject[OutputsKeyNane] = new JArray(CompilerIO.Outputs);
+
+                    JsonSerializer.Create().Serialize(streamWriter, rootObject);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new InvalidDataException($"Could not write the incremental cache file: {cacheFile}", e);
+            }
+        }
+
+        private static void CreatePathIfAbsent(string filePath)
+        {
+            var parentDir = Path.GetDirectoryName(filePath);
+
+            if (!Directory.Exists(parentDir))
+            {
+                Directory.CreateDirectory(parentDir);
+            }
+        }
+
+        public static IncrementalCache ReadFromFile(string cacheFile)
+        {
+            try
+            {
+                using (var streamReader = new StreamReader(new FileStream(cacheFile, FileMode.Open, FileAccess.Read, FileShare.Read)))
+                {
+                    var jObject = JObject.Parse(streamReader.ReadToEnd());
+
+                    if (jObject == null)
+                    {
+                        throw new InvalidDataException();
+                    }
+
+                    var inputs = ReadArray<string>(jObject, InputsKeyName);
+                    var outputs = ReadArray<string>(jObject, OutputsKeyNane);
+
+                    return new IncrementalCache(new CompilerIO(inputs, outputs));
+                }
+            }
+            catch (Exception e)
+            {
+                throw new InvalidDataException($"Could not read the incremental cache file: {cacheFile}", e);
+            }
+        }
+
+        private static IEnumerable<T> ReadArray<T>(JObject jObject, string keyName)
+        {
+            var array = jObject.Value<JToken>(keyName)?.Values<T>();
+
+            if (array == null)
+            {
+                throw new InvalidDataException($"Could not read key {keyName}");
+            }
+
+            return array;
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-build/IncrementalManager.cs
+++ b/src/dotnet/commands/dotnet-build/IncrementalManager.cs
@@ -1,0 +1,207 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Cli.Compiler.Common;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.ProjectModel.Utilities;
+using Microsoft.DotNet.Tools.Compiler;
+using Microsoft.Extensions.PlatformAbstractions;
+using Microsoft.DotNet.ProjectModel.Compilation;
+using NuGet.Protocol.Core.Types;
+
+namespace Microsoft.DotNet.Tools.Build
+{
+    internal class IncrementalManager
+    {
+        private readonly ProjectBuilder _projectBuilder;
+        private readonly CompilerIOManager _compilerIoManager;
+        private readonly IncrementalPreconditionManager _preconditionManager;
+        private readonly bool _shouldSkipDependencies;
+        private readonly string _configuration;
+        private readonly string _buildBasePath;
+        private readonly string _outputPath;
+
+        public IncrementalManager(
+            ProjectBuilder projectBuilder,
+            CompilerIOManager compilerIOManager,
+            IncrementalPreconditionManager incrementalPreconditionManager,
+            bool shouldSkipDependencies,
+            string configuration,
+            string buildBasePath,
+            string outputPath)
+        {
+            _projectBuilder = projectBuilder;
+            _compilerIoManager = compilerIOManager;
+            _preconditionManager = incrementalPreconditionManager;
+            _shouldSkipDependencies = shouldSkipDependencies;
+            _configuration = configuration;
+            _buildBasePath = buildBasePath;
+            _outputPath = outputPath;
+        }
+
+        public IncrementalResult NeedsRebuilding(ProjectGraphNode graphNode)
+        {
+            if (!_shouldSkipDependencies &&
+                graphNode.Dependencies.Any(d => _projectBuilder.GetCompilationResult(d) != CompilationResult.IncrementalSkip))
+            {
+                return new IncrementalResult("dependencies changed");
+            }
+
+            var preconditions = _preconditionManager.GetIncrementalPreconditions(graphNode);
+            if (preconditions.PreconditionsDetected())
+            {
+                return new IncrementalResult($"project is not safe for incremental compilation. Use {BuildCommandApp.BuildProfileFlag} flag for more information.");
+            }
+
+            var compilerIO = _compilerIoManager.GetCompileIO(graphNode);
+
+            var result = CLIChanged(graphNode);
+            if (result.NeedsRebuilding)
+            {
+                return result;
+            }
+
+            result = InputItemsChanged(graphNode, compilerIO);
+            if (result.NeedsRebuilding)
+            {
+                return result;
+            }
+
+            result = TimestampsChanged(compilerIO);
+            if (result.NeedsRebuilding)
+            {
+                return result;
+            }
+
+            return IncrementalResult.DoesNotNeedRebuild;
+        }
+
+        private IncrementalResult CLIChanged(ProjectGraphNode graphNode)
+        {
+            var currentVersionFile = DotnetFiles.VersionFile;
+            var versionFileFromLastCompile = graphNode.ProjectContext.GetSDKVersionFile(_configuration, _buildBasePath, _outputPath);
+
+            if (!File.Exists(currentVersionFile))
+            {
+                // this CLI does not have a version file; cannot tell if CLI changed
+                return IncrementalResult.DoesNotNeedRebuild;
+            }
+
+            if (!File.Exists(versionFileFromLastCompile))
+            {
+                // this is the first compilation; cannot tell if CLI changed
+                return IncrementalResult.DoesNotNeedRebuild;
+            }
+
+            var currentContent = DotnetFiles.ReadAndInterpretVersionFile();
+
+            var versionsAreEqual = string.Equals(currentContent, File.ReadAllText(versionFileFromLastCompile), StringComparison.OrdinalIgnoreCase);
+
+            return versionsAreEqual
+                ? IncrementalResult.DoesNotNeedRebuild
+                : new IncrementalResult("the version or bitness of the CLI changed since the last build");
+        }
+
+        private IncrementalResult InputItemsChanged(ProjectGraphNode graphNode, CompilerIO compilerIO)
+        {
+            // check empty inputs / outputs
+            if (!compilerIO.Inputs.Any())
+            {
+                return new IncrementalResult("the project has no inputs");
+            }
+
+            if (!compilerIO.Outputs.Any())
+            {
+                return new IncrementalResult("the project has no outputs");
+            }
+
+            // check non existent items
+            var result = CheckMissingIO(compilerIO.Inputs, "inputs");
+            if (result.NeedsRebuilding)
+            {
+                return result;
+            }
+
+            result = CheckMissingIO(compilerIO.Outputs, "outputs");
+            if (result.NeedsRebuilding)
+            {
+                return result;
+            }
+
+            return CheckInputGlobChanges(graphNode, compilerIO);
+        }
+
+        private IncrementalResult CheckInputGlobChanges(ProjectGraphNode graphNode, CompilerIO compilerIO)
+        {
+            // check cache against input glob pattern changes
+            var incrementalCacheFile = graphNode.ProjectContext.IncrementalCacheFile(_configuration, _buildBasePath, _outputPath);
+
+            if (!File.Exists(incrementalCacheFile))
+            {
+                // cache is not present (first compilation); can't determine if globs changed; cache will be generated after build processes project
+                return IncrementalResult.DoesNotNeedRebuild;
+            }
+
+            var incrementalCache = IncrementalCache.ReadFromFile(incrementalCacheFile);
+
+            var diffResult = compilerIO.DiffInputs(incrementalCache.CompilerIO);
+
+            if (diffResult.Deletions.Any())
+            {
+                return new IncrementalResult("Input items removed from last build", diffResult.Deletions);
+            }
+
+            if (diffResult.Additions.Any())
+            {
+                return new IncrementalResult("Input items added from last build", diffResult.Additions);
+            }
+
+            return IncrementalResult.DoesNotNeedRebuild;
+        }
+
+        private IncrementalResult CheckMissingIO(IEnumerable<string> items, string itemsType)
+        {
+            var missingItems = items.Where(i => !File.Exists(i)).ToList();
+
+            return missingItems.Any()
+                ? new IncrementalResult($"expected {itemsType} are missing", missingItems)
+                : IncrementalResult.DoesNotNeedRebuild;
+        }
+
+        private IncrementalResult TimestampsChanged(CompilerIO compilerIO)
+        {
+            // find the output with the earliest write time
+            var minDateUtc = DateTime.MaxValue;
+
+            foreach (var outputPath in compilerIO.Outputs)
+            {
+                var lastWriteTimeUtc = File.GetLastWriteTimeUtc(outputPath);
+
+                if (lastWriteTimeUtc < minDateUtc)
+                {
+                    minDateUtc = lastWriteTimeUtc;
+                }
+            }
+
+            // find inputs that are older than the earliest output
+            var newInputs = compilerIO.Inputs.Where(p => File.GetLastWriteTimeUtc(p) >= minDateUtc);
+
+            return newInputs.Any()
+                ? new IncrementalResult("inputs were modified", newInputs)
+                : IncrementalResult.DoesNotNeedRebuild;
+        }
+
+        public void CacheIncrementalState(ProjectGraphNode graphNode)
+        {
+            var incrementalCacheFile = graphNode.ProjectContext.IncrementalCacheFile(_configuration, _buildBasePath, _outputPath);
+
+            var incrementalCache = new IncrementalCache(_compilerIoManager.GetCompileIO(graphNode));
+            incrementalCache.WriteToFile(incrementalCacheFile);
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-build/IncrementalResult.cs
+++ b/src/dotnet/commands/dotnet-build/IncrementalResult.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.DotNet.Tools.Build
+{
+    internal class IncrementalResult
+    {
+        public static readonly IncrementalResult DoesNotNeedRebuild = new IncrementalResult(false, "", Enumerable.Empty<string>());
+
+        public bool NeedsRebuilding { get; }
+        public string Reason { get; }
+        public IEnumerable<string> Items { get; }
+
+        private IncrementalResult(bool needsRebuilding, string reason, IEnumerable<string> items)
+        {
+            NeedsRebuilding = needsRebuilding;
+            Reason = reason;
+            Items = items;
+        }
+
+        public IncrementalResult(string reason)
+            : this(true, reason, Enumerable.Empty<string>())
+        {
+        }
+
+        public IncrementalResult(string reason, IEnumerable<string> items)
+            : this(true, reason, items)
+        {
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-build/ProjectBuilder.cs
+++ b/src/dotnet/commands/dotnet-build/ProjectBuilder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Build
             }
         }
 
-        protected CompilationResult? GetCompilationResult(ProjectGraphNode projectNode)
+        public CompilationResult? GetCompilationResult(ProjectGraphNode projectNode)
         {
             CompilationResult result;
             if (_compilationResults.TryGetValue(projectNode.ProjectContext.Identity, out result))

--- a/test/dotnet-build.Tests/IncrementalTests.cs
+++ b/test/dotnet-build.Tests/IncrementalTests.cs
@@ -38,6 +38,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             buildResult.Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
 
             buildResult = BuildProject(noIncremental: true);
+            buildResult.Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
             Assert.Contains("[Forced Unsafe]", buildResult.StdOut);
         }
 
@@ -85,12 +86,12 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             CreateTestInstance();
             BuildProject().Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
 
-            //change version file
+            // change version file
             var versionFile = Path.Combine(GetIntermediaryOutputPath(), ".SDKVersion");
             File.Exists(versionFile).Should().BeTrue();
             File.AppendAllText(versionFile, "text");
 
-            //assert rebuilt
+            // assert rebuilt
             BuildProject().Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
         }
 
@@ -100,17 +101,78 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             CreateTestInstance();
             BuildProject().Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
 
-            //delete version file
+            // delete version file
             var versionFile = Path.Combine(GetIntermediaryOutputPath(), ".SDKVersion");
             File.Exists(versionFile).Should().BeTrue();
             File.Delete(versionFile);
             File.Exists(versionFile).Should().BeFalse();
 
-            //assert build skipped due to no version file
+            // assert build skipped due to no version file
             BuildProject().Should().HaveSkippedProjectCompilation(MainProject, _appFrameworkFullName);
 
-            //the version file should have been regenerated during the build, even if compilation got skipped
+            // the version file should have been regenerated during the build, even if compilation got skipped
             File.Exists(versionFile).Should().BeTrue();
+        }
+
+        [Fact]
+        public void TestRebuildDeletedSource()
+        {
+            CreateTestInstance();
+            BuildProject().Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
+
+            var sourceFile = Path.Combine(GetProjectDirectory(MainProject), "Program2.cs");
+            File.Delete(sourceFile);
+            Assert.False(File.Exists(sourceFile));
+
+            // second build; should get rebuilt since we deleted a source file
+            BuildProject().Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
+
+            // third build; incremental cache should have been regenerated and project skipped
+            BuildProject().Should().HaveSkippedProjectCompilation(MainProject, _appFrameworkFullName);
+        }
+
+        [Fact]
+        public void TestRebuildRenamedSource()
+        {
+            CreateTestInstance();
+            var buildResult = BuildProject();
+            buildResult.Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
+
+            var sourceFile = Path.Combine(GetProjectDirectory(MainProject), "Program2.cs");
+            var destinationFile = Path.Combine(Path.GetDirectoryName(sourceFile), "ProgramNew.cs");
+            File.Move(sourceFile, destinationFile);
+            Assert.False(File.Exists(sourceFile));
+            Assert.True(File.Exists(destinationFile));
+
+            // second build; should get rebuilt since we renamed a source file
+            buildResult = BuildProject();
+            buildResult.Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
+
+            // third build; incremental cache should have been regenerated and project skipped
+            BuildProject().Should().HaveSkippedProjectCompilation(MainProject, _appFrameworkFullName);
+        }
+
+        [Fact]
+        public void TestRebuildDeletedSourceAfterCliChanged()
+        {
+            CreateTestInstance();
+            BuildProject().Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
+
+            // change version file
+            var versionFile = Path.Combine(GetIntermediaryOutputPath(), ".SDKVersion");
+            File.Exists(versionFile).Should().BeTrue();
+            File.AppendAllText(versionFile, "text");
+
+            // delete a source file
+            var sourceFile = Path.Combine(GetProjectDirectory(MainProject), "Program2.cs");
+            File.Delete(sourceFile);
+            Assert.False(File.Exists(sourceFile));
+
+            // should get rebuilt since we changed version file and deleted source file
+            BuildProject().Should().HaveCompiledProject(MainProject, _appFrameworkFullName);
+
+            // third build; incremental cache should have been regenerated and project skipped
+            BuildProject().Should().HaveSkippedProjectCompilation(MainProject, _appFrameworkFullName);
         }
 
         [Fact]


### PR DESCRIPTION
Build caches the inputs and outputs into a `.IncrementalCache` file that's kept in the intermediate output directory. It uses it to find out when the globbing patterns change, thus making incremental react to file additions, deletion, and renames.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2619)
<!-- Reviewable:end -->