### PR TITLE
Add 'dotnet restore' instruction when lock file is missing (#3051)

### DIFF
--- a/src/dotnet/commands/dotnet-build/CompilerIOManager.cs
+++ b/src/dotnet/commands/dotnet-build/CompilerIOManager.cs
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Tools.Build
         {
             if (project.LockFile == null)
             {
-                var errorMessage = $"Project {project.ProjectName()} does not have a lock file.";
+                var errorMessage = $"Project {project.ProjectName()} does not have a lock file. Please run \"dotnet restore\" to generate a new lock file.";
                 Reporter.Error.WriteLine(errorMessage);
                 throw new InvalidOperationException(errorMessage);
             }

--- a/test/dotnet-build.Tests/IncrementalTests.cs
+++ b/test/dotnet-build.Tests/IncrementalTests.cs
@@ -79,6 +79,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
             buildResult = BuildProject(expectBuildFailure: true);
             Assert.Contains("does not have a lock file", buildResult.StdErr);
+            Assert.Contains("dotnet restore", buildResult.StdErr);
         }
 
         [Fact]


### PR DESCRIPTION
As per #3051, if you run `dotnet run` but forgot to run `dotnet restore` before that, the error message only states what is wrong (missing lock file), not how to fix this. This PR adds an instruction to the error message that states the user should run `dotnet restore`. The exact instruction has been copied from the instruction used in Visual Studio when this error occurs.