### PR TITLE
Fix placeholder resolution logic

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/PackageDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/PackageDescription.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.ProjectModel
 
         public override IEnumerable<LockFileItem> CompileTimeAssemblies => FilterPlaceholders(base.CompileTimeAssemblies);
 
-        public bool HasCompileTimePlaceholder => base.CompileTimeAssemblies.Any(a => PackageDependencyProvider.IsPlaceholderFile(a));
+        public bool HasCompileTimePlaceholder => base.CompileTimeAssemblies.Any() && base.CompileTimeAssemblies.All(a => PackageDependencyProvider.IsPlaceholderFile(a));
 
         private static IEnumerable<LockFileItem> FilterPlaceholders(IEnumerable<LockFileItem> items)
         {


### PR DESCRIPTION
System.Numerics.Vector has a placeholder next to a .dll in the lib folder. The scenario isn't really valid but take it into account and make the placeholder resolution logic a little more robust. A package is considered to have a compile time placeholder if it has files and *all* files are placeholders.

#2824

/cc @ericstj @anurse @pakrym 