### PR TITLE
Make GracefulExceptions print with color on Windows 7 and 8.

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Cli
             }
             catch (GracefulException e)
             {
-                Console.WriteLine(CommandContext.IsVerbose() ? e.ToString().Red().Bold() : e.Message.Red().Bold());
+                Reporter.Output.WriteLine(CommandContext.IsVerbose() ? e.ToString().Red().Bold() : e.Message.Red().Bold());
 
                 return 1;
             }


### PR DESCRIPTION
When an invalid dotnet subcommand name is used, the resulting error message prints ASNI escape codes to the console on Windows 7 and 8:
![looks bad](http://i.imgur.com/IRDYiv3.png)

The root cause is the use of System.Console instead of Reporter to print the text of GracefulExceptions.

Windows 10 1511 and Unix support ANSI escape codes, so that's why this only affects Windows 7 and 8.