### PR TITLE
Update uninstall script to correctly target install root

### DIFF
--- a/scripts/obtain/uninstall/dotnet-uninstall-debian-packages.sh
+++ b/scripts/obtain/uninstall/dotnet-uninstall-debian-packages.sh
@@ -8,7 +8,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 current_user=$(whoami)
 if [ $current_user != "root" ]; then
-    echo "$(basename $0) uninstallation script requires superuser privileges to run"
+    echo "$(basename "$0") uninstallation script requires superuser privileges to run"
     exit 1
 fi
 

--- a/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh
+++ b/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh
@@ -31,7 +31,7 @@ remove_dotnet_pkgs
 [ "$?" -ne 0 ] && echo "Failed to remove dotnet packages." && exit 1
 
 echo "Deleting install root - $dotnet_install_root"
-rm -rf $dotnet_install_location
+rm -rf $dotnet_install_root
 rm -f $dotnet_path_file
 
 echo "dotnet packages removal succeeded."

--- a/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh
+++ b/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh
@@ -17,6 +17,9 @@ dotnet_pkg_name_suffix="com.microsoft.dotnet"
 dotnet_install_root="/usr/local/share/dotnet"
 dotnet_path_file="/etc/paths.d/dotnet"
 
+# nuget paths
+nuget_root=~/.nuget
+
 remove_dotnet_pkgs(){
     installed_pkgs=($(pkgutil --pkgs | grep $dotnet_pkg_name_suffix))
     
@@ -33,6 +36,9 @@ remove_dotnet_pkgs
 echo "Deleting install root - $dotnet_install_root"
 rm -rf $dotnet_install_root
 rm -f $dotnet_path_file
+
+echo "Deleting NuGet package location"
+rm -rf $nuget_root
 
 echo "dotnet packages removal succeeded."
 exit 0

--- a/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh
+++ b/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh
@@ -8,7 +8,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 current_user=$(whoami)
 if [ $current_user != "root" ]; then
-    echo "`basename "$0"` uninstallation script requires superuser privileges to run"
+    echo "$(basename "$0") uninstallation script requires superuser privileges to run"
     exit 1
 fi
 
@@ -16,9 +16,6 @@ fi
 dotnet_pkg_name_suffix="com.microsoft.dotnet"
 dotnet_install_root="/usr/local/share/dotnet"
 dotnet_path_file="/etc/paths.d/dotnet"
-
-# nuget paths
-nuget_root=~/.nuget
 
 remove_dotnet_pkgs(){
     installed_pkgs=($(pkgutil --pkgs | grep $dotnet_pkg_name_suffix))
@@ -34,11 +31,8 @@ remove_dotnet_pkgs
 [ "$?" -ne 0 ] && echo "Failed to remove dotnet packages." && exit 1
 
 echo "Deleting install root - $dotnet_install_root"
-rm -rf $dotnet_install_root
-rm -f $dotnet_path_file
-
-echo "Deleting NuGet package location"
-rm -rf $nuget_root
+rm -r "$dotnet_install_root"
+rm "$dotnet_path_file"
 
 echo "dotnet packages removal succeeded."
 exit 0


### PR DESCRIPTION
- The .NET Core uninstall script did not work for me. 
- I made this change (which made sense to me upon visual inspection of the script) and then the script worked.
