### PR TITLE
Fixed broken Equals (2)

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/AnalyzerOptions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/AnalyzerOptions.cs
@@ -1,9 +1,11 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.DotNet.ProjectModel
 {
-    public class AnalyzerOptions
+    public class AnalyzerOptions : IEquatable<AnalyzerOptions>
     {
         /// <summary>
         /// The identifier indicating the project language as defined by NuGet.
@@ -11,32 +13,45 @@ namespace Microsoft.DotNet.ProjectModel
         /// <remarks>
         /// See https://docs.nuget.org/create/analyzers-conventions for valid values
         /// </remarks>
-        public string LanguageId { get; set; }
+        public string LanguageId { get; }
+
+        public AnalyzerOptions(string languageId = null)
+        {
+            LanguageId = languageId;
+        }
+
+        public bool Equals(AnalyzerOptions other)
+        {
+            return !ReferenceEquals(other, null) && other.LanguageId == LanguageId;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AnalyzerOptions);
+        }
+
+        public override int GetHashCode()
+        {
+            return LanguageId?.GetHashCode() ?? 0;
+        }
 
         public static bool operator ==(AnalyzerOptions left, AnalyzerOptions right)
         {
-            return left.LanguageId == right.LanguageId;
+            if (ReferenceEquals(left, right))
+            {
+                return true;
+            }
+            if (ReferenceEquals(left, null))
+            {
+                return false;
+            }
+
+            return left.Equals(right);
         }
 
         public static bool operator !=(AnalyzerOptions left, AnalyzerOptions right)
         {
             return !(left == right);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj == null)
-            {
-                return false;
-            }
-
-            var options = obj as AnalyzerOptions;
-            return obj != null && (this == options);
-        }
-
-        public override int GetHashCode()
-        {
-            return LanguageId.GetHashCode();
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
@@ -561,7 +561,7 @@ namespace Microsoft.DotNet.ProjectModel
                                     analyzerOption.Value.ToString(),
                                     project.ProjectFilePath);
                             }
-                            analyzerOptions.LanguageId = analyzerOption.Value.ToString();
+                            analyzerOptions = new AnalyzerOptions(analyzerOption.Value.ToString());
                             break;
 
                         default:


### PR DESCRIPTION
Supersedes https://github.com/dotnet/cli/pull/2601. I lost my clone so recreated the PR.

@eerhardt I believe this is more correct. Overloaded operators defer to `.Equals` and proper null checks are in place. For `GetHashCode` to be reliable, it must use immutable fields. So I have made the `LanguageId` property readonly and added a constructor.

It's easiest to review the `AnalyzerOptions` file in full mode.