### PR TITLE
Removing the nuspec schema change used for adding the serviceable tag.

### DIFF
--- a/src/dotnet/commands/dotnet-pack/NuGet/ManifestSchemaUtility.cs
+++ b/src/dotnet/commands/dotnet-pack/NuGet/ManifestSchemaUtility.cs
@@ -41,19 +41,13 @@ namespace NuGet
         /// </summary>
         internal const string SchemaVersionV6 = "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd";
 
-        /// <summary>
-        /// Added serviceble element under metadata.
-        /// </summary>
-        internal const string SchemaVersionV8 = "http://schemas.microsoft.com/packaging/2016/06/nuspec.xsd";
-
         private static readonly string[] VersionToSchemaMappings = new[] {
             SchemaVersionV1,
             SchemaVersionV2,
             SchemaVersionV3,
             SchemaVersionV4,
             SchemaVersionV5,
-            SchemaVersionV6,
-            SchemaVersionV8
+            SchemaVersionV6
         };
 
         public static int GetVersionFromNamespace(string @namespace)

--- a/src/dotnet/commands/dotnet-pack/NuGet/ManifestVersionUtility.cs
+++ b/src/dotnet/commands/dotnet-pack/NuGet/ManifestVersionUtility.cs
@@ -15,9 +15,6 @@ namespace NuGet
         public const int TargetFrameworkSupportForDependencyContentsAndToolsVersion = 4;
         public const int TargetFrameworkSupportForReferencesVersion = 5;
         public const int XdtTransformationVersion = 6;
-        // Note that this version should change from 7 to 8 when the PackageType
-        // schema is merged into here
-        public const int ServiceableVersion = 7;
 
         public static int GetManifestVersion(ManifestMetadata metadata)
         {
@@ -27,10 +24,6 @@ namespace NuGet
         private static int GetMaxVersionFromMetadata(ManifestMetadata metadata)
         {
             // Important: always add newer version checks at the top
-            if (metadata.Serviceable)
-            {
-                return ServiceableVersion;
-            }
 
             bool referencesHasTargetFramework =
               metadata.PackageAssemblyReferences != null &&


### PR DESCRIPTION
Removing the schema change made with the addition of the serviceable pack option.
Fixes NuGet/Home#2938

This is the port to rel/1.0.0-preview2.