### PR TITLE
Add new templates for C# to dotnet new 

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/Library.cs
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/Library.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace ClassLibrary
+{
+    public class Class1
+    {
+        public void Method1()
+        {    
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
@@ -1,9 +1,10 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc3-24126-00"
   },
   "frameworks": {
-    "netstandard1.5": {}
+    "netstandard1.6": {
+        "NETStandard.Library": "1.5.0-rc3-24126-00"
+    }
   }
 }

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "NETStandard.Library": "1.5.0-rc3-24126-00"
+  },
+  "frameworks": {
+    "netstandard1.5": {}
+  }
+}

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/Tests.cs
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/Tests.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Xunit;
+
+namespace Tests
+{
+    public class Tests
+    {
+        [Fact]
+        public void Test1() 
+        {
+            Assert.True(true);
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -2,9 +2,9 @@
     "version": "1.0.0-*",
 
     "dependencies": {
-        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24008",
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc3-24127-01",
         "xunit": "2.1.0",
-        "dotnet-test-xunit": "1.0.0-dev-140469-38"
+        "dotnet-test-xunit": "1.0.0-rc2-192208-24"
     },
 
     "testRunner":  "xunit",

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+
+    "dependencies": {
+        "System.Runtime.Serialization.Primitives": "4.1.1-rc2-24008",
+        "xunit": "2.1.0",
+        "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    },
+
+    "testRunner":  "xunit",
+
+    "frameworks": {
+        "netcoreapp1.0": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.0.0-rc3-004312"
+                }
+            },
+            "imports": [
+                "dotnet5.4",
+                "portable-net451+win8"
+            ]
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
@@ -10,7 +10,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160316"
+    "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509"
   },
   "tools": {
     "dotnet-compile-fsc": {
@@ -23,7 +23,7 @@
     }
   },
   "frameworks": {
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",

--- a/src/dotnet/commands/dotnet-new/Program.cs
+++ b/src/dotnet/commands/dotnet-new/Program.cs
@@ -84,9 +84,9 @@ namespace Microsoft.DotNet.Tools.New
             var dotnetNew = new NewCommand();
             app.OnExecute(() => {
 
-                var csharp = new { Name = "C#", Alias = new[] { "c#", "cs", "csharp" }, TemplatePrefix = "CSharp", Templates = new[] { "Console", "Web" } };
+                var csharp = new { Name = "C#", Alias = new[] { "c#", "cs", "csharp" }, TemplatePrefix = "CSharp", Templates = new[] { "Console", "Web", "Lib", "xunittest" } };
                 var fsharp = new { Name = "F#", Alias = new[] { "f#", "fs", "fsharp" }, TemplatePrefix = "FSharp", Templates = new[] { "Console" } };
-
+                
                 string languageValue = lang.Value() ?? csharp.Name;
 
                 var language = new[] { csharp, fsharp }

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -5,6 +5,8 @@
     "embed": {
       "include": [
         "commands/dotnet-new/CSharp_Console.zip",
+        "commands/dotnet-new/CSharp_Lib.zip",
+        "commands/dotnet-new/CSharp_xunittest.zip",
         "commands/dotnet-new/FSharp_Console.zip",
         "commands/dotnet-new/CSharp_Web.zip"
       ]
@@ -13,7 +15,9 @@
       "exclude": [
         "commands/dotnet-new/CSharp_Console/**",
         "commands/dotnet-new/FSharp_Console/**",
-        "commands/dotnet-new/CSharp_Web/**"
+        "commands/dotnet-new/CSharp_Web/**",
+        "commands/dotnet-new/CSharp_Lib/**",
+        "commands/dotnet-new/CSharp_xunittest/**"
       ]
     }
   },


### PR DESCRIPTION
This is the second PR for the class library and xUnit templates for `dotnet new`. Had to close the #2106  because it was mistakenly opened against rel/1.0.0 branch. 

/cc @eerhardt @brthor @ajaybhargavb 