### PR TITLE
Update version number of Nuget binaries to 3.5.0-beta

### DIFF
--- a/scripts/update-dependencies/project.json
+++ b/scripts/update-dependencies/project.json
@@ -9,7 +9,7 @@
     "Microsoft.CSharp": "4.0.1-rc2-24027",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
     "Microsoft.DotNet.Cli.Build.Framework": "1.0.0-*",
-    "NuGet.Versioning": "3.5.0-beta-1246",
+    "NuGet.Versioning": "3.5.0-beta",
     "Newtonsoft.Json": "7.0.1",
     "Octokit": "0.18.0",
     "Microsoft.Net.Http": "2.2.29"

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -6,10 +6,10 @@
   },
   "dependencies": {
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",
-    "NuGet.Versioning": "3.5.0-beta-1246",
-    "NuGet.Packaging": "3.5.0-beta-1246",
-    "NuGet.Frameworks": "3.5.0-beta-1246",
-    "NuGet.ProjectModel": "3.5.0-beta-1246"
+    "NuGet.Versioning": "3.5.0-beta",
+    "NuGet.Packaging": "3.5.0-beta",
+    "NuGet.Frameworks": "3.5.0-beta",
+    "NuGet.ProjectModel": "3.5.0-beta"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "Microsoft.Extensions.DependencyModel": "1.0.0-*",
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Packaging": "3.5.0-beta-1246",
-    "NuGet.RuntimeModel": "3.5.0-beta-1246",
+    "NuGet.Packaging": "3.5.0-beta",
+    "NuGet.RuntimeModel": "3.5.0-beta",
     "System.Reflection.Metadata": "1.3.0-rc2-24027"
   },
   "frameworks": {

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -17,10 +17,10 @@
   ],
   "dependencies": {
     "NuGet.Commands": {
-      "version": "3.5.0-beta-1246",
+      "version": "3.5.0-beta",
       "exclude": "compile"
     },
-    "NuGet.CommandLine.XPlat": "3.5.0-beta-1246",
+    "NuGet.CommandLine.XPlat": "3.5.0-beta",
     "Newtonsoft.Json": "7.0.1",
     "System.Text.Encoding.CodePages": "4.0.1-rc2-24027",
     "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-24027",

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -11,10 +11,10 @@
     },
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
-    "NuGet.Versioning": "3.5.0-beta-1246",
-    "NuGet.Packaging": "3.5.0-beta-1246",
-    "NuGet.Frameworks": "3.5.0-beta-1246",
-    "NuGet.ProjectModel": "3.5.0-beta-1246",
+    "NuGet.Versioning": "3.5.0-beta",
+    "NuGet.Packaging": "3.5.0-beta",
+    "NuGet.Frameworks": "3.5.0-beta",
+    "NuGet.ProjectModel": "3.5.0-beta",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/tools/RuntimeGraphGenerator/project.json
+++ b/tools/RuntimeGraphGenerator/project.json
@@ -4,8 +4,8 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NuGet.RuntimeModel": "3.5.0-beta-1246",
-    "NuGet.Versioning": "3.5.0-beta-1246",
+    "NuGet.RuntimeModel": "3.5.0-beta",
+    "NuGet.Versioning": "3.5.0-beta",
     "System.CommandLine": "0.1.0-e160119-1",
     "System.Runtime.Serialization.Json": "4.0.2-rc2-24027",
     "Microsoft.DotNet.ProjectModel": "1.0.0-*",


### PR DESCRIPTION
We've removed the buildnumbers to make these packages publishable as the final version for CLI/NetCore RC2 release.
@yishaigalatzer @piotrpMSFT @eerhardt @emgarten 