### PR TITLE
Made path to delete binaries correct in the uninstall script

### DIFF
--- a/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh
+++ b/scripts/obtain/uninstall/dotnet-uninstall-pkgs.sh
@@ -31,7 +31,7 @@ remove_dotnet_pkgs
 [ "$?" -ne 0 ] && echo "Failed to remove dotnet packages." && exit 1
 
 echo "Deleting install root - $dotnet_install_root"
-rm -rf $dotnet_install_location
+rm -rf $dotnet_install_root
 rm -f $dotnet_path_file
 
 echo "dotnet packages removal succeeded."


### PR DESCRIPTION
skipciplease

Unless `$dotnet_install_location` is set somewhere else I think this will fail to delete anything