### PR TITLE
Adding check for self-referencing projects

### DIFF
--- a/TestAssets/NonRestoredTestProjects/TestProjectWithSelfReferencingDependency/Program.cs
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithSelfReferencingDependency/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithSelfReferencingDependency/project.json
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithSelfReferencingDependency/project.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {
+    "TestProjectWithSelfReferencingDependency": {
+      "target": "project"
+    }
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/src/dotnet/commands/dotnet-build/ProjectGraphCollector.cs
+++ b/src/dotnet/commands/dotnet-build/ProjectGraphCollector.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tools.Build
                 foreach (var dependency in project.Dependencies)
                 {
                     LibraryDescription libraryDescription;
-                    if (lookup.TryGetValue(dependency.Name, out libraryDescription))
+                    if ((lookup.TryGetValue(dependency.Name, out libraryDescription)) && (!libraryDescription.Identity.Name.Equals(project.Identity.Name)))
                     {
                         if (libraryDescription.Resolved && libraryDescription.Identity.Type.Equals(LibraryType.Project))
                         {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
@@ -19,5 +19,11 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
             return base.Execute(args);
         }
+
+        public override CommandResult ExecuteWithCapturedOutput(string args = "")
+        {
+            args = $"restore {args}";
+            return base.ExecuteWithCapturedOutput(args);
+        }
     }
 }

--- a/test/dotnet-build.Tests/BuildOutputTests.cs
+++ b/test/dotnet-build.Tests/BuildOutputTests.cs
@@ -351,6 +351,18 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             buildResult.StdErr.Should().Contain("The project has not been restored or restore failed - run `dotnet restore`");
         }
 
+        [Fact]
+        private void App_WithSelfReferencingDependency_FailsBuild()
+        {
+            var testAssetsManager = GetTestGroupTestAssetsManager("NonRestoredTestProjects");
+            var testInstance = testAssetsManager.CreateTestInstance("TestProjectWithSelfReferencingDependency")
+                                                .WithLockFiles();
+
+            var restoreResult = new RestoreCommand() { WorkingDirectory = testInstance.TestRoot }.ExecuteWithCapturedOutput();
+            restoreResult.Should().Fail();
+            restoreResult.StdOut.Should().Contain("error: Cycle detected");
+        }
+
         private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)
         {
             // copy all the files to temp dir


### PR DESCRIPTION
Fixing bug #3385 by adding a check to make sure a project does not reference itself in project.json

/cc @piotrpMSFT @niemyjski 