### PR TITLE
Fixing AzurePublisher to upload files to the correct URL.

### DIFF
--- a/build_projects/dotnet-cli-build/PublishTargets.cs
+++ b/build_projects/dotnet-cli-build/PublishTargets.cs
@@ -239,7 +239,7 @@ namespace Microsoft.DotNet.Cli.Build
 
             var packageName = CliMonikers.GetSdkDebianPackageName(c);
             var installerFile = c.BuildContext.Get<string>("SdkInstallerFile");
-            var uploadUrl = AzurePublisher.CalculateUploadUrlForFile(installerFile, AzurePublisher.Product.Sdk, version);
+            var uploadUrl = AzurePublisher.CalculateFullUrlForFile(installerFile, AzurePublisher.Product.Sdk, version);
 
             DebRepoPublisherTool.PublishDebFileToDebianRepo(
                 packageName,

--- a/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
+++ b/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         public string UploadFile(string file, Product product, string version)
         {
-            string url = CalculateUploadUrlForFile(file, product, version);
+            string url = CalculateRelativePathForFile(file, product, version);
             CloudBlockBlob blob = _blobContainer.GetBlockBlobReference(url);
             blob.UploadFromFileAsync(file, FileMode.Open).Wait();
             SetBlobPropertiesBasedOnFileType(blob);
@@ -194,9 +194,14 @@ namespace Microsoft.DotNet.Cli.Build
             _blobContainer.GetBlockBlobReference(path).DeleteAsync().Wait();
         }
 
-        public static string CalculateUploadUrlForFile(string file, Product product, string version)
+        public static string CalculateFullUrlForFile(string file, Product product, string version)
         {
-            return $"{s_dotnetBlobRootUrl}/{product}/{version}/{Path.GetFileName(file)}";
+            return $"{s_dotnetBlobRootUrl}/{CalculateRelativePathForFile(file, product, version)}";
+        }
+
+        private static string CalculateRelativePathForFile(string file, Product product, string version)
+        {
+            return $"{product}/{version}/{Path.GetFileName(file)}";
         }
 
         public static async Task DownloadFile(string blobFilePath, string localDownloadPath)


### PR DESCRIPTION
Previously it was duplicating the full URL inside of the blob container.

@brthor @livarcocc