### PR TITLE
Fix EULA privacy links

### DIFF
--- a/packaging/osx/clisdk/resources/cs.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/cs.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/de.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/de.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/en.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/en.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/es.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/es.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/fr.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/fr.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/it.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/it.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/ja.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/ja.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/ko.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/ko.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/pl.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/pl.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/pt-br.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/pt-br.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/ru.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/ru.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/tr.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/tr.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/zh-hans.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/zh-hans.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/clisdk/resources/zh-hant.lproj/eula.rtf
+++ b/packaging/osx/clisdk/resources/zh-hant.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/cs.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/cs.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/de.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/de.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/en.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/en.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/es.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/es.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/fr.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/fr.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/it.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/it.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/ja.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/ja.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/ko.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/ko.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/pl.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/pl.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/pt-br.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/pt-br.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/ru.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/ru.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/tr.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/tr.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/zh-hans.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/zh-hans.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 

--- a/packaging/osx/sharedframework/resources/zh-hant.lproj/eula.rtf
+++ b/packaging/osx/sharedframework/resources/zh-hant.lproj/eula.rtf
@@ -34,7 +34,7 @@ BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT
 {\listtext\f0 b.\tab}\b\fs19 Third Party Programs.\b0\fs20  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.\b\fs19\par
 
 \pard 
-{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096.Your }}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096.Your\ul0\cf0}}}}\f0\fs20  use of the software operates as your consent to these practices.\b\par
+{\listtext\f0 2.\tab}\jclisttab\tx360\ls1\nowidctlpar\fi-357\li357\sb120\sa120\fs20 DATA. \b0 The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at {{\field{\*\fldinst{HYPERLINK http://go.microsoft.com/fwlink/?LinkId=528096}}{\fldrslt{http://go.microsoft.com/fwlink/?LinkId=528096\ul0\cf0}}}}\f0\fs20. Your use of the software operates as your consent to these practices.\b\par
 {\listtext\f0 3.\tab}ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.\par
 
 \pard 
@@ -111,4 +111,3 @@ Remarque : Ce logiciel \'e9tant distribu\'e9 au Qu\'e9bec, Canada, certaines des
 \b\lang1033 EFFET JURIDIQUE. \b0 Le pr\'e9sent contrat d\'e9crit certains droits juridiques. Vous pourriez avoir d\rquote autres droits pr\'e9vus par les lois de votre pays. Le pr\'e9sent contrat ne modifie pas les droits que vous conf\'e8rent les lois de votre pays si celles-ci ne le permettent pas.\par
 \b\fs20\lang1036\par
 }
- 


### PR DESCRIPTION
Current link results in a 404 that redirects to the MS homepage.

![capture](https://cloud.githubusercontent.com/assets/1622880/14988068/ec00b944-1117-11e6-8e19-5d94d2bbea09.PNG)

I don't think this conflicts with @jasonwilliams200OK PR for a markdown version. https://github.com/dotnet/cli/issues/2731

Also cross referencing for telemetry policy updates: https://github.com/dotnet/cli/issues/2258

Note: The EULA at https://github.com/dotnet/cli/blob/rel/1.0.0/pkg/projects/dotnet_library_license.txt does not match the text in these files and was committed fairly recently.