### PR TITLE
Add LZMA to THIRD-PARTY-NOTICES + (c) header

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -11,6 +11,13 @@ bring it to our attention. Post an issue or email us:
 
 The attached notices are provided for information only.
 
+License notice for LZMA SDK
+---------------------------
+
+http://www.7-zip.org/sdk.html
+
+LZMA is placed in the public domain.
+
 License notice for RFC 3492
 ---------------------------
 

--- a/src/Microsoft.DotNet.Archive/LZMA/Common/CRC.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Common/CRC.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // Common/CRC.cs
 
 namespace SevenZip

--- a/src/Microsoft.DotNet.Archive/LZMA/Common/InBuffer.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Common/InBuffer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // InBuffer.cs
 
 namespace SevenZip.Buffer

--- a/src/Microsoft.DotNet.Archive/LZMA/Common/OutBuffer.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Common/OutBuffer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // OutBuffer.cs
 
 namespace SevenZip.Buffer

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/LZ/IMatchFinder.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/LZ/IMatchFinder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // IMatchFinder.cs
 
 using System;

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/LZ/LzBinTree.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/LZ/LzBinTree.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // LzBinTree.cs
 
 using System;

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/LZ/LzInWindow.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/LZ/LzInWindow.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // LzInWindow.cs
 
 using System;

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/LZ/LzOutWindow.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/LZ/LzOutWindow.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // LzOutWindow.cs
 
 namespace SevenZip.Compression.LZ

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/LZMA/LzmaBase.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/LZMA/LzmaBase.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // LzmaBase.cs
 
 namespace SevenZip.Compression.LZMA

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/LZMA/LzmaDecoder.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/LZMA/LzmaDecoder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // LzmaDecoder.cs
 
 using System;

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/LZMA/LzmaEncoder.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/LZMA/LzmaEncoder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // LzmaEncoder.cs
 
 using System;

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/RangeCoder/RangeCoder.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/RangeCoder/RangeCoder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace SevenZip.Compression.RangeCoder

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/RangeCoder/RangeCoderBit.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/RangeCoder/RangeCoderBit.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace SevenZip.Compression.RangeCoder

--- a/src/Microsoft.DotNet.Archive/LZMA/Compress/RangeCoder/RangeCoderBitTree.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/Compress/RangeCoder/RangeCoderBitTree.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 namespace SevenZip.Compression.RangeCoder

--- a/src/Microsoft.DotNet.Archive/LZMA/ICoder.cs
+++ b/src/Microsoft.DotNet.Archive/LZMA/ICoder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // ICoder.h
 
 using System;


### PR DESCRIPTION
This adds LZMA to the THIRD-PARTY-NOTICES list for CLI.  Since we've
modified the SDK in porting it to .NET Core and minor bugfixes we've
also been advised to add the .NET Foundation copyright header.

/cc @livarcocc @piotrpMSFT 

Fixes #3544 