### PR TITLE
Move dependency from Microsoft.NETCore.Runtime to Microsoft.NETCore.Runtime.CoreCLR.

### DIFF
--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
@@ -16,7 +16,7 @@
     "netstandard1.6": {
       "dependencies": {
         "NETStandard.Library": "1.6.0-rc3-24201-00",
-        "Microsoft.NETCore.Runtime": "1.0.2-rc3-24201-00"
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00"
       }
     }
   },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
@@ -20,7 +20,7 @@
     "netstandard1.6": {
       "dependencies": {
         "NETStandard.Library": "1.6.0-rc3-24201-00",
-        "Microsoft.NETCore.Runtime": "1.0.2-rc3-24201-00"
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00"
       }
     }
   },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
@@ -20,7 +20,7 @@
     "netstandard1.6": {
       "dependencies": {
         "NETStandard.Library": "1.6.0-rc3-24201-00",
-        "Microsoft.NETCore.Runtime": "1.0.2-rc3-24201-00"
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00"
       }
     }
   },

--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "NETStandard.Library": "1.6.0-rc3-24201-00",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc3-24201-00",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00",
     "Microsoft.CSharp": "4.0.1-rc3-24201-00",
     "System.Dynamic.Runtime": "4.0.11-rc3-24201-00",
     "System.Reflection.Metadata": "1.3.0-rc3-24201-00",

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0-rc3-24201-00",
     "Microsoft.CSharp": "4.0.1-rc3-24201-00",
-    "Microsoft.NETCore.Runtime": "1.0.2-rc3-24201-00",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.2-rc3-24201-00",
     "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24201-00",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"


### PR DESCRIPTION
Making the same change in the CLI as in core-setup.

These 5 projects are all 'self-contained' apps.  The 3 perf ones can't reference NETCore.App because they target 'netstandard1.6', which NETCore.App doesn't support.  (They need to target 2 TFMs - the point of the test.)

@weshaggard @brthor 