### PR TITLE
Update cshtml wildcard in publishOptions

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
@@ -94,7 +94,7 @@
   "publishOptions": {
     "include": [
       "wwwroot",
-      "Views",
+      "**/*.cshtml",
       "appsettings.json",
       "web.config"
     ]


### PR DESCRIPTION
Fix issue #3949

Updating the publishOptions wildcard that used to publish everything in
the views folder to now publish all .cshtml files. The problem was that
the old wildcard only included the Views folder and didn't include
anything in the Areas/*/Views folders (used by views inside areas).

This change makes things much simpler, all .csthml files are published.