### PR TITLE
Update Microsoft.DiaSymReader.Native to 1.4.0-rc

### DIFF
--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -14,7 +14,7 @@
     "Newtonsoft.Json": "7.0.1",
     "Microsoft.DotNet.ProjectModel": { "target": "project" },
     "Microsoft.DiaSymReader": "1.0.6",
-    "Microsoft.DiaSymReader.Native": "1.3.3"
+    "Microsoft.DiaSymReader.Native": "1.4.0-rc"
   },
   "frameworks": {
     "net451": {},

--- a/src/compilers/project.json
+++ b/src/compilers/project.json
@@ -10,7 +10,7 @@
     },
     "Microsoft.CodeAnalysis.CSharp": "1.3.0-beta1-20160429-01",
     "Microsoft.Net.Compilers.netcore": "1.3.0-beta1-20160429-01",
-    "Microsoft.DiaSymReader.Native": "1.3.3"
+    "Microsoft.DiaSymReader.Native": "1.4.0-rc"
   },
   "frameworks": {
     "netstandard1.5": {


### PR DESCRIPTION
The new version doesn't have dependency on VCRUNTIME140.dll.

Fixes https://github.com/dotnet/cli/issues/1433


