### PR TITLE
Add Test for removing readonly flag when copying readonly library assets

### DIFF
--- a/test/Microsoft.DotNet.Compiler.Common.Tests/GivenCommonCompilerOptions.cs
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/GivenCommonCompilerOptions.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.Cli.Compiler.Common.Tests
 {
-    public class Tests : TestBase
+    public class GivenCommonCompilerOptions : TestBase
     {
         [Fact]
         public void SimpleSerialize()

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/GivenThatICopyLibraryAssets.cs
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/GivenThatICopyLibraryAssets.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Xunit;
+using Microsoft.DotNet.Cli.Compiler.Common;
+using Microsoft.DotNet.ProjectModel.Compilation;
+using System.IO;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Microsoft.DotNet.Cli.Compiler.Common.Tests
+{
+    public class GivenThatICopyLibraryAssets
+    {
+        [Fact]
+        public void LibraryAsset_CopyTo_Clears_Readonly()
+        {
+            var libraryAsset = GetMockLibraryAsset(nameof(LibraryAsset_CopyTo_Clears_Readonly));
+            MakeFileReadonly(libraryAsset.ResolvedPath);
+
+            IEnumerable<LibraryAsset> assets = new LibraryAsset[] { libraryAsset };
+
+            var outputDirectory = Path.Combine(AppContext.BaseDirectory,$"{nameof(LibraryAsset_CopyTo_Clears_Readonly)}_out");
+            assets.CopyTo(outputDirectory);
+
+            var copiedFile = Directory.EnumerateFiles(outputDirectory, Path.GetFileName(libraryAsset.RelativePath)).First();
+            FileIsReadonly(copiedFile).Should().BeFalse();
+        }
+
+        [Fact]
+        public void LibraryAsset_StructuredCopyTo_Clears_Readonly()
+        {
+            var libraryAsset = GetMockLibraryAsset(nameof(LibraryAsset_StructuredCopyTo_Clears_Readonly));
+            MakeFileReadonly(libraryAsset.ResolvedPath);
+
+            IEnumerable<LibraryAsset> assets = new LibraryAsset[] { libraryAsset };
+
+            var intermediateDirectory = Path.Combine(AppContext.BaseDirectory,$"{nameof(LibraryAsset_StructuredCopyTo_Clears_Readonly)}_obj");
+            var outputDirectory = Path.Combine(AppContext.BaseDirectory,$"{nameof(LibraryAsset_StructuredCopyTo_Clears_Readonly)}_out");
+            assets.StructuredCopyTo(outputDirectory, intermediateDirectory);
+
+            var copiedFile = Directory.EnumerateFiles(outputDirectory, Path.GetFileName(libraryAsset.RelativePath)).First();
+            FileIsReadonly(copiedFile).Should().BeFalse();
+        }
+
+        private void MakeFileReadonly(string file)
+        {
+            File.SetAttributes(file, File.GetAttributes(file) | FileAttributes.ReadOnly);
+        }
+
+        private bool FileIsReadonly(string file)
+        {
+            return (File.GetAttributes(file) & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
+        }
+
+        private LibraryAsset GetMockLibraryAsset(string mockedLibraryAssetName)
+        {
+            var mockedLibraryAssetFileName = $"{mockedLibraryAssetName}.dll";
+
+            var fakeFile = Path.Combine(AppContext.BaseDirectory, mockedLibraryAssetFileName);
+            File.WriteAllText(fakeFile, mockedLibraryAssetName);
+
+            return new LibraryAsset(mockedLibraryAssetName, mockedLibraryAssetFileName, fakeFile);
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/GivenThatICopyLibraryAssets.cs
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/GivenThatICopyLibraryAssets.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common.Tests
             assets.CopyTo(outputDirectory);
 
             var copiedFile = Directory.EnumerateFiles(outputDirectory, Path.GetFileName(libraryAsset.RelativePath)).First();
-            FileIsReadonly(copiedFile).Should().BeFalse();
+            IsFileReadonly(copiedFile).Should().BeFalse();
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common.Tests
             assets.StructuredCopyTo(outputDirectory, intermediateDirectory);
 
             var copiedFile = Directory.EnumerateFiles(outputDirectory, Path.GetFileName(libraryAsset.RelativePath)).First();
-            FileIsReadonly(copiedFile).Should().BeFalse();
+            IsFileReadonly(copiedFile).Should().BeFalse();
         }
 
         private void MakeFileReadonly(string file)
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Cli.Compiler.Common.Tests
             File.SetAttributes(file, File.GetAttributes(file) | FileAttributes.ReadOnly);
         }
 
-        private bool FileIsReadonly(string file)
+        private bool IsFileReadonly(string file)
         {
             return (File.GetAttributes(file) & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
         }

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/Tests.cs
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/Tests.cs
@@ -5,7 +5,7 @@ using Microsoft.DotNet.ProjectModel;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.DotNet.Cli.Compiler.Common
+namespace Microsoft.DotNet.Cli.Compiler.Common.Tests
 {
     public class Tests : TestBase
     {


### PR DESCRIPTION
Adds unit tests for https://github.com/dotnet/cli/pull/3794

Fixes #3901 

/cc @eerhardt @livarcocc @piotrpMSFT 