### PR TITLE
 Add FreeBSD OS-detection for dotnet-installer.

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -92,6 +92,9 @@ get_current_os_name() {
                 echo "opensuse.13.2"
                 return 0
             fi
+	elif [ "$(uname -s | grep -cim1 freebsd)" -eq 1 ]; then
+            echo "freebsd"
+            return 0
         fi
     fi
     

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -163,7 +163,6 @@ namespace Microsoft.DotNet.Cli
                 exitCode = result.ExitCode;
             }
 
-
             return exitCode;
 
         }


### PR DESCRIPTION
This patch tries to increase portability for the `dotnet-install.sh` script, especially with FreeBSD in mind.

While detecting FreeBSD for now will not result in any valid SDK or download, it is a baby-step in the general direction of getting FreeBSD build-suppot for the dotnet-cli.