### PR TITLE
Fix invalid json in runtimeconfig

### DIFF
--- a/Documentation/specs/runtime-configuration-file.md
+++ b/Documentation/specs/runtime-configuration-file.md
@@ -36,7 +36,7 @@ The files are both JSON files stored in UTF-8 encoding. Below are sample files. 
         "framework": {
             "name": "Microsoft.DotNetCore",
             "version": "1.0.1"
-        }
+        },
         
         "applyPatches": false
     }


### PR DESCRIPTION
The json in  [appname].runtimeconfig.json example is invalid, this adds the missing `,`

skipciplease ( skipci )