### PR TITLE
Execute 'csc' with working directory set to the project directory.

### DIFF
--- a/TestAssets/TestProjects/TestRuleSet/TestLibraryWithRuleSet/Violations.cs
+++ b/TestAssets/TestProjects/TestRuleSet/TestLibraryWithRuleSet/Violations.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+
+namespace TestLibrary
+{
+    public class AttributeWithoutUsage : Attribute
+    {
+    }
+
+    public class ClassWithUndisposedStream
+    {
+        private Stream _nonDisposedStream = new MemoryStream();
+
+        public ClassWithUndisposedStream()
+        {
+        }
+
+        public Stream GetStream()
+        {
+            return _nonDisposedStream;
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestRuleSet/TestLibraryWithRuleSet/project.json
+++ b/TestAssets/TestProjects/TestRuleSet/TestLibraryWithRuleSet/project.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "additionalArguments": [ "/ruleset:../global.ruleset" ]
+  },
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Runtime.Analyzers": {
+      "version": "1.1.0",
+      "type": "build"
+    }
+  },
+  "frameworks": {
+    "netstandard1.5": {}
+  }
+}

--- a/TestAssets/TestProjects/TestRuleSet/global.ruleset
+++ b/TestAssets/TestProjects/TestRuleSet/global.ruleset
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="New Rule Set" Description=" " ToolsVersion="14.0">
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1018" Action="Hidden" />
+  </Rules>
+</RuleSet>

--- a/src/Microsoft.DotNet.Cli.Utils/BuiltInCommand.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/BuiltInCommand.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Cli.Utils
         private readonly Func<string[], int> _builtInCommand;
         private readonly StreamForwarder _stdOut;
         private readonly StreamForwarder _stdErr;
+        private string _workingDirectory;
 
         public string CommandName { get; }
         public string CommandArgs => string.Join(" ", _commandArgs);
@@ -38,6 +39,7 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             TextWriter originalConsoleOut = Console.Out;
             TextWriter originalConsoleError = Console.Error;
+            string originalWorkingDirectory = Directory.GetCurrentDirectory();
 
             try
             {
@@ -51,6 +53,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
                     // Reset the Reporters to the new Console Out and Error.
                     Reporter.Reset();
+
+                    if (!string.IsNullOrEmpty(_workingDirectory))
+                    {
+                        Directory.SetCurrentDirectory(_workingDirectory);
+                    }
 
                     var taskOut = _stdOut.BeginRead(new StreamReader(outStream));
                     var taskErr = _stdErr.BeginRead(new StreamReader(errorStream));
@@ -71,6 +78,7 @@ namespace Microsoft.DotNet.Cli.Utils
             {
                 Console.SetOut(originalConsoleOut);
                 Console.SetError(originalConsoleError);
+                Directory.SetCurrentDirectory(originalWorkingDirectory);
 
                 Reporter.Reset();
             }
@@ -96,6 +104,13 @@ namespace Microsoft.DotNet.Cli.Utils
             }
 
             _stdErr.ForwardTo(writeLine: handler);
+
+            return this;
+        }
+
+        public ICommand WorkingDirectory(string workingDirectory)
+        {
+            _workingDirectory = workingDirectory;
 
             return this;
         }
@@ -129,11 +144,6 @@ namespace Microsoft.DotNet.Cli.Utils
         }
 
         public ICommand ForwardStdOut(TextWriter to = null, bool onlyIfVerbose = false, bool ansiPassThrough = true)
-        {
-            throw new NotImplementedException();
-        }
-
-        public ICommand WorkingDirectory(string projectDirectory)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.DotNet.Cli.Utils/PathUtility.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/PathUtility.cs
@@ -223,5 +223,19 @@ namespace Microsoft.DotNet.Tools.Common
 
             return Path.GetExtension(filePath).Equals(extension, comparison);
         }
+
+        /// <summary>
+        /// Gets the fully-qualified path without failing if the
+        /// path is empty.
+        /// </summary>
+        public static string GetFullPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return path;
+            }
+
+            return Path.GetFullPath(path);
+        }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.ProjectModel
 
         public string RootDirectory => GlobalSettings?.DirectoryPath;
 
-        public string ProjectDirectory => ProjectFile.ProjectDirectory;
+        public string ProjectDirectory => ProjectFile?.ProjectDirectory;
 
         public string PackagesDirectory { get; }
 

--- a/src/dotnet/commands/dotnet-build/BuildCommandApp.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandApp.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Common;
 using NuGet.Frameworks;
 
 // This class is responsible with defining the arguments for the Compile verb.
@@ -97,7 +98,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                 }
 
                 OutputValue = _outputOption.Value();
-                BuildBasePathValue = _buildBasePath.Value();
+                BuildBasePathValue = PathUtility.GetFullPath(_buildBasePath.Value());
                 ConfigValue = _configurationOption.Value() ?? Constants.DefaultConfiguration;
                 RuntimeValue = _runtimeOption.Value();
                 VersionSuffixValue = _versionSuffixOption.Value();

--- a/src/dotnet/commands/dotnet-compile-csc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-csc/Program.cs
@@ -84,6 +84,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
 
                 // Execute CSC!
                 var result = RunCsc(new string[] { $"-noconfig", "@" + $"{rsp}" })
+                    .WorkingDirectory(Directory.GetCurrentDirectory())
                     .ForwardStdErr()
                     .ForwardStdOut()
                     .Execute();

--- a/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
+++ b/src/dotnet/commands/dotnet-compile/ManagedCompiler.cs
@@ -189,6 +189,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             Reporter outputReporter = Reporter.Output;
 
             CommandResult result = _commandFactory.Create($"compile-{compilerName}", new[] { $"@{rsp}" })
+                .WorkingDirectory(context.ProjectDirectory)
                 .OnErrorLine(line => HandleCompilerOutputLine(line, context, diagnostics, errorReporter))
                 .OnOutputLine(line => HandleCompilerOutputLine(line, context, diagnostics, outputReporter))
                 .Execute();

--- a/src/dotnet/commands/dotnet-pack/Program.cs
+++ b/src/dotnet/commands/dotnet-pack/Program.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Common;
 using Microsoft.DotNet.Tools.Pack;
 
 namespace Microsoft.DotNet.Tools.Compiler
@@ -61,7 +62,7 @@ namespace Microsoft.DotNet.Tools.Compiler
 
                 var configValue = configuration.Value() ?? Cli.Utils.Constants.DefaultConfiguration;
                 var outputValue = output.Value();
-                var buildBasePathValue = buildBasePath.Value();
+                var buildBasePathValue = PathUtility.GetFullPath(buildBasePath.Value());
 
                 var contexts = ProjectContext.CreateContextForEachFramework(pathValue, settings);
                 var project = contexts.First().ProjectFile;

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -6,6 +6,7 @@ using System.IO;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Common;
 
 namespace Microsoft.DotNet.Tools.Publish
 {
@@ -37,7 +38,7 @@ namespace Microsoft.DotNet.Tools.Publish
 
                 publish.Framework = framework.Value();
                 publish.Runtime = runtime.Value();
-                publish.BuildBasePath = buildBasePath.Value();
+                publish.BuildBasePath = PathUtility.GetFullPath(buildBasePath.Value());
                 publish.OutputPath = output.Value();
                 publish.Configuration = configuration.Value() ?? Constants.DefaultConfiguration;
                 publish.NativeSubdirectories = nativeSubdirectories.HasValue();

--- a/src/dotnet/commands/dotnet-test/DotnetTestParams.cs
+++ b/src/dotnet/commands/dotnet-test/DotnetTestParams.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Common;
 using NuGet.Frameworks;
 using static System.Int32;
 
@@ -103,7 +104,7 @@ namespace Microsoft.DotNet.Tools.Test
                 }
 
                 Output = _outputOption.Value();
-                BuildBasePath = _buildBasePath.Value();
+                BuildBasePath = PathUtility.GetFullPath(_buildBasePath.Value());
                 Config = _configurationOption.Value() ?? Constants.DefaultConfiguration;
                 Runtime = _runtimeOption.Value();
                 NoBuild = _noBuildOption.HasValue();

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/CommandResultAssertions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/CommandResultAssertions.cs
@@ -81,6 +81,13 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
+        public AndConstraint<CommandResultAssertions> NotHaveStdErrContaining(string pattern)
+        {
+            Execute.Assertion.ForCondition(!_commandResult.StdErr.Contains(pattern))
+                .FailWith(AppendDiagnosticsTo($"The command error output contained a result it should not have contained: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
         public AndConstraint<CommandResultAssertions> HaveStdErrMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             Execute.Assertion.ForCondition(Regex.Match(_commandResult.StdErr, pattern, options).Success)

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/BuildCommand.cs
@@ -217,11 +217,16 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             string cppCompilerFlags="",
             bool buildProfile=true,
             bool noIncremental=false,
-            bool noDependencies=false)
+            bool noDependencies=false,
+            bool skipLoadProject=false)
             : base("dotnet")
         {
             _projectPath = projectPath;
-            _project = ProjectReader.GetProject(projectPath);
+
+            if (!skipLoadProject)
+            {
+                _project = ProjectReader.GetProject(projectPath);
+            }
 
             _outputDirectory = output;
             _buildBasePathDirectory = buildBasePath;

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsProjects.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsProjects.cs
@@ -44,6 +44,26 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
         }
 
         [Fact]
+        public void It_builds_projects_with_ruleset_relative_path()
+        {
+            var testInstance = TestAssetsManager
+                .CreateTestInstance("TestRuleSet")
+                .WithLockFiles();
+
+            new BuildCommand(Path.Combine("TestLibraryWithRuleSet", "project.json"), skipLoadProject: true)
+                .WithWorkingDirectory(testInstance.TestRoot)
+                .ExecuteWithCapturedOutput()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining("CA1001")
+                .And
+                .HaveStdErrContaining("CA2213")
+                .And
+                .NotHaveStdErrContaining("CA1018"); // this violation is hidden in the ruleset
+        }
+
+        [Fact]
         public void It_builds_projects_with_a_local_project_json_path()
         {
             var testInstance = TestAssetsManager

--- a/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
+++ b/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
@@ -176,6 +176,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
             var projectJson = Path.Combine(TestAssetPath, "project.json");
             var command = new Mock<ICommand>();
             command.Setup(c => c.Execute()).Returns(new CommandResult());
+            command.Setup(c => c.WorkingDirectory(It.IsAny<string>())).Returns(() => command.Object);
             command.Setup(c => c.OnErrorLine(It.IsAny<Action<string>>())).Returns(() => command.Object);
             command.Setup(c => c.OnOutputLine(It.IsAny<Action<string>>())).Returns(() => command.Object);
             var commandFactory = new Mock<ICommandFactory>();

--- a/test/dotnet-test.UnitTests/GivenThatWeWantToParseArgumentsForDotnetTest.cs
+++ b/test/dotnet-test.UnitTests/GivenThatWeWantToParseArgumentsForDotnetTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         [Fact]
         public void It_sets_BuildBasePath_when_one_is_passed_in()
         {
-            _dotnetTestFullParams.BuildBasePath.Should().Be(BuildBasePath);
+            _dotnetTestFullParams.BuildBasePath.Should().Be(Path.GetFullPath(BuildBasePath));
         }
 
         [Fact]


### PR DESCRIPTION
When using a ruleset with a relative path in buildOptions, csc can't
find the file because it is not working in the same directory as the
project.

Fix #2710

@brthor @cdmihai

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dotnet/cli/2792)
<!-- Reviewable:end -->
