### PR TITLE
Fixing #3345 by adding the Serviceable attribute to CLI binaries

### DIFF
--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoFileGenerator.cs
@@ -79,6 +79,11 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 attributes[typeof(TargetFrameworkAttribute)] = EscapeCharacters(metadata.TargetFramework);
             };
 
+            if (metadata.IsServiceable)
+            {
+                attributes[typeof(AssemblyMetadataAttribute)] = "Serviceable\", \"True";
+            }
+
             return attributes;
         }
 

--- a/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/AssemblyInfoOptions.cs
@@ -45,6 +45,8 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
         public string TargetFramework { get; set; }
 
+        public bool IsServiceable { get; set; }
+
         public static AssemblyInfoOptions CreateForProject(ProjectContext context)
         {
             var project = context.ProjectFile;

--- a/src/dotnet/commands/dotnet-build/BuildCommandApp.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandApp.cs
@@ -35,6 +35,8 @@ namespace Microsoft.DotNet.Tools.Compiler
         private CommandOption _shouldNotUseIncrementalityArgument;
         private CommandOption _shouldSkipDependenciesArgument;
 
+        private CommandOption _isServiceable;
+
 
         public string BuildBasePathValue { get; set; }
         public string RuntimeValue { get; set; }
@@ -45,6 +47,8 @@ namespace Microsoft.DotNet.Tools.Compiler
         public bool ShouldPrintIncrementalPreconditions { get; set; }
         public bool ShouldNotUseIncrementality { get; set; }
         public bool ShouldSkipDependencies { get; set; }
+
+        public bool IsServiceable { get; set; }
 
         public BuildWorkspace Workspace { get; private set; }
 
@@ -85,6 +89,7 @@ namespace Microsoft.DotNet.Tools.Compiler
             _shouldPrintIncrementalPreconditionsArgument = _app.Option(BuildProfileFlag, "Set this flag to print the incremental safety checks that prevent incremental compilation", CommandOptionType.NoValue);
             _shouldNotUseIncrementalityArgument = _app.Option(NoIncrementalFlag, "Set this flag to turn off incremental build", CommandOptionType.NoValue);
             _shouldSkipDependenciesArgument = _app.Option("--no-dependencies", "Set this flag to ignore project to project references and only build the root project", CommandOptionType.NoValue);
+            _isServiceable = _app.Option("--Serviceable", "Adds the Serviceable attribute to output binaries", CommandOptionType.NoValue);
         }
 
         public int Execute(OnExecute execute, string[] args)
@@ -105,6 +110,7 @@ namespace Microsoft.DotNet.Tools.Compiler
                 ShouldPrintIncrementalPreconditions = _shouldPrintIncrementalPreconditionsArgument.HasValue();
                 ShouldNotUseIncrementality = _shouldNotUseIncrementalityArgument.HasValue();
                 ShouldSkipDependencies = _shouldSkipDependenciesArgument.HasValue();
+                IsServiceable = _isServiceable.HasValue() ? true : false;
 
                 // Set defaults based on the environment
                 if (Workspace == null)

--- a/src/dotnet/commands/dotnet-compile-csc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-csc/Program.cs
@@ -32,6 +32,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
             CommonCompilerOptionsCommandLine commonCompilerCommandLine = CommonCompilerOptionsCommandLine.AddOptions(app);
             AssemblyInfoOptionsCommandLine assemblyInfoCommandLine = AssemblyInfoOptionsCommandLine.AddOptions(app);
 
+            CommandOption serviceable = app.Option("--serviceable", "Adds the Serviceable attribute to output binaries", CommandOptionType.NoValue);
             CommandOption tempOutput = app.Option("--temp-output <arg>", "Compilation temporary directory", CommandOptionType.SingleValue);
             CommandOption outputName = app.Option("--out <arg>", "Name of the output assembly", CommandOptionType.SingleValue);
             CommandOption references = app.Option("--reference <arg>...", "Path to a compiler metadata reference", CommandOptionType.MultipleValue);
@@ -50,6 +51,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 CommonCompilerOptions commonOptions = commonCompilerCommandLine.GetOptionValues();
 
                 AssemblyInfoOptions assemblyInfoOptions = assemblyInfoCommandLine.GetOptionValues();
+                assemblyInfoOptions.IsServiceable = serviceable.HasValue() ? true : false;
 
                 var translated = TranslateCommonOptions(commonOptions, outputName.Value());
 

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -31,6 +31,7 @@ namespace Microsoft.DotNet.Tools.Publish
             var projectPath = app.Argument("<PROJECT>", "The project to publish, defaults to the current directory. Can be a path to a project.json or a project directory");
             var nativeSubdirectories = app.Option("--native-subdirectory", "Temporary mechanism to include subdirectories from native assets of dependency packages in output", CommandOptionType.NoValue);
             var noBuild = app.Option("--no-build", "Do not build projects before publishing", CommandOptionType.NoValue);
+            var serviceable = app.Option("--Serviceable", "Adds the Serviceable attribute to output binaries", CommandOptionType.NoValue);
 
             app.OnExecute(() =>
             {
@@ -45,6 +46,7 @@ namespace Microsoft.DotNet.Tools.Publish
                 publish.ProjectPath = projectPath.Value;
                 publish.VersionSuffix = versionSuffix.Value();
                 publish.ShouldBuild = !noBuild.HasValue();
+                publish.IsServiceable = serviceable.HasValue() ? true : false;
 
                 publish.Workspace = BuildWorkspace.Create(versionSuffix.Value());
 

--- a/src/dotnet/commands/dotnet-publish/PublishCommand.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommand.cs
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.Tools.Publish
         public int NumberOfProjects { get; private set; }
         public int NumberOfPublishedProjects { get; private set; }
         public bool ShouldBuild { get; set; }
+        public bool IsServiceable { get; set; }
 
         public bool TryPrepareForPublish()
         {
@@ -260,6 +261,11 @@ namespace Microsoft.DotNet.Tools.Publish
             {
                 args.Add("--build-base-path");
                 args.Add(buildBasePath);
+            }
+
+            if (IsServiceable)
+            {
+                args.Add("--Serviceable");
             }
 
             var result = Build.BuildCommand.Run(args.ToArray(), Workspace);

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -5,6 +5,7 @@
       "type": "platform",
       "version": "1.0.0"
     },
+    "System.Reflection.Metadata": "1.3.0-rc3-24210-10",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"


### PR DESCRIPTION
Fixing #3345 by adding the Serviceable attributes to the Pack, Build, and Compile commands for non-nuget packages. This will require a follow-up PR to enable Servicing of Stage1 binaries after we publish these bits since the downloaded stage0 does not know about the serviceable attribute and dotnet.dll is built in stage1 (from my testing). 

/cc @piotrpMSFT @brthor @livarcocc @ericstj @eerhardt 
