### PR TITLE
Muxer lock down

### DIFF
--- a/scripts/common/_common.ps1
+++ b/scripts/common/_common.ps1
@@ -13,7 +13,6 @@ $Stage1Dir = $env:Stage1Dir
 $Stage1CompilationDir = $env:Stage1CompilationDir
 $Stage2Dir = $env:Stage2Dir
 $Stage2CompilationDir = $env:Stage2CompilationDir
-$HostDir = $env:HostDir
 $PackageDir = $env:PackageDir
 $TestBinRoot = $env:TestBinRoot
 $TestPackageDir = $env:TestPackageDir

--- a/scripts/dotnet-cli-build/PackageTargets.cs
+++ b/scripts/dotnet-cli-build/PackageTargets.cs
@@ -274,7 +274,6 @@ namespace Microsoft.DotNet.Cli.Build
                 { "Stage2Dir", Dirs.Stage2 },
                 { "STAGE2_DIR", Dirs.Stage2 },
                 { "Stage2CompilationDir", Dirs.Stage2Compilation },
-                { "HostDir", Dirs.Corehost },
                 { "PackageDir", Path.Combine(Dirs.Packages) }, // Legacy name
                 { "TestBinRoot", Dirs.TestOutput },
                 { "TestPackageDir", Dirs.TestPackages },

--- a/scripts/dotnet-cli-build/PrepareTargets.cs
+++ b/scripts/dotnet-cli-build/PrepareTargets.cs
@@ -229,7 +229,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var dotnet = DotNetCli.Stage0;
 
-            dotnet.Restore("--verbosity", "verbose", "--disable-parallel", "--fallbacksource", Dirs.Corehost)
+            dotnet.Restore("--verbosity", "verbose", "--disable-parallel", "--fallbacksource", Dirs.CorehostLocalPackages)
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "src"))
                 .Execute()
                 .EnsureSuccessful();

--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Cli.Build
         [Target]
         public static BuildTargetResult PublishCoreHostPackages(BuildTargetContext c)
         {
-            foreach (var file in Directory.GetFiles(Dirs.Corehost, "*.nupkg"))
+            foreach (var file in Directory.GetFiles(Dirs.CorehostLocalPackages, "*.nupkg"))
             {
                 var hostBlob = $"{Channel}/Binaries/{CliNuGetVersion}/{Path.GetFileName(file)}";
                 AzurePublisherTool.PublishFile(hostBlob, file);

--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Cli.Build
             var dotnet = DotNetCli.Stage2;
             dotnet.Restore("--verbosity", "verbose",
                 "--infer-runtimes",
-                "--fallbacksource", Dirs.Corehost,
+                "--fallbacksource", Dirs.CorehostLocalPackages,
                 "--fallbacksource", Dirs.CorehostDummyPackages)
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "TestPackages"))
                 .Execute()
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.Cli.Build
                 "--verbosity", "verbose",
                 "--infer-runtimes",
                 "--fallbacksource", Dirs.TestPackages,
-                "--fallbacksource", Dirs.Corehost,
+                "--fallbacksource", Dirs.CorehostLocalPackages,
                 "--fallbacksource", Dirs.CorehostDummyPackages)
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "TestProjects"))
                 .Execute()
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.Cli.Build
             dotnet.Restore(
                 "--verbosity", "verbose",
                 "--infer-runtimes",
-                "--fallbacksource", Dirs.Corehost,
+                "--fallbacksource", Dirs.CorehostLocalPackages,
                 "--fallbacksource", Dirs.CorehostDummyPackages)
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "ProjectModelServer", "DthTestProjects"))
                 .Execute();
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Cli.Build
             dotnet.Restore("--verbosity", "verbose",
                 "--infer-runtimes",
                 "--fallbacksource", Dirs.TestPackages,
-                "--fallbacksource", Dirs.Corehost,
+                "--fallbacksource", Dirs.CorehostLocalPackages,
                 "--fallbacksource", Dirs.CorehostDummyPackages)
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "DesktopTestProjects"))
                 .Execute().EnsureSuccessful();
@@ -266,7 +266,7 @@ namespace Microsoft.DotNet.Cli.Build
             CleanNuGetTempCache();
             DotNetCli.Stage2.Restore("--verbosity", "verbose",
                 "--fallbacksource", Dirs.TestPackages,
-                "--fallbacksource", Dirs.Corehost,
+                "--fallbacksource", Dirs.CorehostLocalPackages,
                 "--fallbacksource", Dirs.CorehostDummyPackages)
                 .WorkingDirectory(Path.Combine(c.BuildContext.BuildDirectory, "test"))
                 .Execute()

--- a/scripts/dotnet-cli-build/Utils/BuildVersion.cs
+++ b/scripts/dotnet-cli-build/Utils/BuildVersion.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.DotNet.Cli.Build
+﻿using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Cli.Build
 {
     public class BuildVersion
     {
@@ -13,8 +15,45 @@
         public string VersionSuffix => $"{ReleaseSuffix}-{CommitCountString}";
         public string NuGetVersion => $"{Major}.{Minor}.{Patch}-{VersionSuffix}";
         public string NetCoreAppVersion => $"{Major}.{Minor}.{Patch}-rc2-3{CommitCountString}";
-        public string HostNuGetPackageVersion => $"{Major}.{Minor}.1-rc2-{CommitCountString}-00";
         public string ProductionVersion => $"{Major}.{Minor}.{Patch}";
+
+        // ------------------------------------------HOST-VERSIONING-------------------------------------------
+        //
+        // Host versions are independent of CLI versions. Moreover, these version numbers
+        // are baked into the binary and is used to look up a serviced binary replacement.
+        //
+
+        //
+        // Latest hosts for production of nupkgs.
+        //
+
+        // Version constants without suffix
+        public string LatestHostVersionNoSuffix => "1.0.1";
+        public string LatestHostFxrVersionNoSuffix => "1.0.1";
+        public string LatestHostPolicyVersionNoSuffix => "1.0.1";
+        public string LatestHostPrerelease => "rc2";
+        public string LatestHostBuildMajor => $"{CommitCountString}";
+        public string LatestHostSuffix => $"{LatestHostPrerelease}-{LatestHostBuildMajor}-00";
+
+        // Full versions and package information.
+        private string LatestHostVersion => $"{LatestHostVersionNoSuffix}-{LatestHostSuffix}";
+        private string LatestHostFxrVersion => $"{LatestHostFxrVersionNoSuffix}-{LatestHostSuffix}";
+        public  string LatestHostPolicyVersion => $"{LatestHostPolicyVersionNoSuffix}-{LatestHostSuffix}";
+        public Dictionary<string, string> LatestHostPackages => new Dictionary<string, string>()
+        {
+            { "Microsoft.NETCore.DotNetHost", LatestHostVersion },
+            { "Microsoft.NETCore.DotNetHostResolver", LatestHostFxrVersion },
+            { "Microsoft.NETCore.DotNetHostPolicy", LatestHostPolicyVersion }
+        };
+
+        //
+        // Locked muxer for consumption in CLI.
+        //
+        public bool IsLocked = false; // Set this variable to toggle muxer locking.
+        public string LockedHostFxrVersion => IsLocked ? "1.0.1-rc2-002468-00" : LatestHostFxrVersion;
+
+        //
+        // -----------------------------------------END-OF-HOST-VERSIONING-------------------------------------
 
         public string GenerateMsiVersion()
         {
@@ -29,7 +68,6 @@
             // CLI minor  -> 6 bits
             // CLI patch  -> 6 bits
             // CLI commitcount -> 14 bits
-
             var major = Major << 26;
             var minor = Minor << 20;
             var patch = Patch << 14;

--- a/scripts/dotnet-cli-build/Utils/Dirs.cs
+++ b/scripts/dotnet-cli-build/Utils/Dirs.cs
@@ -22,7 +22,9 @@ namespace Microsoft.DotNet.Cli.Build
         public static readonly string Stage2 = Path.Combine(Output, "stage2");
         public static readonly string Stage2Compilation = Path.Combine(Output, "stage2compilation");
         public static readonly string Stage2Symbols = Path.Combine(Output, "stage2symbols");
-        public static readonly string Corehost = Path.Combine(Output, "corehost");
+        public static readonly string CorehostLatest = Path.Combine(Output, "corehost"); // Not using Path.Combine(Output, "corehost", "latest") to keep signing working.
+        public static readonly string CorehostLocked = Path.Combine(Output, "corehost", "locked");
+        public static readonly string CorehostLocalPackages = Path.Combine(Output, "corehost");
         public static readonly string CorehostDummyPackages = Path.Combine(Output, "corehostdummypackages");
         public static readonly string TestOutput = Path.Combine(Output, "tests");
         public static readonly string TestArtifacts = Path.Combine(TestOutput, "artifacts");

--- a/src/corehost/build.sh
+++ b/src/corehost/build.sh
@@ -103,6 +103,7 @@ esac
 __cmake_defines="${__cmake_defines} ${__arch_define}"
 
 
+# __rid_plat is the base RID that corehost is shipped for, effectively, the name of the folder in "runtimes/{__rid_plat}/native/" inside the nupkgs.
 __rid_plat=
 if [ "$(uname -s)" == "Darwin" ]; then
     __rid_plat=osx.10.10


### PR DESCRIPTION
@piotrpMSFT once this makes through the CI and a build is generated, we need to lock to that version with another commit. I need to resolve the `restore` `publish` of `RestoreLockedCoreHost` target on non-Windows as they want the exact RID apparently. Otherwise, it is close to done.

We have three folders:
`artifacts/win7-x64/corehost/latest`
`artifacts/win7-x64/corehost/locked`
`artifacts/win7-x64/corehost`

1. Binaries get dumped into `latest` by build process.
2. Nupkgs are produced into `corehost` from `latest`.
3. `locked` is populated with what we `locked` on. You can be `locked` on either `latest` available in `corehost` from step 2 or a known version available on the feed.

Working on the CI issues, @Sridhar-MS you can take a look...

Cc @leecow @gkhanna79 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2636)
<!-- Reviewable:end -->