### PR TITLE
Fix: builtIn defaults are not used when builtIn is not specified

### DIFF
--- a/TestAssets/TestProjects/EndToEndTestApp/defaultresource.resx
+++ b/TestAssets/TestProjects/EndToEndTestApp/defaultresource.resx
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+Some content
+</root>

--- a/src/Microsoft.DotNet.ProjectModel/Files/IncludeContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Files/IncludeContext.cs
@@ -62,18 +62,8 @@ namespace Microsoft.DotNet.ProjectModel.Files
                     BuiltInsInclude = CreateCollection(
                         sourceBasePath, "include", ExtractValues(builtIns.Value<JToken>("include")), literalPath: false);
 
-                    if (defaultBuiltInInclude != null && !BuiltInsInclude.Any())
-                    {
-                        BuiltInsInclude = defaultBuiltInInclude.ToList();
-                    }
-
                     BuiltInsExclude = CreateCollection(
                         sourceBasePath, "exclude", ExtractValues(builtIns.Value<JToken>("exclude")), literalPath: false);
-
-                    if (defaultBuiltInExclude != null && !BuiltInsExclude.Any())
-                    {
-                        BuiltInsExclude = defaultBuiltInExclude.ToList();
-                    }
                 }
 
                 var mappings = token.Value<JToken>("mappings") as JObject;
@@ -93,6 +83,18 @@ namespace Microsoft.DotNet.ProjectModel.Files
                                 defaultBuiltInExclude: null));
                     }
                 }
+            }
+
+            if (defaultBuiltInInclude != null &&
+                (BuiltInsInclude == null || !BuiltInsInclude.Any()))
+            {
+                BuiltInsInclude = defaultBuiltInInclude.ToList();
+            }
+
+            if (defaultBuiltInExclude != null &&
+                (BuiltInsExclude == null || !BuiltInsExclude.Any()))
+            {
+                BuiltInsExclude = defaultBuiltInExclude.ToList();
             }
         }
 

--- a/test/Microsoft.DotNet.ProjectModel.Tests/GivenThatIWantToCreateIncludeEntriesFromJson.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/GivenThatIWantToCreateIncludeEntriesFromJson.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.ProjectModel.Tests
 'buildOptions': {
   'compile': {
     'includeFiles': [ 'files/file1.cs', 'files/file2.cs' ],
-    'exclude': 'files/*ex.cs'
+    'exclude': '**/*.cs'
   }
 }}");
 

--- a/test/dotnet-compile.Tests/CompilerTests.cs
+++ b/test/dotnet-compile.Tests/CompilerTests.cs
@@ -166,6 +166,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
             var objDirInfo = new DirectoryInfo(Path.Combine(root, "obj", "Debug", DefaultFramework));
             objDirInfo.Should().HaveFile("EndToEndTestApp.resource1.resources");
             objDirInfo.Should().HaveFile("myresource.resources");
+            objDirInfo.Should().HaveFile("EndToEndTestApp.defaultresource.resources");
         }
 
         [Fact]


### PR DESCRIPTION
Issue #2819 

Currently the default BuiltIn values are being ignored if there is no `builtIns` specified in project.json.

@troydai @pranavkm 