### PR TITLE
Fixing error where lock could not be taken on build folder

### DIFF
--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -60,7 +60,9 @@ namespace Microsoft.DotNet.Cli.Build
             {
                 string targetContainer = $"{Channel}/Binaries/Latest/";
                 string targetVersionFile = $"{targetContainer}{CliNuGetVersion}";
-                string leaseId = AzurePublisherTool.AcquireLeaseOnBlob(targetContainer);
+                string semaphoreBlob = $"{Channel}/Binaries/publishSemaphore";
+                AzurePublisherTool.CreateBlobIfNotExists(semaphoreBlob);
+                string leaseId = AzurePublisherTool.AcquireLeaseOnBlob(semaphoreBlob);
 
                 // Prevent race conditions by dropping a version hint of what version this is. If we see this file
                 // and it is the same as our version then we know that a race happened where two+ builds finished 

--- a/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
+++ b/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
@@ -125,6 +125,20 @@ namespace Microsoft.DotNet.Cli.Build
             }
         }
 
+        public void CreateBlobIfNotExists(string path)
+        {
+            System.Threading.Tasks.Task<bool> task = _blobContainer.GetBlockBlobReference(path).ExistsAsync();
+            task.Wait();
+            if (!task.Result)
+            {
+                CloudBlockBlob blob = _blobContainer.GetBlockBlobReference(path);
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    blob.UploadFromStreamAsync(ms).Wait();
+                }
+            }
+        }
+
         public void DeleteBlob(string path)
         {
             _blobContainer.GetBlockBlobReference(path).DeleteAsync().Wait();


### PR DESCRIPTION
cc @piotrpMSFT 

Ran this and it was able to take the lock, this should fix the 404 blob not found problem

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2774)
<!-- Reviewable:end -->
