### PR TITLE
[DONOTMERGE]Switch to UTF8 for CoreCLR APIs on Windows

### DIFF
--- a/src/corehost/common/pal.windows.cpp
+++ b/src/corehost/common/pal.windows.cpp
@@ -275,18 +275,18 @@ bool pal::pal_clrstring(const pal::string_t& str, std::vector<char>* out)
     out->clear();
 
     // Pass -1 as we want explicit null termination in the char buffer.
-    size_t size = ::WideCharToMultiByte(CP_ACP, 0, str.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    size_t size = ::WideCharToMultiByte(CP_UTF8, 0, str.c_str(), -1, nullptr, 0, nullptr, nullptr);
     if (size == 0)
     {
         return false;
     }
     out->resize(size, '\0');
-    return ::WideCharToMultiByte(CP_ACP, 0, str.c_str(), -1, out->data(), out->size(), nullptr, nullptr) != 0;
+    return ::WideCharToMultiByte(CP_UTF8, 0, str.c_str(), -1, out->data(), out->size(), nullptr, nullptr) != 0;
 }
 
 bool pal::clr_palstring(const char* cstr, pal::string_t* out)
 {
-    return wchar_convert_helper(CP_ACP, cstr, ::strlen(cstr), out);
+    return wchar_convert_helper(CP_UTF8, cstr, ::strlen(cstr), out);
 }
 
 bool pal::realpath(string_t* path)


### PR DESCRIPTION
Fixes #2974

@eerhardt, you would need this fix when you are picking up CoreCLR with this change: https://github.com/dotnet/coreclr/pull/4894