### PR TITLE
Minor improvements to build documentation

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -30,7 +30,7 @@ In order to build .NET Command Line Interface, you need the following installed 
 
 ## Building/Running
 
-1. Run `build.cmd` or `build.sh` from the root depending on your OS.
+1. Run `build.cmd` or `build.sh` from the root depending on your OS. If you don't want to execute tests, run `build.cmd -Targets Compile` or `./build.sh --targets Compile`.
 2. Use `artifacts/{os}-{arch}/stage2/dotnet` to try out the `dotnet` command. You can also add `artifacts/{os}-{arch}/stage2` to the PATH if you want to run `dotnet` from anywhere.
 
 ## A simple test

--- a/build_projects/dotnet-cli-build/build.ps1
+++ b/build_projects/dotnet-cli-build/build.ps1
@@ -5,19 +5,19 @@
 
 param(
     [string]$Configuration="Debug",
-    [string]$Architecture="x64",
     [string[]]$Targets=@("Default"),
+    [string]$Architecture="x64",
     [switch]$NoPackage,
     [switch]$Help)
 
 if($Help)
 {
-    Write-Host "Usage: .\build.ps1 [-Configuration <CONFIGURATION>] [-NoPackage] [-Help] [-Targets <TARGETS...>]"
+    Write-Host "Usage: .\build.ps1 [-Configuration <CONFIGURATION>] [-Targets <TARGETS...>] [-Architecture <ARCHITECTURE>] [-NoPackage] [-Help]"
     Write-Host ""
     Write-Host "Options:"
     Write-Host "  -Configuration <CONFIGURATION>     Build the specified Configuration (Debug or Release, default: Debug)"
-    Write-Host "  -Architecture  <ARCHITECTURE>      Build the specified architecture (x64 or x86 (supported only on Windows), default: x64)"
     Write-Host "  -Targets <TARGETS...>              Comma separated build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
+    Write-Host "  -Architecture <ARCHITECTURE>       Build the specified architecture (x64 or x86 (supported only on Windows), default: x64)"
     Write-Host "  -NoPackage                         Skip packaging targets"
     Write-Host "  -Help                              Display this help message"
     exit 0

--- a/build_projects/dotnet-cli-build/build.sh
+++ b/build_projects/dotnet-cli-build/build.sh
@@ -37,16 +37,15 @@ while [[ $# > 0 ]]; do
             export DOTNET_INSTALL_SKIP_PREREQS=1
             ;;
         --help)
-            echo "Usage: $0 [--configuration <CONFIGURATION>] [--skip-prereqs] [--nopackage] [--docker <IMAGENAME>] [--help] [--targets <TARGETS...>]"
+            echo "Usage: $0 [--configuration <CONFIGURATION>] [--targets <TARGETS...>] [--skip-prereqs] [--nopackage] [--docker <IMAGENAME>] [--help]"
             echo ""
             echo "Options:"
             echo "  --configuration <CONFIGURATION>     Build the specified Configuration (Debug or Release, default: Debug)"
             echo "  --targets <TARGETS...>              Comma separated build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
-            echo "  --nopackage                         Skip packaging targets"
             echo "  --skip-prereqs                      Skip checks for pre-reqs in dotnet_install"
+            echo "  --nopackage                         Skip packaging targets"
             echo "  --docker <IMAGENAME>                Build in Docker using the Dockerfile located in scripts/docker/IMAGENAME"
             echo "  --help                              Display this help message"
-            echo "  <TARGETS...>                        The build targets to run (Init, Compile, Publish, etc.; Default is a full build and publish)"
             exit 0
             ;;
         *)


### PR DESCRIPTION
- explain how to speed up building using `Compile` target
- sort both sets of options in `build.sh` usage the same
- remove redundant and confusing `TARGETS` line from `build.sh` usage