### PR TITLE
Base Prepare Infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,6 @@ cmake/
 [Rr]eleases/
 x64/
 x86/
-build/
 bld/
 [Bb]in/
 [Oo]bj/

--- a/build.proj
+++ b/build.proj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="BuildTheWholeCli" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="build/Microsoft.DotNet.Cli.Prepare.targets" />
 
   <PropertyGroup>
     <!--
@@ -17,9 +18,19 @@
     <CLITargets Condition=" '$(CLITargets)' == '' ">Prepare;Compile;Test;Package;Publish</CLITargets>
     <CLIBuildFileName>$(MSBuildThisFileDirectory)/build_projects/dotnet-cli-build/bin/dotnet-cli-build</CLIBuildFileName>
     <CLIBuildDll>$(CLIBuildFileName).dll</CLIBuildDll>
+
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
   </PropertyGroup>
 
-  <Target Name="BuildDotnetCliBuildFramework" Inputs="" Outputs="">
+  <ItemGroup>
+    <DotnetCliBuildFrameworkInputs Include="build_projects/**/*.cs" />
+    <DotnetCliBuildFrameworkInputs Include="build_projects/**/*.json" />
+  </ItemGroup>
+
+  <Target Name="BuildDotnetCliBuildFramework" 
+          Inputs="@(DotnetCliBuildFrameworkInputs)" 
+          Outputs="$(CLIBuildDll)">
     <Exec Command="$(PlatformScriptHost) $(MSBuildThisFileDirectory)/build_projects/dotnet-cli-build/build$(PlatformScriptExtension) $(NoRunArg)" WorkingDirectory="$(MSBuildThisFileDirectory)"/>
   </Target>
 

--- a/build/Microsoft.DotNet.Cli.Prepare.targets
+++ b/build/Microsoft.DotNet.Cli.Prepare.targets
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Layout" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <UsingTask TaskName="Rid" AssemblyFile="$(CLIBuildDll)" />
+  <UsingTask TaskName="Architecture" AssemblyFile="$(CLIBuildDll)" />
+  <UsingTask TaskName="GenerateBuildVersionInfo" AssemblyFile="$(CLIBuildDll)" />
+
+  <Target Name="Init" >
+    <!-- Current Runtime Information -->
+    <Rid>
+      <Output TaskParameter="OutputRid" PropertyName="Rid" />
+    </Rid>
+    <Architecture>
+      <Output TaskParameter="OutputArchitecture" PropertyName="Architecture" />
+    </Architecture>
+
+    <!-- Common Properties -->
+    <PropertyGroup>
+      <BaseOutputDirectory>$(RepoRoot)/artifacts/$(Rid)</BaseOutputDirectory>
+      <OutputDirectory>$(BaseOutputDirectory)/stage2</OutputDirectory>
+      <Stage2CompilationDirectory>$(BaseOutputDirectory)/stage2compilation</Stage2CompilationDirectory>
+      <IntermediateDirectory>$(BaseOutputDirectory)/intermediate</IntermediateDirectory>
+    </PropertyGroup>
+
+    <!-- Generates BuildVersion Item
+        BuildVersion Metadata:
+          - Major
+          - Minor
+          - Patch
+          - ReleaseSuffix
+          - CommitHash
+          - CommitCount
+          - VersionSuffix
+          - SimpleVersion
+          - NugetVersion
+          - MsiVersion            -->
+    <GenerateBuildVersionInfo RepoRoot="$(RepoRoot)">
+        <Output TaskParameter="OutputBuildVersionInfo"
+                ItemName="BuildVersion" />
+    </GenerateBuildVersionInfo>
+
+    <PropertyGroup>
+      <SdkVersion>@(BuildVersion ->'%(NugetVersion)')</SdkVersion>
+      <SdkBrandName>Microsoft .NET Core 1.0.0 - SDK Preview 2</SdkBrandName>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/build_projects/dotnet-cli-build/Architecture.cs
+++ b/build_projects/dotnet-cli-build/Architecture.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Net.Http;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using static Microsoft.DotNet.Cli.Build.Framework.BuildHelpers;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class Architecture : Task
+    {
+        [Output]
+        public string OutputArchitecture { get; set; }
+
+        public override bool Execute()
+        {
+            OutputArchitecture = RuntimeEnvironment.RuntimeArchitecture;
+
+            return true;
+        }
+    }
+}

--- a/build_projects/dotnet-cli-build/GenerateBuildVersion.cs
+++ b/build_projects/dotnet-cli-build/GenerateBuildVersion.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Net.Http;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Security.Cryptography;
+
+using static Microsoft.DotNet.Cli.Build.Framework.BuildHelpers;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class GenerateBuildVersionInfo : Task
+    {
+        [Required]
+        public string RepoRoot { get; set; }
+
+        [Output]
+        public ITaskItem OutputBuildVersionInfo { get; set; }
+
+        public override bool Execute()
+        {
+            var branchInfo = new BranchInfo(RepoRoot);
+            
+            var commitCount = GitUtils.GetCommitCount();
+            var commitHash = GitUtils.GetCommitHash();
+            
+            var buildVersion = new BuildVersion()
+            {
+                Major = int.Parse(branchInfo.Entries["MAJOR_VERSION"]),
+                Minor = int.Parse(branchInfo.Entries["MINOR_VERSION"]),
+                Patch = int.Parse(branchInfo.Entries["PATCH_VERSION"]),
+                ReleaseSuffix = branchInfo.Entries["RELEASE_SUFFIX"],
+                CommitCount = commitCount
+            };
+
+            OutputBuildVersionInfo = ConstructBuildVersionInfoItem(buildVersion, commitHash);
+
+            return true;
+        }
+
+        private ITaskItem ConstructBuildVersionInfoItem(BuildVersion buildVersion, string commitHash)
+        {
+            var versionInfo = new TaskItem();
+            versionInfo.ItemSpec = "BuildVersionInfo";
+
+            versionInfo.SetMetadata("CommitHash", commitHash);
+            versionInfo.SetMetadata("Major", buildVersion.Major.ToString());
+            versionInfo.SetMetadata("Minor", buildVersion.Minor.ToString());
+            versionInfo.SetMetadata("Patch", buildVersion.Patch.ToString());
+            versionInfo.SetMetadata("ReleaseSuffix", buildVersion.ReleaseSuffix);
+            versionInfo.SetMetadata("CommitCount", buildVersion.CommitCountString);
+            versionInfo.SetMetadata("VersionSuffix", buildVersion.VersionSuffix);
+            versionInfo.SetMetadata("SimpleVersion", buildVersion.SimpleVersion);
+            versionInfo.SetMetadata("NugetVersion", buildVersion.NuGetVersion);
+            versionInfo.SetMetadata("MsiVersion", buildVersion.GenerateMsiVersion());
+
+            return versionInfo;
+        }
+    }
+}

--- a/build_projects/dotnet-cli-build/Rid.cs
+++ b/build_projects/dotnet-cli-build/Rid.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.InteropServices;
+using System.Net.Http;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Cli.Build.Framework;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using static Microsoft.DotNet.Cli.Build.Framework.BuildHelpers;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class Rid : Task
+    {
+        [Output]
+        public string OutputRid { get; set; }
+
+        public override bool Execute()
+        {
+            OutputRid = RuntimeEnvironment.GetRuntimeIdentifier();
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Extracting this from #3696 so everyone can take advantage of the base work I needed to do for package targets.

Included is:
 - A task to get the current rid
 - A task to get the current arch
 - A task to generate an itemgroup with the build version info in metadata
 - base properties in prepare targets needed in other places

@eerhardt @sokket @livarcocc @piotrpMSFT 
