### PR TITLE
Remove optimizationdata subdirectory from optimizationdata path

### DIFF
--- a/src/dotnet/MulticoreJitProfilePathCalculator.cs
+++ b/src/dotnet/MulticoreJitProfilePathCalculator.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli
 
             var rid = PlatformServices.Default.Runtime.GetRuntimeIdentifier();
 
-            _multicoreJitProfilePath = Path.Combine(profileRoot, "optimizationdata", version, rid, "optimizationdata");
+            _multicoreJitProfilePath = Path.Combine(profileRoot, "optimizationdata", version, rid);
         }
 
         private string GetRuntimeDataRootPathString()

--- a/test/dotnet.Tests/GivenThatIWantToManageMulticoreJIT.cs
+++ b/test/dotnet.Tests/GivenThatIWantToManageMulticoreJIT.cs
@@ -108,8 +108,8 @@ namespace Microsoft.DotNet.Tests
             var rid = PlatformServices.Default.Runtime.GetRuntimeIdentifier();
             
             return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? $@"Microsoft\dotnet\optimizationdata\{version}\{rid}\optimizationdata" 
-                : $@".dotnet/optimizationdata/{version}/{rid}/optimizationdata";
+                ? $@"Microsoft\dotnet\optimizationdata\{version}\{rid}" 
+                : $@".dotnet/optimizationdata/{version}/{rid}";
         }
 
         private static string GetDotnetVersion()


### PR DESCRIPTION
PR #3208 moved optimizationdata to a new root directory called optimizationdata. The leaf-node directory optimizationdata is therefore redundant.

/cc @brthor 