### PR TITLE
Enable project model server to clear workspace cache forceful after restore completion

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/Workspace.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Workspace.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.ProjectModel
                 .FirstOrDefault(c => Equals(c.TargetFramework, framework) && string.IsNullOrEmpty(c.RuntimeIdentifier));
         }
 
-        public ProjectContextCollection GetProjectContextCollection(string projectPath)
+        public ProjectContextCollection GetProjectContextCollection(string projectPath, bool clearCache)
         {
             var normalizedPath = ProjectPathHelper.NormalizeProjectDirectoryPath(projectPath);
             if (normalizedPath == null)
@@ -61,10 +61,22 @@ namespace Microsoft.DotNet.ProjectModel
                 return null;
             }
 
+            if (clearCache)
+            {
+                _projectContextsCache.Clear();
+                _projectsCache.Clear();
+                _lockFileCache.Clear();
+            }
+
             return _projectContextsCache.AddOrUpdate(
                 normalizedPath,
                 key => AddProjectContextEntry(key, null),
                 (key, oldEntry) => AddProjectContextEntry(key, oldEntry));
+        }
+
+        public ProjectContextCollection GetProjectContextCollection(string projectPath)
+        {
+            return GetProjectContextCollection(projectPath, clearCache: false);
         }
 
         public Project GetProject(string projectDirectory) => GetProjectCore(projectDirectory)?.Model;

--- a/src/dotnet/commands/dotnet-projectmodel-server/InternalModels/ProjectSnapshot.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/InternalModels/ProjectSnapshot.cs
@@ -19,9 +19,13 @@ namespace Microsoft.DotNet.ProjectModel.Server
         public ErrorMessage GlobalErrorMessage { get; set; }
         public Dictionary<NuGetFramework, ProjectContextSnapshot> ProjectContexts { get; } = new Dictionary<NuGetFramework, ProjectContextSnapshot>();
 
-        public static ProjectSnapshot Create(string projectDirectory, string configuration, DesignTimeWorkspace workspaceContext, IReadOnlyList<string> projectSearchPaths)
+        public static ProjectSnapshot Create(string projectDirectory,
+                                             string configuration,
+                                             DesignTimeWorkspace workspaceContext,
+                                             IReadOnlyList<string> projectSearchPaths,
+                                             bool clearWorkspaceContextCache)
         {
-            var projectContextsCollection = workspaceContext.GetProjectContextCollection(projectDirectory);
+            var projectContextsCollection = workspaceContext.GetProjectContextCollection(projectDirectory, clearWorkspaceContextCache);
             if (!projectContextsCollection.ProjectContexts.Any())
             {
                 throw new InvalidOperationException($"Unable to find project.json in '{projectDirectory}'");

--- a/src/dotnet/commands/dotnet-projectmodel-server/ProjectManager.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/ProjectManager.cs
@@ -200,9 +200,13 @@ namespace Microsoft.DotNet.ProjectModel.Server
                     _configure.Value = message.Payload.GetValue("Configuration");
                     break;
                 case MessageTypes.RefreshDependencies:
+                    // In the case of RefreshDependencies request, the cache will not be reset in any case. The value 
+                    // is set so as to trigger refresh action in later loop.
                     _refreshDependencies.Value = false;
                     break;
                 case MessageTypes.RestoreComplete:
+                    // In the case of RestoreComplete request, the value of the 'Reset' property in payload will determine
+                    // if the cache should be reset. If the property doesn't exist, cache will be reset.
                     _refreshDependencies.Value = message.Payload.HasValues ? message.Payload.Value<bool>("Reset") : true;
                     break;
                 case MessageTypes.FilesChanged:

--- a/src/dotnet/commands/dotnet-projectmodel-server/ProjectManager.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/ProjectManager.cs
@@ -200,15 +200,10 @@ namespace Microsoft.DotNet.ProjectModel.Server
                     _configure.Value = message.Payload.GetValue("Configuration");
                     break;
                 case MessageTypes.RefreshDependencies:
+                    _refreshDependencies.Value = false;
+                    break;
                 case MessageTypes.RestoreComplete:
-                    if (message.Payload.HasValues)
-                    {
-                        _refreshDependencies.Value = message.Payload.Value<bool>("Reset");
-                    }
-                    else
-                    {
-                        _refreshDependencies.Value = true;
-                    }
+                    _refreshDependencies.Value = message.Payload.HasValues ? message.Payload.Value<bool>("Reset") : true;
                     break;
                 case MessageTypes.FilesChanged:
                     _filesChanged.Value = 0;

--- a/test/dotnet-projectmodel-server.Tests/DthTestClient.cs
+++ b/test/dotnet-projectmodel-server.Tests/DthTestClient.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
         {
             // Avoid Socket exception 10006 on Linux
             Thread.Sleep(100);
-            
+
             _socket = new Socket(AddressFamily.InterNetwork,
                                  SocketType.Stream,
                                  ProtocolType.Tcp);
@@ -61,13 +61,18 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
 
         public void SendPayload(string projectPath, string messageType)
         {
+            SendPayload(projectPath, messageType, new { });
+        }
+
+        public void SendPayload(string projectPath, string messageType, object payload)
+        {
             int contextId;
             if (!_projectContexts.TryGetValue(projectPath, out contextId))
             {
                 Assert.True(false, $"Unable to resolve context for {projectPath}");
             }
 
-            SendPayload(contextId, messageType);
+            SendPayload(contextId, messageType, payload);
         }
 
         public void SendPayload(int contextId, string messageType)


### PR DESCRIPTION
Issue #3220 

What's in:
* Add overload to allow `Workspace` to clear the caches for project contexts, project and lock files while get project contexts collection. This will force a clean project model to be created.
* Make project model server to check addition property in `RestoreComple` request to determine if the cache clear is needed. __by default, cache clear is required.__
* This will solve the situation in which user remove the `.nuget/packages` folder however lock file offers no indication if the restore should happen.

/cc @abpiskunov 