### PR TITLE
Create breadcrumb store folder in the sharedframework MSI

### DIFF
--- a/packaging/windows/sharedframework/sharedframework.wxs
+++ b/packaging/windows/sharedframework/sharedframework.wxs
@@ -11,6 +11,27 @@
         <Feature Id="MainFeature" Title="Main Feature" Level="1">
             <ComponentGroupRef Id="InstallFiles" />
             <ComponentGroupRef Id="AuthoredRegistryKeys"/>
+            <Component Id="BreadcrumbStoreFolder" Directory="BreadcrumbStore" Guid="{DA957490-EA59-42B9-B9D6-3E80F6FB0ED0}">
+                <CreateFolder Directory="BreadcrumbStore">
+                    <Permission
+                        User="Everyone"
+                        CreateChild="no"
+                        CreateFile="yes"
+                        Delete="no"
+                        DeleteChild="no"
+                        Read="yes"
+                        ReadAttributes="yes"
+                        ReadExtendedAttributes="yes"
+                        ReadPermission="yes"
+                        Traverse="yes" />
+                    <Permission
+                        User="SYSTEM"
+                        GenericAll="yes" />
+                    <Permission
+                        User="Administrators"
+                        GenericAll="yes" />
+                </CreateFolder>
+            </Component>
         </Feature>
         <Feature Id="Provider" Absent="disallow" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" Level="1" InstallDefault="local" Title="RefCounting" TypicalDefault="install">
             <ComponentRef Id="DotNet_CLI_SharedFramework_$(var.FrameworkName)_$(var.FrameworkComponentVersion)" />
@@ -29,6 +50,13 @@
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="$(var.Program_Files)">
                 <Directory Id="DOTNETHOME" Name="dotnet" />
+            </Directory>
+            <Directory Id="CommonAppDataFolder">
+              <Directory Id="MicrosoftCommonAppData" Name="Microsoft">
+                <Directory Id="NetFrameworkCommonAppData" Name="NetFramework">
+                  <Directory Id="BreadcrumbStore" Name="BreadcrumbStore" />
+                </Directory>
+              </Directory>
             </Directory>
         </Directory>
     </Fragment>


### PR DESCRIPTION
@gkhanna79 , @ericstj 

I tested this by:

1. temporarily changing the folder name and ensuring it was created/deleted as expected.
2. Installing it over my existing Breadcrumb folder. The folder remained, but the permissions on the folder were re-set to what they were initially (i.e. if I give myself access to open the folder and then run the installer, I have to give myself access again). This seems like correct behavior to me. Uninstalling left the folder there, as well.

I'm not very experienced at WiX authoring so I can move this or clean this up if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2662)
<!-- Reviewable:end -->
