### PR TITLE
We need to prevent downloading deb packages on Ubuntu16.04 since we d…

### DIFF
--- a/build_projects/dotnet-cli-build/PrepareTargets.cs
+++ b/build_projects/dotnet-cli-build/PrepareTargets.cs
@@ -187,6 +187,11 @@ namespace Microsoft.DotNet.Cli.Build
         [BuildPlatforms(BuildPlatform.Windows, BuildPlatform.OSX, BuildPlatform.Ubuntu)]
         public static BuildTargetResult DownloadHostAndSharedFxInstallers(BuildTargetContext c)
         {
+            if (CurrentPlatform.IsUbuntu && !CurrentPlatform.IsVersion("14.04"))
+            {
+                return c.Success();
+            }
+
             var sharedFrameworkVersion = CliDependencyVersions.SharedFrameworkVersion;
             var hostVersion = CliDependencyVersions.SharedHostVersion;
 
@@ -198,7 +203,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             Mkdirp(Path.GetDirectoryName(sharedFrameworkInstallerDownloadFile));
             Mkdirp(Path.GetDirectoryName(sharedHostInstallerDownloadFile));
-            
+
             if ( ! File.Exists(sharedFrameworkInstallerDownloadFile))
             {
                 var sharedFrameworkInstallerDestinationFile = c.BuildContext.Get<string>("SharedFrameworkInstallerFile");


### PR DESCRIPTION
We don't have .deb files for ubuntu16 yet, therefore we need to skip trying to install them for ubuntu 16. The way we are skipping it in the code is not ideal, we should have a way to represent to the build platform attribute multiple platforms and some of them being versioned, but that will require bigger changes to the build system.

cc @brthor