### PR TITLE
Fix ExeExtension on non-Windows

### DIFF
--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -27,7 +27,7 @@
         <Inputs>@(CompileStageInputs)</Inputs>
         <StageDirectory>$(Stage1Directory)</StageDirectory>
         <StageSymbolsDirectory>$(Stage1SymbolsDirectory)</StageSymbolsDirectory>
-        <DotnetExe>$(Stage0Path)/dotnet.exe</DotnetExe>
+        <DotnetExe>$(Stage0Path)/dotnet$(ExeExtension)</DotnetExe>
       </Stage>
       <Stage Include="Stage2">
         <Inputs>@(CompileStageInputs)</Inputs>
@@ -41,10 +41,7 @@
   <Target Name="CompileStage"
           Inputs="%(Stage.Inputs)"
           Outputs="%(StageDirectory)/sdk/$(SdkVersion)/dotnet.dll">
-      <PropertyGroup>      
-        <ExeSuffix Condition=" '$(OSName)' == 'win' ">.exe</ExeSuffix>
-        <ExeSuffix Condition=" '$(OSName)' != 'win' "></ExeSuffix>
-
+      <PropertyGroup>
         <DynamicLibPrefix Condition=" '$(OSName)' == 'win' "></DynamicLibPrefix>
         <DynamicLibPrefix Condition=" '$(OSName)' != 'win' ">lib</DynamicLibPrefix>
 
@@ -52,7 +49,7 @@
         <DynamicLibSuffix Condition=" '$(OSName)' == 'osx' ">.dylib</DynamicLibSuffix>
         <DynamicLibSuffix Condition=" '$(DynamicLibSuffix)' == '' ">.so</DynamicLibSuffix>
 
-        <DotnetHostBaseName>dotnet$(ExeSuffix)</DotnetHostBaseName>
+        <DotnetHostBaseName>dotnet$(ExeExtension)</DotnetHostBaseName>
         <DotnetHostFxrBaseName>$(DynamicLibPrefix)hostfxr$(DynamicLibSuffix)</DotnetHostFxrBaseName>
         <HostPolicyBaseName>$(DynamicLibPrefix)hostpolicy$(DynamicLibSuffix)</HostPolicyBaseName>
 
@@ -140,7 +137,7 @@
 
       <!-- Copy Host to SDK Directory -->
       <Copy SourceFiles="$(SharedFrameworkNameVersionPath)/$(DotnetHostBaseName)"
-            DestinationFiles="$(SdkOutputDirectory)/corehost$(ExeSuffix)" />
+            DestinationFiles="$(SdkOutputDirectory)/corehost$(ExeExtension)" />
 
       <Copy SourceFiles="$(SharedFrameworkNameVersionPath)/$(DotnetHostFxrBaseName)"
             DestinationFiles="$(SdkOutputDirectory)/$(DotnetHostFxrBaseName)" />

--- a/build/Microsoft.DotNet.Cli.Prepare.targets
+++ b/build/Microsoft.DotNet.Cli.Prepare.targets
@@ -26,16 +26,18 @@
       <Stage0Path Condition=" '$(OSName)' == 'win' ">$(RepoRoot)/.dotnet_stage0/Windows/$(Architecture)</Stage0Path>
       <Stage0Path Condition=" '$(OSName)' == 'osx' ">$(RepoRoot)/.dotnet_stage0/Darwin</Stage0Path>
       <Stage0Path Condition=" '$(Stage0Path)' == '' ">$(RepoRoot)/.dotnet_stage0/Linux</Stage0Path>
+      <ExeExtension>.exe</ExeExtension>
+      <ExeExtension Condition="'$OSName)' != 'win' "></ExeExtension>
       <DotNetPath>$(Stage0Path)</DotNetPath>
 
       <BaseOutputDirectory>$(RepoRoot)/artifacts/$(Rid)</BaseOutputDirectory>
       <ToolsOutputDirectory>$(BaseOutputDirectory)/tools</ToolsOutputDirectory>
       <Stage1Directory>$(BaseOutputDirectory)/stage1</Stage1Directory>
       <Stage1SymbolsDirectory>$(BaseOutputDirectory)/stage1symbols</Stage1SymbolsDirectory>
-      <DotnetStage1>$(Stage1Directory)/dotnet.exe</DotnetStage1>
+      <DotnetStage1>$(Stage1Directory)/dotnet$(ExeExtension)</DotnetStage1>
       <Stage2Directory>$(BaseOutputDirectory)/stage2</Stage2Directory>
       <Stage2SymbolsDirectory>$(BaseOutputDirectory)/stage2symbols</Stage2SymbolsDirectory>
-      <DotnetStage2>$(Stage2Directory)/dotnet.exe</DotnetStage2>
+      <DotnetStage2>$(Stage2Directory)/dotnet$(ExeExtension)</DotnetStage2>
       <OutputDirectory>$(Stage2Directory)/</OutputDirectory>
       <Stage2CompilationDirectory>$(BaseOutputDirectory)/stage2compilation</Stage2CompilationDirectory>
       <IntermediateDirectory>$(BaseOutputDirectory)/intermediate</IntermediateDirectory>


### PR DESCRIPTION
Fixes issue where non-Windows msbuild-based builds attempt to execute dotnet`.exe`

/cc @livarcocc 