### PR TITLE
align code in dotnet-run

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/WorkspaceContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/WorkspaceContext.cs
@@ -171,9 +171,7 @@ namespace Microsoft.DotNet.ProjectModel
                 EmptyArray<ProjectContext>.Value;
         }
 
-        public ProjectContext GetProjectContext(string projectPath, NuGetFramework framework) => GetProjectContext(projectPath, framework, EmptyArray<string>.Value);
-
-        public ProjectContext GetProjectContext(string projectPath, NuGetFramework framework, IEnumerable<string> runtimeIdentifier)
+        public ProjectContext GetProjectContext(string projectPath, NuGetFramework framework)
         {
             var contexts = GetProjectContextCollection(projectPath);
             if (contexts == null)
@@ -183,11 +181,16 @@ namespace Microsoft.DotNet.ProjectModel
 
             return contexts
                 .ProjectContexts
-                .FirstOrDefault(c => Equals(c.TargetFramework, framework) && RidsMatch(c.RuntimeIdentifier, runtimeIdentifier));
+                .FirstOrDefault(c => Equals(c.TargetFramework, framework) && string.IsNullOrEmpty(c.RuntimeIdentifier));
         }
 
         public ProjectContext GetRuntimeContext(ProjectContext context, IEnumerable<string> runtimeIdentifiers)
         {
+            if(!runtimeIdentifiers.Any())
+            {
+                return context;
+            }
+
             var contexts = GetProjectContextCollection(context.ProjectDirectory);
             if (contexts == null)
             {
@@ -514,12 +517,6 @@ namespace Microsoft.DotNet.ProjectModel
 
                 yield return description;
             }
-        }
-
-        private static bool RidsMatch(string rid, IEnumerable<string> compatibleRids)
-        {
-            return (string.IsNullOrEmpty(rid) && !compatibleRids.Any()) ||
-                (compatibleRids.Contains(rid));
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RunCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RunCommand.cs
@@ -14,50 +14,15 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         private bool _preserveTemporary;
         private string _appArgs;
 
-        private string ProjectPathOption
-        {
-            get
-            {
-                return _projectPath == string.Empty ?
-                                       "" :
-                                       $"-p \"{_projectPath}\"";
-            }
-        }
+        private string ProjectPathOption => string.IsNullOrEmpty(_projectPath) ? "" : $"-p \"{_projectPath}\"";
 
-        private string FrameworkOption
-        {
-            get
-            {
-                return _framework == string.Empty ?
-                                       "" :
-                                       $"-f {_framework}";
-            }
-        }
+        private string FrameworkOption => string.IsNullOrEmpty(_framework) ? "" : $"-f {_framework}";
 
-        private string ConfigurationOption
-        {
-            get
-            {
-                return _configuration == string.Empty ?
-                                       "" :
-                                       $"-c {_configuration}";
-            }
-        }
+        private string ConfigurationOption => string.IsNullOrEmpty(_configuration) ? "" : $"-c {_configuration}";
 
-        private string PreserveTemporaryOption
-        {
-            get
-            {
-                return _preserveTemporary ?
-                                       $"-t \"{_projectPath}\"" :
-                                       "";
-            }
-        }
+        private string PreserveTemporaryOption => _preserveTemporary ? $"-t \"{_projectPath}\"" : "";
 
-        private string AppArgsArgument
-        {
-            get { return _appArgs; }
-        }
+        private string AppArgsArgument => _appArgs;
 
         public RunCommand(
             string projectPath,
@@ -92,9 +57,6 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return base.ExecuteAsync(args);
         }
 
-        private string BuildArgs()
-        {
-            return $"{ProjectPathOption} {FrameworkOption} {ConfigurationOption} {PreserveTemporaryOption} {AppArgsArgument}";
-        }
+        private string BuildArgs() => $"{ProjectPathOption} {FrameworkOption} {ConfigurationOption} {PreserveTemporaryOption} {AppArgsArgument}";
     }
 }

--- a/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
+++ b/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
@@ -220,7 +220,8 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
             }
 
             var workspace = WorkspaceContext.Create(ProjectReaderSettings.ReadFromEnvironment(), designTime: false);
-            var context = workspace.GetProjectContext(projectJson, TestAssetFramework, rids);
+            var context = workspace.GetRuntimeContext(workspace.GetProjectContext(projectJson, TestAssetFramework), rids);
+            context = workspace.GetRuntimeContext(context, rids);
             managedCompiler.Compile(context, _args);
 
             RuntimeOutputDir = Path.Combine(OutputPath, rid);

--- a/test/dotnet-publish.Tests/PublishDesktopTests.cs
+++ b/test/dotnet-publish.Tests/PublishDesktopTests.cs
@@ -89,9 +89,11 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
         }
 
         [WindowsOnlyTheory]
-        [InlineData("KestrelDesktop", "http://localhost:20301")]
-        [InlineData("KestrelDesktopWithRuntimes", "http://localhost:20302")]
-        public async Task DesktopApp_WithKestrel_WorksWhenRun(string project, string url)
+        [InlineData("KestrelDesktop", "http://localhost:20301", null)]
+        [InlineData("KestrelDesktopWithRuntimes", "http://localhost:20302", null)]
+        [InlineData("KestrelDesktop", "http://localhost:20303", "net451")]
+        [InlineData("KestrelDesktopWithRuntimes", "http://localhost:20304", "net451")]
+        public async Task DesktopApp_WithKestrel_WorksWhenRun(string project, string url, string framework)
         {
             // Disabled due to https://github.com/dotnet/cli/issues/2428
             if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
@@ -104,7 +106,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
                 .WithBuildArtifacts();
 
             Task exec = null;
-            var command = new RunCommand(Path.Combine(testInstance.TestRoot, project));
+            var command = new RunCommand(Path.Combine(testInstance.TestRoot, project), framework);
             try
             {
                 exec = command.ExecuteAsync(url);


### PR DESCRIPTION
we used to use different code when --framework was specified than when it was not specified, this synchronizes them to use the same code path which removes a hidden NullRef

also adds tests to cover both cases

/cc @pakrym @davidfowl

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2679)
<!-- Reviewable:end -->
