### PR TITLE
Don't print arguments in default F# app

### DIFF
--- a/src/dotnet/commands/dotnet-new/FSharp_Console/Program.fs
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/Program.fs
@@ -5,5 +5,4 @@ open System
 [<EntryPoint>]
 let main argv = 
     printfn "Hello World!"
-    printfn "%A" argv
     0 // return an integer exit code


### PR DESCRIPTION
When you create an app using `dotnet new -l fs` and run it using `dotnet run`, it prints:

```
Hello World!
[||]
```

The second line looks like some kind of error, until you look at the source code and realize that it's a representation of empty array.

The C# application created using `dotnet new -l cs` does not print its arguments and I'm not sure why the F# application should, especially if the formatting could confuse users new to F#.