### PR TITLE
[DoNotMerge] EndToEnd test needs its own cache

### DIFF
--- a/test/EndToEnd/EndToEndTest.cs
+++ b/test/EndToEnd/EndToEndTest.cs
@@ -218,7 +218,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             Directory.SetCurrentDirectory(RestoredTestProjectDirectory);
 
             new NewCommand().Execute().Should().Pass();
-            new RestoreCommand().Execute().Should().Pass();
+            new RestoreCommand().Execute($"-v information --packages {Path.Combine(RestoredTestProjectDirectory, "EndToEndPackageCache")}").Should().Pass();
 
             Directory.SetCurrentDirectory(currentDirectory);
         }


### PR DESCRIPTION
This fixes #3322. There is an argument to be made that all tests should
do this, but as far as I can tell this and the HelloWorld test are the
only ones using a custom nuget.config which would prevent them from
inheriting using cli-deps.

I've also turned up verbosity of restore on this test so we can validate
the feeds it is pulling from in the future.

This can't be merged until a fix for #3315 goes in, so there isn't noise
in CI.