### PR TITLE
Change the host MSI dependency key for correct reference counting.

### DIFF
--- a/packaging/windows/clisdk/dotnet.wxs
+++ b/packaging/windows/clisdk/dotnet.wxs
@@ -13,7 +13,7 @@
             <ComponentGroupRef Id="AuthoredRegistryKeys"/>
         </Feature>
         <Feature Id="Provider" Absent="disallow" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" Level="1" InstallDefault="local" Title="RefCounting" TypicalDefault="install">
-            <ComponentRef Id="Dotnet_CLI_$(var.Dotnet_DisplayVersion)" />
+            <ComponentRef Id="$(var.DependencyKeyId)" />
         </Feature>
         <Property Id="ProductFamily" Value="$(var.ProductFamily)" />
         <Property Id="ProductEdition" Value="$(var.ProductEdition)" />

--- a/packaging/windows/clisdk/provider.wxs
+++ b/packaging/windows/clisdk/provider.wxs
@@ -2,8 +2,8 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
   <?include "Variables.wxi" ?>
   <Fragment>
-    <Component Id="Dotnet_CLI_$(var.Dotnet_DisplayVersion)" Directory="TARGETDIR" Win64="no" Guid="3B7DF8C8-9BB9-3F4C-8CBF-E393E4D7FF43">
-      <dep:Provides Key="Dotnet.CLI_$(var.Dotnet_DisplayVersion)" />
+    <Component Id="$(var.DependencyKeyId)" Directory="TARGETDIR" Win64="no" Guid="3B7DF8C8-9BB9-3F4C-8CBF-E393E4D7FF43">
+      <dep:Provides Key="$(var.DependencyKey)" />
     </Component>
   </Fragment>
 </Wix>

--- a/packaging/windows/clisdk/variables.wxi
+++ b/packaging/windows/clisdk/variables.wxi
@@ -25,4 +25,7 @@
   <?else?>
   <?error Invalid Platform ($(var.Platform))?>
   <?endif?>
+
+  <?define DependencyKey   = "Dotnet_CLI_$(var.Dotnet_DisplayVersion)_$(var.Platform)"?>
+  <?define DependencyKeyId = "$(var.DependencyKey)" ?>
 </Include>

--- a/packaging/windows/host/generatemsi.ps1
+++ b/packaging/windows/host/generatemsi.ps1
@@ -7,7 +7,6 @@ param(
     [Parameter(Mandatory=$true)][string]$WixRoot,
     [Parameter(Mandatory=$true)][string]$ProductMoniker,
     [Parameter(Mandatory=$true)][string]$DotnetMSIVersion,
-    [Parameter(Mandatory=$true)][string]$DotnetCLIDisplayVersion,
     [Parameter(Mandatory=$true)][string]$DotnetCLINugetVersion,
     [Parameter(Mandatory=$true)][string]$Architecture,
     [Parameter(Mandatory=$true)][string]$WixObjRoot
@@ -31,7 +30,6 @@ function RunCandle
         -dMicrosoftEula="$RepoRoot\packaging\osx\clisdk\resources\en.lproj\eula.rtf" `
         -dProductMoniker="$ProductMoniker" `
         -dBuildVersion="$DotnetMSIVersion" `
-        -dDisplayVersion="$DotnetCLIDisplayVersion" `
         -dNugetVersion="$DotnetCLINugetVersion" `
         -arch $Architecture `
         "$AuthWsxRoot\host.wxs" `

--- a/packaging/windows/host/host.wxs
+++ b/packaging/windows/host/host.wxs
@@ -13,7 +13,7 @@
             <ComponentGroupRef Id="AuthoredRegistryKeys"/>
         </Feature>
         <Feature Id="Provider" Absent="disallow" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" Level="1" InstallDefault="local" Title="RefCounting" TypicalDefault="install">
-            <ComponentRef Id="Dotnet_CLI_SharedHost_$(var.Dotnet_DisplayVersion)" />
+            <ComponentRef Id="$(var.DependencyKeyId)" />
         </Feature>
         <Property Id="ProductCPU" Value="$(var.Platform)" />
         <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />

--- a/packaging/windows/host/provider.wxs
+++ b/packaging/windows/host/provider.wxs
@@ -2,8 +2,8 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
   <?include "Variables.wxi" ?>
   <Fragment>
-    <Component Id="Dotnet_CLI_SharedHost_$(var.Dotnet_DisplayVersion)" Directory="TARGETDIR" Win64="no" Guid="82516259-FF21-446E-A432-1FFCA5A02296">
-      <dep:Provides Key="Dotnet_CLI_SharedHost_$(var.Dotnet_DisplayVersion)" />
+    <Component Id="$(var.DependencyKeyId)" Directory="TARGETDIR" Win64="no" Guid="82516259-FF21-446E-A432-1FFCA5A02296">
+      <dep:Provides Key="$(var.DependencyKey)" />
     </Component>
   </Fragment>
 </Wix>

--- a/packaging/windows/host/variables.wxi
+++ b/packaging/windows/host/variables.wxi
@@ -5,7 +5,6 @@
   <?define Servicing_Key_SPIndex   =   "0" ?>
   <?define Servicing_Key_SPName   =   "Beta" ?>
   <?define Dotnet_ProductVersion   =   "$(var.BuildVersion)" ?>
-  <?define Dotnet_DisplayVersion   =   "$(var.DisplayVersion)" ?>
   <?define Dotnet_BuildVersion   =   "$(var.BuildVersion)" ?>
   <?define Manufacturer     =   "Microsoft Corporation" ?>
   <?define ProductName      =   "$(var.ProductMoniker) ($(var.NugetVersion) $(sys.BUILDARCH))" ?>
@@ -26,4 +25,7 @@
   <?else?>
   <?error Invalid Platform ($(var.Platform))?>
   <?endif?>
+
+  <?define DependencyKey   = "Dotnet_CLI_SharedHost_$(var.Platform)"?>
+  <?define DependencyKeyId = "$(var.DependencyKey)" ?>
 </Include>

--- a/packaging/windows/sharedframework/generatebundle.ps1
+++ b/packaging/windows/sharedframework/generatebundle.ps1
@@ -25,6 +25,7 @@ function RunCandleForBundle
 
     Write-Host Running candle for bundle..
     $AuthWsxRoot =  Join-Path $RepoRoot "packaging\windows\sharedframework"
+    $SharedFrameworkComponentVersion = $SharedFrameworkNugetVersion.Replace('-', '_');
 
     .\candle.exe -nologo `
         -dMicrosoftEula="$RepoRoot\packaging\osx\sharedframework\resources\en.lproj\eula.rtf" `
@@ -35,6 +36,7 @@ function RunCandleForBundle
         -dSharedHostMsiSourcePath="$SharedHostMSIFile" `
         -dFrameworkName="$SharedFrameworkNugetName" `
         -dFrameworkDisplayVersion="$SharedFrameworkNugetVersion" `
+        -dFrameworkComponentVersion="$SharedFrameworkComponentVersion" `
         -dFrameworkUpgradeCode="$SharedFrameworkUpgradeCode" `
         -arch "$Architecture" `
         -ext WixBalExtension.dll `

--- a/packaging/windows/sharedframework/provider.wxs
+++ b/packaging/windows/sharedframework/provider.wxs
@@ -2,8 +2,8 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
   <?include "Variables.wxi" ?>
   <Fragment>
-    <Component Id="DotNet_CLI_SharedFramework_$(var.FrameworkName)_$(var.FrameworkComponentVersion)" Directory="TARGETDIR" Win64="no" Guid="F47B3A4D-7CEB-4F18-8464-0F6C5978E08E">
-      <dep:Provides Key="DotNet.CLI.SharedFramework.$(var.FrameworkName)_$(var.FrameworkComponentVersion)" />
+    <Component Id="$(var.DependencyKeyId)" Directory="TARGETDIR" Win64="no" Guid="F47B3A4D-7CEB-4F18-8464-0F6C5978E08E">
+      <dep:Provides Key="$(var.DependencyKey)" />
     </Component>
   </Fragment>
 </Wix>

--- a/packaging/windows/sharedframework/sharedframework.wxs
+++ b/packaging/windows/sharedframework/sharedframework.wxs
@@ -34,7 +34,7 @@
             </Component>
         </Feature>
         <Feature Id="Provider" Absent="disallow" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" Level="1" InstallDefault="local" Title="RefCounting" TypicalDefault="install">
-            <ComponentRef Id="DotNet_CLI_SharedFramework_$(var.FrameworkName)_$(var.FrameworkComponentVersion)" />
+            <ComponentRef Id="$(var.DependencyKeyId)" />
         </Feature>
 
         <Property Id="MSIFASTINSTALL" Value="7" />

--- a/packaging/windows/sharedframework/variables.wxi
+++ b/packaging/windows/sharedframework/variables.wxi
@@ -28,4 +28,7 @@
   <?else?>
   <?error Invalid Platform ($(var.Platform))?>
   <?endif?>
+
+  <?define DependencyKey  = "DotNet.CLI.SharedFramework.$(var.FrameworkName)_$(var.FrameworkComponentVersion)_$(var.Platform)"?>
+  <?define DependencyKeyId = "$(var.DependencyKey)" ?>
 </Include>

--- a/scripts/dotnet-cli-build/MsiTargets.cs
+++ b/scripts/dotnet-cli-build/MsiTargets.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             Cmd("powershell", "-NoProfile", "-NoLogo",
                 Path.Combine(Dirs.RepoRoot, "packaging", "windows", "host", "generatemsi.ps1"),
-                inputDir, SharedHostMsi, WixRoot, sharedHostBrandName, MsiVersion, CliDisplayVersion, CliNugetVersion, Arch, wixObjRoot)
+                inputDir, SharedHostMsi, WixRoot, sharedHostBrandName, MsiVersion, CliNugetVersion, Arch, wixObjRoot)
                     .Execute()
                     .EnsureSuccessful();
             return c.Success();


### PR DESCRIPTION
Earlier the host MSI dependency key changed for every version. Therefore
the following steps uninstalled host aggressively.
- Install a older dotnet CLI bundle (say v1)
- Install a newer dotnet CLI bundle (say v2)
- Uninstall the newer CLI bundle. This removes the host completely and
  leaves the older version v1 unusable.

With this fix all the versions of the CLI in the machine will reference
count the host correctly. And the host dependency key will be constant from build-to-build.

Fixes - #2713

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2789)
<!-- Reviewable:end -->
