### PR TITLE
Workaround for 2734

### DIFF
--- a/scripts/dotnet-cli-build/Utils/Dirs.cs
+++ b/scripts/dotnet-cli-build/Utils/Dirs.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Cli.Build
         public static readonly string Stage2Compilation = Path.Combine(Output, "stage2compilation");
         public static readonly string Stage2Symbols = Path.Combine(Output, "stage2symbols");
         public static readonly string CorehostLatest = Path.Combine(Output, "corehost"); // Not using Path.Combine(Output, "corehost", "latest") to keep signing working.
-        public static readonly string CorehostLocked = Path.Combine(Output, "corehost", "locked");
+        public static readonly string CorehostLocked = Path.Combine(Output, "corehost"); // Workaround for Issue: 2734. After fixing it, use "corehost/locked".
         public static readonly string CorehostLocalPackages = Path.Combine(Output, "corehost");
         public static readonly string CorehostDummyPackages = Path.Combine(Output, "corehostdummypackages");
         public static readonly string TestOutput = Path.Combine(Output, "tests");


### PR DESCRIPTION
I am on my mobile right now, I'll have to debug what the issue is on the VSO machines once I get in. This should solve it in the short term.

@Sridhar-MS @petermarcu @piotrpMSFT.

The restore and publish of hostfxr package is failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2735)
<!-- Reviewable:end -->
