### PR TITLE
Adding publishing variables to the dockerrun.sh file

### DIFF
--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -126,5 +126,8 @@ docker run $INTERACTIVE -t --rm --sig-proxy=true \
     -e NUGET_FEED_URL \
     -e NUGET_API_KEY \
     -e GITHUB_PASSWORD \
+    -e STORAGE_KEY \
+    -e STORAGE_ACCOUNT \
+    -e STORAGE_CONTAINER \
     $DOTNET_BUILD_CONTAINER_TAG \
     $BUILD_COMMAND "$@"


### PR DESCRIPTION
Adding the storage variables to the dockerrun.sh file so that they are set as env variables in docker.

cc @brthor @eerhardt @piotrpMSFT 