### PR TITLE
show absolute path to the publish folder

### DIFF
--- a/src/dotnet/commands/dotnet-publish/PublishCommand.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommand.cs
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.Tools.Publish
 
             RunScripts(context, ScriptNames.PostPublish, contextVariables);
 
-            Reporter.Output.WriteLine($"publish: Published to {outputPath}".Green().Bold());
+            Reporter.Output.WriteLine($"publish: Published to {Path.Combine(ProjectPath, outputPath)}".Green().Bold());
 
             return true;
         }


### PR DESCRIPTION
The output in the console shows the absolute path to the publish folder.

Related issue:
 #3784

