### PR TITLE
Update dotnet-new templates to new project.json schema

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.pretemplate
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.pretemplate
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0-*",
-  "compilationOptions": {
+  "buildOptions": {
     "emitEntryPoint": true
   },
   "dependencies": {

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.pretemplate
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.pretemplate
@@ -1,12 +1,14 @@
 {
   "version": "1.0.0-*",
-  "compilationOptions": {
-    "emitEntryPoint": true
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "compilerName": "fsc",
+    "compile": {
+      "includeFiles": [
+        "Program.fs"
+      ]
+    }
   },
-  "compilerName": "fsc",
-  "compileFiles": [
-    "Program.fs"
-  ],
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",
     "Microsoft.NETCore.App": {

--- a/test/dotnet-new.Tests/GivenThatIWantANewCSApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewCSApp.cs
@@ -35,6 +35,24 @@ namespace Microsoft.DotNet.Tests
                 .Should().Pass();
         }
         
+        [Fact]
+        public void When_dotnet_build_is_invoked_Then_project_builds_without_warnings()
+        {
+            var rootPath = Temp.CreateDirectory().Path;
+
+            new TestCommand("dotnet") { WorkingDirectory = rootPath }
+                .Execute("new");
+
+            new TestCommand("dotnet") { WorkingDirectory = rootPath }
+                .Execute("restore");
+
+            var buildResult = new TestCommand("dotnet") { WorkingDirectory = rootPath }
+                .ExecuteWithCapturedOutput("build");
+            
+            buildResult.Should().Pass();
+            buildResult.Should().NotHaveStdErr();
+        }
+        
         private static void AddProjectJsonDependency(string projectJsonPath, string dependencyId, string dependencyVersion)
         {
             var projectJsonRoot = ReadProject(projectJsonPath);


### PR DESCRIPTION
C# and F# templates are using deprecated project.json elements (`compilationOptions`), causing a warning to be generated when building newly created projects.

Fixes #2843 

Also added a test to ensure no warnings / error messages are generated when building a C# project created by dotnet-new.