### PR TITLE
perf tests: add fallback feed to dotnet restore

### DIFF
--- a/test/Performance/run-perftests.py
+++ b/test/Performance/run-perftests.py
@@ -177,7 +177,7 @@ def run_perf_test(runid, cli_path, xunitperf_src_path):
             print("# Deleting {file}".format(file = project_lock_path))
             os.remove(project_lock_path)
         run_command(
-            cli_path, 'restore',
+            cli_path, 'restore', '-f', 'https://dotnet.myget.org/f/dotnet-core',
             title = "Dotnet restore using \"{cli}\"".format(cli = cli_path),
             from_dir = SCRIPT_ROOT_PATH,
         )


### PR DESCRIPTION
The perf tests use `dotnet restore` to download test dependencies. The
perf tests' project.json may sometimes refer to a version of the
framework that is not yet published, which can cause the restore command
to fail. This change addresses the issue by adding a fallback nuget feed
that contains not-yet-published version of the framework.