### PR TITLE
Setup the registry keys for CLI bundle detection.

### DIFF
--- a/packaging/windows/clisdk/registrykeys.wxs
+++ b/packaging/windows/clisdk/registrykeys.wxs
@@ -3,23 +3,9 @@
   <?include "Variables.wxi" ?>
   <Fragment>
     <ComponentGroup Id="AuthoredRegistryKeys">
-      <!-- Include the 64-bit registry keys only in the 64-bit installer -->
-      <?if $(var.Platform) = x64?>
-      <Component Id="SetupRegistry_x64" Directory="TARGETDIR" Win64="yes">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup">
-          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
-          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
-          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.Dotnet_ProductVersion)" />
-        </RegistryKey>
-      </Component>
-      <?endif?>
-
-      <!-- Always install the 32-bit registry keys and env vars -->
       <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Win64="no">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup">
-          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
-          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
-          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.Dotnet_ProductVersion)" />
+        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sdk">
+          <RegistryValue Action="write" Name="$(var.NugetVersion)" Type="integer" Value="1" KeyPath="yes"/>
         </RegistryKey>
       </Component>
     </ComponentGroup>

--- a/packaging/windows/host/registrykeys.wxs
+++ b/packaging/windows/host/registrykeys.wxs
@@ -3,28 +3,12 @@
   <?include "Variables.wxi" ?>
   <Fragment>
     <ComponentGroup Id="AuthoredRegistryKeys">
-      <?if $(var.Platform) = x64?>
-      <Component Id="SetupRegistry_x64" Directory="TARGETDIR" Win64="yes">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\sharedhost\Setup">
-          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
-          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
-          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.Dotnet_ProductVersion)" />
-        </RegistryKey>
-        <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]" Part="last" Action="set" System="yes" />
-      </Component>
-      <?endif?>
-
-      <?if $(var.Platform) = x86?>
       <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Win64="no">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\sharedhost\Setup">
-          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
-          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[DOTNETHOME]" />
-          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.Dotnet_ProductVersion)" />
+        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedhost">
+          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.NugetVersion)" KeyPath="yes"/>
         </RegistryKey>
         <Environment Id="E_PATH" Name="PATH" Value="[DOTNETHOME]" Part="last" Action="set" System="yes" />
       </Component>
-      <?endif?>
-
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/packaging/windows/sharedframework/registrykeys.wxs
+++ b/packaging/windows/sharedframework/registrykeys.wxs
@@ -3,26 +3,11 @@
   <?include "Variables.wxi" ?>
   <Fragment>
     <ComponentGroup Id="AuthoredRegistryKeys">
-      <?if $(var.Platform) = x64?>
-      <Component Id="SetupRegistry_x64" Directory="TARGETDIR" Win64="yes">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\sharedframework\$(var.FrameworkName) $(var.FrameworkDisplayVersion)\Setup">
-          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
-          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[SHAREDFRAMEWORKHOME]" />
-          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.FrameworkDisplayVersion)" />
-        </RegistryKey>
-      </Component>
-      <?endif?>
-
-      <?if $(var.Platform) = x86?>
       <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Win64="no">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\sharedframework\$(var.FrameworkName) $(var.FrameworkDisplayVersion)\Setup">
-          <RegistryValue Action="write" Name="Install" Type="integer" Value="1" KeyPath="yes"/>
-          <RegistryValue Action="write" Name="InstallDir" Type="string" Value="[SHAREDFRAMEWORKHOME]" />
-          <RegistryValue Action="write" Name="Version" Type="string" Value="$(var.FrameworkDisplayVersion)" />
+        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sharedfx\$(var.FrameworkName)">
+          <RegistryValue Action="write" Name="$(var.FrameworkDisplayVersion)" Type="integer" Value="1" KeyPath="yes"/>
         </RegistryKey>
       </Component>
-      <?endif?>
-
     </ComponentGroup>
   </Fragment>
 </Wix>


### PR DESCRIPTION
For 1.0.0-rc2 release of the CLI/SharedFx only set the current version in the registry. The future releases will also set any backward compatible versions along with the current version.

The spec - https://github.com/dotnet/cli/issues/2588#issuecomment-215912323

Fixes - #2588

cc @piotrpMSFT @krwq @robmen @joeloff
