### PR TITLE
Aligning the two versions of run-build

### DIFF
--- a/init-tools.ps1
+++ b/init-tools.ps1
@@ -8,33 +8,8 @@ param(
 
 $RepoRoot = "$PSScriptRoot"
 
-# Load Branch Info
-cat "$RepoRoot\branchinfo.txt" | ForEach-Object {
-    if(!$_.StartsWith("#") -and ![String]::IsNullOrWhiteSpace($_)) {
-        $splat = $_.Split([char[]]@("="), 2)
-        Set-Content "env:\$($splat[0])" -Value $splat[1]
-    }
-}
-
-# Use a repo-local install directory (but not the artifacts directory because that gets cleaned a lot
-if (!$env:DOTNET_INSTALL_DIR)
-{
-    $env:DOTNET_INSTALL_DIR="$RepoRoot\.dotnet_stage0\$Architecture"
-}
-
-if (!(Test-Path $env:DOTNET_INSTALL_DIR))
-{
-    mkdir $env:DOTNET_INSTALL_DIR | Out-Null
-}
-
 # Install a stage 0
 Write-Host "Installing .NET Core CLI Stage 0 from branchinfo channel"
     
 & "$RepoRoot\scripts\obtain\dotnet-install.ps1" -Channel $env:CHANNEL -Architecture $Architecture -Verbose
 if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
-
-# Put the stage0 on the path
-$env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
-
-# Disable first run since we want to control all package sources
-$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1

--- a/run-build.sh
+++ b/run-build.sh
@@ -36,6 +36,10 @@ while [[ $# > 0 ]]; do
             # Allow CI to disable prereqs check since the CI has the pre-reqs but not ldconfig it seems
             export DOTNET_INSTALL_SKIP_PREREQS=1
             ;;
+        --architecture)
+            ARCHITECTURE=$2
+            shift
+            ;;
         --help)
             echo "Usage: $0 [--configuration <CONFIGURATION>] [--targets <TARGETS...>] [--skip-prereqs] [--nopackage] [--docker <IMAGENAME>] [--help]"
             echo ""


### PR DESCRIPTION
Aligning the two versions of run-build we have in what each do and the parameters they get.

cc @brthor @sokket @eerhardt @piotrpMSFT 