### PR TITLE
Bumping JSON.NET to 9.0.1

### DIFF
--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "NuGet.Versioning": "3.5.0-beta2-1392",
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1-beta1",
     "Octokit": "0.18.0",
     "Microsoft.Net.Http": "2.2.29"
   },

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -8,7 +8,7 @@
     "Microsoft.Extensions.DependencyModel": {
       "target": "project"
     },
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1-beta1",
     "NuGet.Packaging": "3.5.0-beta2-1392",
     "NuGet.RuntimeModel": "3.5.0-beta2-1392",
     "System.Reflection.Metadata": "1.3.0-rc3-24206-00"

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -9,7 +9,7 @@
     "Microsoft.DotNet.InternalAbstractions": {
       "target": "project"
     },
-    "Newtonsoft.Json": "7.0.1"
+    "Newtonsoft.Json": "9.0.1-beta1"
   },
   "frameworks": {
     "net451": {},

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -7,7 +7,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1-beta1",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -25,7 +25,7 @@
       "exclude": "compile"
     },
     "NuGet.CommandLine.XPlat": "3.5.0-beta2-1392",
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1-beta1",
     "System.Text.Encoding.CodePages": "4.0.1-rc3-24206-00",
     "System.Diagnostics.FileVersionInfo": "4.0.0-rc3-24206-00",
     "Microsoft.ApplicationInsights": "2.0.0",

--- a/test/Microsoft.DotNet.ProjectModel.Tests/GivenThatIWantToLoadAProjectJsonFile.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/GivenThatIWantToLoadAProjectJsonFile.cs
@@ -747,7 +747,7 @@ namespace Microsoft.DotNet.ProjectModel.Tests
             dependency.Type.Should().Be(LibraryDependencyType.Default);
             dependency.SourceFilePath.Should().Be(ProjectFilePath);
             dependency.SourceLine.Should().Be(3);
-            dependency.SourceColumn.Should().Be(31);
+            dependency.SourceColumn.Should().Be(30);
         }
 
         [Fact]
@@ -769,7 +769,7 @@ namespace Microsoft.DotNet.ProjectModel.Tests
             dependency.Type.Should().Be(LibraryDependencyType.Default);
             dependency.SourceFilePath.Should().Be(ProjectFilePath);
             dependency.SourceLine.Should().Be(3);
-            dependency.SourceColumn.Should().Be(25);
+            dependency.SourceColumn.Should().Be(24);
         }
 
         [Fact]
@@ -909,7 +909,7 @@ namespace Microsoft.DotNet.ProjectModel.Tests
             tool.Type.Should().Be(LibraryDependencyType.Default);
             tool.SourceFilePath.Should().Be(ProjectFilePath);
             tool.SourceLine.Should().Be(3);
-            tool.SourceColumn.Should().Be(25);
+            tool.SourceColumn.Should().Be(24);
         }
 
         [Fact]
@@ -931,7 +931,7 @@ namespace Microsoft.DotNet.ProjectModel.Tests
             tool.Type.Should().Be(LibraryDependencyType.Default);
             tool.SourceFilePath.Should().Be(ProjectFilePath);
             tool.SourceLine.Should().Be(3);
-            tool.SourceColumn.Should().Be(19);
+            tool.SourceColumn.Should().Be(18);
         }
 
         [Fact]

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -12,7 +12,7 @@
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1-beta1",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },

--- a/test/dotnet-new.Tests/project.json
+++ b/test/dotnet-new.Tests/project.json
@@ -8,7 +8,7 @@
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1-beta1",
     "dotnet": {
       "target": "project"
     },

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -5,7 +5,7 @@
       "type": "platform",
       "version": "1.0.0-rc3-004408"
     },
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1-beta1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -5,7 +5,7 @@
       "type": "platform",
       "version": "1.0.0-rc3-004408"
     },
-    "Newtonsoft.Json": "7.0.1",
+    "Newtonsoft.Json": "9.0.1-beta1",
     "dotnet": {
       "target": "project"
     },


### PR DESCRIPTION
Bumping our Json.NET version to 9.0.1-beta1 

Fixing bug #3377

/cc: @piotrpMSFT 

/fyi: @Eilon @javiercn