### PR TITLE
dotnet build raises errors MVC apps target net46.

### DIFF
--- a/TestAssets/TestProjects/AppWithNet46AndRoslyn/.noautobuild
+++ b/TestAssets/TestProjects/AppWithNet46AndRoslyn/.noautobuild
@@ -1,0 +1,1 @@
+noautobuild

--- a/TestAssets/TestProjects/AppWithNet46AndRoslyn/Program.cs
+++ b/TestAssets/TestProjects/AppWithNet46AndRoslyn/Program.cs
@@ -1,0 +1,10 @@
+namespace AppWithNet46AndRoslyn
+{
+    public class MyApp
+    {
+        public static void Main()
+        {
+            System.Console.WriteLine("Hello, World!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/AppWithNet46AndRoslyn/project.json
+++ b/TestAssets/TestProjects/AppWithNet46AndRoslyn/project.json
@@ -1,0 +1,11 @@
+{
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160429-01"
+  },
+  "frameworks": {
+    "net46": { }
+  }
+}

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsProjects.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsProjects.cs
@@ -100,5 +100,20 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
                 "TestLibraryWithXmlDoc.xml"
             });
         }
+
+        [WindowsOnlyFact]
+        public void It_builds_projects_targeting_net46_and_Roslyn()
+        {
+            var testInstance = TestAssetsManager
+                .CreateTestInstance("AppWithNet46AndRoslyn")
+                .WithLockFiles();
+
+            var testProject = Path.Combine(testInstance.TestRoot, "project.json");
+
+            new BuildCommand(testProject)
+                .Execute()
+                .Should()
+                .Pass();
+        }
     }
 }


### PR DESCRIPTION
The issue is when the ProjectContextBuilder sees a CompileTimePlaceholder `_._` file on a full framework, it assumes that dependency has to come from the "Reference Assemblies" directory.  If it can't be found there, an error is raised.  However, there are other reasons `_._` placeholders are created (when a NuGet package doesn't want its dependencies to be exposed in the Compile dependencies of its consumers). And these placeholders can exist for assemblies that aren't in the full framework - in this case System.Diagnostics.FileVersionInfo and others.

To fix this, if the reference can't be resolved from the "Reference Assemblies" folder, it is just skipped. If the compiler really needs that assembly, it will raise an error to the user.  Dotnet build shouldn't raise the error.

Fix #2906 

@piotrpMSFT @davidfowl @ericstj 