### PR TITLE
Fix publish

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -18,8 +18,8 @@
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
     <CLIBuildFileName>$(RepoRoot)/build_projects/dotnet-cli-build/bin/dotnet-cli-build</CLIBuildFileName>
     <CLIBuildDll>$(CLIBuildFileName).dll</CLIBuildDll>
-    <BuildToolsDir>$(RepoRoot)/build_tools</BuildToolsDir>
-    <ToolsDir>$(BuildToolsDir)</ToolsDir>
+    <BuildToolsDir>$(RepoRoot)/build_tools/</BuildToolsDir>
+    <ToolsDir>$(BuildToolsDir)/</ToolsDir>
 
     <CoreSetupChannel>preview</CoreSetupChannel>
     <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>

--- a/build.proj
+++ b/build.proj
@@ -81,6 +81,7 @@
 
   <Target DependsOnTargets="$(CLITargets)" Name="BuildTheWholeCli"></Target>
 
+  <Import Project="$(BuildToolsDir)/Build.Common.targets" />
   <Import Project="build/Microsoft.DotNet.Cli.Prepare.targets" />
   <Import Project="build/Microsoft.DotNet.Cli.Compile.targets" />
   <Import Project="build/Microsoft.DotNet.Cli.Package.targets" />

--- a/build/Microsoft.DotNet.Cli.Publish.targets
+++ b/build/Microsoft.DotNet.Cli.Publish.targets
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(BuildToolsDir)/PublishContent.targets" />
+  <Import Project="$(BuildToolsDir)PublishContent.targets" />
   <Import Project="$(MSBuildThisFileDirectory)/publish/Microsoft.DotNet.Cli.Badge.targets" />
 
-  <UsingTask TaskName="UploadToAzure" AssemblyFile="$(BuildToolsTaskDir)/Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="UploadToAzure" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
   <UsingTask TaskName="FinalizeBuild" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="SetBlobPropertiesBasedOnFileType" AssemblyFile="$(CLIBuildDll)" />
 

--- a/build/Microsoft.DotNet.Cli.tasks
+++ b/build/Microsoft.DotNet.Cli.tasks
@@ -23,7 +23,7 @@
   <UsingTask TaskName="SetEnvVar" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="TarGzFileCreateFromDirectory" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="TarGzFileExtractToDirectory" AssemblyFile="$(CLIBuildDll)" />
-  <UsingTask TaskName="UploadToAzure" AssemblyFile="$(BuildToolsTaskDir)/Microsoft.DotNet.Build.CloudTestTasks.dll"/>
-  <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(BuildToolsDir)/Microsoft.DotNet.Build.Tasks.dll"/>
-  <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsDir)/Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="UploadToAzure" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.CloudTestTasks.dll"/>
+  <UsingTask TaskName="ZipFileCreateFromDirectory" AssemblyFile="$(BuildToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="ZipFileExtractToDirectory" AssemblyFile="$(BuildToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
 </Project>


### PR DESCRIPTION
We needed to import Build.Common.targets. as it is a requirement for BuildTools.

Also, needed to fix the way we do paths by having the trailing slash in the path definition instead of in the target file property definition. I only fixed this for the paths that were related to publish, but we should probably to that for everything. Right now, I am not doing that to unblock Publishing, as it has been broken for a while.

cc @eerhardt @piotrpMSFT @brthor 