### PR TITLE
Fixed OutputPath in Configurer xproj

### DIFF
--- a/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.xproj
+++ b/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>e5ed47ef-bf25-4da9-a7fe-290c642cbf0f</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Configurer</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This is required for building in VS.