### PR TITLE
Fix bug to install x64 and x86 SxS.

### DIFF
--- a/packaging/windows/clisdk/bundle.wxs
+++ b/packaging/windows/clisdk/bundle.wxs
@@ -23,11 +23,8 @@
 
     <swid:Tag Regid="microsoft.com" InstallPath="[DOTNETHOME]" />
 
-    <Variable Name="DOTNETHOME" Type="string" Value="[ProgramFiles6432Folder]dotnet" bal:Overridable="yes" />
+    <Variable Name="DOTNETHOME" Type="string" Value="[ProgramFiles6432Folder]dotnet" bal:Overridable="no" />
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker)" bal:Overridable="no" />
-
-    <util:RegistrySearch Id="PreviousInstallFolderSearch" Root="HKLM" Key="SOFTWARE\dotnet\Setup" Value="InstallDir" Variable="PreviousInstallFolder" />
-    <util:DirectorySearch Path="[PreviousInstallFolder]" Variable="DOTNETHOME" After="PreviousInstallFolderSearch" Condition="PreviousInstallFolder" />
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
       <ExePackage Name="VC_redist.$(var.Platform).exe"

--- a/packaging/windows/sharedframework/bundle.wxs
+++ b/packaging/windows/sharedframework/bundle.wxs
@@ -23,11 +23,8 @@
 
     <swid:Tag Regid="microsoft.com" InstallPath="[DOTNETHOME]" />
 
-    <Variable Name="DOTNETHOME" Type="string" Value="[ProgramFiles6432Folder]dotnet" bal:Overridable="yes" />
+    <Variable Name="DOTNETHOME" Type="string" Value="[ProgramFiles6432Folder]dotnet" bal:Overridable="no" />
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker)" bal:Overridable="no" />
-
-    <util:RegistrySearch Id="PreviousInstallFolderSearch" Root="HKLM" Key="SOFTWARE\dotnet\sharedframework\$(var.FrameworkName) $(var.FrameworkDisplayVersion)\Setup" Value="InstallDir" Variable="PreviousInstallFolder" />
-    <util:DirectorySearch Path="[PreviousInstallFolder]" Variable="DOTNETHOME" After="PreviousInstallFolderSearch" Condition="PreviousInstallFolder" />
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
       <ExePackage Name="VC_redist.$(var.Platform).exe"


### PR DESCRIPTION
Remove code to find the previous install folder, always install into
%ProgramW6432%. Also remove the option to allow DOTNETHOME to be
overridable.

Fixes - #2743

cc @robmen @piotrpMSFT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2770)
<!-- Reviewable:end -->
