### PR TITLE
Reduce nuget output

### DIFF
--- a/src/dotnet/commands/dotnet-restore/NuGet3.cs
+++ b/src/dotnet/commands/dotnet-restore/NuGet3.cs
@@ -10,13 +10,13 @@ namespace Microsoft.DotNet.Tools.Restore
 {
     internal static class NuGet3
     {
-        public static int Restore(IEnumerable<string> args, bool quiet)
+        public static int Restore(IEnumerable<string> args)
         {
             var prefixArgs = new List<string>();
-            if (quiet)
+            if (!args.Any(s => s.Equals("--verbosity", StringComparison.OrdinalIgnoreCase) || s.Equals("-v", StringComparison.OrdinalIgnoreCase)))
             {
                 prefixArgs.Add("--verbosity");
-                prefixArgs.Add("Error");
+                prefixArgs.Add("minimal");
             }
             prefixArgs.Add("restore");
 

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -24,16 +24,12 @@ namespace Microsoft.DotNet.Tools.Restore
                 Description = "Restores dependencies listed in project.json"
             };
 
-            // Parse --quiet, because we have to handle that specially since NuGet3 has a different
-            // "--verbosity" switch that goes BEFORE the command
-            var quiet = args.Any(s => s.Equals("--quiet", StringComparison.OrdinalIgnoreCase));
-            args = args.Where(s => !s.Equals("--quiet", StringComparison.OrdinalIgnoreCase)).ToArray();
 
             app.OnExecute(() =>
             {
                 try
                 {
-                    return NuGet3.Restore(args, quiet);
+                    return NuGet3.Restore(args);
                 }
                 catch (InvalidOperationException e)
                 {

--- a/test/EndToEnd/EndToEndTest.cs
+++ b/test/EndToEnd/EndToEndTest.cs
@@ -218,7 +218,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             Directory.SetCurrentDirectory(RestoredTestProjectDirectory);
 
             new NewCommand().Execute().Should().Pass();
-            new RestoreCommand().Execute("--quiet").Should().Pass();
+            new RestoreCommand().Execute().Should().Pass();
 
             Directory.SetCurrentDirectory(currentDirectory);
         }

--- a/test/Performance/HelloWorld.cs
+++ b/test/Performance/HelloWorld.cs
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Tests.Performance
 
             var restoreCommand = new RestoreCommand();
             restoreCommand.WorkingDirectory = RestoredTestProjectDirectory;
-            restoreCommand.Execute("--quiet").Should().Pass();
+            restoreCommand.Execute().Should().Pass();
         }
     }
 }


### PR DESCRIPTION
This addresses part of #1623. Unfortunately, because the CLI takes Nuget
as a binary, it is hard to get to where I think we should really be.
This change makes default verbosity "minimal", which is the first level
where you get any status output. Unfortunately, things like package
downgrade warnings and the like still appear there. This does hide all
the "info" and "trace" messages by default.

I also removed the now useless (and previously undocumented)
--quiet.