### PR TITLE
Remove File.Copy optimization during expansion

### DIFF
--- a/src/Microsoft.DotNet.Archive/IndexedArchive.cs
+++ b/src/Microsoft.DotNet.Archive/IndexedArchive.cs
@@ -238,7 +238,7 @@ namespace Microsoft.DotNet.Archive
         private class ExtractSource
         {
             private string _entryName;
-            private string _localPath;
+            private readonly string _localPath;
             private ThreadLocalZipArchive _archive;
 
             public ExtractSource(string sourceString, Dictionary<string, string> externalFiles, ThreadLocalZipArchive archive)
@@ -271,20 +271,9 @@ namespace Microsoft.DotNet.Archive
                 }
                 else
                 {
-                    // we open the archive each time since ZipArchive is not thread safe and we want to be able
-                    // to extract from many threads
-                    //using (var archive = new ZipArchive(File.Open(_archivePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete)))
                     using (var sourceStream = _archive.Archive.GetEntry(_entryName).Open())
                     {
                         sourceStream.CopyTo(destinationStream);
-
-                        var destinationFileStream = destinationStream as FileStream;
-                        if (destinationFileStream != null)
-                        {
-                            // Set Local path  so that the next copy operation using the same source will
-                            // do a copy instead of a write.
-                            _localPath = destinationFileStream.Name;
-                        }
                     }
                 }
 


### PR DESCRIPTION
- If this PR should not run tests please add text "skip[REMOVE_THIS]ci[REMOVE_THIS]please" (remove the marked text, no quotes).
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.

Previously we'd keep track of any file that we extracted once and try
to reuse that file (by copying it) if we needed the same file later at a
different destination.  The reason was that it's theoretically faster to do
a file copy than a createfile and write, since the copy can happen
entirely in the kernel.  In practice we were foiled by AV scanners.

This happens to be the only time during extraction where we let a file
close after writing it and then try and use it again.  Sure enough on
fast machines we were seeing that as soon as we closed it MsMpEng would
map the file for exclusive access causing our copy to fail with a
sharing violation.

To fix this, I've removed the copy optimization and will just write the
file from the in-memory archive every time.

/cc @livarcocc 