### PR TITLE
update nuget to 3.5.0-beta2-1392

### DIFF
--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -13,7 +13,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24131-00",
     "System.Xml.XmlSerializer": "4.0.11-rc3-24131-00",
     "WindowsAzure.Storage": "6.2.2-preview",
-    "NuGet.CommandLine.XPlat": "3.5.0-rc-1285",
+    "NuGet.CommandLine.XPlat": "3.5.0-beta2-1392",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"
     },

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -12,7 +12,7 @@
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"
     },
-    "NuGet.Versioning": "3.5.0-rc-1285",
+    "NuGet.Versioning": "3.5.0-beta2-1392",
     "Newtonsoft.Json": "7.0.1",
     "Octokit": "0.18.0",
     "Microsoft.Net.Http": "2.2.29"

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -8,10 +8,10 @@
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
-    "NuGet.Versioning": "3.5.0-rc-1285",
-    "NuGet.Packaging": "3.5.0-rc-1285",
-    "NuGet.Frameworks": "3.5.0-rc-1285",
-    "NuGet.ProjectModel": "3.5.0-rc-1285"
+    "NuGet.Versioning": "3.5.0-beta2-1392",
+    "NuGet.Packaging": "3.5.0-beta2-1392",
+    "NuGet.Frameworks": "3.5.0-beta2-1392",
+    "NuGet.ProjectModel": "3.5.0-beta2-1392"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -9,8 +9,8 @@
       "target": "project"
     },
     "Newtonsoft.Json": "7.0.1",
-    "NuGet.Packaging": "3.5.0-rc-1285",
-    "NuGet.RuntimeModel": "3.5.0-rc-1285",
+    "NuGet.Packaging": "3.5.0-beta2-1392",
+    "NuGet.RuntimeModel": "3.5.0-beta2-1392",
     "System.Reflection.Metadata": "1.3.0-rc3-24131-00"
   },
   "frameworks": {

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "NuGet.Commands": {
-      "version": "3.5.0-rc-1285",
+      "version": "3.5.0-beta2-1392",
       "exclude": "compile"
     },
-    "NuGet.CommandLine.XPlat": "3.5.0-rc-1285",
+    "NuGet.CommandLine.XPlat": "3.5.0-beta2-1392",
     "Newtonsoft.Json": "7.0.1",
     "System.Text.Encoding.CodePages": "4.0.1-rc3-24131-00",
     "System.Diagnostics.FileVersionInfo": "4.0.0-rc3-24131-00",

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -20,10 +20,10 @@
     },
     "System.Diagnostics.TraceSource": "4.0.0-rc3-24131-00",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24131-00",
-    "NuGet.Versioning": "3.5.0-rc-1285",
-    "NuGet.Packaging": "3.5.0-rc-1285",
-    "NuGet.Frameworks": "3.5.0-rc-1285",
-    "NuGet.ProjectModel": "3.5.0-rc-1285",
+    "NuGet.Versioning": "3.5.0-beta2-1392",
+    "NuGet.Packaging": "3.5.0-beta2-1392",
+    "NuGet.Frameworks": "3.5.0-beta2-1392",
+    "NuGet.ProjectModel": "3.5.0-beta2-1392",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },


### PR DESCRIPTION
retargeting pull request https://github.com/dotnet/cli/pull/3329 to rel/1.0.0-preview2 .

Update nuget to 3.5.0-beta2-1392 . This build has been upgraded to depend on the following:
• CoreCLR/CoreFX/WCF – rc3-24128-00
• Microsoft.NetCore.App – 1.0.0-rc3-004338
• CLI – 1.0.0-preview2-002911