### PR TITLE
Removing ForwardStdOut and ForwardStdErr from a couple of extra places

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -157,8 +157,6 @@ namespace Microsoft.DotNet.Cli
             else
             {
                 CommandResult result = Command.Create("dotnet-" + command, appArgs, FrameworkConstants.CommonFrameworks.NetStandardApp15)
-                    .ForwardStdErr()
-                    .ForwardStdOut()
                     .Execute();
                 exitCode = result.ExitCode;
             }

--- a/src/dotnet/commands/dotnet-test/ConsoleTestRunner.cs
+++ b/src/dotnet/commands/dotnet-test/ConsoleTestRunner.cs
@@ -24,8 +24,6 @@ namespace Microsoft.DotNet.Tools.Test
                     GetCommandArgs(projectContext, dotnetTestParams),
                     projectContext.TargetFramework,
                     dotnetTestParams.Config)
-                .ForwardStdErr()
-                .ForwardStdOut()
                 .Execute()
                 .ExitCode;
         }


### PR DESCRIPTION
Removing ForwardStdOut and ForwardStdErr from the ConsoleTestRunner and from dotnet verbs that are not built-in. BuiltIn verbs were already not using it.

Fixes https://github.com/dotnet/cli/issues/1977#issuecomment-231213110.

cc @piotrpMSFT @eerhardt @brthor 