### PR TITLE
Re-enable tests disabled for crossgen enabling

### DIFF
--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsProjects.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsProjects.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
                 .Pass();
         }
 
-        //[Fact] https://github.com/dotnet/cli/issues/3269
+        [Fact]
         public void It_builds_projects_with_ruleset_relative_path()
         {
             var testInstance = TestAssetsManager

--- a/test/dotnet-compile.Tests/CompilerTests.cs
+++ b/test/dotnet-compile.Tests/CompilerTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
             Assert.True(File.Exists(generatedSatelliteAssemblyPath), $"File {generatedSatelliteAssemblyPath} was not found.");
         }
 
-        //[Fact] https://github.com/dotnet/cli/issues/3269
+        [Fact]
         public void LibraryWithAnalyzer()
         {
             var root = Temp.CreateDirectory();


### PR DESCRIPTION
Now that https://github.com/dotnet/coreclr/issues/5201 is fixed, these tests should pass.

Fix #3269