### PR TITLE
Publish sdk zips to Azure

### DIFF
--- a/build_projects/dotnet-cli-build/PackageTargets.cs
+++ b/build_projects/dotnet-cli-build/PackageTargets.cs
@@ -194,6 +194,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             CreateZipFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkSDKHostRoot"), c.BuildContext.Get<string>("CombinedFrameworkSDKHostCompressedFile"));
             CreateZipFromDirectory(c.BuildContext.Get<string>("CombinedFrameworkSDKRoot"), c.BuildContext.Get<string>("CombinedFrameworkSDKCompressedFile"));
+            CreateZipFromDirectory(c.BuildContext.Get<string>("CLISDKRoot"), c.BuildContext.Get<string>("SdkCompressedFile"));
             CreateZipFromDirectory(Path.Combine(Dirs.Stage2Symbols, "sdk"), c.BuildContext.Get<string>("SdkSymbolsCompressedFile"));
 
             return c.Success();

--- a/build_projects/dotnet-cli-build/PublishTargets.cs
+++ b/build_projects/dotnet-cli-build/PublishTargets.cs
@@ -191,6 +191,7 @@ namespace Microsoft.DotNet.Cli.Build
         [Target(
             nameof(PublishTargets.PublishCombinedHostFrameworkSdkArchiveToAzure),
             nameof(PublishTargets.PublishCombinedFrameworkSDKArchiveToAzure),
+            nameof(PublishTargets.PublishSDKArchiveToAzure),
             nameof(PublishTargets.PublishSDKSymbolsArchiveToAzure))]
         public static BuildTargetResult PublishArchivesToAzure(BuildTargetContext c) => c.Success();
 
@@ -241,6 +242,18 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var version = CliNuGetVersion;
             var archiveFile = c.BuildContext.Get<string>("CombinedFrameworkSDKCompressedFile");
+
+            AzurePublisherTool.PublishArchive(archiveFile, Channel, version);
+
+            return c.Success();
+        }
+
+        [Target]
+        [BuildPlatforms(BuildPlatform.Windows)]
+        public static BuildTargetResult PublishSDKArchiveToAzure(BuildTargetContext c)
+        {
+            var version = CliNuGetVersion;
+            var archiveFile = c.BuildContext.Get<string>("SdkCompressedFile");
 
             AzurePublisherTool.PublishArchive(archiveFile, Channel, version);
 


### PR DESCRIPTION
@piotrpMSFT this is to allow Antares to take new SDK zips without having the problem of overwriting other components in use. Since the M.N.A has stabilized to 1.0.0, the SDK+FX zips are attempting to overwrite the runtime libraries affecting their unzip deployment.

Cc @brthor 

Eventually, I assume we would have a file called "artifacts.txt" similar to the version badge, that is a summary of the build output and inputs in Azure that our consumers can use.
