### PR TITLE
Memory usage improvements in build

### DIFF
--- a/TestAssets/TestProjects/TestLibraryWithAnalyzer/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithAnalyzer/project.json
@@ -1,8 +1,5 @@
 {
   "version": "1.0.0-*",
-  "compilationOptions": {
-    "emitEntryPoint": true
-  },
   "dependencies": {
     "NETStandard.Library": "1.5.0-rc2-24018",
     "System.Runtime.Analyzers": {

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-  "projects": [ "src", "test", "tools" ]
+    "projects": [ "src", "test", "tools" ]
 }

--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -280,7 +280,7 @@ namespace Microsoft.DotNet.Cli.Build
             return rid;
         }
 
-        [Target]
+        [Target(nameof(PrepareTargets.Init))]
         public static BuildTargetResult CompileStage1(BuildTargetContext c)
         {
             CleanBinObj(c, Path.Combine(c.BuildContext.BuildDirectory, "src"));
@@ -305,7 +305,7 @@ namespace Microsoft.DotNet.Cli.Build
             return result;
         }
 
-        [Target]
+        [Target(nameof(PrepareTargets.Init))]
         public static BuildTargetResult CompileStage2(BuildTargetContext c)
         {
             var configuration = c.BuildContext.Get<string>("Configuration");

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -7,8 +7,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using NuGet.Frameworks;
+using System.Threading.Tasks;
 using Microsoft.DotNet.ProjectModel;
+using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -131,12 +132,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
             Reporter.Verbose.WriteLine($"Process ID: {_process.Id}");
 
-            var threadOut = _stdOut.BeginRead(_process.StandardOutput);
-            var threadErr = _stdErr.BeginRead(_process.StandardError);
-
+            var taskOut = _stdOut.BeginRead(_process.StandardOutput);
+            var taskErr = _stdErr.BeginRead(_process.StandardError);
             _process.WaitForExit();
-            threadOut.Join();
-            threadErr.Join();
+
+            Task.WaitAll(taskOut, taskErr);
 
             var exitCode = _process.ExitCode;
 

--- a/src/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/StreamForwarder.cs
@@ -1,8 +1,11 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.IO;
-using System.Text;
-using System.Threading;
 using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -17,7 +20,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public string CapturedOutput
         {
-            get 
+            get
             {
                 return _capture?.GetStringBuilder()?.ToString();
             }
@@ -43,18 +46,16 @@ namespace Microsoft.DotNet.Cli.Utils
             return this;
         }
 
-        public Thread BeginRead(TextReader reader)
+        public Task BeginRead(TextReader reader)
         {
-            var thread = new Thread(() => Read(reader)) { IsBackground = true };
-            thread.Start();
-            return thread;
+            return Task.Run(() => Read(reader));
         }
 
         public void Read(TextReader reader)
         {
             var bufferSize = 1;
 
-            int readCharacterCount; 
+            int readCharacterCount;
             char currentCharacter;
 
             var buffer = new char[bufferSize];
@@ -93,7 +94,7 @@ namespace Microsoft.DotNet.Cli.Utils
         }
 
         private void WriteLine(string str)
-        { 
+        {
             if (_capture != null)
             {
                 _capture.WriteLine(str);

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePatcher.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePatcher.cs
@@ -13,10 +13,12 @@ namespace Microsoft.DotNet.ProjectModel.Graph
     {
         private readonly LockFile _lockFile;
         private Dictionary<string, IList<LockFileTargetLibrary>> _msbuildTargetLibraries;
+        private readonly LockFileReader _reader;
 
-        public LockFilePatcher(LockFile lockFile)
+        public LockFilePatcher(LockFile lockFile, LockFileReader reader)
         {
             _lockFile = lockFile;
+            _reader = reader;
 
             var msbuildProjectLibraries = lockFile.ProjectLibraries.Where(MSBuildDependencyProvider.IsMSBuildProjectLibrary);
             _msbuildTargetLibraries = msbuildProjectLibraries.ToDictionary(GetProjectLibraryKey, l => GetTargetsForLibrary(_lockFile, l));
@@ -27,8 +29,8 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             var exportFilePath = GetExportFilePath(_lockFile.LockFilePath);
             if (File.Exists(exportFilePath) && _msbuildTargetLibraries.Any())
             {
-                var exportFile = LockFileReader.ReadExportFile(exportFilePath);
-                PatchLockWithExport(exportFile);   
+                var exportFile = _reader.ReadExportFile(exportFilePath);
+                PatchLockWithExport(exportFile);
             }
             else
             {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
@@ -13,15 +13,24 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ProjectModel.Graph
 {
-    public static class LockFileReader
-    {        
+    public class LockFileReader
+    {
+        private readonly LockFileSymbolTable _symbols;
+
+        public LockFileReader() : this(new LockFileSymbolTable()) { }
+
+        public LockFileReader(LockFileSymbolTable symbols)
+        {
+            _symbols = symbols;
+        }
+
         public static LockFile Read(string lockFilePath, bool designTime)
         {
             using (var stream = ResilientFileStreamOpener.OpenFile(lockFilePath))
             {
                 try
                 {
-                    return Read(lockFilePath, stream, designTime);
+                    return new LockFileReader().ReadLockFile(lockFilePath, stream, designTime);
                 }
                 catch (FileFormatException ex)
                 {
@@ -34,7 +43,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             }
         }
 
-        public static LockFile Read(string lockFilePath, Stream stream, bool designTime)
+        public LockFile ReadLockFile(string lockFilePath, Stream stream, bool designTime)
         {
             try
             {
@@ -47,10 +56,10 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                 }
 
                 var lockFile = ReadLockFile(lockFilePath, jobject);
-                
+
                 if (!designTime)
                 {
-                    var patcher = new LockFilePatcher(lockFile);
+                    var patcher = new LockFilePatcher(lockFile, this);
                     patcher.Patch();
                 }
 
@@ -70,7 +79,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             }
         }
 
-        public static ExportFile ReadExportFile(string fragmentLockFilePath)
+        public ExportFile ReadExportFile(string fragmentLockFilePath)
         {
             using (var stream = ResilientFileStreamOpener.OpenFile(fragmentLockFilePath))
             {
@@ -100,7 +109,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             }
         }
 
-        private static LockFile ReadLockFile(string lockFilePath, JsonObject cursor)
+        private LockFile ReadLockFile(string lockFilePath, JsonObject cursor)
         {
             var lockFile = new LockFile(lockFilePath);
             lockFile.Version = ReadInt(cursor, "version", defaultValue: int.MinValue);
@@ -111,7 +120,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             return lockFile;
         }
 
-        private static void ReadLibrary(JsonObject json, LockFile lockFile)
+        private void ReadLibrary(JsonObject json, LockFile lockFile)
         {
             if (json == null)
             {
@@ -128,9 +137,9 @@ namespace Microsoft.DotNet.ProjectModel.Graph
 
                 var parts = key.Split(new[] { '/' }, 2);
                 var name = parts[0];
-                var version = parts.Length == 2 ? NuGetVersion.Parse(parts[1]) : null;
+                var version = parts.Length == 2 ? _symbols.GetVersion(parts[1]) : null;
 
-                var type = value.ValueAsString("type")?.Value;
+                var type = _symbols.GetString(value.ValueAsString("type")?.Value);
 
                 if (type == null || string.Equals(type, "package", StringComparison.OrdinalIgnoreCase))
                 {
@@ -162,7 +171,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             }
         }
 
-        private static LockFileTarget ReadTarget(string property, JsonValue json)
+        private LockFileTarget ReadTarget(string property, JsonValue json)
         {
             var jobject = json as JsonObject;
             if (jobject == null)
@@ -172,10 +181,10 @@ namespace Microsoft.DotNet.ProjectModel.Graph
 
             var target = new LockFileTarget();
             var parts = property.Split(new[] { '/' }, 2);
-            target.TargetFramework = NuGetFramework.Parse(parts[0]);
+            target.TargetFramework = _symbols.GetFramework(parts[0]);
             if (parts.Length == 2)
             {
-                target.RuntimeIdentifier = parts[1];
+                target.RuntimeIdentifier = _symbols.GetString(parts[1]);
             }
 
             target.Libraries = ReadObject(jobject, ReadTargetLibrary);
@@ -183,7 +192,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             return target;
         }
 
-        private static LockFileTargetLibrary ReadTargetLibrary(string property, JsonValue json)
+        private LockFileTargetLibrary ReadTargetLibrary(string property, JsonValue json)
         {
             var jobject = json as JsonObject;
             if (jobject == null)
@@ -194,17 +203,17 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             var library = new LockFileTargetLibrary();
 
             var parts = property.Split(new[] { '/' }, 2);
-            library.Name = parts[0];
+            library.Name = _symbols.GetString(parts[0]);
             if (parts.Length == 2)
             {
-                library.Version = NuGetVersion.Parse(parts[1]);
+                library.Version = _symbols.GetVersion(parts[1]);
             }
 
-            library.Type = jobject.ValueAsString("type");
+            library.Type = _symbols.GetString(jobject.ValueAsString("type"));
             var framework = jobject.ValueAsString("framework");
             if (framework != null)
             {
-                library.TargetFramework = NuGetFramework.Parse(framework);
+                library.TargetFramework = _symbols.GetFramework(framework);
             }
 
             library.Dependencies = ReadObject(jobject.ValueAsJsonObject("dependencies"), ReadPackageDependency);
@@ -215,10 +224,11 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             library.NativeLibraries = ReadObject(jobject.ValueAsJsonObject("native"), ReadFileItem);
             library.ContentFiles = ReadObject(jobject.ValueAsJsonObject("contentFiles"), ReadContentFile);
             library.RuntimeTargets = ReadObject(jobject.ValueAsJsonObject("runtimeTargets"), ReadRuntimeTarget);
+
             return library;
         }
 
-        private static LockFileRuntimeTarget ReadRuntimeTarget(string property, JsonValue json)
+        private LockFileRuntimeTarget ReadRuntimeTarget(string property, JsonValue json)
         {
             var jsonObject = json as JsonObject;
             if (jsonObject == null)
@@ -227,13 +237,13 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             }
 
             return new LockFileRuntimeTarget(
-                path: property,
-                runtime: jsonObject.ValueAsString("rid"),
-                assetType: jsonObject.ValueAsString("assetType")
+                path: _symbols.GetString(property),
+                runtime: _symbols.GetString(jsonObject.ValueAsString("rid")),
+                assetType: _symbols.GetString(jsonObject.ValueAsString("assetType"))
                 );
         }
 
-        private static LockFileContentFile ReadContentFile(string property, JsonValue json)
+        private LockFileContentFile ReadContentFile(string property, JsonValue json)
         {
             var contentFile = new LockFileContentFile()
             {
@@ -248,7 +258,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                 BuildAction.TryParse(jsonObject.ValueAsString("buildAction"), out action);
 
                 contentFile.BuildAction = action;
-                var codeLanguage = jsonObject.ValueAsString("codeLanguage");
+                var codeLanguage = _symbols.GetString(jsonObject.ValueAsString("codeLanguage"));
                 if (codeLanguage == "any")
                 {
                     codeLanguage = null;
@@ -262,37 +272,37 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             return contentFile;
         }
 
-        private static ProjectFileDependencyGroup ReadProjectFileDependencyGroup(string property, JsonValue json)
+        private ProjectFileDependencyGroup ReadProjectFileDependencyGroup(string property, JsonValue json)
         {
             return new ProjectFileDependencyGroup(
                 string.IsNullOrEmpty(property) ? null : NuGetFramework.Parse(property),
                 ReadArray(json, ReadString));
         }
 
-        private static PackageDependency ReadPackageDependency(string property, JsonValue json)
+        private PackageDependency ReadPackageDependency(string property, JsonValue json)
         {
             var versionStr = ReadString(json);
             return new PackageDependency(
-                property,
-                versionStr == null ? null : VersionRange.Parse(versionStr));
+                _symbols.GetString(property),
+                versionStr == null ? null : _symbols.GetVersionRange(versionStr));
         }
 
-        private static LockFileItem ReadFileItem(string property, JsonValue json)
+        private LockFileItem ReadFileItem(string property, JsonValue json)
         {
-            var item = new LockFileItem { Path = PathUtility.GetPathWithDirectorySeparator(property) };
+            var item = new LockFileItem { Path = _symbols.GetString(PathUtility.GetPathWithDirectorySeparator(property)) };
             var jobject = json as JsonObject;
 
             if (jobject != null)
             {
                 foreach (var subProperty in jobject.Keys)
                 {
-                    item.Properties[subProperty] = jobject.ValueAsString(subProperty);
+                    item.Properties[_symbols.GetString(subProperty)] = jobject.ValueAsString(subProperty);
                 }
             }
             return item;
         }
 
-        private static string ReadFrameworkAssemblyReference(JsonValue json)
+        private string ReadFrameworkAssemblyReference(JsonValue json)
         {
             return ReadString(json);
         }
@@ -318,9 +328,9 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             return items;
         }
 
-        private static IList<string> ReadPathArray(JsonValue json, Func<JsonValue, string> readItem)
+        private IList<string> ReadPathArray(JsonValue json, Func<JsonValue, string> readItem)
         {
-            return ReadArray(json, readItem).Select(f => PathUtility.GetPathWithDirectorySeparator(f)).ToList();
+            return ReadArray(json, readItem).Select(f => _symbols.GetString(PathUtility.GetPathWithDirectorySeparator(f))).ToList();
         }
 
         private static IList<TItem> ReadObject<TItem>(JsonObject json, Func<string, JsonValue, TItem> readItem)
@@ -368,11 +378,11 @@ namespace Microsoft.DotNet.ProjectModel.Graph
             }
         }
 
-        private static string ReadString(JsonValue json)
+        private string ReadString(JsonValue json)
         {
             if (json is JsonString)
             {
-                return (json as JsonString).Value;
+                return _symbols.GetString((json as JsonString).Value);
             }
             else if (json is JsonNull)
             {

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileSymbolTable.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileSymbolTable.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.ProjectModel.Graph
+{
+    public class LockFileSymbolTable
+    {
+        private ConcurrentDictionary<string, NuGetVersion> _versionTable = new ConcurrentDictionary<string, NuGetVersion>(Environment.ProcessorCount * 4, 1000, StringComparer.Ordinal);
+        private ConcurrentDictionary<string, VersionRange> _versionRangeTable = new ConcurrentDictionary<string, VersionRange>(Environment.ProcessorCount * 4, 1000, StringComparer.Ordinal);
+        private ConcurrentDictionary<string, NuGetFramework> _frameworksTable = new ConcurrentDictionary<string, NuGetFramework>(Environment.ProcessorCount * 4, 1000, StringComparer.Ordinal);
+        private ConcurrentDictionary<string, string> _stringsTable = new ConcurrentDictionary<string, string>(Environment.ProcessorCount * 4, 1000, StringComparer.Ordinal);
+
+        public NuGetVersion GetVersion(string versionString) => _versionTable.GetOrAdd(versionString, (s) => NuGetVersion.Parse(s));
+        public VersionRange GetVersionRange(string versionRangeString) => _versionRangeTable.GetOrAdd(versionRangeString, (s) => VersionRange.Parse(s));
+        public NuGetFramework GetFramework(string frameworkString) => _frameworksTable.GetOrAdd(frameworkString, (s) => NuGetFramework.Parse(s));
+        public string GetString(string frameworkString) => _stringsTable.GetOrAdd(frameworkString, frameworkString);
+    }
+}

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -154,39 +154,6 @@ namespace Microsoft.DotNet.ProjectModel
                         .BuildAllTargets();
         }
 
-
-        /// <summary>
-        /// Creates a project context based on existing context but using runtime target
-        /// </summary>
-        /// <param name="context"></param>
-        /// <param name="runtimeIdentifiers"></param>
-        /// <returns></returns>
-
-        public ProjectContext CreateRuntimeContext(IEnumerable<string> runtimeIdentifiers)
-        {
-            // Temporary until we have removed RID inference from NuGet
-            if(TargetFramework.IsCompileOnly)
-            {
-                return this;
-            }
-
-            var context = CreateBuilder(ProjectFile.ProjectFilePath, TargetFramework)
-                .WithRuntimeIdentifiers(runtimeIdentifiers)
-                .WithLockFile(LockFile)
-                .Build();
-
-            if (!context.IsPortable && context.RuntimeIdentifier == null)
-            {
-                // We are standalone, but don't support this runtime
-                var rids = string.Join(", ", runtimeIdentifiers);
-                throw new InvalidOperationException($"Can not find runtime target for framework '{TargetFramework}' compatible with one of the target runtimes: '{rids}'. " +
-                                                    "Possible causes:" + Environment.NewLine +
-                                                    "1. The project has not been restored or restore failed - run `dotnet restore`" + Environment.NewLine +
-                                                    $"2. The project does not list one of '{rids}' in the 'runtimes' section.");
-            }
-            return context;
-        }
-
         public OutputPaths GetOutputPaths(string configuration, string buidBasePath = null, string outputPath = null)
         {
             return OutputPathsCalculator.GetOutputPaths(ProjectFile,

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContextCollection.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContextCollection.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.ProjectModel
 {
@@ -12,6 +14,8 @@ namespace Microsoft.DotNet.ProjectModel
         public Project Project { get; set; }
 
         public List<ProjectContext> ProjectContexts { get; } = new List<ProjectContext>();
+
+        public IEnumerable<ProjectContext> FrameworkOnlyContexts => ProjectContexts.Where(c => string.IsNullOrEmpty(c.RuntimeIdentifier));
 
         public List<DiagnosticMessage> ProjectDiagnostics { get; } = new List<DiagnosticMessage>();
 
@@ -49,6 +53,16 @@ namespace Microsoft.DotNet.ProjectModel
 
                 return false;
             }
+        }
+
+        public ProjectContext GetTarget(NuGetFramework targetFramework) => GetTarget(targetFramework, string.Empty);
+
+        public ProjectContext GetTarget(NuGetFramework targetFramework, string runtimeIdentifier)
+        {
+            return ProjectContexts
+                .FirstOrDefault(c =>
+                    Equals(c.TargetFramework, targetFramework) &&
+                    string.Equals(c.RuntimeIdentifier ?? string.Empty, runtimeIdentifier ?? string.Empty));
         }
 
         public void Reset()

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
@@ -85,8 +85,16 @@ namespace Microsoft.DotNet.ProjectModel
             var project = new Project();
 
             var reader = new StreamReader(stream);
+            JObject rawProject;
+            using (var jsonReader = new JsonTextReader(reader))
+            {
+                rawProject = JObject.Load(jsonReader);
 
-            var rawProject = JObject.Parse(reader.ReadToEnd());
+                // Try to read another token to ensure we're at the end of the document.
+                // This will no-op if we are, and throw a JsonReaderException if there is additional content (which is what we want)
+                jsonReader.Read();
+            }
+
             if (rawProject == null)
             {
                 throw FileFormatException.Create(

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/FrameworkReferenceResolver.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/FrameworkReferenceResolver.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
+using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.DotNet.ProjectModel.Utilities;
 using Microsoft.Extensions.DependencyModel.Resolution;
@@ -23,7 +25,7 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
 
         private static FrameworkReferenceResolver _default;
 
-        private readonly IDictionary<NuGetFramework, FrameworkInformation> _cache = new Dictionary<NuGetFramework, FrameworkInformation>();
+        private readonly ConcurrentDictionary<NuGetFramework, FrameworkInformation> _cache = new ConcurrentDictionary<NuGetFramework, FrameworkInformation>();
 
         private static readonly IDictionary<NuGetFramework, NuGetFramework[]> _aliases = new Dictionary<NuGetFramework, NuGetFramework[]>
         {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/MSBuildDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/MSBuildDependencyProvider.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
                     LibraryDependencyType.Default));
             }
 
-            if (!targetFramework.IsPackageBased)
+            if (!targetFramework.IsPackageBased())
             {
                 // Only add framework assemblies for non-package based frameworks.
                 foreach (var frameworkAssembly in targetLibrary.FrameworkAssemblies)

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
                     LibraryDependencyType.Default));
             }
 
-            if (!targetFramework.IsPackageBased)
+            if (!targetFramework.IsPackageBased())
             {
                 // Only add framework assemblies for non-package based frameworks.
                 foreach (var frameworkAssembly in targetLibrary.FrameworkAssemblies)

--- a/src/Microsoft.DotNet.ProjectModel/Utilities/FrameworksExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Utilities/FrameworksExtensions.cs
@@ -56,7 +56,7 @@ namespace NuGet.Frameworks
             }
             return name + "-" + frameworkName.Profile;
         }
-        
+
         internal static bool IsPackageBased(this NuGetFramework self)
         {
             return self.IsPackageBased ||

--- a/src/Microsoft.DotNet.ProjectModel/Utilities/ResilientFileStreamOpener.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Utilities/ResilientFileStreamOpener.cs
@@ -13,18 +13,18 @@ namespace Microsoft.DotNet.ProjectModel.Utilities
         {
             return OpenFile(filepath, 0);
         }
-       
+
         public static FileStream OpenFile(string filepath, int retry)
         {
             if (retry < 0)
             {
                 throw new ArgumentException("Retry can't be fewer than 0", nameof(retry));
             }
-            
+
             var count = 0;
             while (true)
             {
-                try 
+                try
                 {
                     return new FileStream(filepath, FileMode.Open, FileAccess.Read, FileShare.Read);
                 }

--- a/src/Microsoft.Extensions.DependencyModel/Resolution/DotNetReferenceAssembliesPathResolver.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/DotNetReferenceAssembliesPathResolver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
     public class DotNetReferenceAssembliesPathResolver
     {
         public static readonly string DotNetReferenceAssembliesPathEnv = "DOTNET_REFERENCE_ASSEMBLIES_PATH";
-        
+
         internal static string Resolve(IEnvironment envirnment, IFileSystem fileSystem, IRuntimeEnvironment runtimeEnvironment)
         {
             var path = envirnment.GetEnvironmentVariable(DotNetReferenceAssembliesPathEnv);
@@ -19,40 +19,40 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
             {
                 return path;
             }
-            
+
             return GetDefaultDotNetReferenceAssembliesPath(fileSystem, runtimeEnvironment);
         }
-        
+
         public static string Resolve()
         {
             return Resolve(EnvironmentWrapper.Default, FileSystemWrapper.Default, PlatformServices.Default.Runtime);
         }
-                
+
         private static string GetDefaultDotNetReferenceAssembliesPath(IFileSystem fileSystem, IRuntimeEnvironment runtimeEnvironment)
-        {            
+        {
             var os = runtimeEnvironment.OperatingSystemPlatform;
-            
+
             if (os == Platform.Windows)
             {
                 return null;
             }
-            
-            if (os == Platform.Darwin && 
+
+            if (os == Platform.Darwin &&
                 fileSystem.Directory.Exists("/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks"))
             {
                 return "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/xbuild-frameworks";
             }
-            
+
             if (fileSystem.Directory.Exists("/usr/local/lib/mono/xbuild-frameworks"))
             {
                 return "/usr/local/lib/mono/xbuild-frameworks";
             }
-            
+
             if (fileSystem.Directory.Exists("/usr/lib/mono/xbuild-frameworks"))
             {
                 return "/usr/lib/mono/xbuild-frameworks";
             }
-            
+
             return null;
         }
     }

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Cli
                 command = "help";
             }
 
-            int exitCode;            
+            int exitCode;
             Func<string[], int> builtIn;
             if (s_builtIns.TryGetValue(command, out builtIn))
             {
@@ -175,16 +175,16 @@ namespace Microsoft.DotNet.Cli
         {
             return (shortName != null && candidate.Equals("-" + shortName)) || (longName != null && candidate.Equals("--" + longName));
         }
-        
+
         private static string GetCommitSha()
         {
             var versionFile = DotnetFiles.VersionFile;
-            
+
             if (File.Exists(versionFile))
             {
                 return File.ReadLines(versionFile).FirstOrDefault()?.Substring(0, 10);
             }
-            
+
             return null;
         }
     }

--- a/src/dotnet/ProjectGlobbingResolver.cs
+++ b/src/dotnet/ProjectGlobbingResolver.cs
@@ -52,12 +52,17 @@ namespace Microsoft.DotNet.Tools.Compiler
                         yield return filePatternMatch.Path;
                     }
                 }
+                else if (value.Contains("*"))
+                {
+                    throw new InvalidOperationException($"Globbing pattern '{value}' did not match any files");
+                }
+                else if (value.EndsWith(Project.FileName))
+                {
+                    throw new InvalidOperationException($"Could not find project file '{value}'");
+                }
                 else
                 {
-                    throw new InvalidOperationException($"Could not resolve project path from '{value}':" +
-                                                        "1. It's not project file" +
-                                                        "2. It's not directory containing project.json file" +
-                                                        "3. Globbing returned no mathces");
+                    throw new InvalidOperationException($"Couldn't find '{Project.FileName}' in '{value}'");
                 }
             }
         }

--- a/src/dotnet/commands/dotnet-build/CompilerIOManager.cs
+++ b/src/dotnet/commands/dotnet-build/CompilerIOManager.cs
@@ -18,16 +18,19 @@ namespace Microsoft.DotNet.Tools.Build
         private readonly string _outputPath;
         private readonly string _buildBasePath;
         private readonly IList<string> _runtimes;
+        private readonly WorkspaceContext _workspace;
 
         public CompilerIOManager(string configuration,
             string outputPath,
             string buildBasePath,
-            IEnumerable<string> runtimes)
+            IEnumerable<string> runtimes,
+            WorkspaceContext workspace)
         {
             _configuration = configuration;
             _outputPath = outputPath;
             _buildBasePath = buildBasePath;
             _runtimes = runtimes.ToList();
+            _workspace = workspace;
         }
 
         public bool AnyMissingIO(ProjectContext project, IEnumerable<string> items, string itemsType)
@@ -75,7 +78,7 @@ namespace Microsoft.DotNet.Tools.Build
             var allOutputPath = new HashSet<string>(calculator.CompilationFiles.All());
             if (isRootProject && project.ProjectFile.HasRuntimeOutput(_configuration))
             {
-                var runtimeContext = project.CreateRuntimeContext(_runtimes);
+                var runtimeContext = _workspace.GetRuntimeContext(project, _runtimes);
                 foreach (var path in runtimeContext.GetOutputPaths(_configuration, _buildBasePath, _outputPath).RuntimeFiles.All())
                 {
                     allOutputPath.Add(path);

--- a/src/dotnet/commands/dotnet-build/DotnetProjectBuilder.cs
+++ b/src/dotnet/commands/dotnet-build/DotnetProjectBuilder.cs
@@ -33,7 +33,8 @@ namespace Microsoft.DotNet.Tools.Build
                 args.ConfigValue,
                 args.OutputValue,
                 args.BuildBasePathValue,
-                args.GetRuntimes()
+                args.GetRuntimes(),
+                args.Workspace
                 );
             _scriptRunner = new ScriptRunner();
             _commandFactory = new DotNetCommandFactory();
@@ -120,7 +121,7 @@ namespace Microsoft.DotNet.Tools.Build
         private void MakeRunnable(ProjectGraphNode graphNode)
         {
             var runtimeContext = graphNode.ProjectContext.ProjectFile.HasRuntimeOutput(_args.ConfigValue) ?
-                graphNode.ProjectContext.CreateRuntimeContext(_args.GetRuntimes()) :
+                _args.Workspace.GetRuntimeContext(graphNode.ProjectContext, _args.GetRuntimes()) :
                 graphNode.ProjectContext;
 
             var outputPaths = runtimeContext.GetOutputPaths(_args.ConfigValue, _args.BuildBasePathValue, _args.OutputValue);

--- a/src/dotnet/commands/dotnet-compile/CompilationDriver.cs
+++ b/src/dotnet/commands/dotnet-compile/CompilationDriver.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                 success &= _managedCompiler.Compile(context, args);
                 if (args.IsNativeValue && success)
                 {
-                    var runtimeContext = context.CreateRuntimeContext(args.GetRuntimes());
+                    var runtimeContext = args.Workspace.GetRuntimeContext(context, args.GetRuntimes());
                     success &= _nativeCompiler.Compile(runtimeContext, args);
                 }
             }

--- a/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
+++ b/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
@@ -170,7 +170,7 @@ namespace Microsoft.DotNet.Tools.Compiler
 
             if (context.ProjectFile.HasRuntimeOutput(args.ConfigValue))
             {
-                var runtimeContext = context.CreateRuntimeContext(args.GetRuntimes());
+                var runtimeContext = args.Workspace.GetRuntimeContext(context, args.GetRuntimes());
                 var runtimeOutputPath = runtimeContext.GetOutputPaths(args.ConfigValue, args.BuildBasePathValue, args.OutputValue);
 
                 contextVariables.Add(

--- a/src/dotnet/commands/dotnet-projectmodel-server/InternalModels/ProjectSnapshot.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/InternalModels/ProjectSnapshot.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.DotNet.ProjectModel.Server.Helpers;
 using Microsoft.DotNet.ProjectModel.Server.Models;
@@ -35,12 +36,12 @@ namespace Microsoft.DotNet.ProjectModel.Server
             snapshot.ProjectSearchPaths = currentSearchPaths.ToList();
             snapshot.GlobalJsonPath = globalSettings?.FilePath;
 
-            foreach (var projectContext in projectContextsCollection.ProjectContexts)
+            foreach (var projectContext in projectContextsCollection.FrameworkOnlyContexts)
             {
-                snapshot.ProjectContexts[projectContext.TargetFramework] = 
+                snapshot.ProjectContexts[projectContext.TargetFramework] =
                     ProjectContextSnapshot.Create(projectContext, configuration, currentSearchPaths);
             }
-            
+
             return snapshot;
         }
     }

--- a/src/dotnet/commands/dotnet-projectmodel-server/ProjectManager.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/ProjectManager.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.ProjectModel.Server
             catch (Exception ex)
             {
                 _log.LogError("A unexpected exception occurred: {0}", ex.ToString());
-                
+
                 var error = new ErrorMessage
                 {
                     Message = ex.Message

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ProjectModel;
 
 namespace Microsoft.DotNet.Tools.Publish
 {
@@ -43,6 +44,8 @@ namespace Microsoft.DotNet.Tools.Publish
                 publish.ProjectPath = projectPath.Value;
                 publish.VersionSuffix = versionSuffix.Value();
                 publish.ShouldBuild = !noBuild.HasValue();
+
+                publish.Workspace = WorkspaceContext.Create(versionSuffix.Value(), designTime: false);
 
                 if (string.IsNullOrEmpty(publish.ProjectPath))
                 {

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -42,7 +42,10 @@ namespace Microsoft.DotNet.Tools.Test
                     RegisterForParentProcessExit(dotnetTestParams.ParentProcessId.Value);
                 }
 
-                var projectContexts = CreateProjectContexts(dotnetTestParams.ProjectPath, dotnetTestParams.Runtime);
+                // Create a workspace
+                var workspace = WorkspaceContext.Create(ProjectReaderSettings.ReadFromEnvironment(), designTime: false);
+
+                var projectContexts = CreateProjectContexts(workspace, dotnetTestParams.ProjectPath, dotnetTestParams.Runtime);
 
                 var projectContext = projectContexts.First();
 
@@ -98,7 +101,7 @@ namespace Microsoft.DotNet.Tools.Test
             }
         }
 
-        private static IEnumerable<ProjectContext> CreateProjectContexts(string projectPath, string runtime)
+        private static IEnumerable<ProjectContext> CreateProjectContexts(WorkspaceContext workspace, string projectPath, string runtime)
         {
             projectPath = projectPath ?? Directory.GetCurrentDirectory();
 
@@ -116,7 +119,8 @@ namespace Microsoft.DotNet.Tools.Test
                 new[] { runtime } :
                 PlatformServices.Default.Runtime.GetAllCandidateRuntimeIdentifiers();
 
-            return ProjectContext.CreateContextForEachFramework(projectPath).Select(context => context.CreateRuntimeContext(runtimeIdentifiers));
+            var contexts = workspace.GetProjectContextCollection(projectPath).FrameworkOnlyContexts;
+            return contexts.Select(c => workspace.GetRuntimeContext(c, runtimeIdentifiers));
         }
     }
 }

--- a/test/Microsoft.DotNet.ProjectModel.Tests/PackageDependencyProviderTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/PackageDependencyProviderTests.cs
@@ -43,14 +43,14 @@ namespace Microsoft.DotNet.ProjectModel.Tests
         }
 
         [Theory]
-        [InlineDataAttribute("TestMscorlibReference", true)]
-        [InlineDataAttribute("TestMscorlibReference", false)]
-        [InlineDataAttribute("TestMicrosoftCSharpReference", true)]
-        [InlineDataAttribute("TestMicrosoftCSharpReference", false)]
-        [InlineDataAttribute("TestSystemReference", true)]
-        [InlineDataAttribute("TestSystemReference", false)]
-        [InlineDataAttribute("TestSystemCoreReference", true)]
-        [InlineDataAttribute("TestSystemCoreReference", false)]
+        [InlineData("TestMscorlibReference", true)]
+        [InlineData("TestMscorlibReference", false)]
+        [InlineData("TestMicrosoftCSharpReference", true)]
+        [InlineData("TestMicrosoftCSharpReference", false)]
+        [InlineData("TestSystemReference", true)]
+        [InlineData("TestSystemReference", false)]
+        [InlineData("TestSystemCoreReference", true)]
+        [InlineData("TestSystemCoreReference", false)]
         public void TestDuplicateDefaultDesktopReferences(string sampleName, bool withLockFile)
         {
             var instance = TestAssetsManager.CreateTestInstance(sampleName);
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.ProjectModel.Tests
 
             Assert.Equal(4, context.RootProject.Dependencies.Count());
         }
-        
+
         [Fact]
         public void NoDuplicateReferencesWhenFrameworkMissing()
         {
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.ProjectModel.Tests
             // Will fail with dupes if any
             context.LibraryManager.GetLibraries().ToDictionary(l => l.Identity.Name);
         }
-        
+
         [Fact]
         public void NetCore50ShouldNotResolveFrameworkAssemblies()
         {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -109,12 +109,11 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         private CommandResult RunProcess(string executable, string args, StreamForwarder stdOut, StreamForwarder stdErr)
         {
             CurrentProcess = StartProcess(executable, args);
-            var threadOut = stdOut.BeginRead(CurrentProcess.StandardOutput);
-            var threadErr = stdErr.BeginRead(CurrentProcess.StandardError);
+            var taskOut = stdOut.BeginRead(CurrentProcess.StandardOutput);
+            var taskErr = stdErr.BeginRead(CurrentProcess.StandardError);
 
             CurrentProcess.WaitForExit();
-            threadOut.Join();
-            threadErr.Join();
+            Task.WaitAll(taskOut, taskErr);
 
             var result = new CommandResult(
                 CurrentProcess.StartInfo,
@@ -128,14 +127,13 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         private Task<CommandResult> RunProcessAsync(string executable, string args, StreamForwarder stdOut, StreamForwarder stdErr)
         {
             CurrentProcess = StartProcess(executable, args);
-            var threadOut = stdOut.BeginRead(CurrentProcess.StandardOutput);
-            var threadErr = stdErr.BeginRead(CurrentProcess.StandardError);
+            var taskOut = stdOut.BeginRead(CurrentProcess.StandardOutput);
+            var taskErr = stdErr.BeginRead(CurrentProcess.StandardError);
 
             var tcs = new TaskCompletionSource<CommandResult>();
             CurrentProcess.Exited += (sender, arg) =>
             {
-                threadOut.Join();
-                threadErr.Join();
+                Task.WaitAll(taskOut, taskErr);
                 var result = new CommandResult(
                                     CurrentProcess.StartInfo,
                                     CurrentProcess.ExitCode,

--- a/test/dotnet-compile.UnitTests/GivenACompilationDriver.cs
+++ b/test/dotnet-compile.UnitTests/GivenACompilationDriver.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
         private Mock<ICompiler> _nativeCompilerMock;
         private List<ProjectContext> _contexts;
         private BuildCommandApp _args;
+        private readonly WorkspaceContext _workspace;
 
         public GivenACompilationDriverController()
         {
@@ -34,12 +35,13 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
                 .Compile(It.IsAny<ProjectContext>(), It.IsAny<BuildCommandApp>()))
                 .Returns(true);
 
+            _workspace = WorkspaceContext.Create(ProjectReaderSettings.ReadFromEnvironment(), designTime: false);
             _contexts = new List<ProjectContext>
             {
-                ProjectContext.Create(_projectJson, NuGetFramework.Parse("netcoreapp1.0"))
+                _workspace.GetProjectContext(_projectJson, NuGetFramework.Parse("netcoreapp1.0"))
             };
 
-            _args = new BuildCommandApp("dotnet compile", ".NET Compiler", "Compiler for the .NET Platform");
+            _args = new BuildCommandApp("dotnet compile", ".NET Compiler", "Compiler for the .NET Platform", WorkspaceContext.Create(designTime: false));
         }
 
         [Fact]

--- a/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
+++ b/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
@@ -188,7 +188,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
                     It.IsAny<string>()))
                 .Returns(command.Object);
 
-            var _args = new BuildCommandApp("dotnet compile", ".NET Compiler", "Compiler for the .NET Platform");
+            var _args = new BuildCommandApp("dotnet compile", ".NET Compiler", "Compiler for the .NET Platform", WorkspaceContext.Create(designTime: false));
             _args.ConfigValue = ConfigValue;
 
             PreCompileScriptVariables = new Dictionary<string, string>();
@@ -219,7 +219,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
                 rids.Add(rid);
             }
 
-            var context = ProjectContext.Create(projectJson, TestAssetFramework, rids);
+            var workspace = WorkspaceContext.Create(ProjectReaderSettings.ReadFromEnvironment(), designTime: false);
+            var context = workspace.GetProjectContext(projectJson, TestAssetFramework, rids);
             managedCompiler.Compile(context, _args);
 
             RuntimeOutputDir = Path.Combine(OutputPath, rid);

--- a/test/dotnet-projectmodel-server.Tests/DthTestClient.cs
+++ b/test/dotnet-projectmodel-server.Tests/DthTestClient.cs
@@ -228,7 +228,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
             _writer.Dispose();
             _networkStream.Dispose();
             _readCancellationToken.Cancel();
-            
+
             try
             {
                 _socket.Shutdown(SocketShutdown.Both);

--- a/test/dotnet-projectmodel-server.Tests/DthTests.cs
+++ b/test/dotnet-projectmodel-server.Tests/DthTests.cs
@@ -506,13 +506,13 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
                 var testProjectRoot = Path.Combine(RepoRoot, "TestAssets", "ProjectModelServer", "MSBuildReferencesProjects", "ValidCase01");
                 foreach (var classLibrary in classLibraries)
                 {
-                    dependencies.RetrieveDependency(classLibrary)
-                                .AssertProperty("Type", LibraryType.MSBuildProject.ToString())
-                                .AssertProperty("Path", NormalizePathString(Path.Combine(testProjectRoot, classLibrary, $"{classLibrary}.csproj")))
-                                .AssertProperty<bool>("Resolved", true)
-                                .AssertProperty("Name", classLibrary)
-                                .AssertProperty<JArray>("Errors", array => array.Count == 0)
-                                .AssertProperty<JArray>("Warnings", array => array.Count == 0);
+                    var dependency = dependencies.RetrieveDependency(classLibrary);
+                    dependency.AssertProperty("Type", LibraryType.MSBuildProject.ToString());
+                    dependency.AssertProperty("Path", NormalizePathString(Path.Combine(testProjectRoot, classLibrary, $"{classLibrary}.csproj")));
+                    dependency.AssertProperty<bool>("Resolved", true);
+                    dependency.AssertProperty("Name", classLibrary);
+                    dependency.AssertProperty<JArray>("Errors", array => array.Count == 0);
+                    dependency.AssertProperty<JArray>("Warnings", array => array.Count == 0);
                 }
 
                 var references = messages.RetrieveSingleMessage(MessageTypes.References)
@@ -632,12 +632,12 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
                 afterDependencies.RetrieveDependency("ClassLibrary3");
             }
         }
-        
+
         [Fact]
         public void TestMscorlibLibraryDuplication()
         {
             var projectPath = Path.Combine(RepoRoot, "TestAssets", "ProjectModelServer", "MscorlibLibraryDuplication");
-            
+
             using (var server = new DthTestServer(_loggerFactory))
             using (var client = new DthTestClient(server, _loggerFactory))
             {

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -28,7 +28,8 @@
     }
   },
   "content": [
-    "../../TestAssets/TestProjects/ProjectWithTests/project.json"
+    "../../TestAssets/TestProjects/ProjectWithTests/project.json",
+    "../../TestAssets/TestProjects/ProjectWithTests/project.lock.json"
   ],
   "testRunner": "xunit"
 }


### PR DESCRIPTION
* Use a WorkspaceContext in dotnet-build to cache project data across
multiple compilations in a single build action
* Dramatically reduce string and object duplication by introducing a
"Symbol Table" that shares instances of NuGetVersion, NuGetFramework,
VersionRange and string across multiple lock-file parses

Test Results:
* Testing was done by compiling Microsoft.AspNetCore.Mvc (and it's
dependencies) and taking memory snapshots after each compilation in
dotMemory
* We used to allocate ~3MB and deallocate ~2.5MB on EACH compilation in
a single build action. This has been reduced to ~120KB
allocated/deallocated
* After introducing WorkspaceContext, total memory usage spiked from 6MB
across the whole build action to about 13MB, introducing the symbol
table dropped it back to about 5-6MB.

Part of fixes for #2520 

/cc @davidfowl @pakrym @troydai (for DTH-related changes) @cdmihai

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2626)
<!-- Reviewable:end -->
