### PR TITLE
Prefer servicing for native dll search order

### DIFF
--- a/src/corehost/cli/deps_resolver.h
+++ b/src/corehost/cli/deps_resolver.h
@@ -31,6 +31,7 @@ public:
         , m_portable(init.is_portable)
         , m_deps(nullptr)
         , m_fx_deps(nullptr)
+        , m_core_servicing(args.core_servicing)
     {
         m_deps_file = args.deps_path;
         if (m_portable)
@@ -149,6 +150,9 @@ private:
     std::unordered_map<pal::string_t, pal::string_t> m_prerelease_roll_forward_cache;
 
     pal::string_t m_package_cache;
+
+    // Servicing root, could be empty on platforms that don't support or when errors occur.
+    pal::string_t m_core_servicing;
 
     // Special entry for api-sets
     std::unordered_set<pal::string_t> m_api_set_paths;

--- a/src/corehost/common/utils.cpp
+++ b/src/corehost/common/utils.cpp
@@ -37,6 +37,11 @@ bool ends_with(const pal::string_t& value, const pal::string_t& suffix, bool mat
 
 bool starts_with(const pal::string_t& value, const pal::string_t& prefix, bool match_case)
 {
+    if (prefix.empty())
+    {
+        // Cannot start with an empty string.
+        return false;
+    }
     auto cmp = match_case ? pal::strncmp : pal::strncasecmp;
     return (value.size() >= prefix.size()) &&
         cmp(value.c_str(), prefix.c_str(), prefix.size()) == 0;


### PR DESCRIPTION
@gkhanna79 PTAL. Because we process native DLL directories in the order of the assets' directories, the directories of non-serviced assets gets appended first to the `NATIVE_DLL_SEARCH_DIRECTORIES`. However, servicing locations should get preference first. Note that this is not a problem for TPA because they are files and not directories.