### PR TITLE
Set DOTNET_CLI_TELEMETRY_PROFILE for CLI Repo builds

### DIFF
--- a/build_projects/dotnet-cli-build/PrepareTargets.cs
+++ b/build_projects/dotnet-cli-build/PrepareTargets.cs
@@ -38,7 +38,8 @@ namespace Microsoft.DotNet.Cli.Build
             nameof(UpdateTemplateVersions), 
             nameof(CheckPrereqs), 
             nameof(LocateStage0), 
-            nameof(ExpectedBuildArtifacts))]
+            nameof(ExpectedBuildArtifacts),
+            nameof(SetTelemetryProfile))]
         public static BuildTargetResult Init(BuildTargetContext c)
         {
             var configEnv = Environment.GetEnvironmentVariable("CONFIGURATION");
@@ -355,6 +356,21 @@ cmake is required to build the native host 'corehost'";
                 }
                 return c.Failed(message);
             }
+
+            return c.Success();
+        }
+
+        [Target]
+        public static BuildTargetResult SetTelemetryProfile(BuildTargetContext c)
+        {
+            var gitResult = Cmd("git", "rev-parse", "HEAD")
+                .CaptureStdOut()
+                .Execute();
+            gitResult.EnsureSuccessful();
+
+            var commitHash = gitResult.StdOut.Trim();
+
+            Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_PROFILE", $"https://github.com/dotnet/cli;{commitHash}");
 
             return c.Success();
         }


### PR DESCRIPTION
Sets the DOTNET_CLI_TELEMETRY_PROFILE to `https://github.com/dotnet/cli;<commit hash>`

This environment variable opts-in the CLI builds to identify themselves in telemetry data. We will now be able to distinguish CLI build-generated telemetry from other telemetry. CLI builds will be identified by the presence of `https://github.com/dotnet/cli`. The commit hash will help us understand how the CLI builds evolved over time.

/cc @livarcocc @brthor @jeffschwMSFT @LakshanF @blackdwarf 

