### PR TITLE
Add missing comma to F# lib project.json

### DIFF
--- a/src/dotnet/commands/dotnet-new/FSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Lib/project.json.template
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "buildOptions": {
-    "debugType": "portable"
+    "debugType": "portable",
     "compilerName": "fsc",
     "compile": {
       "includeFiles": [


### PR DESCRIPTION
A comma was missing in the F# Library project.json template file.

/cc @eerhardt @jaredpar 
