### PR TITLE
Fix publish CoreHost NuGet packages

### DIFF
--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -458,7 +458,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             List<string> buildVersions = new List<string>();
 
-            Regex buildVersionRegex = new Regex(@"Binaries/(?<version>\d+\.\d+\.\d+-[^-]+-\d{6})/$");
+            Regex buildVersionRegex = new Regex(@"Binaries/(?<version>\d+\.\d+\.\d+(?<prerelease>-[^-]+-\d{6})?)/$");
 
             foreach (string file in AzurePublisherTool.ListBlobs(hostBlob))
             {
@@ -535,7 +535,9 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             if (missingRuntime)
+            {
                 Console.WriteLine($"Build version {buildVersion} is missing some runtime packages so not pushing this drop.");
+            }
 
             return !missingRuntime;
         }

--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
@@ -435,6 +436,120 @@ namespace Microsoft.DotNet.Cli.Build
                 }
             }
             return c.Success();
+        }
+
+        private const string PackagePushedSemaphoreFileName = "packages.pushed";
+
+        [Target(nameof(PrepareTargets.Init), nameof(InitPublish))]
+        public static BuildTargetResult PullNupkgFilesFromBlob(BuildTargetContext c)
+        {
+            Directory.CreateDirectory(Dirs.PackagesNoRID);
+
+            var hostBlob = $"{Channel}/Binaries/";
+
+            string forcePushBuild = Environment.GetEnvironmentVariable("FORCE_PUBLISH_BLOB_BUILD_VERSION");
+
+            if (!string.IsNullOrEmpty(forcePushBuild))
+            {
+                Console.WriteLine($"Forcing all nupkg packages for build version {forcePushBuild}.");
+                DownloadPackagesForPush(hostBlob + forcePushBuild);
+                return c.Success();
+            }
+
+            List<string> buildVersions = new List<string>();
+
+            // The corehost packages are published to the CLI version, which is "preview1-xxxxxx" right now.
+            // But there are -rc2-xxxxxx blobs on Azure, which breaks the sort descending.  So only look for
+            // -p(.*)-xxxxxx for now to ignore those rc2 packages.
+            Regex buildVersionRegex = new Regex(@"Binaries/(?<version>\d+\.\d+\.\d+-p[^-]+-\d{6})/$");
+
+            foreach (string file in AzurePublisherTool.ListBlobs(hostBlob))
+            {
+                var match = buildVersionRegex.Match(file);
+                if (match.Success)
+                {
+                    buildVersions.Add(match.Groups["version"].Value);
+                }
+            }
+
+            // Sort decending
+            buildVersions.Sort();
+            buildVersions.Reverse();
+
+            // Try to publish the last 10 builds
+            foreach (var bv in buildVersions.Take(10))
+            {
+                Console.WriteLine($"Checking drop version: {bv}");
+
+                if (ShouldDownloadAndPush(hostBlob, bv))
+                {
+                    DownloadPackagesForPush(hostBlob + bv);
+                }
+            }
+
+            return c.Success();
+        }
+
+        private static bool ShouldDownloadAndPush(string hostBlob, string buildVersion)
+        {
+            // Set of runtime ids to look for to act as the signal that the build
+            // as finished each of these legs of the build.
+            Dictionary<string, bool> runtimes = new Dictionary<string, bool>()
+            {
+                {"win7-x64", false },
+                {"win7-x86", false },
+                {"osx.10.10-x64", false },
+                {"rhel.7-x64", false },
+                {"ubuntu.14.04-x64", false },
+                {"debian.8-x64", false },
+            };
+
+            var buildFiles = AzurePublisherTool.ListBlobs(hostBlob + buildVersion);
+
+            foreach (var bf in buildFiles)
+            {
+                string buildFile = Path.GetFileName(bf);
+
+                if (buildFile == PackagePushedSemaphoreFileName)
+                {
+                    Console.WriteLine($"Found '{PackagePushedSemaphoreFileName}' for build version {buildVersion} so skipping this drop.");
+                    // Nothing to do because the latest build is uploaded.
+                    return false;
+                }
+
+                foreach (var runtime in runtimes.Keys)
+                {
+                    if (buildFile.StartsWith($"runtime.{runtime}"))
+                    {
+                        runtimes[runtime] = true;
+                        break;
+                    }
+                }
+            }
+
+            bool missingRuntime = false;
+            foreach (var runtime in runtimes)
+            {
+                if (!runtime.Value)
+                {
+                    missingRuntime = true;
+                    Console.WriteLine($"Version {buildVersion} missing packages for runtime {runtime.Key}");
+                }
+            }
+
+            if (missingRuntime)
+                Console.WriteLine($"Build version {buildVersion} is missing some runtime packages so not pushing this drop.");
+
+            return !missingRuntime;
+        }
+
+        private static void DownloadPackagesForPush(string pathToDownload)
+        {
+            AzurePublisherTool.DownloadFiles(pathToDownload, ".nupkg", Dirs.PackagesNoRID);
+
+            string pushedSemaphore = Path.Combine(Dirs.PackagesNoRID, PackagePushedSemaphoreFileName);
+            File.WriteAllText(pushedSemaphore, $"Packages pushed for build {pathToDownload}");
+            AzurePublisherTool.PublishFile(pathToDownload + "/" + PackagePushedSemaphoreFileName, pushedSemaphore);
         }
     }
 }

--- a/scripts/dotnet-cli-build/PublishTargets.cs
+++ b/scripts/dotnet-cli-build/PublishTargets.cs
@@ -228,7 +228,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             foreach (var file in Directory.GetFiles(Dirs.CorehostLocalPackages, "*.nupkg"))
             {
-                var hostBlob = $"{Channel}/Binaries/{CliNuGetVersion}/{Path.GetFileName(file)}";
+                var hostBlob = $"{Channel}/Binaries/{SharedFrameworkNugetVersion}/{Path.GetFileName(file)}";
                 AzurePublisherTool.PublishFile(hostBlob, file);
                 Console.WriteLine($"Publishing package {hostBlob} to Azure.");
             }
@@ -458,10 +458,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             List<string> buildVersions = new List<string>();
 
-            // The corehost packages are published to the CLI version, which is "preview1-xxxxxx" right now.
-            // But there are -rc2-xxxxxx blobs on Azure, which breaks the sort descending.  So only look for
-            // -p(.*)-xxxxxx for now to ignore those rc2 packages.
-            Regex buildVersionRegex = new Regex(@"Binaries/(?<version>\d+\.\d+\.\d+-p[^-]+-\d{6})/$");
+            Regex buildVersionRegex = new Regex(@"Binaries/(?<version>\d+\.\d+\.\d+-[^-]+-\d{6})/$");
 
             foreach (string file in AzurePublisherTool.ListBlobs(hostBlob))
             {

--- a/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
+++ b/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
@@ -205,15 +205,5 @@ namespace Microsoft.DotNet.Cli.Build
                 }
             }
         }
-
-        public IEnumerable<string> ListBlobs(string blobVirtualDirectory)
-        {
-            CloudBlobDirectory blobDir = _blobContainer.GetDirectoryReference(blobVirtualDirectory);
-            BlobContinuationToken continuationToken = new BlobContinuationToken();
-
-            var blobFiles = blobDir.ListBlobsSegmentedAsync(continuationToken).Result;
-
-            return blobFiles.Results.Select(bf => bf.Uri.AbsoluteUri);
-        }
     }
 }

--- a/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
+++ b/scripts/dotnet-cli-build/Publishing/AzurePublisher.cs
@@ -187,5 +187,33 @@ namespace Microsoft.DotNet.Cli.Build
         {
             return $"{channel}/Binaries/{version}/{Path.GetFileName(archiveFile)}";
         }
+
+        public void DownloadFiles(string blobVirtualDirectory, string fileExtension, string downloadPath)
+        {
+            CloudBlobDirectory blobDir = _blobContainer.GetDirectoryReference(blobVirtualDirectory);
+            BlobContinuationToken continuationToken = new BlobContinuationToken();
+
+            var blobFiles = blobDir.ListBlobsSegmentedAsync(continuationToken).Result;
+
+            foreach (var blobFile in blobFiles.Results.OfType<CloudBlockBlob>())
+            {
+                if (Path.GetExtension(blobFile.Uri.AbsoluteUri) == fileExtension)
+                {
+                    string localBlobFile = Path.Combine(downloadPath, Path.GetFileName(blobFile.Uri.AbsoluteUri));
+                    Console.WriteLine($"Downloading {blobFile.Uri.AbsoluteUri} to {localBlobFile}...");
+                    blobFile.DownloadToFileAsync(localBlobFile, FileMode.Create).Wait();
+                }
+            }
+        }
+
+        public IEnumerable<string> ListBlobs(string blobVirtualDirectory)
+        {
+            CloudBlobDirectory blobDir = _blobContainer.GetDirectoryReference(blobVirtualDirectory);
+            BlobContinuationToken continuationToken = new BlobContinuationToken();
+
+            var blobFiles = blobDir.ListBlobsSegmentedAsync(continuationToken).Result;
+
+            return blobFiles.Results.Select(bf => bf.Uri.AbsoluteUri);
+        }
     }
 }

--- a/scripts/dotnet-cli-build/Utils/Dirs.cs
+++ b/scripts/dotnet-cli-build/Utils/Dirs.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public static readonly string Intermediate = Path.Combine(Output, "intermediate");
         public static readonly string PackagesIntermediate = Path.Combine(Output, "packages/intermediate");
+        public static readonly string PackagesNoRID = Path.Combine(RepoRoot, "artifacts", "packages");
         public static readonly string Packages = Path.Combine(Output, "packages");
         public static readonly string Stage1 = Path.Combine(Output, "stage1");
         public static readonly string Stage1Compilation = Path.Combine(Output, "stage1compilation");


### PR DESCRIPTION
Merging the PullNupkgFilesFromBlob target into rel/1.0.0 so it picks up the correct channel.

Fixing the publish script to push the CoreHost nupkgs to the correct version folder, not the CLI version folder.

This needs to be fixed ASAP so consumers can start consuming our RC3 packages.  I consciously didn't refactor the publishing code into the 'FinalizeBuild' target because that would have taken more time. We can do that separately, if we feel it is needed.

@weshaggard @Sridhar-MS @brthor @livarcocc 