### PR TITLE
Fix the dotnet-new README.md

### DIFF
--- a/src/dotnet/commands/dotnet-new/README.md
+++ b/src/dotnet/commands/dotnet-new/README.md
@@ -29,7 +29,7 @@ Language of project. Defaults to `C##`. Also `csharp` ( `fsharp` ) or `cs` ( `fs
 
 `-t`, `--type`
 
-Type of the project. Valid values are "console" (default), "lib" and "xunittest"
+Type of the project. Valid value is "console".
 
 ## EXAMPLES
 


### PR DESCRIPTION
Remove the `--type` additional options that are not valid. 

skip ci please

Fix #2867