### PR TITLE
remove clang-3.5 as a dependency of the deb package

### DIFF
--- a/packaging/debian/dotnet-debian_config.json
+++ b/packaging/debian/dotnet-debian_config.json
@@ -29,7 +29,6 @@
     },
 
     "debian_dependencies":{
-        "clang-3.5" : {},
         "%SHARED_FRAMEWORK_DEBIAN_PACKAGE_NAME%" : {}
     }
 }


### PR DESCRIPTION
Partially fixes #3088 

This removes the clang dependency from our sdk package

cc @blackdwarf 
