### PR TITLE
update ubuntu 16 dockerfile from core-setup

### DIFF
--- a/scripts/docker/ubuntu.16.04/Dockerfile
+++ b/scripts/docker/ubuntu.16.04/Dockerfile
@@ -5,21 +5,28 @@
 
 FROM ubuntu:16.04
 
-# Install the base toolchain we need to build anything (clang, cmake, make and the like)
-# this does not include libraries that we need to compile different projects, we'd like
-# them in a different layer.
+# Misc Dependencies for build
 RUN apt-get update && \
-    apt-get install -y wget && \
-    echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | tee /etc/apt/sources.list.d/llvm.list && \
-    wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | apt-key add - && \
-    apt-get update && \
-    apt-get install -y cmake \
-            make \
-            llvm-3.5 \
-            clang-3.5 \
-            lldb-3.6 \
-            lldb-3.6-dev && \
-    apt-get clean
+    apt-get -qqy install \
+        curl \
+        make \
+        unzip \
+        gettext \
+        sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Build Prereqs
+RUN apt-get update && \
+    apt-get -qqy install \
+        debhelper \
+        build-essential \
+        devscripts \
+        git \
+        cmake \
+        clang-3.5 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install tools used by the VSO build automation.  nodejs-legacy is a Debian specific
 # package that provides `node' on the path (which azure cli needs).
@@ -34,17 +41,19 @@ RUN apt-get install -y git \
     npm install -g azure-cli && \
     npm cache clean
 
-# Dependencies for CoreCLR and CoreFX
-RUN apt-get install -y gettext \
-            libunwind8-dev \
-            libkrb5-dev \
-            libunwind8 \
-            libicu-dev \
-            liblttng-ust-dev \
-            libcurl4-openssl-dev \
-            libssl-dev \
-            uuid-dev && \
-    apt-get clean
+# This could become a "microsoft/coreclr" image, since it just installs the dependencies for CoreCLR (and stdlib)
+RUN apt-get update && \
+    apt-get -qqy install \
+        libunwind8 \
+        libkrb5-3 \
+        libicu55 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        zlib1g \
+        libuuid1 \
+        liblldb-3.6 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0


### PR DESCRIPTION
Update ubuntu 16 dockerfile.

I'm not sure how this was still working, llvm apt still added.

@livarcocc @ellismg @eerhardt @piotrpMSFT 

This is blocking our VSO builds