### PR TITLE
Azure Publisher: TryDeleteBlob

### DIFF
--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli.Build
                 else
                 {
                     // This is an old drop of latest so remove all old files to ensure a clean state
-                    AzurePublisherTool.ListBlobs($"{targetContainer}").ToList().ForEach(f => AzurePublisherTool.DeleteBlob(f));
+                    AzurePublisherTool.ListBlobs($"{targetContainer}").ToList().ForEach(f => AzurePublisherTool.TryDeleteBlob(f));
 
                     // Drop the version file signaling such for any race-condition builds (see above comment).
                     AzurePublisherTool.DropLatestSpecifiedVersion(targetVersionFile);

--- a/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
+++ b/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
@@ -139,6 +139,22 @@ namespace Microsoft.DotNet.Cli.Build
             }
         }
 
+        public bool TryDeleteBlob(string path)
+        {
+            try
+            {
+                DeleteBlob(path);
+                
+                return true;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Deleting blob {path} failed with \r\n{e.Message}");
+                
+                return false;
+            }
+        }
+
         public void DeleteBlob(string path)
         {
             _blobContainer.GetBlockBlobReference(path).DeleteAsync().Wait();


### PR DESCRIPTION
Builds are currently failing because we try to delete blobs that don't exist. This change logs & ignores the exception.