### PR TITLE
Update the StubPackageBuilder NETStandardLibrary version number to match the current CoreFX version number.

### DIFF
--- a/build_projects/dotnet-host-build/StubPackageBuilder.cs
+++ b/build_projects/dotnet-host-build/StubPackageBuilder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Host.Build
         {
             var projectJson = new StringBuilder();
             projectJson.Append("{");
-            projectJson.Append("  \"dependencies\": { \"NETStandard.Library\": \"1.5.0-rc2-24008\" },");
+            projectJson.Append("  \"dependencies\": { \"NETStandard.Library\": \"1.5.0-rc2-24027\" },");
             projectJson.Append("  \"frameworks\": { \"netcoreapp1.0\": { \"imports\": [\"netstandard1.5\", \"dnxcore50\"] } },");
             projectJson.Append("  \"runtimes\": { \"win7-x64\": { } },");
             projectJson.Append("}");
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Host.Build
             projectJson.Append("{");
             projectJson.Append($"  \"version\": \"{version}\",");
             projectJson.Append($"  \"name\": \"{packageId}\",");
-            projectJson.Append("  \"dependencies\": { \"NETStandard.Library\": \"1.5.0-rc2-24008\" },");
+            projectJson.Append("  \"dependencies\": { \"NETStandard.Library\": \"1.5.0-rc2-24027\" },");
             projectJson.Append("  \"frameworks\": { \"netcoreapp1.0\": { \"imports\": [\"netstandard1.5\", \"dnxcore50\"] } },");
             projectJson.Append("}");
 


### PR DESCRIPTION
The win x64 VSO build is currently failing during RestoreLockedHost with error:

```
2016-05-17T04:41:56.2580331Z Errors in F:\Agent\_work\1\s\artifacts\win10-x64\intermediate\lockedHostTemp\project.json
2016-05-17T04:41:56.2580331Z     Microsoft.Win32.Primitives 4.0.1-rc2-24008 provides a compile-time reference assembly for Microsoft.Win32.Primitives on .NETCoreApp,Version=v1.0, but there is no run-time assembly compatible with win7-x64.
2016-05-17T04:41:56.2580331Z     System.AppContext 4.1.0-rc2-24008 provides a compile-time reference assembly for System.AppContext on .NETCoreApp,Version=v1.0, but there is no run-time assembly compatible with win7-x64.
2016-05-17T04:41:56.2580331Z     System.Collections 4.0.11-rc2-24008 provides a compile-time reference assembly for System.Collections on .NETCoreApp,Version=v1.0, but there is no run-time assembly compatible with win7-x64.
2016-05-17T04:41:56.2580331Z     System.Console 4.0.0-rc2-24008 provides a compile-time reference assembly for System.Console on .NETCoreApp,Version=v1.0, but there is no run-time assembly compatible with win7-x64.
2016-05-17T04:41:56.2580331Z     System.Diagnostics.Debug 4.0.11-rc2-24008 provides a compile-time reference assembly for System.Diagnostics.Debug on .NETCoreApp,Version=v1.0, but there is no run-time assembly compatible with win7-x64.
2016-05-17T04:41:56.2580331Z     System.Diagnostics.Tools 4.0.1-rc2-24008 provides a compile-time reference assembly for System.Diagnostics.Tools on .NETCoreApp,Version=v1.0, but there is no run-time assembly compatible with win7-x64.
2016-05-17T04:41:56.2580331Z     System.Diagnostics.Tracing 4.1.0-rc2-24008 provides a compile-time reference assembly for System.Diagnostics.Tracing on .NETCoreApp,Version=v1.0, but there is no run-time assembly compatible with win7-x64.
2016-05-17T04:41:56.2580331Z     System.Globalization 4.0.11-rc2-24008 provides a compile-time reference assembly for System.Globalization on .NETCoreApp,Version=v1.0, but there is no run-time assembly compatible with win7-x64.
```

Bumping up this version to unblock the build.