### PR TITLE
Updated version badge so it is readable with the current version numbers

### DIFF
--- a/resources/images/version_badge.svg
+++ b/resources/images/version_badge.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="180" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="20">
     <mask id="a">
-        <rect width="180" height="20" rx="0" fill="#fff" />
+        <rect width="200" height="20" rx="0" fill="#fff" />
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h52v20H0z" />
-        <path fill="#007ec6" d="M52 0h115v20H52z" />
+        <path fill="#007ec6" d="M52 0h148v20H52z" />
         <path fill="url(#b)" d="M0 0h150v20H0z" />
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="26" y="15" fill="#010101" fill-opacity=".3">version</text>
         <text x="26" y="14">version</text>
-        <text x="110" y="15" fill="#010101" fill-opacity=".3">ver_number</text>
-        <text x="110" y="14">ver_number</text>
+        <text x="125" y="15" fill="#010101" fill-opacity=".3">ver_number</text>
+        <text x="125" y="14">ver_number</text>
     </g>
 </svg>


### PR DESCRIPTION
Fixes #3747 - This has been annoying me for some time :)

Looks like the following now:
![image](https://cloud.githubusercontent.com/assets/8290530/16500196/475b5f04-3ec9-11e6-96c3-a931bfefd0c5.png)

@brthor, @eerhardt