### PR TITLE
Use ordinal comparison when searching for escape sequence in build framework console

### DIFF
--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/AnsiConsole.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             var escapeScan = 0;
             for (;;)
             {
-                var escapeIndex = message.IndexOf("\x1b[", escapeScan);
+                var escapeIndex = message.IndexOf("\x1b[", escapeScan, StringComparison.Ordinal);
                 if (escapeIndex == -1)
                 {
                     var text = message.Substring(escapeScan);


### PR DESCRIPTION
Fixes #3431

This is the same change as #2096, only in Microsoft.DotNet.Cli.Build.Framework instead of Microsoft.DotNet.Cli.Utils.