### PR TITLE
Move RestorePackages to Prepare, not Init.

### DIFF
--- a/build_projects/dotnet-cli-build/PrepareTargets.cs
+++ b/build_projects/dotnet-cli-build/PrepareTargets.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class PrepareTargets
     {
-        [Target(nameof(Init))]
+        [Target(nameof(Init), nameof(RestorePackages))]
         public static BuildTargetResult Prepare(BuildTargetContext c) => c.Success();
 
         [Target(nameof(CheckPrereqCmakePresent), nameof(CheckPlatformDependencies))]
@@ -38,8 +38,7 @@ namespace Microsoft.DotNet.Cli.Build
             nameof(UpdateTemplateVersions), 
             nameof(CheckPrereqs), 
             nameof(LocateStage0), 
-            nameof(ExpectedBuildArtifacts),
-            nameof(RestorePackages))]
+            nameof(ExpectedBuildArtifacts))]
         public static BuildTargetResult Init(BuildTargetContext c)
         {
             var configEnv = Environment.GetEnvironmentVariable("CONFIGURATION");


### PR DESCRIPTION
RestorePackages will fail if the 'artifacts\rid\corehost` folder doesn't exist. So other targets that depend on Init can't run unless the host has been built.

This is blocking the 'PullNupkgFilesFromBlob' target from publishing our nupkgs.

@brthor