### PR TITLE
Add NUGET and GITHUB environment variables to the dockerrun.sh file.

### DIFF
--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -107,5 +107,8 @@ docker run $INTERACTIVE -t --rm --sig-proxy=true \
     -e PUBLISH_TO_AZURE_BLOB \
     -e DOCKER_HUB_REPO \
     -e DOCKER_HUB_TRIGGER_TOKEN \
+    -e NUGET_FEED_URL \
+    -e NUGET_API_KEY \
+    -e GITHUB_PASSWORD \
     $DOTNET_BUILD_CONTAINER_TAG \
     $BUILD_COMMAND "$@"


### PR DESCRIPTION
The `FinalizeBuild` step fails if it is run on a Linux build where we use docker. This is because the right environment variables are not getting passed through.

Adding the environment variables fixes this issue.