### PR TITLE
Fixed links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Building from source
 
 If you are building from source, take note that the build depends on NuGet packages hosted on MyGet, so if it is down, the build may fail. If that happens, you can always see the [MyGet status page](http://status.myget.org/) for more info. 
 
-Read over the [contributing guidelines](https://github.com/dotnet/cli/tree/master/CONTRIBUTING.md) and [developer documentation](https://github.com/dotnet/cli/tree/master/Documentation) for prerequisites for building from source.
+Read over the [contributing guidelines](CONTRIBUTING.md) and [developer documentation](Documentation) for prerequisites for building from source.
 
 Questions & Comments
 --------------------


### PR DESCRIPTION
There is no `master` branch, so the old links didn't work.

New links are relative, so they should work correctly on any branch.

