### PR TITLE
Fix Ubuntu build break.

### DIFF
--- a/build_projects/dotnet-cli-build/CliMonikers.cs
+++ b/build_projects/dotnet-cli-build/CliMonikers.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.DotNet.Cli.Build.Framework;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public static class CliMonikers
+    {
+        public static string GetSdkDebianPackageName(BuildTargetContext c)
+        {
+            var nugetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").NuGetVersion;
+
+            return $"dotnet-dev-{nugetVersion}";
+        }
+    }
+}

--- a/build_projects/dotnet-cli-build/DebTargets.cs
+++ b/build_projects/dotnet-cli-build/DebTargets.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Cli.Build
         public static BuildTargetResult GenerateSdkDeb(BuildTargetContext c)
         {
             var channel = c.BuildContext.Get<string>("Channel").ToLower();
-            var packageName = Monikers.GetSdkDebianPackageName(c);
+            var packageName = CliMonikers.GetSdkDebianPackageName(c);
             var version = c.BuildContext.Get<BuildVersion>("BuildVersion").NuGetVersion;
             var debFile = c.BuildContext.Get<string>("SdkInstallerFile");
             var manPagesDir = Path.Combine(Dirs.RepoRoot, "Documentation", "manpages");
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             IEnumerable<string> orderedPackageNames = new List<string>()
             {
-                Monikers.GetSdkDebianPackageName(c),
+                CliMonikers.GetSdkDebianPackageName(c),
                 Monikers.GetDebianSharedFrameworkPackageName(CliDependencyVersions.SharedFrameworkVersion),
                 Monikers.GetDebianSharedHostPackageName(c)
             };

--- a/build_projects/dotnet-cli-build/PublishTargets.cs
+++ b/build_projects/dotnet-cli-build/PublishTargets.cs
@@ -276,7 +276,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var version = CliNuGetVersion;
 
-            var packageName = Monikers.GetSdkDebianPackageName(c);
+            var packageName = CliMonikers.GetSdkDebianPackageName(c);
             var installerFile = c.BuildContext.Get<string>("SdkInstallerFile");
             var uploadUrl = AzurePublisherTool.CalculateInstallerUploadUrl(installerFile, Channel, version);
 

--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -45,54 +45,6 @@ namespace Microsoft.DotNet.Cli.Build
             return $"{CurrentPlatform.Current}_{CurrentArchitecture.Current}";
         }
 
-        public static string GetDebianPackageName(BuildTargetContext c)
-        {
-            var channel = c.BuildContext.Get<string>("Channel").ToLower();
-            var packageName = "";
-            switch (channel)
-            {
-                case "dev":
-                    packageName = "dotnet-nightly";
-                    break;
-                case "beta":
-                case "rc1":
-                case "rc2":
-                case "preview":
-                case "rtm":
-                    packageName = "dotnet";
-                    break;
-                default:
-                    throw new Exception($"Unknown channel - {channel}");
-            }
-
-            return packageName;
-        }
-
-        public static string GetSdkDebianPackageName(BuildTargetContext c)
-        {
-            var channel = c.BuildContext.Get<string>("Channel").ToLower();
-            var nugetVersion = c.BuildContext.Get<BuildVersion>("BuildVersion").NuGetVersion;
-
-            var packagePrefix = "";
-            switch (channel)
-            {
-                case "dev":
-                    packagePrefix = "dotnet-nightly";
-                    break;
-                case "beta":
-                case "rc1":
-                case "rc2":
-                case "preview":
-                case "rtm":
-                    packagePrefix = "dotnet";
-                    break;
-                default:
-                    throw new Exception($"Unknown channel - {channel}");
-            }
-
-            return $"{packagePrefix}-dev-{nugetVersion}";
-        }
-
         public static string GetDebianSharedFrameworkPackageName(string sharedFrameworkNugetVersion)
         {
             return $"dotnet-sharedframework-{SharedFrameworkName}-{sharedFrameworkNugetVersion}".ToLower();


### PR DESCRIPTION
Ubuntu is currently broken because we added a new channel, and a switch statement wasn't expecting the new channel.

The fix is to eliminate the switch statement on the channel and always return "dotnet-dev-<version>" for the debian sdk package name.

@brthor 