### PR TITLE
dotnet crashes with an unresolved 'platform' dependency.

### DIFF
--- a/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/Program.cs
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/project.json
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/project.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "ThisIsNotARealDependencyAndIfSomeoneGoesAndAddsAProjectWithThisNameIWillFindThemAndPunishThem": {
+      "type": "platform",
+      "version": "1.0.0"
+    }
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
@@ -277,7 +277,7 @@ namespace Microsoft.DotNet.ProjectModel
 
                     if (platformDependency != null)
                     {
-                        platformLibrary = libraries[new LibraryKey(platformDependency.Value.Name)];
+                        libraries.TryGetValue(new LibraryKey(platformDependency.Value.Name), out platformLibrary);
                     }
                 }
             }

--- a/test/dotnet.Tests/GivenThatDotNetRunsCommands.cs
+++ b/test/dotnet.Tests/GivenThatDotNetRunsCommands.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.IO;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Tests
+{
+    public class GivenThatDotNetRunsCommands : TestBase
+    {
+        [Fact]
+        public void UnresolvedPlatformReferencesFailAsExpected()
+        {
+            var testAssetsManager = GetTestGroupTestAssetsManager("NonRestoredTestProjects");
+            var testInstance = testAssetsManager.CreateTestInstance("TestProjectWithUnresolvedPlatformDependency");
+
+            new RestoreCommand()
+                .WithWorkingDirectory(testInstance.TestRoot)
+                .Execute()
+                .Should()
+                .Fail();
+            new DirectoryInfo(testInstance.TestRoot)
+                .Should()
+                .HaveFile("project.lock.json");
+
+            new DotnetCommand()
+                .ExecuteWithCapturedOutput("crash")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining("No executable found matching command \"dotnet-crash\"");
+        }
+    }
+}


### PR DESCRIPTION
Fixed by calling TryGetValue instead of a dictionary indexer when looking up platform dependencies in ProjectContextBuilder.

Fix #2693

@brthor 