### PR TITLE
Clean up from the move to RC3 packages. 

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,6 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core" />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/build_projects/dotnet-cli-build/build.ps1
+++ b/build_projects/dotnet-cli-build/build.ps1
@@ -35,9 +35,6 @@ else
     $env:DOTNET_BUILD_SKIP_PACKAGING=0
 }
 
-Write-Host "Disabling crossgen for the CLI build. See issue - https://github.com/dotnet/cli/issues/3059"
-$env:DISABLE_CROSSGEN=1
-
 # Load Branch Info
 cat "$RepoRoot\branchinfo.txt" | ForEach-Object {
     if(!$_.StartsWith("#") -and ![String]::IsNullOrWhiteSpace($_)) {

--- a/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Crossgen.cs
@@ -154,9 +154,14 @@ namespace Microsoft.DotNet.Cli.Build
 
                 IList<string> crossgenArgs = new List<string> {
                     "-readytorun", "-in", file, "-out", tempPathName,
-                    "-JITPath", GetLibCLRJitPathForVersion(),
                     "-platform_assemblies_paths", platformAssembliesPaths
                 };
+
+                if (CurrentPlatform.IsUnix)
+                {
+                    crossgenArgs.Add("-JITPath");
+                    crossgenArgs.Add(GetLibCLRJitPathForVersion());
+                }
 
                 ExecSilent(_crossGenPath, crossgenArgs, env);
 


### PR DESCRIPTION
Removed the dotnet-core dependency on NuGet.Config now that we have RC3 packages in the cli-deps feed.
Re-enabled crossgen for windows now that we added JITPath to the crossgen call.

cc @eerhardt @brthor 