### PR TITLE
dotnet build fails if the directory contains unicode characters

### DIFF
--- a/TestAssets/TestProjects/TestAppWithUnicodéPath/Program.cs
+++ b/TestAssets/TestProjects/TestAppWithUnicodéPath/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestAppWithUnicodéPath/Program.cs
+++ b/TestAssets/TestProjects/TestAppWithUnicodéPath/Program.cs
@@ -6,7 +6,7 @@ namespace ConsoleApplication
     {
         public static void Main(string[] args)
         {
-            Console.WriteLine("Hello World!");
+            Console.WriteLine("Hélló Wórld!");
         }
     }
 }

--- a/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
+++ b/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "Microsoft.NETCore.App": "1.0.0-rc2-*"
+  },
+  "frameworks": {
+    "netcoreapp1.0": { }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {},
+    "osx.10.10-x64": {},
+    "osx.10.11-x64": {},
+    "ubuntu.14.04-x64": {},
+    "centos.7-x64": {},
+    "rhel.7.2-x64": {},
+    "debian.8-x64": {}
+  }
+}

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel.Server;
 using Microsoft.DotNet.Tools.Build;
@@ -40,6 +41,8 @@ namespace Microsoft.DotNet.Cli
         public static int Main(string[] args)
         {
             DebugHelper.HandleDebugSwitch(ref args);
+
+            InitializeProcess();
 
             try
             {
@@ -136,6 +139,13 @@ namespace Microsoft.DotNet.Cli
 
             return exitCode;
 
+        }
+
+        private static void InitializeProcess()
+        {
+            // by default, .NET Core doesn't have all code pages needed for Console apps.
+            // see the .NET Core Notes in https://msdn.microsoft.com/en-us/library/system.diagnostics.process(v=vs.110).aspx
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 
         internal static bool TryGetBuiltInCommand(string commandName, out Func<string[], int> builtInCommand)

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests.cs
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests.cs
@@ -51,6 +51,7 @@ namespace Microsoft.DotNet.Tests.ArgumentForwarding
         /// <param name="testUserArgument"></param>
         [Theory]
         [InlineData(@"""abc"" d e")]
+        [InlineData(@"""ábc"" d é")]
         [InlineData(@"""abc""      d e")]
         [InlineData("\"abc\"\t\td\te")]
         [InlineData(@"a\\b d""e f""g h")]

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsProjects.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsProjects.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Builder.Tests
+{
+    public class GivenDotnetBuildBuildsProjects : TestBase
+    {
+        [Fact]
+        public void It_builds_projects_with_Unicode_in_path()
+        {
+            var testInstance = TestAssetsManager
+                .CreateTestInstance("TestAppWithUnicodéPath")
+                .WithLockFiles();
+
+            var testProjectDirectory = testInstance.TestRoot;
+
+            var buildCommand = new BuildCommand("");
+            buildCommand.WorkingDirectory = testProjectDirectory;
+            
+            buildCommand.ExecuteWithCapturedOutput()
+                .Should()
+                .Pass();
+        }
+
+        [Fact]
+        public void It_builds_projects_with_Unicode_in_path_project_path_passed()
+        {
+            var testInstance = TestAssetsManager
+                .CreateTestInstance("TestAppWithUnicodéPath")
+                .WithLockFiles();
+
+            var testProject = Path.Combine(testInstance.TestRoot, "project.json");
+
+            new BuildCommand(testProject)
+                .ExecuteWithCapturedOutput()
+                .Should()
+                .Pass();
+        }
+    }
+}

--- a/test/dotnet-run.Tests/RunTests.cs
+++ b/test/dotnet-run.Tests/RunTests.cs
@@ -68,6 +68,19 @@ namespace Microsoft.DotNet.Tools.Run.Tests
             new RunCommand(instance.TestRoot).Execute().Should().Pass();
         }
 
+        [Fact]
+        public void ItRunsAppsThatOutputUnicodeCharacters()
+        {
+            TestInstance instance = TestAssetsManager.CreateTestInstance("TestAppWithUnicodéPath")
+                                                     .WithLockFiles()
+                                                     .WithBuildArtifacts();
+            new RunCommand(instance.TestRoot)
+                .ExecuteWithCapturedOutput()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hélló Wórld!");
+        }
 
         private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)
         {


### PR DESCRIPTION
This fix contains @schellap's fix for https://github.com/dotnet/cli/pull/2673, which is needed to fix this bug and will be rebased out once @schellap merges his change.

Fix #2486 

@brthor @Sridhar-MS @piotrpMSFT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2680)
<!-- Reviewable:end -->
