### PR TITLE
Performance Fixes 

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Tracing/PerfTraceOutput.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Tracing/PerfTraceOutput.cs
@@ -50,7 +50,8 @@ namespace Microsoft.DotNet.Cli.Utils
                 AppendTime(builder, e.Duration.TotalSeconds / root.Duration.TotalSeconds, 0.2);
             }
             AppendTime(builder, e.Duration.TotalSeconds / parent?.Duration.TotalSeconds, 0.5);
-            builder.Append($"{e.Duration.ToString("ss\\.fff\\s").Blue()}]");
+            builder.Append($"{(int)e.Duration.TotalSeconds}.{e.Duration.Milliseconds:000}s".Blue());
+            builder.Append("]");
         }
 
         private static void AppendTime(StringBuilder builder, double? percent, double treshold)

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -114,14 +114,12 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                     .Select((export, index) => index);
             }
 
-            foreach(var index in _cachedProjectExportIndices)
-            {
-                var export = _cachedExports[index];
-
-                _cachedExports[index] = GenerateExportFromLibrary(_seenMetadataReferences, export.Library);
-            }
-
-            return _cachedExports;
+            return _cachedExports.Select(export =>
+                {
+                    return Equals(export.Library.Identity.Type, LibraryType.Project)
+                        ? GenerateExportFromLibrary(_seenMetadataReferences, export.Library)
+                        : export;
+                });
         }
 
         private IEnumerable<LibraryExport> CalculateAllExports()

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         private HashSet<string> _seenMetadataReferences;
 
         private List<LibraryExport> _cachedExports;
-        private List<int> _projectExportIndices;
+        private IEnumerable<int> _cachedProjectExportIndices;
 
         public LibraryExporter(ProjectDescription rootProject,
             LibraryManager manager,
@@ -121,7 +121,7 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                 _cachedExports[index] = GenerateExportFromLibrary(_seenMetadataReferences, export.Library);
             }
 
-            return refreshedExports;
+            return _cachedExports;
         }
 
         private IEnumerable<LibraryExport> CalculateAllExports()

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -27,6 +27,7 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         private HashSet<string> _seenMetadataReferences;
 
         private List<LibraryExport> _cachedExports;
+        private List<int> _projectExportIndices;
 
         public LibraryExporter(ProjectDescription rootProject,
             LibraryManager manager,
@@ -107,21 +108,17 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
             if (_cachedExports == null)
             {
                 _cachedExports = CalculateAllExports().ToList();
+
+                _cachedProjectExportIndices = _cachedExports
+                    .Where(export => Equals(export.Library.Identity.Type, LibraryType.Project))
+                    .Select((export, index) => index);
             }
 
-            var refreshedExports = new LibraryExport[_cachedExports.Count()];
-
-            int index = 0;
-            foreach (var export in _cachedExports)
+            foreach(var index in _cachedProjectExportIndices)
             {
-                if (Equals(export.Library.Identity.Type, LibraryType.Project))
-                {
-                    refreshedExports[index++] = export;
-                }
-                else
-                {
-                    refreshedExports[index++] = GenerateExportFromLibrary(_seenMetadataReferences, export.Library);
-                }
+                var export = _cachedExports[index];
+
+                _cachedExports[index] = GenerateExportFromLibrary(_seenMetadataReferences, export.Library);
             }
 
             return refreshedExports;

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -115,11 +115,6 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
             int index = 0;
             foreach (var export in _cachedExports)
             {
-                foreach (var reference in export.CompilationAssemblies)
-                {
-                    seenMetadataReferences.Add(reference.Name);
-                }
-
                 if (Equals(export.Library.Identity.Type, LibraryType.Project))
                 {
                     refreshedCache[index++] = GenerateExportFromLibrary(seenMetadataReferences, export.Library);
@@ -129,6 +124,10 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                     refreshedCache[index++] = export;
                 }
 
+                foreach (var reference in export.CompilationAssemblies)
+                {
+                    seenMetadataReferences.Add(reference.Name);
+                }
             }
 
             return refreshedCache;

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -26,7 +26,6 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         private readonly string _solutionRootPath;
 
         private List<LibraryExport> _cachedExports;
-        private IEnumerable<int> _cachedProjectExportIndices;
 
         public LibraryExporter(ProjectDescription rootProject,
             LibraryManager manager,

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -103,13 +103,24 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         {
             if (_cachedExports == null)
             {
-                return (_cachedExports = CalculateAllExports().ToList());
+                _cachedExports = CalculateAllExports().ToList();
             }
 
-            var nonProjectExports = _cachedExports.Where(export => !Equals(export.Library.Identity.Type, LibraryType.Project));
-            var projectExports = _cachedExports.Where(export => Equals(export.Library.Identity.Type, LibraryType.Project));
-            var refreshedProjectExports = projectExports.Select(export => GenerateExportFromLibrary(_seenMetadataReferences, export.Library));
+            var refreshedExports = new string[_cachedExports.Count()];
 
+            int index = 0;
+            foreach (var export in _cachedExports)
+            {
+                if (Equals(export.Library.Identity.Type, LibraryType.Project))
+                {
+                    refreshedExports[index++] = export;
+                }
+                else
+                {
+                    refreshedExports[index++] = GenerateExportFromLibrary(_seenMetadataReferences, export.Library);
+                }
+            }
+            
             return nonProjectExports.Concat(refreshedProjectExports);
         }
 

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -86,9 +86,9 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         /// </summary>
         private IEnumerable<LibraryExport> ExportLibraries(Func<LibraryDescription, bool> condition)
         {
-            IEnumerable<LibraryExport> exports = _cachedExports ?? (_cachedExports = CalculateAllExports().ToArray());
+            _cachedExports = _cachedExports ?? CalculateAllExports().ToArray();
 
-            foreach (var export in exports)
+            foreach (var export in _cachedExports)
             {
                 if (!condition(export.Library))
                 {

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         private readonly ProjectDescription _rootProject;
         private readonly string _buildBasePath;
         private readonly string _solutionRootPath;
+
         private IEnumerable<LibraryExport> _cachedExports;
 
         public LibraryExporter(ProjectDescription rootProject,
@@ -85,11 +86,9 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         /// </summary>
         private IEnumerable<LibraryExport> ExportLibraries(Func<LibraryDescription, bool> condition)
         {
-            if (_cachedExports == null)
-            {
-                _cachedExports =  GetAllExportsImpl().ToArray();
-            }
-            foreach (var export in _cachedExports)
+            IEnumerable<LibraryExport> exports = _cachedExports ?? (_cachedExports = CalculateAllExports().ToArray());
+
+            foreach (var export in exports)
             {
                 if (!condition(export.Library))
                 {
@@ -99,11 +98,9 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
             }
         }
 
-        private IEnumerable<LibraryExport> GetAllExportsImpl()
+        private IEnumerable<LibraryExport> CalculateAllExports()
         {
-            using (PerfTrace.Current.CaptureTiming())
-            {
-                var seenMetadataReferences = new HashSet<string>();
+            var seenMetadataReferences = new HashSet<string>();
 
             // Iterate over libraries in the library manager
             foreach (var library in LibraryManager.GetLibraries())

--- a/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Compilation/LibraryExporter.cs
@@ -87,6 +87,9 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
         /// </summary>
         private IEnumerable<LibraryExport> ExportLibraries(Func<LibraryDescription, bool> condition)
         {
+            // Project Exports cannot be cached because the binding redirect file
+            // for desktop apps is not added to runtimeassets of the project
+            // until after the project is built.
             var cache = GetCacheWithRefreshedProjectExports();
 
             foreach (var export in cache)
@@ -106,7 +109,7 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                 _cachedExports = CalculateAllExports().ToList();
             }
 
-            var refreshedExports = new string[_cachedExports.Count()];
+            var refreshedExports = new LibraryExport[_cachedExports.Count()];
 
             int index = 0;
             foreach (var export in _cachedExports)
@@ -120,8 +123,8 @@ namespace Microsoft.DotNet.ProjectModel.Compilation
                     refreshedExports[index++] = GenerateExportFromLibrary(_seenMetadataReferences, export.Library);
                 }
             }
-            
-            return nonProjectExports.Concat(refreshedProjectExports);
+
+            return refreshedExports;
         }
 
         private IEnumerable<LibraryExport> CalculateAllExports()

--- a/src/Microsoft.DotNet.ProjectModel/Files/PatternGroup.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Files/PatternGroup.cs
@@ -8,11 +8,14 @@ using System.Linq;
 using Microsoft.DotNet.ProjectModel.FileSystemGlobbing;
 using Newtonsoft.Json.Linq;
 
+using FourStringTuple = System.Tuple<string, string, string, string>;
+
 namespace Microsoft.DotNet.ProjectModel.Files
 {
     public class PatternGroup
     {
-        private static readonly Dictionary<string, IEnumerable<string>> s_resolvedFilesCache = new Dictionary<string, IEnumerable<string>>();
+        private static readonly Dictionary<FourStringTuple, IEnumerable<string>> s_resolvedFilesCache = 
+            new Dictionary<FourStringTuple, IEnumerable<string>>();
         
         private readonly List<PatternGroup> _excludeGroups = new List<PatternGroup>();
         private readonly Matcher _matcher = new Matcher();
@@ -84,10 +87,10 @@ namespace Microsoft.DotNet.ProjectModel.Files
 
         public IEnumerable<string> SearchFiles(string rootDirectory)
         {
-            var patternUnionKey = rootDirectory
-                + (IncludePatterns.Any() ? " ++ " + string.Join(", ", IncludePatterns): "")
-                + (IncludeLiterals.Any() ? " + " + string.Join(", ", IncludeLiterals) : "")
-                + (ExcludePatterns.Any() ? " -- " + string.Join(", ", ExcludePatterns) : "");
+            var patternUnionKey = new FourStringTuple(rootDirectory, 
+                (IncludePatterns.Any() ? string.Join(", ", IncludePatterns): ""),
+                (IncludeLiterals.Any() ? string.Join(", ", IncludeLiterals) : ""),
+                (ExcludePatterns.Any() ? string.Join(", ", ExcludePatterns) : ""));
 
             IEnumerable<string> resolvedFiles;
             lock (s_resolvedFilesCache)
@@ -153,6 +156,14 @@ namespace Microsoft.DotNet.ProjectModel.Files
         public override string ToString()
         {
             return string.Format("Pattern group: Literals [{0}] Includes [{1}] Excludes [{2}]", string.Join(", ", IncludeLiterals), string.Join(", ", IncludePatterns), string.Join(", ", ExcludePatterns));
+        }
+
+        public static void ClearCache()
+        {
+            if (s_resolvedFilesCache != null)
+            {
+                s_resolvedFilesCache.Clear();
+            }
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.ProjectModel
     public class ProjectContext
     {
         private string[] _runtimeFallbacks;
+        private LibraryExporter _exporter;
 
         public ProjectContextIdentity Identity { get; }
 
@@ -71,12 +72,16 @@ namespace Microsoft.DotNet.ProjectModel
 
         public LibraryExporter CreateExporter(string configuration, string buildBasePath = null)
         {
+            if (_exporter != null)
+            {
+                return _exporter;
+            }
             if (IsPortable && RuntimeIdentifier != null && _runtimeFallbacks == null)
             {
                 var graph = RuntimeGraphCollector.Collect(LibraryManager.GetLibraries());
                 _runtimeFallbacks = graph.ExpandRuntime(RuntimeIdentifier).ToArray();
             }
-            return new LibraryExporter(RootProject,
+            return _exporter = new LibraryExporter(RootProject,
                 LibraryManager,
                 configuration,
                 RuntimeIdentifier,

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -14,8 +14,8 @@ namespace Microsoft.DotNet.ProjectModel
 {
     public class ProjectContext
     {
-        private readonly Dictionary<Tuple<string, string>, LibraryExporter> _cachedExporters = 
-            new Dictionary<Tuple<string, string>, LibraryExporter>();
+        private readonly Dictionary<Tuple<string, string, string>, LibraryExporter> _cachedExporters = 
+            new Dictionary<Tuple<string, string, string>, LibraryExporter>();
         
         private string[] _runtimeFallbacks;
 
@@ -75,7 +75,10 @@ namespace Microsoft.DotNet.ProjectModel
         public LibraryExporter CreateExporter(string configuration, string buildBasePath = null)
         {
             LibraryExporter exporter;
-            var libraryExporterCacheKey = Tuple.Create(configuration ?? "" , buildBasePath ?? "");
+            var libraryExporterCacheKey = Tuple.Create(
+                configuration ?? "", 
+                buildBasePath ?? "",
+                RootDirectory);
 
             if (_cachedExporters.TryGetValue(libraryExporterCacheKey, out exporter))
             {

--- a/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectContext.cs
@@ -14,7 +14,8 @@ namespace Microsoft.DotNet.ProjectModel
 {
     public class ProjectContext
     {
-        private readonly Dictionary<string, LibraryExporter> _cachedExporters = new Dictionary<string, LibraryExporter>();
+        private readonly Dictionary<Tuple<string, string>, LibraryExporter> _cachedExporters = 
+            new Dictionary<Tuple<string, string>, LibraryExporter>();
         
         private string[] _runtimeFallbacks;
 
@@ -74,7 +75,7 @@ namespace Microsoft.DotNet.ProjectModel
         public LibraryExporter CreateExporter(string configuration, string buildBasePath = null)
         {
             LibraryExporter exporter;
-            var libraryExporterCacheKey = "+ " + (configuration ?? "") + " - " + (buildBasePath ?? "");
+            var libraryExporterCacheKey = Tuple.Create(configuration ?? "" , buildBasePath ?? "");
 
             if (_cachedExporters.TryGetValue(libraryExporterCacheKey, out exporter))
             {

--- a/src/Microsoft.DotNet.ProjectModel/ProjectModelPlatformExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectModelPlatformExtensions.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Microsoft.DotNet.ProjectModel.Compilation;
 using Microsoft.DotNet.ProjectModel.Graph;
-using Microsoft.DotNet.Cli.Utils;
 using System;
 
 namespace Microsoft.DotNet.ProjectModel

--- a/src/Microsoft.DotNet.ProjectModel/ProjectModelPlatformExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectModelPlatformExtensions.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Microsoft.DotNet.ProjectModel.Compilation;
 using Microsoft.DotNet.ProjectModel.Graph;
-using System;
 
 namespace Microsoft.DotNet.ProjectModel
 {
@@ -29,11 +28,12 @@ namespace Microsoft.DotNet.ProjectModel
             foreach (var dependency in dependencies)
             {
                 var export = exports[dependency.Name];
-                if (export.Library.Identity.Version.Equals(dependency.VersionRange.MinVersion) 
-                    && !exclusionList.Contains(dependency.Name))
+                if (export.Library.Identity.Version.Equals(dependency.VersionRange.MinVersion))
                 {
-                    exclusionList.Add(export.Library.Identity.Name);
-                    CollectDependencies(exports, export.Library.Dependencies, exclusionList);
+                    if (exclusionList.Add(export.Library.Identity.Name))
+                    {
+                        CollectDependencies(exports, export.Library.Dependencies, exclusionList);
+                    }
                 }
             }
         }

--- a/src/dotnet/commands/dotnet-projectmodel-server/InternalModels/ProjectContextSnapshot.cs
+++ b/src/dotnet/commands/dotnet-projectmodel-server/InternalModels/ProjectContextSnapshot.cs
@@ -26,6 +26,9 @@ namespace Microsoft.DotNet.ProjectModel.Server
 
         public static ProjectContextSnapshot Create(ProjectContext context, string configuration, IEnumerable<string> previousSearchPaths)
         {
+            // Clear cached file glob results
+            PatternGroup.ClearCache();
+
             var snapshot = new ProjectContextSnapshot();
 
             var allDependencyDiagnostics = new List<DiagnosticMessage>();
@@ -78,6 +81,9 @@ namespace Microsoft.DotNet.ProjectModel.Server
 
         private static IEnumerable<string> GetSourceFiles(ProjectContext context, string configuration)
         {
+            // Clear cached glob results
+            PatternGroup.ClearCache();
+
             var compilerOptions = context.ProjectFile.GetCompilerOptions(context.TargetFramework, configuration);
 
             if (compilerOptions.CompileInclude == null)

--- a/test/Microsoft.DotNet.ProjectModel.Tests/GivenAProjectContext.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/GivenAProjectContext.cs
@@ -1,0 +1,72 @@
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.ProjectModel.Compilation;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.ProjectModel.Tests
+{
+    public class GivenAProjectContext : TestBase
+    {
+        [Fact]
+        public void It_caches_library_exporter_when_configuration_and_buildBasePath_keep_value()
+        {
+            var projectContext = GetProjectContext();
+
+            var configurations = new string[] { "TestConfig", "TestConfig", "TestConfig2", "TestConfig2" };
+            var buildBasePaths = new string[] { null, AppContext.BaseDirectory, null, AppContext.BaseDirectory };
+
+            for(int i=0; i<configurations.Length; ++i)
+            {
+                var configuration = configurations[i];
+                var buildBasePath = buildBasePaths[i];
+
+                var exporter1 = projectContext.CreateExporter(configuration, buildBasePath);
+                var exporter2 = projectContext.CreateExporter(configuration, buildBasePath);
+
+                ReferenceEquals(exporter1, exporter2).Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void It_does_not_cache_library_exporter_when_configuration_or_buildBasePath_changes()
+        {
+            var projectContext = GetProjectContext();
+
+            var configurations = new string[] { "TestConfig", "TestConfig", "TestConfig2", "TestConfig2" };
+            var buildBasePaths = new string[] { null, AppContext.BaseDirectory, null, AppContext.BaseDirectory };
+            var previousExporters = new List<LibraryExporter>();
+
+            for(int i=0; i<configurations.Length; ++i)
+            {
+                var configuration = configurations[i];
+                var buildBasePath = buildBasePaths[i];
+                var exporter = projectContext.CreateExporter(configuration, buildBasePath);
+
+                foreach (var previousExporter in previousExporters)
+                {
+                    ReferenceEquals(exporter, previousExporter).Should().BeFalse();
+                }
+
+                previousExporters.Add(exporter);
+            }
+        }
+
+        private ProjectContext GetProjectContext()
+        {
+            var testInstance = TestAssetsManager.CreateTestInstance("TestAppSimple")
+                                                .WithLockFiles();
+
+            return ProjectContext.Create(testInstance.TestRoot, FrameworkConstants.CommonFrameworks.NetCoreApp10);
+        }
+    }
+}

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -21,7 +21,8 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
+    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
+    "NuGet.Frameworks": "3.5.0-beta2-1484"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.Extensions.DependencyModel.Tests/FunctionalTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/FunctionalTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.DependencyModel
             {
                 if (Directory.Exists(Path.Combine(rootPath, dir)))
                 {
-                    Directory.Delete(Path.Combine(rootPath, dir));
+                    Directory.Delete(Path.Combine(rootPath, dir), true);
                 }
             }
         }

--- a/test/Microsoft.Extensions.DependencyModel.Tests/FunctionalTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/FunctionalTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Extensions.DependencyModel
 
         private void CleanBinObj(string rootPath)
         {
-            var dirs = new string{} ["bin", "obj"];
+            var dirs = new string[] {"bin", "obj"};
 
             foreach (var dir in dirs)
             {

--- a/test/Microsoft.Extensions.DependencyModel.Tests/FunctionalTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/FunctionalTests.cs
@@ -30,6 +30,8 @@ namespace Microsoft.Extensions.DependencyModel
             var testProjectPath = Path.Combine(RepoRoot, "TestAssets", "TestProjects", "DependencyContextValidator", appname);
             var testProject = Path.Combine(testProjectPath, "project.json");
 
+            CleanBinObj(testProjectPath);
+
             var runCommand = new RunCommand(testProject);
             var result = runCommand.ExecuteWithCapturedOutput();
             result.Should().Pass();
@@ -50,6 +52,8 @@ namespace Microsoft.Extensions.DependencyModel
             var testProjectPath = Path.Combine(RepoRoot, "TestAssets", "TestProjects", "DependencyContextValidator", appname);
             var testProject = Path.Combine(testProjectPath, "project.json");
 
+            CleanBinObj(testProjectPath);
+
             var publishCommand = new PublishCommand(testProject);
             publishCommand.Execute().Should().Pass();
 
@@ -69,6 +73,8 @@ namespace Microsoft.Extensions.DependencyModel
             var testProjectPath = Path.Combine(RepoRoot, "TestAssets", "TestProjects", "DependencyContextValidator", "TestAppFullClr");
             var testProject = Path.Combine(testProjectPath, "project.json");
 
+            CleanBinObj(testProjectPath);
+
             var runCommand = new RunCommand(testProject);
             var result = runCommand.ExecuteWithCapturedOutput();
             result.Should().Pass();
@@ -82,12 +88,27 @@ namespace Microsoft.Extensions.DependencyModel
             var testProjectPath = Path.Combine(RepoRoot, "TestAssets", "TestProjects", "DependencyContextValidator", "TestAppFullClr");
             var testProject = Path.Combine(testProjectPath, "project.json");
 
+            CleanBinObj(testProjectPath);
+
             var publishCommand = new PublishCommand(testProject);
             publishCommand.Execute().Should().Pass();
 
             var result = TestExecutable(publishCommand.GetOutputDirectory().FullName, publishCommand.GetOutputExecutable(), string.Empty);
             ValidateRuntimeLibrariesFullClr(result, "TestAppFullClr");
             ValidateCompilationLibrariesFullClr(result, "TestAppFullClr");
+        }
+
+        private void CleanBinObj(string rootPath)
+        {
+            var dirs = new string{} ["bin", "obj"];
+
+            foreach (var dir in dirs)
+            {
+                if (Directory.Exists(Path.Combine(rootPath, dir)))
+                {
+                    Directory.Delete(Path.Combine(rootPath, dir));
+                }
+            }
         }
 
         private void ValidateRuntimeLibrariesFullClr(CommandResult result, string appname)


### PR DESCRIPTION
Fixed Conflicts/Refactored/Fixed bugs on a commit from @pakrym:
https://github.com/dotnet/cli/issues/3839
https://github.com/dotnet/cli/issues/3840

Added Tests for https://github.com/dotnet/cli/issues/3839

Last commit fixes https://github.com/dotnet/cli/issues/3841
GetTypeBuildExclusion list optimized by enforcing a single visit of each node in the dependency graph, using an iterative rather than recursive graph walk, and replacing the set difference operations with a graph subset search. 

Performance increased by `.4s` on my macbook. 
Also optimized GetPlatformExclusionList graph walk by enforcing single node visit. 

Performance Data OLD:
```
Performance Summary:
[100.00% 2.392s] Thread 1
  [99.97% 99.97% 2.392s] Program:Main
    [00.28% 00.28% 0.006s] Program:ConfigureDotNetForFirstTimeUse
    [09.62% 09.62% 0.230s] Program:ResolveRootContexts
      [03.27% 33.99% 0.078s] Program:Loading project.json /Users/brthor/code/test/new/project.json
      [06.28% 65.22% 0.150s] Program:Waiting for project contexts to finish loading
    [00.13% 00.13% 0.003s] Program:Collect graph
    [88.87% 88.90% 2.126s] ProjectBuilder:Build new
      [01.43% 01.61% 0.034s] ProjectBuilder:HasSourceFiles new
      [02.21% 02.48% 0.052s] ProjectBuilder:NeedsRebuilding new
      [81.96% 92.22% 1.961s] ProjectBuilder:RunCompile new
        [19.86% 24.23% 0.475s] ProjectModelPlatformExtensions:GetTypeBuildExclusionList
          [19.84% 99.90% 0.474s] ProjectModelPlatformExtensions:GetTypeBuildExclusionList-marknonbuild
        [47.61% 58.09% 1.139s] Command:Execute dotnet /Users/brthor/code/cli/artifacts/osx.10.11-x64/stage2/sdk/1.0.0-featantares-003217/csc.dll -noconfig @/Users/brthor/code/test/new/obj/Debug/netcoreapp1.0/dotnet-compile-csc.rsp
      [01.51% 01.69% 0.036s] ProjectModelPlatformExtensions:platform exclusion
```

NEW 

```
Performance Summary:
[100.00% 1.891s] Thread 1
  [99.85% 99.85% 1.888s] Program:Main
    [00.40% 00.40% 0.007s] Program:ConfigureDotNetForFirstTimeUse
    [11.20% 11.22% 0.211s] Program:ResolveRootContexts
      [03.78% 33.78% 0.071s] Program:Loading project.json /Users/brthor/code/test/new/project.json
      [07.33% 65.47% 0.138s] Program:Waiting for project contexts to finish loading
    [00.15% 00.15% 0.002s] Program:Collect graph
    [86.56% 86.69% 1.637s] ProjectBuilder:Build new
      [01.81% 02.09% 0.034s] ProjectBuilder:HasSourceFiles new
      [03.07% 03.54% 0.057s] ProjectBuilder:NeedsRebuilding new
      [79.10% 91.38% 1.495s] ProjectBuilder:RunCompile new
        [60.08% 75.96% 1.136s] Command:Execute dotnet /Users/brthor/code/cli/artifacts/osx.10.11-x64/stage2/sdk/1.0.0-featantares-003217/csc.dll -noconfig @/Users/brthor/code/test/new/obj/Debug/netcoreapp1.0/dotnet-compile-csc.rsp
```

/cc @pakrym @anurse @eerhardt @piotrpMSFT 