### PR TITLE
Move the Microsoft.NETCore.App dependency under the Framework

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
@@ -4,13 +4,15 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0-rc3-004312"
-    }
   },
   "frameworks": {
     "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-rc3-004312"
+        }
+      },
       "imports": "dnxcore50"
     }
   }

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
@@ -10,11 +10,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316",
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0-rc3-004312"
-    }
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316"
   },
   "tools": {
     "dotnet-compile-fsc": {
@@ -28,6 +24,12 @@
   },
   "frameworks": {
     "netstandard1.5": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-rc3-004312"
+        }
+      },
       "imports": [
         "portable-net45+win8",
         "dnxcore50"


### PR DESCRIPTION
As per #2970, this PR moves the main metapackage dependency under the
framework. In the F# project.json, it moves *just this* under the
framework, while the F# Core package remains under general
dependencies. The rationale is that since this is an F# project, this
packages is needed for all TFMs in the project.

Fixes #2970

/cc @enricosada @eerhardt @brthor @piotrpMSFT 