### PR TITLE
NuGet imports before and after

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{ED2FE3E2-F7E7-4389-8231-B65123F2076F}"
 EndProject
@@ -24,10 +24,6 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.Testin
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{0722D325-24C8-4E83-B5AF-0A083E7F0749}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "MultiProjectValidator", "tools\MultiProjectValidator\MultiProjectValidator.xproj", "{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}"
-EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Extensions.DependencyModel", "src\Microsoft.Extensions.DependencyModel\Microsoft.Extensions.DependencyModel.xproj", "{688870C8-9843-4F9E-8576-D39290AD0F25}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "EndToEnd", "test\EndToEnd\EndToEnd.xproj", "{65741CB1-8AEE-4C66-8198-10A7EA0E4258}"
@@ -43,8 +39,6 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dotnet-compile.Tests", "test\dotnet-compile.Tests\dotnet-compile.Tests.xproj", "{833FFEE1-7EED-4F51-8DFD-946D48893D6E}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dotnet-publish.Tests", "test\dotnet-publish.Tests\dotnet-publish.Tests.xproj", "{386D412C-003C-47B1-8258-0E35865CB7C4}"
-EndProject
-Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dotnet-projectmodel-server.Tests", "test\dotnet-projectmodel-server.Tests\dotnet-projectmodel-server.Tests.xproj", "{11C77123-E4DA-499F-8900-80C88C2C69F2}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.DotNet.Files", "src\Microsoft.DotNet.Files\Microsoft.DotNet.Files.xproj", "{D521DD9F-0614-4929-93B4-D8FA5682C174}"
 EndProject
@@ -126,9 +120,11 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dotnet-build3.Tests", "test
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{89905EC4-BC0F-443B-8ADF-691321F10108}"
 	ProjectSection(SolutionItems) = preProject
+		build\Microsoft.DotNet.Cli.Compile.targets = build\Microsoft.DotNet.Cli.Compile.targets
 		build\Microsoft.DotNet.Cli.Monikers.props = build\Microsoft.DotNet.Cli.Monikers.props
 		build\Microsoft.DotNet.Cli.Package.targets = build\Microsoft.DotNet.Cli.Package.targets
 		build\Microsoft.DotNet.Cli.Prepare.targets = build\Microsoft.DotNet.Cli.Prepare.targets
+		build\Microsoft.DotNet.Cli.Test.targets = build\Microsoft.DotNet.Cli.Test.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "package", "package", "{FD7D515A-D10F-4F49-B8AE-21CF7ED071AE}"
@@ -139,6 +135,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "package", "package", "{FD7D
 		build\package\Microsoft.DotNet.Cli.Installer.PKG.targets = build\package\Microsoft.DotNet.Cli.Installer.PKG.targets
 		build\package\Microsoft.DotNet.Cli.Layout.targets = build\package\Microsoft.DotNet.Cli.Layout.targets
 		build\package\Microsoft.DotNet.Cli.Nupkg.targets = build\package\Microsoft.DotNet.Cli.Nupkg.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "compile", "compile", "{8E3354BD-827F-41B7-9EE6-6BE1F1EDD8E9}"
+	ProjectSection(SolutionItems) = preProject
+		build\compile\Microsoft.DotNet.Cli.LzmaArchive.targets = build\compile\Microsoft.DotNet.Cli.LzmaArchive.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{FF498306-2DE2-47F6-8C35-3CF0589CF2B8}"
+	ProjectSection(SolutionItems) = preProject
+		build\test\ProjectsToTest.props = build\test\ProjectsToTest.props
+		build\test\TestPackageProjects.props = build\test\TestPackageProjects.props
 	EndProjectSection
 EndProject
 Global
@@ -233,22 +240,6 @@ Global
 		{DCDFE282-03DE-4DBC-B90C-CC3CE3EC8162}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{DCDFE282-03DE-4DBC-B90C-CC3CE3EC8162}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{DCDFE282-03DE-4DBC-B90C-CC3CE3EC8162}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Debug|x64.Build.0 = Debug|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.MinSizeRel|x64.Build.0 = Debug|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Release|Any CPU.Build.0 = Release|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Release|x64.ActiveCfg = Release|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.Release|x64.Build.0 = Release|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 		{688870C8-9843-4F9E-8576-D39290AD0F25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{688870C8-9843-4F9E-8576-D39290AD0F25}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{688870C8-9843-4F9E-8576-D39290AD0F25}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -361,22 +352,6 @@ Global
 		{386D412C-003C-47B1-8258-0E35865CB7C4}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{386D412C-003C-47B1-8258-0E35865CB7C4}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{386D412C-003C-47B1-8258-0E35865CB7C4}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.Debug|x64.Build.0 = Debug|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.MinSizeRel|x64.Build.0 = Debug|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.Release|x64.ActiveCfg = Release|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.Release|x64.Build.0 = Release|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
-		{11C77123-E4DA-499F-8900-80C88C2C69F2}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 		{D521DD9F-0614-4929-93B4-D8FA5682C174}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D521DD9F-0614-4929-93B4-D8FA5682C174}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D521DD9F-0614-4929-93B4-D8FA5682C174}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -931,7 +906,6 @@ Global
 		{A16958E1-24C7-4F1E-B317-204AD91625DD} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{BD7833F8-3209-4682-BF75-B4BCA883E279} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{DCDFE282-03DE-4DBC-B90C-CC3CE3EC8162} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
-		{08A68C6A-86F6-4ED2-89A7-B166D33E9F85} = {0722D325-24C8-4E83-B5AF-0A083E7F0749}
 		{688870C8-9843-4F9E-8576-D39290AD0F25} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{65741CB1-8AEE-4C66-8198-10A7EA0E4258} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{E4F46EAB-B5A5-4E60-9B9D-40A1FADBF45C} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
@@ -940,7 +914,6 @@ Global
 		{833FFEE1-7EED-4F51-8DFD-946D48833333} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{833FFEE1-7EED-4F51-8DFD-946D48893D6E} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{386D412C-003C-47B1-8258-0E35865CB7C4} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
-		{11C77123-E4DA-499F-8900-80C88C2C69F2} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{D521DD9F-0614-4929-93B4-D8FA5682C174} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{CB710268-4A82-48E4-9531-FAF1C8F78F4B} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{920B71D8-62DA-4F5E-8A26-926C113F1D97} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
@@ -980,5 +953,7 @@ Global
 		{35B19F22-B8C0-4849-9C35-3F809B7588B8} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{49D7318E-D198-4E2B-BBEA-3A24D805F88D} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{FD7D515A-D10F-4F49-B8AE-21CF7ED071AE} = {89905EC4-BC0F-443B-8ADF-691321F10108}
+		{8E3354BD-827F-41B7-9EE6-6BE1F1EDD8E9} = {89905EC4-BC0F-443B-8ADF-691321F10108}
+		{FF498306-2DE2-47F6-8C35-3CF0589CF2B8} = {89905EC4-BC0F-443B-8ADF-691321F10108}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.xproj
+++ b/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>e5ed47ef-bf25-4da9-a7fe-290c642cbf0f</ProjectGuid>
     <RootNamespace>Microsoft.DotNet.Configurer</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/dotnet/14.1/Imports/Microsoft.Common.props/ImportBefore/Microsoft.NuGet.ImportBefore.props
+++ b/src/dotnet/14.1/Imports/Microsoft.Common.props/ImportBefore/Microsoft.NuGet.ImportBefore.props
@@ -1,0 +1,17 @@
+<!--
+***********************************************************************************************
+Microsoft.NuGet.ImportBefore.props
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <NuGetProps Condition="'$(NuGetProps)'==''">$(MSBuildExtensionsPath)\Microsoft.NuGet.props</NuGetProps>
+  </PropertyGroup>
+  <Import Condition="Exists('$(NuGetProps)')" Project="$(NuGetProps)" />
+</Project>

--- a/src/dotnet/14.1/Microsoft.Common.Targets/ImportAfter/Microsoft.NuGet.ImportAfter.targets
+++ b/src/dotnet/14.1/Microsoft.Common.Targets/ImportAfter/Microsoft.NuGet.ImportAfter.targets
@@ -1,0 +1,17 @@
+<!--
+***********************************************************************************************
+Microsoft.NuGet.ImportAfter.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <NuGetTargets Condition="'$(NuGetTargets)'==''">$(MSBuildExtensionsPath)\Microsoft.NuGet.targets</NuGetTargets>
+  </PropertyGroup>
+  <Import Condition="Exists('$(NuGetTargets)')" Project="$(NuGetTargets)" />
+</Project>

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -21,6 +21,9 @@
       ]
     }
   },
+  "publishOptions": {
+    "include": "14.1/**"
+  },
   "dependencies": {
     "NuGet.Commands": {
       "version": "3.5.0-beta2-1484",


### PR DESCRIPTION
Add Microsoft.NuGet.ImportBefore and ImportAfter files so .nuget.props and .nuget.targets files get picked up invoking 'dotnet build3'.

We currently ship Microsoft.NuGet.props|.targets, but these files are not picked up because nothing is importing them. This change ensures they are imported correctly in 'dotnet build3'.

I also fixed some .xproj and .sln file issues to get our code to work in VS.

/cc @piotrpMSFT @brthor @livarcocc 