### PR TITLE
Removed publish logic that triggered dotnet-preview Docker builds.

### DIFF
--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -123,8 +123,6 @@ docker run $INTERACTIVE -t --rm --sig-proxy=true \
     -e REPO_SERVER \
     -e DOTNET_BUILD_SKIP_CROSSGEN \
     -e PUBLISH_TO_AZURE_BLOB \
-    -e DOCKER_HUB_REPO \
-    -e DOCKER_HUB_TRIGGER_TOKEN \
     -e NUGET_FEED_URL \
     -e NUGET_API_KEY \
     -e GITHUB_PASSWORD \


### PR DESCRIPTION
This logic is no longer needed in CLI as it has been moved to Maestro (https://github.com/dotnet/versions/pull/12).  Also note that I have already updated the VSO build definitions to remove the DOCKER_HUB_REPO and DOCKER_HUB_TRIGGER_TOKEN variables since they are no longer needed.

@naamunds, @eerhardt, @brthor, @sokket 
