### PR TITLE
Re-enable Kestrel tests now that we have ASP.NET packages built on CoreFX rc3.

### DIFF
--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
-    "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc3-21310",
+    "Microsoft.AspNetCore.Hosting": "1.0.0-rc3-21310",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc3-21310",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24210-10"
   },
   "buildOptions": {

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
-    "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc3-21310",
+    "Microsoft.AspNetCore.Hosting": "1.0.0-rc3-21310",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc3-21310",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24210-10"
   },
   "buildOptions": {

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
-    "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc3-21310",
+    "Microsoft.AspNetCore.Hosting": "1.0.0-rc3-21310",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc3-21310",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-24210-10"
   },
   "buildOptions": {

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/src/Startup.cs
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/src/Startup.cs
@@ -22,12 +22,7 @@ namespace SampleApp
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
-            var ksi = app.ServerFeatures.Get<IKestrelServerInformation>();
-            ksi.NoDelay = true;
-
             loggerFactory.AddConsole(LogLevel.Error);
-
-            app.UseKestrelConnectionLogging();
 
             app.Run(async context =>
             {
@@ -64,7 +59,11 @@ namespace SampleApp
             Args = string.Join(" ", args);
 
             var host = new WebHostBuilder()
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel(options =>
+                {
+                    options.NoDelay = true;
+                    options.UseConnectionLogging();
+                })
                 .UseUrls(url.ToString())
                 .UseStartup<Startup>()
                 .Build();

--- a/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
-    "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254"
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc3-21310",
+    "Microsoft.AspNetCore.Hosting": "1.0.0-rc3-21310",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc3-21310"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
-    "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
-    "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254"
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc3-21310",
+    "Microsoft.AspNetCore.Hosting": "1.0.0-rc3-21310",
+    "Microsoft.Extensions.Logging.Console": "1.0.0-rc3-21310"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/TestProjects/KestrelSample/src/Startup.cs
+++ b/TestAssets/TestProjects/KestrelSample/src/Startup.cs
@@ -22,12 +22,7 @@ namespace SampleApp
 
         public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
-            var ksi = app.ServerFeatures.Get<IKestrelServerInformation>();
-            ksi.NoDelay = true;
-
             loggerFactory.AddConsole(LogLevel.Error);
-
-            app.UseKestrelConnectionLogging();
 
             app.Run(async context =>
             {
@@ -64,7 +59,11 @@ namespace SampleApp
             Args = string.Join(" ", args);
 
             var host = new WebHostBuilder()
-                .UseServer("Microsoft.AspNetCore.Server.Kestrel")
+                .UseKestrel(options =>
+                {
+                    options.NoDelay = true;
+                    options.UseConnectionLogging();
+                })
                 .UseUrls(url.ToString())
                 .UseStartup<Startup>()
                 .Build();

--- a/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
@@ -9,7 +9,7 @@
           "type": "platform",
           "version": "1.0.0-rc3-004459-00"
         },
-        "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
+        "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc3-21310",
         "Libuv": "1.9.0-rc2-20896"
       },
       "imports": "dnxcore50"

--- a/build_projects/dotnet-cli-build/TestTargets.cs
+++ b/build_projects/dotnet-cli-build/TestTargets.cs
@@ -34,8 +34,7 @@ namespace Microsoft.DotNet.Cli.Build
             "dotnet-run.UnitTests",
             "dotnet-test.Tests",
             "dotnet-test.UnitTests",
-            // TODO: https://github.com/dotnet/cli/issues/3216
-            //"Kestrel.Tests",
+            "Kestrel.Tests",
             "Microsoft.DotNet.Cli.Utils.Tests",
             "Microsoft.DotNet.Compiler.Common.Tests",
             "Microsoft.DotNet.ProjectModel.Tests",


### PR DESCRIPTION
Fix #3216

@livarcocc @pranavkm 