### PR TITLE
Expand timeout setting for project model server

### DIFF
--- a/test/dotnet-projectmodel-server.Tests/DthTestClient.cs
+++ b/test/dotnet-projectmodel-server.Tests/DthTestClient.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
         private readonly NetworkStream _networkStream;
         private readonly BlockingCollection<DthMessage> _messageQueue;
         private readonly CancellationTokenSource _readCancellationToken;
+        private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(20);
 
         // Keeps track of initialized project contexts
         // REVIEW: This needs to be exposed if we ever create 2 clients in order to simulate how build
@@ -129,7 +130,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
             var result = new List<DthMessage>();
             while (count > 0)
             {
-                result.Add(GetResponse(timeout: TimeSpan.FromSeconds(10)));
+                result.Add(GetResponse(timeout: _defaultTimeout));
                 count--;
             }
 
@@ -138,7 +139,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
 
         public List<DthMessage> DrainAllMessages()
         {
-            return DrainAllMessages(TimeSpan.FromSeconds(10));
+            return DrainAllMessages(_defaultTimeout);
         }
 
         /// <summary>
@@ -173,7 +174,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
         /// <returns>The first match message</returns>
         public DthMessage DrainTillFirst(string type)
         {
-            return DrainTillFirst(type, TimeSpan.FromSeconds(10));
+            return DrainTillFirst(type, _defaultTimeout);
         }
 
         /// <summary>


### PR DESCRIPTION
This is an experiment to verify if the timeout setting of current project model server tests causes the random failures.

Here's what we know:
* There aren't changes made to either project model server codes or tests.
* The random failure are all on Linux based CI.
* The random failure begin showing up recently. 
* There is a reconfiguration happened to Linux CI machines. 

In addition, in my investigation of the test log I found a common symptom. Over the course of the test run all failed tests happened at the same moment. The tests ended before the moment and the tests began after the moment all passed. As if the test machine frozen at a moment which causes the timeout.

_Update_

@eerhardt points out a PR in which tests failed on OSX and Windows as well: https://github.com/dotnet/cli/pull/3388.