### PR TITLE
Enable stack protect and fpic/fpie for host

### DIFF
--- a/src/corehost/cli/CMakeLists.txt
+++ b/src/corehost/cli/CMakeLists.txt
@@ -8,6 +8,8 @@ if(WIN32)
     add_compile_options($<$<CONFIG:RelWithDebInfo>:/MT>)
     add_compile_options($<$<CONFIG:Release>:/MT>)
     add_compile_options($<$<CONFIG:Debug>:/MTd>)
+else()
+    add_compile_options(-fPIE)
 endif()
 
 include(setup.cmake)

--- a/src/corehost/cli/dll/CMakeLists.txt
+++ b/src/corehost/cli/dll/CMakeLists.txt
@@ -8,6 +8,8 @@ if(WIN32)
     add_compile_options($<$<CONFIG:RelWithDebInfo>:/MT>)
     add_compile_options($<$<CONFIG:Release>:/MT>)
     add_compile_options($<$<CONFIG:Debug>:/MTd>)
+else()
+    add_compile_options(-fPIC)
 endif()
 
 include(../setup.cmake)

--- a/src/corehost/cli/fxr/CMakeLists.txt
+++ b/src/corehost/cli/fxr/CMakeLists.txt
@@ -8,6 +8,8 @@ if(WIN32)
     add_compile_options($<$<CONFIG:RelWithDebInfo>:/MT>)
     add_compile_options($<$<CONFIG:Release>:/MT>)
     add_compile_options($<$<CONFIG:Debug>:/MTd>)
+else()
+    add_compile_options(-fPIC)
 endif()
 
 include(../setup.cmake)

--- a/src/corehost/cli/setup.cmake
+++ b/src/corehost/cli/setup.cmake
@@ -43,6 +43,9 @@ endif()
 # containing the reference instead of using definitions from other modules.
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
+    add_compile_options(-fstack-protector-strong)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    add_compile_options(-fstack-protector)
 endif()
 
 if(CLI_CMAKE_PLATFORM_ARCH_I386)


### PR DESCRIPTION
There are three components for the host:
```
hostpolicy.dll
hostfxr.dll
dotnet.exe
```
Enables stack protection and position independent code for the binaries.