### PR TITLE
Specify KB information in the prerequisites

### DIFF
--- a/Documentation/cli-prerequisites.md
+++ b/Documentation/cli-prerequisites.md
@@ -12,7 +12,7 @@ On Windows, the only dependency is the VC++ Redistributable. Depending on the ve
 * Windows 10
     * [Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145)
 * Pre-Windows 10
-    * Please make sure that your Windows installation is up-to-date with latest hotfixes installed through Windows Update.
+    * Please make sure that your Windows installation is up-to-date and includes hotfix [KB2533623] (https://support.microsoft.com/en-us/kb/2533623) installed through Windows Update.
     * [Visual C++ Redistributable for Visual Studio 2012 Update 4](https://www.microsoft.com/en-us/download/confirmation.aspx?id=30679)
 
 ## Ubuntu


### PR DESCRIPTION
skip ci please

Since we use LoadLibraryExW with flags that require hotfix KB2533623 to be installed on Windows 7 and Windows Server 2008 R2 and Windows Server 2008, we need to update our pre-requisites to reflect this.
See: https://msdn.microsoft.com/en-us/library/windows/desktop/ms684179(v=vs.85).aspx

https://support.microsoft.com/en-us/kb/2533623
This is a 5 year old KB, but there are OSes that may not have updated, yet want to use .NET Core.

@gkhanna79, @blackdwarf