### PR TITLE
Project.json schema warnings don't get displayed

### DIFF
--- a/TestAssets/TestProjects/TestLibraryWithDeprecatedProjectFile/Helper.cs
+++ b/TestAssets/TestProjects/TestLibraryWithDeprecatedProjectFile/Helper.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace TestLibrary
+{
+    public static class Helper
+    {
+        public static void SayHi()
+        {
+            Console.WriteLine("Hello there!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestLibraryWithDeprecatedProjectFile/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithDeprecatedProjectFile/project.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0-*",
+  "compilationOptions": {
+    "xmlDoc": true
+  },
+  "packInclude": {},
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc2-24027"
+  },
+  "frameworks": {
+    "netstandard1.5": {}
+  }
+}

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContextBuilder.cs
@@ -355,8 +355,14 @@ namespace Microsoft.DotNet.ProjectModel
                 }
             }
 
+            List<DiagnosticMessage> allDiagnostics = new List<DiagnosticMessage>(diagnostics);
+            if (Project != null)
+            {
+                allDiagnostics.AddRange(Project.Diagnostics);
+            }
+
             // Create a library manager
-            var libraryManager = new LibraryManager(libraries.Values.ToList(), diagnostics, Project?.ProjectFilePath);
+            var libraryManager = new LibraryManager(libraries.Values.ToList(), allDiagnostics, Project?.ProjectFilePath);
 
             return new ProjectContext(
                 globalSettings,
@@ -445,7 +451,7 @@ namespace Microsoft.DotNet.ProjectModel
                     var dependency = new LibraryRange(library.Identity.Name, LibraryType.ReferenceAssembly);
 
                     var replacement = referenceAssemblyDependencyResolver.GetDescription(dependency, TargetFramework);
-                    
+
                     // If the reference is unresolved, just skip it.  Don't replace the package dependency
                     if (replacement == null)
                     {

--- a/test/dotnet-build.Tests/BuildWarningsTests.cs
+++ b/test/dotnet-build.Tests/BuildWarningsTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Builder.Tests
+{
+    public class BuildWarningsTests : TestBase
+    {
+        [Fact]
+        public void HavingDeprecatedProjectFileProducesWarning()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("TestLibraryWithDeprecatedProjectFile").WithLockFiles();
+
+            new BuildCommand(testInstance.TestRoot)
+                .ExecuteWithCapturedOutput()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdErrContaining("DOTNET1015: The 'compilationOptions' option is deprecated. Use 'buildOptions' instead.")
+                .And
+                .HaveStdErrContaining("DOTNET1015: The 'packInclude' option is deprecated. Use 'files' in 'packOptions' instead.");
+        }
+    }
+}


### PR DESCRIPTION
When building a project.json that has schema warnings (and other warnings), we are not writing the warnings to the console. This is a regression.

The fix is to add all diagnostic messages to the LibraryManager, which is responsible to hold all the diagnostic messages.

Fix #3021

@brthor @Sridhar-MS @livarcocc 