### PR TITLE
Don't use black color in the console

### DIFF
--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/BuildSetup.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/BuildSetup.cs
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             {
                 foreach (var targetOverride in _overrides)
                 {
-                    Reporter.Verbose.WriteLine($"Target {targetOverride.Name} from {targetOverride.OriginalSource} was overridden in {targetOverride.OverrideSource}".Black());
+                    Reporter.Verbose.WriteLine($"Target {targetOverride.Name} from {targetOverride.OriginalSource} was overridden in {targetOverride.OverrideSource}");
                 }
             }
 


### PR DESCRIPTION
In the standard white text on black background console, text printed like this is invisible.

There don't seem to be any other uses of `.Black()` in the solution.