### PR TITLE
Add analyzer support for local project 

### DIFF
--- a/src/Microsoft.DotNet.ProjectModel/Project.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Project.cs
@@ -64,6 +64,8 @@ namespace Microsoft.DotNet.ProjectModel
 
         public string TestRunner { get; set; }
 
+        public string Type { get; set; }
+
         public ProjectFilesCollection Files { get; set; }
 
         public PackOptions PackOptions { get; set; }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectReader.cs
@@ -145,6 +145,7 @@ namespace Microsoft.DotNet.ProjectModel
             project.Title = rawProject.Value<string>("title");
             project.EntryPoint = rawProject.Value<string>("entryPoint");
             project.TestRunner = rawProject.Value<string>("testRunner");
+            project.Type = rawProject.Value<string>("type");
             project.Authors =
                 rawProject.Value<JToken>("authors")?.Values<string>().ToArray() ?? EmptyArray<string>.Value;
             project.Language = rawProject.Value<string>("language");


### PR DESCRIPTION
https://github.com/dotnet/cli/issues/3765

#83 added support for referencing 3rd party code analyzers. 
I am developing solution, where I would like to add my own, solution-specific code analysis. It is not currently possible to reference project.json-project and use it as code analyzer.

- Added 'type' field to project.json
- When 'type' is 'analyzer', referenced project is used for code analysis during build