### PR TITLE
Improving Telemetry performance

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -132,6 +132,8 @@ namespace Microsoft.DotNet.Cli
                 command = "help";
             }
 
+            telemetryClient.TrackEvent(command, null, null);
+
             int exitCode;
             Func<string[], int> builtIn;
             if (s_builtIns.TryGetValue(command, out builtIn))
@@ -147,13 +149,6 @@ namespace Microsoft.DotNet.Cli
                 exitCode = result.ExitCode;
             }
 
-            telemetryClient.TrackEvent(
-                command,
-                null,
-                new Dictionary<string, double>
-                {
-                    ["ExitCode"] = exitCode
-                });
 
             return exitCode;
 

--- a/src/dotnet/Telemetry.cs
+++ b/src/dotnet/Telemetry.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/dotnet/Telemetry.cs
+++ b/src/dotnet/Telemetry.cs
@@ -58,41 +58,6 @@ namespace Microsoft.DotNet.Cli
                 return;
             }
 
-            _isCollectingTelemetry = true;
-            try
-            {
-                //initialize in task to offload to parallel thread
-                _trackEventTask = Task.Factory.StartNew(() => InitializeTelemetry());
-            }
-            catch(Exception)
-            {
-                Debug.Fail("Exception during telemetry task initialization");
-            }
-        }
-
-        public void TrackEvent(string eventName, IList<string> properties, IDictionary<string, double> measurements)
-        {
-            if (!_isCollectingTelemetry)
-            {
-                return;
-            }
-
-            try
-            {
-                _trackEventTask = _trackEventTask.ContinueWith(
-                    x => TrackEventTask(eventName,
-                        properties,
-                        measurements)
-                );
-            }
-            catch(Exception)
-            {
-                Debug.Fail("Exception during telemetry task continuation");
-            }
-        }
-
-        private void InitializeTelemetry()
-        {
             try
             {
                 using (PerfTrace.Current.CaptureTiming())
@@ -101,11 +66,9 @@ namespace Microsoft.DotNet.Cli
                     _trackEventTask = Task.Factory.StartNew(() => InitializeTelemetry());
                 }
             }
-            catch (Exception)
+            catch(Exception)
             {
-                // we dont want to fail the tool if telemetry fais. We should be able to detect abnormalities from data
-                // at the server end
-                Debug.Fail("Exception during telemetry initialization");
+                Debug.Fail("Exception during telemetry task initialization");
             }
         }
 

--- a/src/dotnet/Telemetry.cs
+++ b/src/dotnet/Telemetry.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli
                 _sampleRate = ReciprocalSampleRateValueForTest;
             }
 
-            _isCollectingTelemetry = (Environment.TickCount % _sampleRate == 0);    
+            _isCollectingTelemetry = (Environment.TickCount % _sampleRate == 0);
             if(!_isCollectingTelemetry)
             {
                 return;
@@ -69,19 +69,19 @@ namespace Microsoft.DotNet.Cli
                 Debug.Fail("Exception during telemetry task initialization");
             }
         }
-        
+
         public void TrackEvent(string eventName, IList<string> properties, IDictionary<string, double> measurements)
         {
             if (!_isCollectingTelemetry)
             {
                 return;
             }
-            
+
             try
             {
                 _trackEventTask = _trackEventTask.ContinueWith(
-                    x => TrackEventTask(eventName, 
-                        properties, 
+                    x => TrackEventTask(eventName,
+                        properties,
                         measurements)
                 );
             }
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Cli
                 Debug.Fail("Exception during telemetry task continuation");
             }
         }
-        
+
         private void InitializeTelemetry()
         {
             try
@@ -108,7 +108,7 @@ namespace Microsoft.DotNet.Cli
                 Debug.Fail("Exception during telemetry initialization");
             }
         }
-        
+
         public void TrackEvent(string eventName, IDictionary<string, string> properties, IDictionary<string, double> measurements)
         {
             if (!Enabled)
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Cli
             if (!_isCollectingTelemetry)
             {
                 return;
-            }                
+            }
             try
             {
                 using (PerfTrace.Current.CaptureTiming())
@@ -223,9 +223,9 @@ namespace Microsoft.DotNet.Cli
                 }
                 return eventProperties;
             }
-            else 
+            else
             {
-                return _commonProperties;    
+                return _commonProperties;
             }
         }
     }

--- a/src/dotnet/Telemetry.cs
+++ b/src/dotnet/Telemetry.cs
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Cli
             try
             {
                 _trackEventTask = _trackEventTask.ContinueWith(
-                    () => TrackEventTask(eventName, 
+                    x => TrackEventTask(eventName, 
                         properties, 
                         measurements)
                 );

--- a/src/dotnet/Telemetry.cs
+++ b/src/dotnet/Telemetry.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.ApplicationInsights;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.InternalAbstractions;
@@ -10,17 +11,27 @@ namespace Microsoft.DotNet.Cli
     public class Telemetry : ITelemetry
     {
         private bool _isInitialized = false;
+        private bool _isCollectingTelemetry = false;
         private TelemetryClient _client = null;
 
         private Dictionary<string, string> _commonProperties = null;
         private Dictionary<string, double> _commonMeasurements = null;
+        private Task _trackEventTask = null;
 
+        private int _sampleRate = 1;
+        private bool _isTestMachine = false;
+
+        private const int ReciprocalSampleRateValue = 1;
+        private const int ReciprocalSampleRateValueForTest = 1;
         private const string InstrumentationKey = "74cc1c9e-3e6e-4d05-b3fc-dde9101d0254";
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";
+        private const string TestMachineFlag = "TEST_MACHINE";
+        private const string TestMachine = "Test Machine";
         private const string OSVersion = "OS Version";
         private const string OSPlatform = "OS Platform";
         private const string RuntimeId = "Runtime Id";
         private const string ProductVersion = "Product Version";
+        private const string ReciprocalSampleRate = "Reciprocal SampleRate";
 
         public bool Enabled { get; }
 
@@ -33,26 +44,27 @@ namespace Microsoft.DotNet.Cli
                 return;
             }
 
+            _sampleRate = ReciprocalSampleRateValue;
+            _isTestMachine = Env.GetEnvironmentVariableAsBool(TestMachineFlag);
+
+            if(_isTestMachine)
+            {
+                _sampleRate = ReciprocalSampleRateValueForTest;
+            }
+
+            _isCollectingTelemetry = (Environment.TickCount % _sampleRate == 0);    
+            if(!_isCollectingTelemetry)
+            {
+                return;
+            }
+
             try
             {
                 using (PerfTrace.Current.CaptureTiming())
                 {
-                    _client = new TelemetryClient();
-                    _client.InstrumentationKey = InstrumentationKey;
-                    _client.Context.Session.Id = Guid.NewGuid().ToString();
-
-
-                _client.Context.Device.OperatingSystem = RuntimeEnvironment.OperatingSystem;
-
-                    _commonProperties = new Dictionary<string, string>();
-                _commonProperties.Add(OSVersion, RuntimeEnvironment.OperatingSystemVersion);
-                _commonProperties.Add(OSPlatform, RuntimeEnvironment.OperatingSystemPlatform.ToString());
-                _commonProperties.Add(RuntimeId, RuntimeEnvironment.GetRuntimeIdentifier());
-                    _commonProperties.Add(ProductVersion, Product.Version);
-                    _commonMeasurements = new Dictionary<string, double>();
+                    //initialize in task to offload to parallel thread
+                    _trackEventTask = Task.Factory.StartNew(() => InitializeTelemetry());
                 }
-
-                _isInitialized = true;
             }
             catch (Exception)
             {
@@ -61,31 +73,82 @@ namespace Microsoft.DotNet.Cli
                 Debug.Fail("Exception during telemetry initialization");
             }
         }
-
+        
         public void TrackEvent(string eventName, IDictionary<string, string> properties, IDictionary<string, double> measurements)
         {
-            if (!_isInitialized)
+            if (!Enabled)
+            {
+                return;
+            }
+            if (!_isCollectingTelemetry)
+            {
+                return;
+            }                
+            try
+            {
+                using (PerfTrace.Current.CaptureTiming())
+                {
+                    _trackEventTask = _trackEventTask.ContinueWith(
+                        x => TrackEventTask(eventName, properties, measurements)
+                    );
+                }
+            }
+            catch(Exception)
+            {
+                Debug.Fail("Exception during telemetry task continuation");
+            }
+        }
+
+        private void InitializeTelemetry()
+        {
+            try
+            {
+                _client = new TelemetryClient();
+                _client.InstrumentationKey = InstrumentationKey;
+                _client.Context.Session.Id = Guid.NewGuid().ToString();
+
+                var runtimeEnvironment = PlatformServices.Default.Runtime;
+                _client.Context.Device.OperatingSystem = RuntimeEnvironment.OperatingSystem;
+
+                _commonProperties = new Dictionary<string, string>();
+                _commonProperties.Add(OSVersion, RuntimeEnvironment.OperatingSystemVersion);
+                _commonProperties.Add(OSPlatform, RuntimeEnvironment.OperatingSystemPlatform.ToString());
+                _commonProperties.Add(RuntimeId, RuntimeEnvironment.GetRuntimeIdentifier());
+                _commonProperties.Add(ProductVersion, Product.Version);
+                _commonProperties.Add(TestMachine, _isTestMachine.ToString());
+                _commonProperties.Add(ReciprocalSampleRate, _sampleRate.ToString());
+                _commonMeasurements = new Dictionary<string, double>();
+                _isInitialized = true;
+            }
+            catch(Exception)
+            {
+                _isInitialized = false;
+                // we dont want to fail the tool if telemetry fails.
+                Debug.Fail("Exception during telemetry initialization");
+                return;
+            }
+        }
+
+        private void TrackEventTask(string eventName, IDictionary<string, string> properties, IDictionary<string, double> measurements)
+        {
+            if(!_isInitialized)
             {
                 return;
             }
 
-            using (PerfTrace.Current.CaptureTiming())
+            try
             {
-                Dictionary<string, double> eventMeasurements = GetEventMeasures(measurements);
-                Dictionary<string, string> eventProperties = GetEventProperties(properties);
+                var eventMeasurements = GetEventMeasures(measurements);
+                var eventProperties = GetEventProperties(properties);
 
-                try
-                {
-                    _client.TrackEvent(eventName, eventProperties, eventMeasurements);
-                    _client.Flush();
-                }
-                catch (Exception)
-                {
-                    Debug.Fail("Exception during TrackEvent");
-                }
+                _client.TrackEvent(eventName, eventProperties, eventMeasurements);
+                _client.Flush();
+            }
+            catch (Exception)
+            {
+                Debug.Fail("Exception during TrackEvent");
             }
         }
-
 
         private Dictionary<string, double> GetEventMeasures(IDictionary<string, double> measurements)
         {

--- a/src/dotnet/Telemetry.cs
+++ b/src/dotnet/Telemetry.cs
@@ -86,6 +86,7 @@ namespace Microsoft.DotNet.Cli
             {
                 using (PerfTrace.Current.CaptureTiming())
                 {
+                    //continue task in existing parallel thread
                     _trackEventTask = _trackEventTask.ContinueWith(
                         x => TrackEventTask(eventName, properties, measurements)
                     );
@@ -105,7 +106,6 @@ namespace Microsoft.DotNet.Cli
                 _client.InstrumentationKey = InstrumentationKey;
                 _client.Context.Session.Id = Guid.NewGuid().ToString();
 
-                var runtimeEnvironment = PlatformServices.Default.Runtime;
                 _client.Context.Device.OperatingSystem = RuntimeEnvironment.OperatingSystem;
 
                 _commonProperties = new Dictionary<string, string>();
@@ -123,7 +123,6 @@ namespace Microsoft.DotNet.Cli
                 _isInitialized = false;
                 // we dont want to fail the tool if telemetry fails.
                 Debug.Fail("Exception during telemetry initialization");
-                return;
             }
         }
 
@@ -136,15 +135,15 @@ namespace Microsoft.DotNet.Cli
 
             try
             {
-                var eventMeasurements = GetEventMeasures(measurements);
                 var eventProperties = GetEventProperties(properties);
+                var eventMeasurements = GetEventMeasures(measurements);
 
                 _client.TrackEvent(eventName, eventProperties, eventMeasurements);
                 _client.Flush();
             }
             catch (Exception)
             {
-                Debug.Fail("Exception during TrackEvent");
+                Debug.Fail("Exception during TrackEventTask");
             }
         }
 

--- a/test/dotnet-test.Tests/GivenThatWeWantToUseDotnetTestE2EInDesignTimeForMultipleTFms.cs
+++ b/test/dotnet-test.Tests/GivenThatWeWantToUseDotnetTestE2EInDesignTimeForMultipleTFms.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using FluentAssertions;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
@@ -14,13 +15,13 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
 {
     public class GivenThatWeWantToUseDotnetTestE2EInDesignTimeForMultipleTFms : TestBase
     {
-        private readonly string _projectFilePath;
-        private readonly string _netCoreAppOutputPath;
-        private readonly string _net451OutputPath;
+        private string _projectFilePath;
+        private string _netCoreAppOutputPath;
+        private string _net451OutputPath;
 
-        public GivenThatWeWantToUseDotnetTestE2EInDesignTimeForMultipleTFms()
+        private void Setup([CallerMemberName] string callingMethod = "")
         {
-            var testInstance = TestAssetsManager.CreateTestInstance(Path.Combine("ProjectsWithTests", "MultipleFrameworkProject"));
+            var testInstance = TestAssetsManager.CreateTestInstance(Path.Combine("ProjectsWithTests", "MultipleFrameworkProject"), callingMethod);
 
             _projectFilePath = Path.Combine(testInstance.TestRoot, "project.json");
             var contexts = ProjectContext.CreateContextForEachFramework(
@@ -51,6 +52,8 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         [WindowsOnlyFact]
         public void It_discovers_tests_for_the_ProjectWithTestsWithNetCoreApp()
         {
+            Setup();
+
             using (var adapter = new Adapter("TestDiscovery.Start"))
             {
                 adapter.Listen();
@@ -68,6 +71,8 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         [WindowsOnlyFact]
         public void It_discovers_tests_for_the_ProjectWithTestsWithNet451()
         {
+            Setup();
+
             using (var adapter = new Adapter("TestDiscovery.Start"))
             {
                 adapter.Listen();
@@ -86,6 +91,8 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         [Fact]
         public void It_runs_tests_for_netcoreapp10()
         {
+            Setup();
+
             using (var adapter = new Adapter("TestExecution.GetTestRunnerProcessStartInfo"))
             {
                 adapter.Listen();
@@ -105,6 +112,8 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         [WindowsOnlyFact]
         public void It_runs_tests_for_net451()
         {
+            Setup();
+
             using (var adapter = new Adapter("TestExecution.GetTestRunnerProcessStartInfo"))
             {
                 adapter.Listen();


### PR DESCRIPTION
Improved telemetry performance to minimize impact on CLI.

Addressing issue #2595
Overall run time now minimally effected by telemetry.

Moved TrackEvent up earlier and run async with the rest.

The Async task will be dropped if not completed by end of normal run time. 
Dropped exitcode from telemetry.
Added flag for Test Machines(e.g CI and others)

Edit:
Dropped collection of all arguments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2724)
<!-- Reviewable:end -->


