### PR TITLE
Trim non split assemblies from published `refs` folder.

### DIFF
--- a/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
@@ -3,7 +3,9 @@
     "emitEntryPoint": true,
     "preserveCompilationContext": true
   },
-  "dependencies": {},
+  "dependencies": {
+    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160425-01"
+  },
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {

--- a/scripts/dotnet-cli-build/CompileTargets.cs
+++ b/scripts/dotnet-cli-build/CompileTargets.cs
@@ -694,30 +694,40 @@ namespace Microsoft.DotNet.Cli.Build
                 deps = JObject.ReadFrom(reader);
             }
 
-            var target = deps["targets"][deps["runtimeTarget"]["name"].Value<string>()];
-            var library = target.Children<JProperty>().First();
-            var version = library.Name.Substring(library.Name.IndexOf('/') + 1);
-            if (newName == null)
+            string version = null;
+            foreach (JProperty target in deps["targets"])
             {
-                library.Remove();
+                var targetLibrary = target.Value.Children<JProperty>().FirstOrDefault();
+                if (targetLibrary == null)
+                {
+                    continue;
+                }
+                version = targetLibrary.Name.Substring(targetLibrary.Name.IndexOf('/') + 1);
+                if (newName == null)
+                {
+                    targetLibrary.Remove();
+                }
+                else
+                {
+                    targetLibrary.Replace(new JProperty(newName + '/' + version, targetLibrary.Value));
+                }
             }
-            else
+            if (version != null)
             {
-                library.Replace(new JProperty(newName + '/' + version, library.Value));
-            }
-            library = deps["libraries"].Children<JProperty>().First();
-            if (newName == null)
-            {
-                library.Remove();
-            }
-            else
-            {
-                library.Replace(new JProperty(newName + '/' + version, library.Value));
-            }
-            using (var file = File.CreateText(depsFile))
-            using (var writer = new JsonTextWriter(file) { Formatting = Formatting.Indented })
-            {
-                deps.WriteTo(writer);
+                var library = deps["libraries"].Children<JProperty>().First();
+                if (newName == null)
+                {
+                    library.Remove();
+                }
+                else
+                {
+                    library.Replace(new JProperty(newName + '/' + version, library.Value));
+                }
+                using (var file = File.CreateText(depsFile))
+                using (var writer = new JsonTextWriter(file) { Formatting = Formatting.Indented })
+                {
+                    deps.WriteTo(writer);
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.ProjectModel/ProjectModelPlatformExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectModelPlatformExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.ProjectModel.Compilation;
+using Microsoft.DotNet.ProjectModel.Graph;
+
+namespace Microsoft.DotNet.ProjectModel
+{
+    public static class ProjectModelPlatformExtensions
+    {
+        public static IEnumerable<LibraryExport> ExcludePlatformExports(this ProjectContext context, IEnumerable<LibraryExport> allExports)
+        {
+            var exclusionList = context.GetPlatformExclusionList(allExports);
+            return allExports.Where(e => !exclusionList.Contains(e.Library.Identity.Name));
+        }
+
+        public static HashSet<string> GetPlatformExclusionList(this ProjectContext context, IEnumerable<LibraryExport> allExports)
+        {
+            var exclusionList = new HashSet<string>();
+            var redistPackage = context.PlatformLibrary;
+            if (redistPackage == null)
+            {
+                return exclusionList;
+            }
+            var exports = allExports
+                .Where(e => e.Library.Identity.Type.Equals(LibraryType.Package))
+                .ToDictionary(e => e.Library.Identity.Name);
+
+            var redistExport = exports[redistPackage.Identity.Name];
+
+            exclusionList.Add(redistExport.Library.Identity.Name);
+            CollectDependencies(exports, redistExport.Library.Dependencies, exclusionList);
+            return exclusionList;
+        }
+
+        private static void CollectDependencies(Dictionary<string, LibraryExport> exports, IEnumerable<LibraryRange> dependencies, HashSet<string> exclusionList)
+        {
+            foreach (var dependency in dependencies)
+            {
+                var export = exports[dependency.Name];
+                if (export.Library.Identity.Version.Equals(dependency.VersionRange.MinVersion))
+                {
+                    exclusionList.Add(export.Library.Identity.Name);
+                    CollectDependencies(exports, export.Library.Dependencies, exclusionList);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContext.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContext.cs
@@ -8,34 +8,6 @@ using System.Reflection;
 
 namespace Microsoft.Extensions.DependencyModel
 {
-    public class TargetInfo
-    {
-        public TargetInfo(string framework,
-            string runtime,
-            string runtimeSignature,
-            bool isPortable)
-        {
-            if (string.IsNullOrEmpty(framework))
-            {
-                throw new ArgumentException(nameof(framework));
-            }
-
-            Framework = framework;
-            Runtime = runtime;
-            RuntimeSignature = runtimeSignature;
-            IsPortable = isPortable;
-        }
-
-        public string Framework { get; }
-
-        public string Runtime { get; }
-
-        public string RuntimeSignature { get; }
-
-        public bool IsPortable { get; }
-
-    }
-
     public class DependencyContext
     {
         private static readonly Lazy<DependencyContext> _defaultContext = new Lazy<DependencyContext>(LoadDefault);

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextLoader.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextLoader.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Extensions.DependencyModel
 {
     public class DependencyContextLoader
     {
-        private static Lazy<string[]> _depsFiles = new Lazy<string[]>(GetHostDepsList);
-
         private const string DepsJsonExtension = ".deps.json";
 
         private readonly string _entryPointDepsLocation;
@@ -21,8 +19,8 @@ namespace Microsoft.Extensions.DependencyModel
         private readonly IDependencyContextReader _jsonReader;
 
         public DependencyContextLoader() : this(
-            GetDefaultEntrypointDepsLocation(),
-            GetDefaultRuntimeDepsLocation(),
+            DependencyContextPaths.Current.Application,
+            DependencyContextPaths.Current.SharedRuntime,
             FileSystemWrapper.Default,
             new DependencyContextJsonReader())
         {
@@ -129,36 +127,5 @@ namespace Microsoft.Extensions.DependencyModel
 
             return null;
         }
-
-        private static string GetDefaultRuntimeDepsLocation()
-        {
-            var deps = _depsFiles.Value;
-            if (deps != null && deps.Length > 1)
-            {
-                return deps[1];
-            }
-            return null;
-        }
-
-        private static string GetDefaultEntrypointDepsLocation()
-        {
-            var deps = _depsFiles.Value;
-            if (deps != null && deps.Length > 0)
-            {
-                return deps[0];
-            }
-            return null;
-        }
-
-        private static string[] GetHostDepsList()
-        {
-            // TODO: We're going to replace this with AppContext.GetData
-            var appDomainType = typeof(object).GetTypeInfo().Assembly?.GetType("System.AppDomain");
-            var currentDomain = appDomainType?.GetProperty("CurrentDomain")?.GetValue(null);
-            var deps = appDomainType?.GetMethod("GetData")?.Invoke(currentDomain, new[] { "APP_CONTEXT_DEPS_FILES" });
-
-            return (deps as string)?.Split(new [] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-        }
-
     }
 }

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextPaths.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextPaths.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Microsoft.Extensions.DependencyModel
+{
+    internal class DependencyContextPaths
+    {
+        private static readonly string DepsFilesProperty = "APP_CONTEXT_DEPS_FILES";
+
+        public static DependencyContextPaths Current { get; } = GetCurrent();
+
+        public string Application { get; }
+
+        public string SharedRuntime { get; }
+
+        public DependencyContextPaths(string application, string sharedRuntime)
+        {
+            Application = application;
+            SharedRuntime = sharedRuntime;
+        }
+
+        private static DependencyContextPaths GetCurrent()
+        {
+#if NETSTANDARD1_5
+            var deps = AppContext.GetData(DepsFilesProperty);
+#else
+            var deps = AppDomain.CurrentDomain.GetData(DepsFilesProperty);
+#endif
+            var files = (deps as string)?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            return new DependencyContextPaths(
+                files != null && files.Length > 0 ? files[0] : null,
+                files != null && files.Length > 1 ? files[1] : null
+                );
+
+        }
+    }
+}

--- a/src/Microsoft.Extensions.DependencyModel/TargetInfo.cs
+++ b/src/Microsoft.Extensions.DependencyModel/TargetInfo.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Microsoft.Extensions.DependencyModel
+{
+    public class TargetInfo
+    {
+        public TargetInfo(string framework,
+            string runtime,
+            string runtimeSignature,
+            bool isPortable)
+        {
+            if (string.IsNullOrEmpty(framework))
+            {
+                throw new ArgumentException(nameof(framework));
+            }
+
+            Framework = framework;
+            Runtime = runtime;
+            RuntimeSignature = runtimeSignature;
+            IsPortable = isPortable;
+        }
+
+        public string Framework { get; }
+
+        public string Runtime { get; }
+
+        public string RuntimeSignature { get; }
+
+        public bool IsPortable { get; }
+
+    }
+}

--- a/test/dotnet-publish.Tests/PublishPortableTests.cs
+++ b/test/dotnet-publish.Tests/PublishPortableTests.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.DotNet.TestFramework;
-using Microsoft.DotNet.Tools.Test.Utilities;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using FluentAssertions;
 using Xunit;
 
 namespace Microsoft.DotNet.Tools.Publish.Tests
@@ -93,7 +94,9 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             publishCommand.GetOutputDirectory(true).Should().HaveFile("PortableAppCompilationContext.dll");
 
             var refsDirectory = new DirectoryInfo(Path.Combine(publishCommand.GetOutputDirectory(true).FullName, "refs"));
-            // Should have compilation time assemblies
+            // Microsoft.CodeAnalysis.CSharp is IL only
+            refsDirectory.Should().NotHaveFile("Microsoft.CodeAnalysis.CSharp.dll");
+            // System.IO has facede
             refsDirectory.Should().HaveFile("System.IO.dll");
             // Libraries in which lib==ref should be deduped
             refsDirectory.Should().NotHaveFile("PortableAppCompilationContext.dll");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/cli/issues/2772
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2757)
<!-- Reviewable:end -->
