### PR TITLE
Remove updating dotnet/versions repo with the latest shared framework version.

### DIFF
--- a/build_projects/dotnet-cli-build/PublishTargets.cs
+++ b/build_projects/dotnet-cli-build/PublishTargets.cs
@@ -148,10 +148,6 @@ namespace Microsoft.DotNet.Cli.Build
             string nugetFeedUrl = EnvVars.EnsureVariable("NUGET_FEED_URL");
             string apiKey = EnvVars.EnsureVariable("NUGET_API_KEY");
             NuGetUtil.PushPackages(Dirs.PackagesNoRID, nugetFeedUrl, apiKey);
-
-            string githubAuthToken = EnvVars.EnsureVariable("GITHUB_PASSWORD");
-            VersionRepoUpdater repoUpdater = new VersionRepoUpdater(githubAuthToken);
-            repoUpdater.UpdatePublishedVersions(Dirs.PackagesNoRID, $"build-info/dotnet/cli/{GitUtils.GetBranchName()}/CORE_SETUP_LATEST").Wait();
         }
 
         private static bool CheckIfAllBuildsHavePublished()

--- a/build_projects/shared-build-targets-utils/Utils/GitUtils.cs
+++ b/build_projects/shared-build-targets-utils/Utils/GitUtils.cs
@@ -14,11 +14,6 @@ namespace Microsoft.DotNet.Cli.Build
             return ExecuteGitCommand("rev-parse", "HEAD");
         }
 
-        public static string GetBranchName()
-        {
-            return ExecuteGitCommand("rev-parse", "--abbrev-ref", "HEAD");
-        }
-
         private static string ExecuteGitCommand(params string[] args)
         {
             var gitResult = Cmd("git", args)


### PR DESCRIPTION
This is breaking the build, and it should be done in core-setup instead.

@brthor 