### PR TITLE
Move command line parsing into try/catch for test.

### DIFF
--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -26,10 +26,10 @@ namespace Microsoft.DotNet.Tools.Test
 
             var dotnetTestParams = new DotnetTestParams();
 
-            dotnetTestParams.Parse(args);
-
             try
             {
+                dotnetTestParams.Parse(args);
+            
                 if (dotnetTestParams.Help)
                 {
                     return 0;

--- a/test/dotnet-test.Tests/GivenThatWeWantToRunTests.cs
+++ b/test/dotnet-test.Tests/GivenThatWeWantToRunTests.cs
@@ -25,5 +25,19 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                 .And
                 .HaveStdErrContaining("dotnet restore");
         }
+        
+        [Fact]
+        public void It_fails_correctly_with_invalid_runtime_parameter()
+        {
+            var instance = TestAssetsManager.CreateTestInstance(Path.Combine("ProjectsWithTests", "NetCoreAppOnlyProject"));
+
+            new DotnetTestCommand()
+                .WithLockFiles()
+                .ExecuteWithCapturedOutput(instance.TestRoot)
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining("Missing value for option 'runtime'");
+        }
     }
 }

--- a/test/dotnet-test.Tests/GivenThatWeWantToRunTests.cs
+++ b/test/dotnet-test.Tests/GivenThatWeWantToRunTests.cs
@@ -25,19 +25,5 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                 .And
                 .HaveStdErrContaining("dotnet restore");
         }
-        
-        [Fact]
-        public void It_fails_correctly_with_invalid_runtime_parameter()
-        {
-            var instance = TestAssetsManager.CreateTestInstance(Path.Combine("ProjectsWithTests", "NetCoreAppOnlyProject"));
-
-            new DotnetTestCommand()
-                .WithLockFiles()
-                .ExecuteWithCapturedOutput(instance.TestRoot)
-                .Should()
-                .Fail()
-                .And
-                .HaveStdErrContaining("Missing value for option 'runtime'");
-        }
     }
 }

--- a/test/dotnet-test.Tests/GivenThatWeWantToRunTestsInTheConsole.cs
+++ b/test/dotnet-test.Tests/GivenThatWeWantToRunTestsInTheConsole.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
@@ -94,6 +95,44 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
             var testCommand = new DotnetTestCommand();
             result = testCommand.Execute($"{_projectFilePath} -o {_defaultOutputPath} --no-build");
             result.Should().Pass();
+        }
+        
+        [Theory]
+        [MemberData("ArgumentNames")]
+        public void It_fails_correctly_with_unspecified_arguments_with_long_form(string argument)
+        {
+            new DotnetTestCommand()
+                .ExecuteWithCapturedOutput($"{_projectFilePath} --{argument}")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining($"Missing value for option '{argument}'");
+        }
+        
+        [Theory]
+        [MemberData("ArgumentNames")]
+        public void It_fails_correctly_with_unspecified_arguments_with_short_form(string argument)
+        {
+            new DotnetTestCommand()
+                .ExecuteWithCapturedOutput($"{_projectFilePath} -{argument[0]}")
+                .Should()
+                .Fail()
+                .And
+                .HaveStdErrContaining($"Missing value for option '{argument}'");
+        }
+        
+        public static IEnumerable<object[]> ArgumentNames
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] { "output" },
+                    new object[] { "configuration" },
+                    new object[] { "runtime" },
+                    new object[] { "build-base-path" }
+                };
+            }
         }
 
         private string GetNotSoLongBuildBasePath()


### PR DESCRIPTION
This moves command line parsing inside of the try-catch so that any exceptions that bubble up do not cause a hard crash.

If invalid parameters are specified in `dotnet test`, the CLI does not
catch exceptions that can be thrown such as when specifying `-r` without
a runtime.

Fixes #3084.