### PR TITLE
Fix the project.json for C# library and add tests

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
@@ -8,7 +8,7 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc3-24126-00"
+        "NETStandard.Library": "1.6.0-rc3-24210-06"
       }
     }
   }

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
@@ -7,7 +7,9 @@
   },
   "frameworks": {
     "netstandard1.6": {
-      "NETStandard.Library": "1.5.0-rc3-24126-00"
+      "dependencies": {
+        "NETStandard.Library": "1.5.0-rc3-24126-00"
+      }
     }
   }
 }

--- a/src/dotnet/commands/dotnet-new/README.md
+++ b/src/dotnet/commands/dotnet-new/README.md
@@ -29,7 +29,16 @@ Language of project. Defaults to `C##`. Also `csharp` ( `fsharp` ) or `cs` ( `fs
 
 `-t`, `--type`
 
-Type of the project. Valid values are "console" and "web".
+Type of the project. Valid values for C# are:
+
+* `console`
+* `web`
+* `lib`
+* `xunittest`
+
+Valid values for F# are:
+
+* `console`
 
 ## EXAMPLES
 

--- a/test/dotnet-new.Tests/GivenThatIWantANewCSLIbrary.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewCSLIbrary.cs
@@ -25,8 +25,6 @@ namespace Microsoft.DotNet.Tests
             new TestCommand("dotnet") { WorkingDirectory = rootPath }
                 .Execute("new --type lib");
             
-            // AddProjectJsonDependency(projectJsonFile, "Newtonsoft.Json", "7.0.1");
-
             new TestCommand("dotnet") { WorkingDirectory = rootPath }
                 .Execute("restore")
                 .Should().Pass();
@@ -52,57 +50,5 @@ namespace Microsoft.DotNet.Tests
         }
 
 
-        // [Fact]
-        // public void When_NewtonsoftJson_dependency_added_Then_project_restores_and_runs()
-        // {
-        //     var rootPath = Temp.CreateDirectory().Path;
-        //     var projectJsonFile = Path.Combine(rootPath, "project.json");
-
-        //     new TestCommand("dotnet") { WorkingDirectory = rootPath }
-        //         .Execute("new");
-            
-        //     AddProjectJsonDependency(projectJsonFile, "Newtonsoft.Json", "7.0.1");
-
-        //     new TestCommand("dotnet") { WorkingDirectory = rootPath }
-        //         .Execute("restore")
-        //         .Should().Pass();
-
-        //     new TestCommand("dotnet") { WorkingDirectory = rootPath }
-        //         .Execute("run")
-        //         .Should().Pass();
-        // }
-        
-        
-        private static void AddProjectJsonDependency(string projectJsonPath, string dependencyId, string dependencyVersion)
-        {
-            var projectJsonRoot = ReadProject(projectJsonPath);
-
-            var dependenciesNode = projectJsonRoot
-                .Descendants()
-                .OfType<JProperty>()
-                .First(p => p.Name == "dependencies");
-
-            ((JObject)dependenciesNode.Value).Add(new JProperty(dependencyId, dependencyVersion));
-
-            WriteProject(projectJsonRoot, projectJsonPath);
-        }
-
-        private static JObject ReadProject(string projectJsonPath)
-        {
-            using (TextReader projectFileReader = File.OpenText(projectJsonPath))
-            {
-                var projectJsonReader = new JsonTextReader(projectFileReader);
-
-                var serializer = new JsonSerializer();
-                return serializer.Deserialize<JObject>(projectJsonReader);
-            }
-        }
-
-        private static void WriteProject(JObject projectRoot, string projectJsonPath)
-        {
-            string projectJson = JsonConvert.SerializeObject(projectRoot, Formatting.Indented);
-
-            File.WriteAllText(projectJsonPath, projectJson + Environment.NewLine);
-        }
     }
 }

--- a/test/dotnet-new.Tests/GivenThatIWantANewCSLIbrary.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewCSLIbrary.cs
@@ -1,0 +1,108 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using FluentAssertions;
+
+namespace Microsoft.DotNet.Tests
+{
+    public class GivenThatIWantANewCSLibrary : TestBase
+    {
+        
+        [Fact]
+        public void When_library_created_Then_project_restores()
+        {
+            var rootPath = Temp.CreateDirectory().Path;
+            var projectJsonFile = Path.Combine(rootPath, "project.json");
+
+            new TestCommand("dotnet") { WorkingDirectory = rootPath }
+                .Execute("new --type lib");
+            
+            // AddProjectJsonDependency(projectJsonFile, "Newtonsoft.Json", "7.0.1");
+
+            new TestCommand("dotnet") { WorkingDirectory = rootPath }
+                .Execute("restore")
+                .Should().Pass();
+            
+        }
+
+        [Fact]
+        public void When_dotnet_build_is_invoked_Then_project_builds_without_warnings()
+        {
+            var rootPath = Temp.CreateDirectory().Path;
+
+            new TestCommand("dotnet") { WorkingDirectory = rootPath }
+                .Execute("new --type lib");
+
+            new TestCommand("dotnet") { WorkingDirectory = rootPath }
+                .Execute("restore");
+
+            var buildResult = new TestCommand("dotnet") { WorkingDirectory = rootPath }
+                .ExecuteWithCapturedOutput("build");
+            
+            buildResult.Should().Pass();
+            buildResult.Should().NotHaveStdErr();
+        }
+
+
+        // [Fact]
+        // public void When_NewtonsoftJson_dependency_added_Then_project_restores_and_runs()
+        // {
+        //     var rootPath = Temp.CreateDirectory().Path;
+        //     var projectJsonFile = Path.Combine(rootPath, "project.json");
+
+        //     new TestCommand("dotnet") { WorkingDirectory = rootPath }
+        //         .Execute("new");
+            
+        //     AddProjectJsonDependency(projectJsonFile, "Newtonsoft.Json", "7.0.1");
+
+        //     new TestCommand("dotnet") { WorkingDirectory = rootPath }
+        //         .Execute("restore")
+        //         .Should().Pass();
+
+        //     new TestCommand("dotnet") { WorkingDirectory = rootPath }
+        //         .Execute("run")
+        //         .Should().Pass();
+        // }
+        
+        
+        private static void AddProjectJsonDependency(string projectJsonPath, string dependencyId, string dependencyVersion)
+        {
+            var projectJsonRoot = ReadProject(projectJsonPath);
+
+            var dependenciesNode = projectJsonRoot
+                .Descendants()
+                .OfType<JProperty>()
+                .First(p => p.Name == "dependencies");
+
+            ((JObject)dependenciesNode.Value).Add(new JProperty(dependencyId, dependencyVersion));
+
+            WriteProject(projectJsonRoot, projectJsonPath);
+        }
+
+        private static JObject ReadProject(string projectJsonPath)
+        {
+            using (TextReader projectFileReader = File.OpenText(projectJsonPath))
+            {
+                var projectJsonReader = new JsonTextReader(projectFileReader);
+
+                var serializer = new JsonSerializer();
+                return serializer.Deserialize<JObject>(projectJsonReader);
+            }
+        }
+
+        private static void WriteProject(JObject projectRoot, string projectJsonPath)
+        {
+            string projectJson = JsonConvert.SerializeObject(projectRoot, Formatting.Indented);
+
+            File.WriteAllText(projectJsonPath, projectJson + Environment.NewLine);
+        }
+    }
+}

--- a/test/dotnet-new.Tests/GivenThatIWantANewCSxUnitProject.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewCSxUnitProject.cs
@@ -13,17 +13,17 @@ using FluentAssertions;
 
 namespace Microsoft.DotNet.Tests
 {
-    public class GivenThatIWantANewCSLibrary : TestBase
+    public class GivenThatIWantANewCSxUnitProject : TestBase
     {
         
         [Fact]
-        public void When_library_created_Then_project_restores()
+        public void When_xUnit_project_created_Then_project_restores()
         {
             var rootPath = Temp.CreateDirectory().Path;
             var projectJsonFile = Path.Combine(rootPath, "project.json");
 
             new TestCommand("dotnet") { WorkingDirectory = rootPath }
-                .Execute("new --type lib")
+                .Execute("new --type xunittest")
                 .Should()
                 .Pass();
             
@@ -34,19 +34,19 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void When_dotnet_build_is_invoked_Then_project_builds_without_warnings()
+        public void When_dotnet_test_is_invoked_Then_tests_run_without_errors()
         {
             var rootPath = Temp.CreateDirectory().Path;
 
             new TestCommand("dotnet") { WorkingDirectory = rootPath }
-                .Execute("new --type lib");
+                .Execute("new --type xunittest");
 
             new TestCommand("dotnet") { WorkingDirectory = rootPath }
                 .Execute("restore");
 
             var buildResult = new TestCommand("dotnet")
                 .WithWorkingDirectory(rootPath)
-                .ExecuteWithCapturedOutput("build")
+                .ExecuteWithCapturedOutput("test")
                 .Should()
                 .Pass()
                 .And


### PR DESCRIPTION
This commit fixes the bug introduced in project.json for the C# Library
template. It also adds two simple tests for the library template that
drop the class library and then restore and another that also builds.

Fixes #3496

/cc @eerhardt @piotrpMSFT @weshaggard 