### PR TITLE
Move PullNupkgFilesFromBlob into FinalizeBuild.

### DIFF
--- a/build_projects/dotnet-cli-build/NuGetUtil.cs
+++ b/build_projects/dotnet-cli-build/NuGetUtil.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using System.Reflection;
+using Microsoft.DotNet.Cli.Build.Framework;
+using NugetProgram = NuGet.CommandLine.XPlat.Program;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public static class NuGetUtil
+    {
+        public static void PushPackages(string packagesPath, string destinationUrl, string apiKey)
+        {
+            int result = RunNuGetCommand(
+                "push",
+                "-s", destinationUrl,
+                "-k", apiKey,
+                Path.Combine(packagesPath, "*.nupkg"));
+
+            if (result != 0)
+            {
+                throw new BuildFailureException($"NuGet Push failed with exit code '{result}'.");
+            }
+        }
+
+        private static int RunNuGetCommand(params string[] nugetArgs)
+        {
+            var nugetAssembly = typeof(NugetProgram).GetTypeInfo().Assembly;
+            var mainMethod = nugetAssembly.EntryPoint;
+            return (int)mainMethod.Invoke(null, new object[] { nugetArgs });
+        }
+    }
+}
+

--- a/build_projects/dotnet-cli-build/PrepareTargets.cs
+++ b/build_projects/dotnet-cli-build/PrepareTargets.cs
@@ -62,17 +62,8 @@ namespace Microsoft.DotNet.Cli.Build
         [Target]
         public static BuildTargetResult GenerateVersions(BuildTargetContext c)
         {
-            var gitResult = Cmd("git", "rev-list", "--count", "HEAD")
-                .CaptureStdOut()
-                .Execute();
-            gitResult.EnsureSuccessful();
-            var commitCount = int.Parse(gitResult.StdOut);
-
-            gitResult = Cmd("git", "rev-parse", "HEAD")
-                .CaptureStdOut()
-                .Execute();
-            gitResult.EnsureSuccessful();
-            var commitHash = gitResult.StdOut.Trim();
+            var commitCount = GitUtils.GetCommitCount();
+            var commitHash = GitUtils.GetCommitHash();
 
             var branchInfo = ReadBranchInfo(c, Path.Combine(c.BuildContext.BuildDirectory, "branchinfo.txt"));
             var buildVersion = new BuildVersion()

--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -12,7 +12,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24027",
     "System.Xml.XmlSerializer": "4.0.11-rc2-24027",
     "WindowsAzure.Storage": "6.2.2-preview",
-
+    "NuGet.CommandLine.XPlat": "3.5.0-rc-1285",
     "Microsoft.DotNet.Cli.Build.Framework": { "target": "project" },
     "shared-build-targets-utils": { "target": "project" }
   },

--- a/build_projects/dotnet-host-build/PrepareTargets.cs
+++ b/build_projects/dotnet-host-build/PrepareTargets.cs
@@ -55,17 +55,8 @@ namespace Microsoft.DotNet.Host.Build
         [Target]
         public static BuildTargetResult GenerateVersions(BuildTargetContext c)
         {
-            var gitResult = Cmd("git", "rev-list", "--count", "HEAD")
-                .CaptureStdOut()
-                .Execute();
-            gitResult.EnsureSuccessful();
-            var commitCount = int.Parse(gitResult.StdOut);
-
-            gitResult = Cmd("git", "rev-parse", "HEAD")
-                .CaptureStdOut()
-                .Execute();
-            gitResult.EnsureSuccessful();
-            var commitHash = gitResult.StdOut.Trim();
+            var commitCount = GitUtils.GetCommitCount();
+            var commitHash = GitUtils.GetCommitHash();
 
             var hostVersion = new HostVersion()
             {

--- a/build_projects/shared-build-targets-utils/Utils/GitUtils.cs
+++ b/build_projects/shared-build-targets-utils/Utils/GitUtils.cs
@@ -1,0 +1,32 @@
+﻿using static Microsoft.DotNet.Cli.Build.Framework.BuildHelpers;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public static class GitUtils
+    {
+        public static int GetCommitCount()
+        {
+            return int.Parse(ExecuteGitCommand("rev-list", "--count", "HEAD"));
+        }
+
+        public static string GetCommitHash()
+        {
+            return ExecuteGitCommand("rev-parse", "HEAD");
+        }
+
+        public static string GetBranchName()
+        {
+            return ExecuteGitCommand("rev-parse", "--abbrev-ref", "HEAD");
+        }
+
+        private static string ExecuteGitCommand(params string[] args)
+        {
+            var gitResult = Cmd("git", args)
+                .CaptureStdOut()
+                .Execute();
+            gitResult.EnsureSuccessful();
+
+            return gitResult.StdOut.Trim();
+        }
+    }
+}


### PR DESCRIPTION
Removing the need for a separate VSO build definition to push our nuget packages to MyGet by adding a NuGetUtil.PushPackages method that calls into NuGet XPlat CommandLine "push" command.

Also, update dotnet/versions for the DotNetHost and NetCore.App packages.

Fix #3031

@sokket @brthor @livarcocc 

/cc @weshaggard 