### PR TITLE
Fixed bug in build process with ReadOnly file flag

### DIFF
--- a/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,62 +10,77 @@ using Microsoft.DotNet.ProjectModel.Graph;
 
 namespace Microsoft.DotNet.Cli.Compiler.Common
 {
-    public static class LibraryExporterExtensions
-    {
-        public static IEnumerable<LibraryExport> GetAllProjectTypeDependencies(this LibraryExporter exporter)
-        {
-            return
-                exporter.GetDependencies(LibraryType.Project)
-                    .Concat(exporter.GetDependencies(LibraryType.MSBuildProject));
-        }
+	public static class LibraryExporterExtensions
+	{
+		public static IEnumerable<LibraryExport> GetAllProjectTypeDependencies(this LibraryExporter exporter)
+		{
+			return
+				exporter.GetDependencies(LibraryType.Project)
+					.Concat(exporter.GetDependencies(LibraryType.MSBuildProject));
+		}
 
-        public static void CopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath)
-        {
-            if (!Directory.Exists(destinationPath))
-            {
-                Directory.CreateDirectory(destinationPath);
-            }
+		public static void CopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath)
+		{
+			if (!Directory.Exists(destinationPath))
+			{
+				Directory.CreateDirectory(destinationPath);
+			}
 
-            foreach (var asset in assets)
-            {
-                File.Copy(asset.ResolvedPath, Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath)), overwrite: true);
-            }
-        }
+			foreach (var asset in assets)
+			{
+				var file = Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath));
+				File.Copy(asset.ResolvedPath, file, overwrite: true);
+				RemoveFileAttribute(file, FileAttributes.ReadOnly);
+			}
+		}
 
-        public static void StructuredCopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath, string tempLocation)
-        {
-            if (!Directory.Exists(destinationPath))
-            {
-                Directory.CreateDirectory(destinationPath);
-            }
+		private static void RemoveFileAttribute(String file, FileAttributes attribute)
+		{
+			if (File.Exists(file))
+			{
+				var fileAttributes = File.GetAttributes(file);
+				if ((fileAttributes & attribute) == attribute)
+				{
+					File.SetAttributes(file, fileAttributes & ~attribute);
+				}
+			}
+		}
 
-            foreach (var asset in assets)
-            {
-                var targetName = ResolveTargetName(destinationPath, asset);
-                var transformedFile = asset.GetTransformedFile(tempLocation);
+		public static void StructuredCopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath, string tempLocation)
+		{
+			if (!Directory.Exists(destinationPath))
+			{
+				Directory.CreateDirectory(destinationPath);
+			}
 
-                File.Copy(transformedFile, targetName, overwrite: true);
-            }
-        }
+			foreach (var asset in assets)
+			{
+				var targetName = ResolveTargetName(destinationPath, asset);
+				var transformedFile = asset.GetTransformedFile(tempLocation);
 
-        private static string ResolveTargetName(string destinationPath, LibraryAsset asset)
-        {
-            string targetName;
-            if (!string.IsNullOrEmpty(asset.RelativePath))
-            {
-                targetName = Path.Combine(destinationPath, asset.RelativePath);
-                var destinationAssetPath = Path.GetDirectoryName(targetName);
+				File.Copy(transformedFile, targetName, overwrite: true);
+				RemoveFileAttribute(targetName, FileAttributes.ReadOnly);
+			}
+		}
 
-                if (!Directory.Exists(destinationAssetPath))
-                {
-                    Directory.CreateDirectory(destinationAssetPath);
-                }
-            }
-            else
-            {
-                targetName = Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath));
-            }
-            return targetName;
-        }
-    }
+		private static string ResolveTargetName(string destinationPath, LibraryAsset asset)
+		{
+			string targetName;
+			if (!string.IsNullOrEmpty(asset.RelativePath))
+			{
+				targetName = Path.Combine(destinationPath, asset.RelativePath);
+				var destinationAssetPath = Path.GetDirectoryName(targetName);
+
+				if (!Directory.Exists(destinationAssetPath))
+				{
+					Directory.CreateDirectory(destinationAssetPath);
+				}
+			}
+			else
+			{
+				targetName = Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath));
+			}
+			return targetName;
+		}
+	}
 }

--- a/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 exporter.GetDependencies(LibraryType.Project)
                     .Concat(exporter.GetDependencies(LibraryType.MSBuildProject));
         }
-        
+
         public static void CopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath)
         {
             if (!Directory.Exists(destinationPath))
@@ -31,18 +31,6 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
                 var file = Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath));
                 File.Copy(asset.ResolvedPath, file, overwrite: true);
                 RemoveFileAttribute(file, FileAttributes.ReadOnly);
-            }
-        }
-
-        private static void RemoveFileAttribute(String file, FileAttributes attribute)
-        {
-            if (File.Exists(file))
-            {
-                var fileAttributes = File.GetAttributes(file);
-                if ((fileAttributes & attribute) == attribute)
-                {
-                    File.SetAttributes(file, fileAttributes & ~attribute);
-                }
             }
         }
 
@@ -60,6 +48,18 @@ namespace Microsoft.DotNet.Cli.Compiler.Common
 
                 File.Copy(transformedFile, targetName, overwrite: true);
                 RemoveFileAttribute(targetName, FileAttributes.ReadOnly);
+            }
+        }
+        
+        private static void RemoveFileAttribute(String file, FileAttributes attribute)
+        {
+            if (File.Exists(file))
+            {
+                var fileAttributes = File.GetAttributes(file);
+                if ((fileAttributes & attribute) == attribute)
+                {
+                    File.SetAttributes(file, fileAttributes & ~attribute);
+                }
             }
         }
 

--- a/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
+++ b/src/Microsoft.DotNet.Compiler.Common/LibraryExporterExtensions.cs
@@ -10,77 +10,77 @@ using Microsoft.DotNet.ProjectModel.Graph;
 
 namespace Microsoft.DotNet.Cli.Compiler.Common
 {
-	public static class LibraryExporterExtensions
-	{
-		public static IEnumerable<LibraryExport> GetAllProjectTypeDependencies(this LibraryExporter exporter)
-		{
-			return
-				exporter.GetDependencies(LibraryType.Project)
-					.Concat(exporter.GetDependencies(LibraryType.MSBuildProject));
-		}
+    public static class LibraryExporterExtensions
+    {
+        public static IEnumerable<LibraryExport> GetAllProjectTypeDependencies(this LibraryExporter exporter)
+        {
+            return
+                exporter.GetDependencies(LibraryType.Project)
+                    .Concat(exporter.GetDependencies(LibraryType.MSBuildProject));
+        }
+        
+        public static void CopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath)
+        {
+            if (!Directory.Exists(destinationPath))
+            {
+                Directory.CreateDirectory(destinationPath);
+            }
 
-		public static void CopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath)
-		{
-			if (!Directory.Exists(destinationPath))
-			{
-				Directory.CreateDirectory(destinationPath);
-			}
+            foreach (var asset in assets)
+            {
+                var file = Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath));
+                File.Copy(asset.ResolvedPath, file, overwrite: true);
+                RemoveFileAttribute(file, FileAttributes.ReadOnly);
+            }
+        }
 
-			foreach (var asset in assets)
-			{
-				var file = Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath));
-				File.Copy(asset.ResolvedPath, file, overwrite: true);
-				RemoveFileAttribute(file, FileAttributes.ReadOnly);
-			}
-		}
+        private static void RemoveFileAttribute(String file, FileAttributes attribute)
+        {
+            if (File.Exists(file))
+            {
+                var fileAttributes = File.GetAttributes(file);
+                if ((fileAttributes & attribute) == attribute)
+                {
+                    File.SetAttributes(file, fileAttributes & ~attribute);
+                }
+            }
+        }
 
-		private static void RemoveFileAttribute(String file, FileAttributes attribute)
-		{
-			if (File.Exists(file))
-			{
-				var fileAttributes = File.GetAttributes(file);
-				if ((fileAttributes & attribute) == attribute)
-				{
-					File.SetAttributes(file, fileAttributes & ~attribute);
-				}
-			}
-		}
+        public static void StructuredCopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath, string tempLocation)
+        {
+            if (!Directory.Exists(destinationPath))
+            {
+                Directory.CreateDirectory(destinationPath);
+            }
 
-		public static void StructuredCopyTo(this IEnumerable<LibraryAsset> assets, string destinationPath, string tempLocation)
-		{
-			if (!Directory.Exists(destinationPath))
-			{
-				Directory.CreateDirectory(destinationPath);
-			}
+            foreach (var asset in assets)
+            {
+                var targetName = ResolveTargetName(destinationPath, asset);
+                var transformedFile = asset.GetTransformedFile(tempLocation);
 
-			foreach (var asset in assets)
-			{
-				var targetName = ResolveTargetName(destinationPath, asset);
-				var transformedFile = asset.GetTransformedFile(tempLocation);
+                File.Copy(transformedFile, targetName, overwrite: true);
+                RemoveFileAttribute(targetName, FileAttributes.ReadOnly);
+            }
+        }
 
-				File.Copy(transformedFile, targetName, overwrite: true);
-				RemoveFileAttribute(targetName, FileAttributes.ReadOnly);
-			}
-		}
+        private static string ResolveTargetName(string destinationPath, LibraryAsset asset)
+        {
+            string targetName;
+            if (!string.IsNullOrEmpty(asset.RelativePath))
+            {
+                targetName = Path.Combine(destinationPath, asset.RelativePath);
+                var destinationAssetPath = Path.GetDirectoryName(targetName);
 
-		private static string ResolveTargetName(string destinationPath, LibraryAsset asset)
-		{
-			string targetName;
-			if (!string.IsNullOrEmpty(asset.RelativePath))
-			{
-				targetName = Path.Combine(destinationPath, asset.RelativePath);
-				var destinationAssetPath = Path.GetDirectoryName(targetName);
-
-				if (!Directory.Exists(destinationAssetPath))
-				{
-					Directory.CreateDirectory(destinationAssetPath);
-				}
-			}
-			else
-			{
-				targetName = Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath));
-			}
-			return targetName;
-		}
-	}
+                if (!Directory.Exists(destinationAssetPath))
+                {
+                    Directory.CreateDirectory(destinationAssetPath);
+                }
+            }
+            else
+            {
+                targetName = Path.Combine(destinationPath, Path.GetFileName(asset.ResolvedPath));
+            }
+            return targetName;
+        }
+    }
 }


### PR DESCRIPTION
+ added function RemoveFileAttribute to LibraryExporterExtensions

This fixes the bug with with readonly libraries (e.g. in TFS). Assemblies in bin directory now gets the ReadOnly flag removed if it was set. 