### PR TITLE
Remove final 'Exit 0' 

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -355,4 +355,3 @@ else {
 }
 
 Say "Installation finished"
-exit 0

--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -329,7 +329,7 @@ $IsSdkInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -Relativ
 Say-Verbose ".NET SDK installed? $IsSdkInstalled"
 if ($IsSdkInstalled) {
     Say ".NET SDK version $SpecificVersion is already installed."
-    exit 0
+    return
 }
 
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null


### PR DESCRIPTION
skipciplease

Removed final 'Exit 0' as this is causing entire build processes to exit which reference the script as part of the overall build script. Exit 0 was previously added without any discussion on whether it was necessary, and it doesn't appear to be.