### PR TITLE
Only publish SharedFramework + SDK for Windows

### DIFF
--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -174,6 +174,7 @@ namespace Microsoft.DotNet.Cli.Build
         }
 
         [Target]
+        [BuildPlatforms(BuildPlatform.Windows)]
         public static BuildTargetResult PublishCombinedFrameworkSDKArchiveToAzure(BuildTargetContext c)
         {
             var version = CliNuGetVersion;


### PR DESCRIPTION
We don't build the combined framework + SDK tarball for any Unix
platforms, but we were incorrectly trying to publish it. Make the
publish step for this artifact specific to Windows as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2699)
<!-- Reviewable:end -->
