### PR TITLE
Fixing ProjectDependenciesCommandFactory to resolve tools

### DIFF
--- a/TestAssets/TestPackages/ToolWithOutputName/Program.cs
+++ b/TestAssets/TestPackages/ToolWithOutputName/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Tool with output name!");
+        }
+    }
+}

--- a/TestAssets/TestPackages/ToolWithOutputName/project.json
+++ b/TestAssets/TestPackages/ToolWithOutputName/project.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0.0",
+  "compilationOptions": {
+    "outputName": "dotnet-tool-with-output-name",
+    "emitEntryPoint": true
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-rc2-*"
+        }
+      }
+    }
+  }
+}

--- a/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/Program.cs
+++ b/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("App with a dependency on a tool whose package name is different from the dll name!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "version": "1.0.0-rc2-*",
+      "type": "platform"
+    }
+  },
+  "frameworks": {
+    "netcoreapp1.0": { }
+  },
+
+  "tools": {
+    "ToolWithOutputName": {
+      "version": "1.0.0",
+      "target": "package"
+    }
+  }
+}

--- a/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/Program.cs
+++ b/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Contains a dependency on a tool whose package name is different from the dll name.");
+        }
+    }
+}

--- a/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
@@ -1,0 +1,27 @@
+{
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "ToolWithOutputName": {
+      "version": "1.0.0",
+      "target": "package"
+    },
+    "Microsoft.NETCore.App": {
+      "version": "1.0.0-rc2-*",
+      "type": "platform"
+    }
+  },
+  "frameworks": {
+    "netcoreapp1.0": { }
+  },
+   "tools": {
+    "dotnet-dependency-tool-invoker": {
+      "version": "1.0.0-*",
+      "imports": [
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  }
+}

--- a/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
+++ b/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
@@ -1,8 +1,7 @@
 {
   "compilationOptions": {
     "outputName": "MyApp",
-    "emitEntryPoint": true,
-    "preserveCompilationContext": true
+    "emitEntryPoint": true
   },
   "dependencies": {
     "Microsoft.NETCore.App": "1.0.0-rc2-*"

--- a/scripts/dotnet-cli-build/TestPackageProjects.cs
+++ b/scripts/dotnet-cli-build/TestPackageProjects.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Cli.Build
                 Name = "dotnet-dependency-tool-invoker",
                 IsTool = true,
                 Path = "TestAssets/TestPackages/dotnet-dependency-tool-invoker",
-                IsApplicable = CurrentPlatform.IsWindows,
+                IsApplicable = true,
                 VersionSuffix = s_testPackageBuildVersionSuffix,
                 Clean = true,
                 Frameworks = new [] { "netcoreapp1.0" }
@@ -101,6 +101,16 @@ namespace Microsoft.DotNet.Cli.Build
                 Name = "dotnet-portable",
                 IsTool = true,
                 Path = "TestAssets/TestPackages/dotnet-portable",
+                IsApplicable = true,
+                VersionSuffix = string.Empty,
+                Clean = true,
+                Frameworks = new [] { "netcoreapp1.0" }
+            },
+            new TestPackageProject()
+            {
+                Name = "ToolWithOutputName",
+                IsTool = true,
+                Path = "TestAssets/TestPackages/ToolWithOutputName",
                 IsApplicable = true,
                 VersionSuffix = string.Empty,
                 Clean = true,

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
@@ -22,8 +22,8 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 {
     public class GivenAProjectDependenciesCommandFactory : TestBase
     {
-        private static readonly NuGetFramework s_desktopTestFramework = FrameworkConstants.CommonFrameworks.Net451;  
-        
+        private static readonly NuGetFramework s_desktopTestFramework = FrameworkConstants.CommonFrameworks.Net451;
+
         [WindowsOnlyFact]
         public void It_resolves_desktop_apps_defaulting_to_Debug_Configuration()
         {
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .WithLockFiles();
 
             var buildCommand = new BuildCommand(
-                Path.Combine(testInstance.TestRoot, "project.json"), 
+                Path.Combine(testInstance.TestRoot, "project.json"),
                 configuration: configuration)
                     .ExecuteWithCapturedOutput()
                     .Should()
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .WithLockFiles();
 
             var buildCommand = new BuildCommand(
-                Path.Combine(testInstance.TestRoot, "project.json"), 
+                Path.Combine(testInstance.TestRoot, "project.json"),
                 configuration: configuration)
                     .ExecuteWithCapturedOutput()
                     .Should()
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .WithLockFiles();
 
             var buildCommand = new BuildCommand(
-                Path.Combine(testInstance.TestRoot, "project.json"), 
+                Path.Combine(testInstance.TestRoot, "project.json"),
                 configuration: configuration)
                     .ExecuteWithCapturedOutput()
                     .Should()
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .WithLockFiles();
 
             var buildCommand = new BuildCommand(
-                Path.Combine(testInstance.TestRoot, "project.json"), 
+                Path.Combine(testInstance.TestRoot, "project.json"),
                 configuration: configuration)
                     .ExecuteWithCapturedOutput()
                     .Should()
@@ -146,6 +146,37 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             command.CommandName.Should().Contain(Path.Combine(testInstance.TestRoot, "bin", configuration));
             Path.GetFileName(command.CommandName).Should().Be("dotnet-desktop-and-portable.exe");
+        }
+
+        [Fact]
+        public void It_resolves_tools_whose_package_name_is_different_than_dll_name()
+        {
+            var configuration = "Debug";
+
+            var testAssetManager = new TestAssetsManager(Path.Combine(RepoRoot, "TestAssets", "TestProjects"));
+            var testInstance = testAssetManager.CreateTestInstance("AppWithDirectDependencyWithOutputName")
+                .WithLockFiles();
+
+            var buildCommand = new BuildCommand(
+                Path.Combine(testInstance.TestRoot, "project.json"),
+                configuration: configuration)
+                    .ExecuteWithCapturedOutput()
+                    .Should()
+                    .Pass();
+
+            var context = ProjectContext.Create(testInstance.TestRoot, FrameworkConstants.CommonFrameworks.NetCoreApp10);
+
+            var factory = new ProjectDependenciesCommandFactory(
+                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                configuration,
+                null,
+                null,
+                testInstance.TestRoot);
+
+            var command = factory.Create("dotnet-tool-with-output-name", null);
+
+            command.CommandArgs.Should().Contain(
+                Path.Combine("ToolWithOutputName", "1.0.0", "lib", "netcoreapp1.0", "dotnet-tool-with-output-name.dll"));
         }
     }
 }

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -29,8 +29,10 @@
     }
   },
   "content": [
+    "../../TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/**/*",
     "../../TestAssets/TestProjects/AppWithDirectAndToolDependency/**/*",
     "../../TestAssets/TestProjects/AppWithDirectDependency/**/*",
+    "../../TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/**/*",
     "../../TestAssets/TestProjects/AppWithToolDependency/**/*",
     "../../TestAssets/TestProjects/DependencyContextFromTool/**/*",
     "../../TestAssets/DesktopTestProjects/AppWithDirectDependencyDesktopAndPortable/**/*"


### PR DESCRIPTION
if the package name is different from the dll name

Addresses #2592

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2620)
<!-- Reviewable:end -->
