### PR TITLE
Fixed instructions to compile without tests

### DIFF
--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -30,7 +30,7 @@ In order to build .NET Command Line Interface, you need the following installed 
 
 ## Building/Running
 
-1. Run `build.cmd` or `build.sh` from the root depending on your OS. If you don't want to execute tests, run `build.cmd -Targets Compile` or `./build.sh --targets Compile`.
+1. Run `build.cmd` or `build.sh` from the root depending on your OS. If you don't want to execute tests, run `build.cmd -Targets Prepare,Compile` or `./build.sh --targets Prepare,Compile`.
 2. Use `artifacts/{os}-{arch}/stage2/dotnet` to try out the `dotnet` command. You can also add `artifacts/{os}-{arch}/stage2` to the PATH if you want to run `dotnet` from anywhere.
 
 ## A simple test


### PR DESCRIPTION
Fixes #3763.

I'm suggesting to always use `Prepare,Compile`, instead of "`Prepare,Compile` the first time, `Compile` after that" because:

1. Using just `Compile` does not work for me, even after using `Prepare,Compile`.
2. It's simpler.