### PR TITLE
Console.Write() doesn't show output until a newline

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -111,6 +111,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Performance", "test\Perform
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "binding-redirects.Tests", "test\binding-redirects.Tests\binding-redirects.Tests.xproj", "{27DBF851-F2E3-4FD5-BF4D-A73C81933283}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dotnet-run.UnitTests", "test\dotnet-run.UnitTests\dotnet-run.UnitTests.xproj", "{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -795,6 +797,22 @@ Global
 		{27DBF851-F2E3-4FD5-BF4D-A73C81933283}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{27DBF851-F2E3-4FD5-BF4D-A73C81933283}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{27DBF851-F2E3-4FD5-BF4D-A73C81933283}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.Debug|x64.Build.0 = Debug|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.Release|x64.ActiveCfg = Release|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.Release|x64.Build.0 = Release|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -847,5 +865,6 @@ Global
 		{35E3C2DC-9B38-4EC5-8DD7-C32458DC485F} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{6A3095FF-A7C5-4300-85A9-C025C384401D} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{27DBF851-F2E3-4FD5-BF4D-A73C81933283} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
+		{2A5EEC38-3030-44EF-9E58-6771E7BAB01D} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 	EndGlobalSection
 EndGlobal

--- a/scripts/dotnet-cli-build/TestTargets.cs
+++ b/scripts/dotnet-cli-build/TestTargets.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.Cli.Build
             "dotnet-publish.Tests",
             "dotnet-resgen.Tests",
             "dotnet-run.Tests",
+            "dotnet-run.UnitTests",
             "dotnet-test.Tests",
             "dotnet-test.UnitTests",
             "Kestrel.Tests",

--- a/test/dotnet-run.UnitTests/GivenARunCommand.cs
+++ b/test/dotnet-run.UnitTests/GivenARunCommand.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using System.IO;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Tools.Test.Utilities;
+using Moq;
 using NuGet.Frameworks;
 using Xunit;
 
@@ -28,95 +27,27 @@ namespace Microsoft.DotNet.Tools.Run.Tests
                 .Should()
                 .Pass();
 
-            RunCommand runCommand = new RunCommand(new FailOnRedirectOutputCommandFactory());
+            // use MockBehavior.Strict to ensure the RunCommand doesn't call CaptureStdOut, ForwardStdOut, etc.
+            Mock<ICommand> failOnRedirectOutputCommand = new Mock<ICommand>(MockBehavior.Strict);
+            failOnRedirectOutputCommand
+                .Setup(c => c.Execute())
+                .Returns(new CommandResult(null, RunExitCode, null, null));
+
+            Mock<ICommandFactory> commandFactoryMock = new Mock<ICommandFactory>();
+            commandFactoryMock
+                .Setup(c => c.Create(
+                                It.IsAny<string>(),
+                                It.IsAny<IEnumerable<string>>(),
+                                It.IsAny<NuGetFramework>(),
+                                It.IsAny<string>()))
+                .Returns(failOnRedirectOutputCommand.Object);
+
+            RunCommand runCommand = new RunCommand(commandFactoryMock.Object);
             runCommand.Project = instance.TestRoot;
 
             runCommand.Start()
                 .Should()
                 .Be(RunExitCode);
-        }
-
-        private class FailOnRedirectOutputCommandFactory : ICommandFactory
-        {
-            public ICommand Create(string commandName, IEnumerable<string> args, NuGetFramework framework = null, string configuration = "Debug")
-            {
-                return new FailOnRedirectOutputCommand();
-            }
-
-            /// <summary>
-            /// A Command that will fail if a caller tries redirecting StdOut or StdErr.
-            /// </summary>
-            private class FailOnRedirectOutputCommand : ICommand
-            {
-                public CommandResult Execute()
-                {
-                    return new CommandResult(null, RunExitCode, null, null);
-                }
-
-                public ICommand CaptureStdErr()
-                {
-                    throw new NotSupportedException();
-                }
-
-                public ICommand CaptureStdOut()
-                {
-                    throw new NotSupportedException();
-                }
-
-                public ICommand ForwardStdErr(TextWriter to = null, bool onlyIfVerbose = false, bool ansiPassThrough = true)
-                {
-                    throw new NotSupportedException();
-                }
-
-                public ICommand ForwardStdOut(TextWriter to = null, bool onlyIfVerbose = false, bool ansiPassThrough = true)
-                {
-                    throw new NotSupportedException();
-                }
-
-                public ICommand OnErrorLine(Action<string> handler)
-                {
-                    throw new NotSupportedException();
-                }
-
-                public ICommand OnOutputLine(Action<string> handler)
-                {
-                    throw new NotSupportedException();
-                }
-
-                public string CommandArgs
-                {
-                    get
-                    {
-                        throw new NotImplementedException();
-                    }
-                }
-
-                public string CommandName
-                {
-                    get
-                    {
-                        throw new NotImplementedException();
-                    }
-                }
-
-                public CommandResolutionStrategy ResolutionStrategy
-                {
-                    get
-                    {
-                        throw new NotImplementedException();
-                    }
-                }
-
-                public ICommand EnvironmentVariable(string name, string value)
-                {
-                    throw new NotImplementedException();
-                }
-
-                public ICommand WorkingDirectory(string projectDirectory)
-                {
-                    throw new NotImplementedException();
-                }
-            }
         }
     }
 }

--- a/test/dotnet-run.UnitTests/GivenARunCommand.cs
+++ b/test/dotnet-run.UnitTests/GivenARunCommand.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using NuGet.Frameworks;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Run.Tests
+{
+    public class GivenARunCommand : TestBase
+    {
+        private const int RunExitCode = 29;
+
+        [Fact]
+        public void ItDoesntRedirectStandardOutAndError()
+        {
+            TestInstance instance = TestAssetsManager.CreateTestInstance("TestAppSimple")
+                                         .WithLockFiles();
+
+            new BuildCommand(instance.TestRoot)
+                .Execute()
+                .Should()
+                .Pass();
+
+            RunCommand runCommand = new RunCommand(new FailOnRedirectOutputCommandFactory());
+            runCommand.Project = instance.TestRoot;
+
+            runCommand.Start()
+                .Should()
+                .Be(RunExitCode);
+        }
+
+        private class FailOnRedirectOutputCommandFactory : ICommandFactory
+        {
+            public ICommand Create(string commandName, IEnumerable<string> args, NuGetFramework framework = null, string configuration = "Debug")
+            {
+                return new FailOnRedirectOutputCommand();
+            }
+
+            /// <summary>
+            /// A Command that will fail if a caller tries redirecting StdOut or StdErr.
+            /// </summary>
+            private class FailOnRedirectOutputCommand : ICommand
+            {
+                public CommandResult Execute()
+                {
+                    return new CommandResult(null, RunExitCode, null, null);
+                }
+
+                public ICommand CaptureStdErr()
+                {
+                    throw new NotSupportedException();
+                }
+
+                public ICommand CaptureStdOut()
+                {
+                    throw new NotSupportedException();
+                }
+
+                public ICommand ForwardStdErr(TextWriter to = null, bool onlyIfVerbose = false, bool ansiPassThrough = true)
+                {
+                    throw new NotSupportedException();
+                }
+
+                public ICommand ForwardStdOut(TextWriter to = null, bool onlyIfVerbose = false, bool ansiPassThrough = true)
+                {
+                    throw new NotSupportedException();
+                }
+
+                public ICommand OnErrorLine(Action<string> handler)
+                {
+                    throw new NotSupportedException();
+                }
+
+                public ICommand OnOutputLine(Action<string> handler)
+                {
+                    throw new NotSupportedException();
+                }
+
+                public string CommandArgs
+                {
+                    get
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+
+                public string CommandName
+                {
+                    get
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+
+                public CommandResolutionStrategy ResolutionStrategy
+                {
+                    get
+                    {
+                        throw new NotImplementedException();
+                    }
+                }
+
+                public ICommand EnvironmentVariable(string name, string value)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public ICommand WorkingDirectory(string projectDirectory)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+    }
+}

--- a/test/dotnet-run.UnitTests/dotnet-run.UnitTests.xproj
+++ b/test/dotnet-run.UnitTests/dotnet-run.UnitTests.xproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.24720" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.24720</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>2a5eec38-3030-44ef-9e58-6771e7bab01d</ProjectGuid>
+    <RootNamespace>Microsoft.DotNet.Tools.Run.UnitTests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/dotnet-run.UnitTests/project.json
+++ b/test/dotnet-run.UnitTests/project.json
@@ -13,6 +13,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
+    "moq.netcore": "4.4.0-beta8",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {

--- a/test/dotnet-run.UnitTests/project.json
+++ b/test/dotnet-run.UnitTests/project.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0-rc3-*"
+    },
+    "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
+    "dotnet": {
+      "target": "project"
+    },
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net451+win8"
+      ]
+    }
+  },
+  "testRunner": "xunit"
+}


### PR DESCRIPTION
When running an app with `dotnet run`, we are redirecting the standard out and error just to print it out to our standard out and error. However, we are batching the output until we hit a newline, which isn't ideal for console apps.

To fix this, `dotnet run` no longer redirects the standard out and error.

Fix #2777

@brthor @anurse 