### PR TITLE
fix #3469 by correcting overflow and enabling tests

### DIFF
--- a/build_projects/dotnet-cli-build/TestTargets.cs
+++ b/build_projects/dotnet-cli-build/TestTargets.cs
@@ -39,6 +39,7 @@ namespace Microsoft.DotNet.Cli.Build
             "Microsoft.DotNet.Cli.Utils.Tests",
             "Microsoft.DotNet.Compiler.Common.Tests",
             "Microsoft.DotNet.ProjectModel.Tests",
+            "Microsoft.DotNet.ProjectModel.Loader.Tests",
             "Microsoft.Extensions.DependencyModel.Tests",
             "Performance"
         };

--- a/src/Microsoft.DotNet.ProjectModel.Loader/LoaderProjectContextExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/LoaderProjectContextExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.ProjectModel.Loader
         public static AssemblyLoadContext CreateLoadContext(
             this ProjectContext context,
             string runtimeIdentifier,
-            string configuration) => CreateLoadContext(context, runtimeIdentifier, configuration);
+            string configuration) => CreateLoadContext(context, runtimeIdentifier, configuration, outputPath: null);
 
         public static AssemblyLoadContext CreateLoadContext(
             this ProjectContext context,

--- a/test/Microsoft.DotNet.ProjectModel.Loader.Tests/ProjectLoadContextTest.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Loader.Tests/ProjectLoadContextTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.ProjectModel.Loader.Tests
         [Fact]
         public void LoadContextCanLoadProjectOutput()
         {
-            var testInstance = TestAssetsManager.CreateTestInstance("TestProjectWithResource")
+            var testInstance = TestAssetsManager.CreateTestInstance("TestProjectWithCultureSpecificResource")
                 .WithLockFiles()
                 .WithBuildArtifacts();
 
@@ -23,10 +23,11 @@ namespace Microsoft.DotNet.ProjectModel.Loader.Tests
             var loadContext = context.CreateLoadContext(rid, Constants.DefaultConfiguration);
 
             // Load the project assembly
-            var asm = loadContext.LoadFromAssemblyName(new AssemblyName("TestProjectWithResource"));
+            var asm = loadContext.LoadFromAssemblyName(new AssemblyName("TestProjectWithCultureSpecificResource"));
 
             // Call Program.GetMessage() and assert the output
-            var message = (string)asm.GetType("TestProjectWithCultureSpecificResource").GetRuntimeMethod("GetMessage", Type.EmptyTypes).Invoke(null, new object[0]);
+            var typ = asm.GetType("TestProjectWithCultureSpecificResource.Program");
+            var message = (string)typ.GetRuntimeMethod("GetMessage", Type.EmptyTypes).Invoke(null, new object[0]);
             Assert.Equal("Hello World!" + Environment.NewLine + "Bonjour!", message);
         }
     }

--- a/test/Microsoft.DotNet.ProjectModel.Loader.Tests/ProjectLoadContextTest.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Loader.Tests/ProjectLoadContextTest.cs
@@ -17,17 +17,17 @@ namespace Microsoft.DotNet.ProjectModel.Loader.Tests
                 .WithLockFiles()
                 .WithBuildArtifacts();
 
-            var rid = DependencyContext.Default.Target.Runtime;
+            var runtimeIdentifier = DependencyContext.Default.Target.Runtime;
 
-            var context = ProjectContext.Create(testInstance.TestRoot, NuGetFramework.Parse("netcoreapp1.0"), new[] { rid });
-            var loadContext = context.CreateLoadContext(rid, Constants.DefaultConfiguration);
+            var context = ProjectContext.Create(testInstance.TestRoot, NuGetFramework.Parse("netcoreapp1.0"), new[] { runtimeIdentifier });
+            var loadContext = context.CreateLoadContext(runtimeIdentifier, Constants.DefaultConfiguration);
 
             // Load the project assembly
-            var asm = loadContext.LoadFromAssemblyName(new AssemblyName("TestProjectWithCultureSpecificResource"));
+            var assembly = loadContext.LoadFromAssemblyName(new AssemblyName("TestProjectWithCultureSpecificResource"));
 
             // Call Program.GetMessage() and assert the output
-            var typ = asm.GetType("TestProjectWithCultureSpecificResource.Program");
-            var message = (string)typ.GetRuntimeMethod("GetMessage", Type.EmptyTypes).Invoke(null, new object[0]);
+            var type = assembly.GetType("TestProjectWithCultureSpecificResource.Program");
+            var message = (string)type.GetRuntimeMethod("GetMessage", Type.EmptyTypes).Invoke(null, new object[0]);
             Assert.Equal("Hello World!" + Environment.NewLine + "Bonjour!", message);
         }
     }


### PR DESCRIPTION
I added tests that would have caught this but they weren't in the list of Test projects in `TestTargets` :(.

This was a simple typo that caused a StackOverflow. Corrected, reenabled the test AND verified that it was actually running and passing :).

Fixes #3469 

/cc @piotrpMSFT @NTaylorMullen @muratg @natemcmaster 

