### PR TITLE
Update nuget version to 3.5.0-rc-1285

### DIFF
--- a/scripts/update-dependencies/project.json
+++ b/scripts/update-dependencies/project.json
@@ -9,7 +9,7 @@
     "Microsoft.CSharp": "4.0.1-rc2-24027",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
     "Microsoft.DotNet.Cli.Build.Framework": "1.0.0-*",
-    "NuGet.Versioning": "3.5.0-beta",
+    "NuGet.Versioning": "3.5.0-rc-1285",
     "Newtonsoft.Json": "7.0.1",
     "Octokit": "0.18.0",
     "Microsoft.Net.Http": "2.2.29"

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -6,10 +6,10 @@
   },
   "dependencies": {
     "Microsoft.DotNet.ProjectModel": { "target": "project" },
-    "NuGet.Versioning": "3.5.0-beta",
-    "NuGet.Packaging": "3.5.0-beta",
-    "NuGet.Frameworks": "3.5.0-beta",
-    "NuGet.ProjectModel": "3.5.0-beta"
+    "NuGet.Versioning": "3.5.0-rc-1285",
+    "NuGet.Packaging": "3.5.0-rc-1285",
+    "NuGet.Frameworks": "3.5.0-rc-1285",
+    "NuGet.ProjectModel": "3.5.0-rc-1285"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/LibraryManager.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/LibraryManager.cs
@@ -170,11 +170,6 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
                             continue;
                         }
 
-                        if (library.Identity.Version.IsPrerelease && !versionRange.IncludePrerelease)
-                        {
-                            versionRange = VersionRange.SetIncludePrerelease(versionRange, includePrerelease: true);
-                        }
-
                         if (item.Library != library && !versionRange.Satisfies(library.Identity.Version))
                         {
                             var message = $"Dependency conflict. {item.Library.Identity} expected {FormatLibraryRange(item.Dependency)} but got {library.Identity.Version}";

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "Microsoft.Extensions.DependencyModel": { "target": "project" },
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Packaging": "3.5.0-beta",
-    "NuGet.RuntimeModel": "3.5.0-beta",
+    "NuGet.Packaging": "3.5.0-rc-1285",
+    "NuGet.RuntimeModel": "3.5.0-rc-1285",
     "System.Reflection.Metadata": "1.3.0-rc2-24027"
   },
   "frameworks": {

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -17,10 +17,10 @@
   ],
   "dependencies": {
     "NuGet.Commands": {
-      "version": "3.5.0-beta",
+      "version": "3.5.0-rc-1285",
       "exclude": "compile"
     },
-    "NuGet.CommandLine.XPlat": "3.5.0-beta",
+    "NuGet.CommandLine.XPlat": "3.5.0-rc-1285",
     "Newtonsoft.Json": "7.0.1",
     "System.Text.Encoding.CodePages": "4.0.1-rc2-24027",
     "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-24027",

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -11,10 +11,10 @@
     },
     "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
-    "NuGet.Versioning": "3.5.0-beta",
-    "NuGet.Packaging": "3.5.0-beta",
-    "NuGet.Frameworks": "3.5.0-beta",
-    "NuGet.ProjectModel": "3.5.0-beta",
+    "NuGet.Versioning": "3.5.0-rc-1285",
+    "NuGet.Packaging": "3.5.0-rc-1285",
+    "NuGet.Frameworks": "3.5.0-rc-1285",
+    "NuGet.ProjectModel": "3.5.0-rc-1285",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/tools/RuntimeGraphGenerator/project.json
+++ b/tools/RuntimeGraphGenerator/project.json
@@ -4,8 +4,8 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NuGet.RuntimeModel": "3.5.0-beta",
-    "NuGet.Versioning": "3.5.0-beta",
+    "NuGet.RuntimeModel": "3.5.0-rc-1285",
+    "NuGet.Versioning": "3.5.0-rc-1285",
     "System.CommandLine": "0.1.0-e160119-1",
     "System.Runtime.Serialization.Json": "4.0.2-rc2-24027",
     "Microsoft.DotNet.ProjectModel": { "target": "project" },


### PR DESCRIPTION
This is required to update the corefx dependencies from RC2 to RC3. Some
of the corefx libs have 'netstandard1.6' as TFM and this version of Nuget
supports that TFM.

Also the 'VersionRange.IncludePrerelease' has been removed from nuget and by
default 'VersionRange.Satisfies' returns true for any prerelease version.

cc @joelverhagen @emgarten @rrelyea @piotrpMSFT @eerhardt 