### PR TITLE
Lock muxer to 1.0.1-rc2-002543-00

### DIFF
--- a/scripts/dotnet-cli-build/Utils/BuildVersion.cs
+++ b/scripts/dotnet-cli-build/Utils/BuildVersion.cs
@@ -49,8 +49,8 @@ namespace Microsoft.DotNet.Cli.Build
         //
         // Locked muxer for consumption in CLI.
         //
-        public bool IsLocked = false; // Set this variable to toggle muxer locking.
-        public string LockedHostFxrVersion => IsLocked ? "1.0.1-rc2-002468-00" : LatestHostFxrVersion;
+        public bool IsLocked = true; // Set this variable to toggle muxer locking.
+        public string LockedHostFxrVersion => IsLocked ? "1.0.1-rc2-002543-00" : LatestHostFxrVersion;
 
         //
         // -----------------------------------------END-OF-HOST-VERSIONING-------------------------------------


### PR DESCRIPTION
Any updates or bug fixes to muxer from now on should use a different version (this happens during build based on commit count.)

@gkhanna79 @Sridhar-MS @piotrpMSFT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2742)
<!-- Reviewable:end -->
