### PR TITLE
Upgrade the "dotnet-test-xunit" version to "1.0.0-rc2-192208-24"

### DIFF
--- a/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
     "xunit": "2.1.0"
   },

--- a/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
@@ -8,7 +8,7 @@
     "System.Linq.Expressions": "4.0.11-rc2-24027",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -19,7 +19,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -20,7 +20,7 @@
     },
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Kestrel.Tests/project.json
+++ b/test/Kestrel.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -26,7 +26,7 @@
     },
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -16,7 +16,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -16,7 +16,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "FluentAssertions": "4.0.0",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "Microsoft.DotNet.TestFramework": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": { "target": "project" },
     "Microsoft.DotNet.ProjectModel": { "target": "project" },

--- a/test/Microsoft.Extensions.DependencyModel.Tests/project.json
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/project.json
@@ -19,7 +19,7 @@
     "FluentAssertions": "4.0.0",
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Performance/project.json
+++ b/test/Performance/project.json
@@ -17,7 +17,7 @@
     },
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028"
   },
   "frameworks": {

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -15,7 +15,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
@@ -19,7 +19,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "FluentAssertions": "4.2.2"
   },
   "frameworks": {

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
@@ -14,7 +14,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "FluentAssertions": "4.2.2",
     "moq.netcore": "4.4.0-beta8"
   },

--- a/test/binding-redirects.Tests/project.json
+++ b/test/binding-redirects.Tests/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-24027",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/crossgen.Tests/project.json
+++ b/test/crossgen.Tests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -14,7 +14,7 @@
     },
     "Newtonsoft.Json": "7.0.1",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-compile-fsc.Tests/project.json
+++ b/test/dotnet-compile-fsc.Tests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -25,7 +25,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet-new.Tests/project.json
+++ b/test/dotnet-new.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -14,7 +14,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -18,7 +18,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "System.Net.NameResolution": "4.0.0-rc2-24027"
   },
   "frameworks": {

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -12,7 +12,7 @@
     },
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-24027"
   },
   "frameworks": {

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -14,7 +14,7 @@
     },
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-run.UnitTests/project.json
+++ b/test/dotnet-run.UnitTests/project.json
@@ -14,7 +14,7 @@
     },
     "xunit": "2.1.0",
     "moq.netcore": "4.4.0-beta8",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -19,7 +19,7 @@
     "System.Net.Sockets": "4.1.0-rc2-24027",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -14,7 +14,7 @@
       "exclude": "Compile"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36",
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -18,7 +18,7 @@
     },
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0-rc2-20581",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
The earlier version "1.0.0-rc2-173361-36" is missing from the cli-deps feed.

This is failing our OSX CI runs.

@sridhar-MS @brthor @livarcocc 