### PR TITLE
fix typo in dotnet-install file

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -668,4 +668,4 @@ else
     say "Binaries of dotnet can be found in $bin_path"
 fi
 
-say "Installation finished successfuly."
+say "Installation finished successfully."


### PR DESCRIPTION
Fix typo:
successfuly => successfully