### PR TITLE
Fix null reference output on missing project for dotnet run

### DIFF
--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -72,8 +72,8 @@ namespace Microsoft.DotNet.Tools.Run
             if (projectContextCollection == null)
             {
                 throw new InvalidOperationException("Couldn't find a project to run. Possible causes:" + Environment.NewLine +
-                    "1. There is no project.json file in the current working directory." + Environment.NewLine +
-                    "2. The path specified with `--project` does not exist or does not contain a project.json file.");
+                    "1. There is no project in the current working directory - use `dotnet run --project` to specify a path." + Environment.NewLine +
+                    "2. The path specified with `--project` does not exist or does not contain a project.");
             }
             var frameworkContexts = projectContextCollection.FrameworkOnlyContexts;
 

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -68,7 +68,14 @@ namespace Microsoft.DotNet.Tools.Run
                 Configuration = Constants.DefaultConfiguration;
             }
 
-            var frameworkContexts = _workspace.GetProjectContextCollection(Project).FrameworkOnlyContexts;
+            var projectContextCollection = _workspace.GetProjectContextCollection(Project);
+            if (projectContextCollection == null)
+            {
+                throw new InvalidOperationException("Couldn't find a project to run. Possible causes:" + Environment.NewLine +
+                    "1. There is no project.json file in the current working directory." + Environment.NewLine +
+                    "2. The path specified with `--project` does not exist or does not contain a project.json file.");
+            }
+            var frameworkContexts = projectContextCollection.FrameworkOnlyContexts;
 
             var rids = RuntimeEnvironmentRidExtensions.GetAllCandidateRuntimeIdentifiers();
 

--- a/test/dotnet-run.Tests/RunTests.cs
+++ b/test/dotnet-run.Tests/RunTests.cs
@@ -154,6 +154,22 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                         "arg: [one]",
                         "arg: [two]"));
         }
+        
+        [Fact]
+        public void ItHandlesUnknownProjectFileCorrectly()
+        {
+            new RunCommand("bad path")
+                .ExecuteWithCapturedOutput()    
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining(
+                    JoinWithNewlines(
+                        "Couldn't find a project to run. Possible causes:",
+                        "1. There is no project.json file in the current working directory.",
+                        "2. The path specified with `--project` does not exist or does not contain a project.json file."
+                    ));        
+        }
 
         private static string JoinWithNewlines(params string[] values)
         {

--- a/test/dotnet-run.Tests/RunTests.cs
+++ b/test/dotnet-run.Tests/RunTests.cs
@@ -166,8 +166,8 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                 .HaveStdErrContaining(
                     JoinWithNewlines(
                         "Couldn't find a project to run. Possible causes:",
-                        "1. There is no project.json file in the current working directory.",
-                        "2. The path specified with `--project` does not exist or does not contain a project.json file."
+                        "1. There is no project in the current working directory - use `dotnet run --project` to specify a path.",
+                        "2. The path specified with `--project` does not exist or does not contain a project."
                     ));        
         }
 


### PR DESCRIPTION
This pull request attempts to address #2965 when `dotnet run` cannot find a project to run.

This change simply guards against the null value, and if null, gives a more helpful error message.

It may be worthwhile to pull out the logic from `Workspace.NormalizeProjectPath` to show the possible paths that it is looking for a project file, but I'm not sure where that new logic should belong or if it is worth doing.