### PR TITLE
Add plain-text version of EULA, include in archives.

### DIFF
--- a/build_projects/dotnet-cli-build/PackageTargets.cs
+++ b/build_projects/dotnet-cli-build/PackageTargets.cs
@@ -159,6 +159,14 @@ namespace Microsoft.DotNet.Cli.Build
             string hostFxrPublishRoot = c.BuildContext.Get<string>("HostFxrPublishRoot");
             Utils.CopyDirectoryRecursively(hostFxrPublishRoot, combinedRoot);
 
+            string licenseSource = Path.Combine(Dirs.RepoRoot, "packaging", "LICENSE.txt");
+            string licenseDestination = Path.Combine(combinedRoot, "LICENSE.txt");
+            File.Copy(licenseSource, licenseDestination);
+
+            string tpnSource = Path.Combine(Dirs.RepoRoot, "THIRD-PARTY-NOTICES");
+            string tpnDestination = Path.Combine(combinedRoot, "THIRD-PARTY-NOTICES");
+            File.Copy(tpnSource, tpnDestination);
+
             c.BuildContext["CombinedFrameworkSDKHostRoot"] = combinedRoot;
             return c.Success();
         }
@@ -177,6 +185,14 @@ namespace Microsoft.DotNet.Cli.Build
 
             string sharedFrameworkPublishRoot = c.BuildContext.Get<string>("SharedFrameworkPublishRoot");
             Utils.CopyDirectoryRecursively(sharedFrameworkPublishRoot, combinedRoot);
+
+            string licenseSource = Path.Combine(Dirs.RepoRoot, "packaging", "LICENSE.txt");
+            string licenseDestination = Path.Combine(combinedRoot, "LICENSE.txt");
+            File.Copy(licenseSource, licenseDestination);
+
+            string tpnSource = Path.Combine(Dirs.RepoRoot, "THIRD-PARTY-NOTICES");
+            string tpnDestination = Path.Combine(combinedRoot, "THIRD-PARTY-NOTICES");
+            File.Copy(tpnSource, tpnDestination);
 
             c.BuildContext["CombinedFrameworkSDKRoot"] = combinedRoot;
             return c.Success();

--- a/packaging/LICENSE.txt
+++ b/packaging/LICENSE.txt
@@ -1,0 +1,64 @@
+MICROSOFT SOFTWARE LICENSE TERMS
+MICROSOFT .NET LIBRARY 
+These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. Please read them. They apply to the software named above, which includes the media on which you received it, if any. The terms also apply to any Microsoft
+  * updates,
+  * supplements,
+  * Internet-based services, and
+  * support services
+for this software, unless other terms accompany those items. If so, those terms apply.
+BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT USE THE SOFTWARE.
+IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE PERPETUAL RIGHTS BELOW.
+1. INSTALLATION AND USE RIGHTS. 
+  a. Installation and Use. You may install and use any number of copies of the software to design, develop and test your programs.
+  b. Third Party Programs. The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.
+2. DATA. The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at http://go.microsoft.com/fwlink/?LinkId=528096.Your use of the software operates as your consent to these practices.
+3. ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.
+  a. DISTRIBUTABLE CODE. The software is comprised of Distributable Code. "Distributable Code" is code that you are permitted to distribute in programs you develop if you comply with the terms below.
+    i. Right to Use and Distribute. 
+      * You may copy and distribute the object code form of the software.
+      * Third Party Distribution. You may permit distributors of your programs to copy and distribute the Distributable Code as part of those programs.
+    ii. Distribution Requirements. For any Distributable Code you distribute, you must
+      * add significant primary functionality to it in your programs;
+      * require distributors and external end users to agree to terms that protect it at least as much as this agreement;
+      * display your valid copyright notice on your programs; and
+      * indemnify, defend, and hold harmless Microsoft from any claims, including attorneys' fees, related to the distribution or use of your programs.
+    iii. Distribution Restrictions. You may not
+      * alter any copyright, trademark or patent notice in the Distributable Code;
+      * use Microsoft's trademarks in your programs' names or in a way that suggests your programs come from or are endorsed by Microsoft;
+      * include Distributable Code in malicious, deceptive or unlawful programs; or
+      * modify or distribute the source code of any Distributable Code so that any part of it becomes subject to an Excluded License. An Excluded License is one that requires, as a condition of use, modification or distribution, that
+      * the code be disclosed or distributed in source code form; or
+      * others have the right to modify it.
+4. SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
+  * work around any technical limitations in the software;
+  * reverse engineer, decompile or disassemble the software, except and only to the extent that applicable law expressly permits, despite this limitation;
+  * publish the software for others to copy;
+  * rent, lease or lend the software;
+  * transfer the software or this agreement to any third party; or
+  * use the software for commercial software hosting services.
+5. BACKUP COPY. You may make one backup copy of the software. You may use it only to reinstall the software.
+6. DOCUMENTATION. Any person that has valid access to your computer or internal network may copy and use the documentation for your internal, reference purposes.
+7. EXPORT RESTRICTIONS. The software is subject to United States export laws and regulations. You must comply with all domestic and international export laws and regulations that apply to the software. These laws include restrictions on destinations, end users and end use. For additional information, see www.microsoft.com/exporting.
+8. SUPPORT SERVICES. Because this software is "as is," we may not provide support services for it.
+9. ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
+10. APPLICABLE LAW.
+  a. United States. If you acquired the software in the United States, Washington state law governs the interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws principles. The laws of the state where you live govern all other claims, including claims under state consumer protection laws, unfair competition laws, and in tort.
+  b. Outside the United States. If you acquired the software in any other country, the laws of that country apply.
+11. LEGAL EFFECT. This agreement describes certain legal rights. You may have other rights under the laws of your country. You may also have rights with respect to the party from whom you acquired the software. This agreement does not change your rights under the laws of your country if the laws of your country do not permit it to do so.
+12. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED "AS-IS." YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. YOU MAY HAVE ADDITIONAL CONSUMER RIGHTS OR STATUTORY GUARANTEES UNDER YOUR LOCAL LAWS WHICH THIS AGREEMENT CANNOT CHANGE. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+FOR AUSTRALIA - YOU HAVE STATUTORY GUARANTEES UNDER THE AUSTRALIAN CONSUMER LAW AND NOTHING IN THESE TERMS IS INTENDED TO AFFECT THOSE RIGHTS.
+13. LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
+This limitation applies to
+  * anything related to the software, services, content (including code) on third party Internet sites, or third party programs; and
+  * claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
+It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
+Please note: As this software is distributed in Quebec, Canada, some of the clauses in this agreement are provided below in French.
+Remarque : Ce logiciel étant distribué au Québec, Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en français.
+EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel quel ». Toute utilisation de ce logiciel est à votre seule risque et péril. Microsoft n'accorde aucune autre garantie expresse. Vous pouvez bénéficier de droits additionnels en vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de qualité marchande, d'adéquation à un usage particulier et d'absence de contrefaçon sont exclues.
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US. Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages, y compris les dommages spéciaux, indirects ou accessoires et pertes de bénéfices.
+Cette limitation concerne :
+  * tout ce qui est relié au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou dans des programmes tiers ; et
+  * les réclamations au titre de violation de contrat ou de garantie, ou au titre de responsabilité stricte, de négligence ou d'une autre faute dans la limite autorisée par la loi en vigueur.
+Elle s'applique également, même si Microsoft connaissait ou devrait connaître l'éventualité d'un tel dommage. Si votre pays n'autorise pas l'exclusion ou la limitation de responsabilité pour les dommages indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou l'exclusion ci-dessus ne s'appliquera pas à votre égard.
+EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous pourriez avoir d'autres droits prévus par les lois de votre pays. Le présent contrat ne modifie pas les droits que vous confèrent les lois de votre pays si celles-ci ne le permettent pas.
+


### PR DESCRIPTION
Addresses https://github.com/dotnet/cli/issues/3037.

I've created a text version of eula.rtf. I did this by copy-pasting the contents of eula.rtf from Word 2016 into a text editor, and then fixing up the spacing of the document.

This file, as well as THIRD-PARTY-NOTICES are included in the zip/tar archives we produce from here. They are included in the root of the archive.

@leecow , @joshfree , @richlander 