### PR TITLE
Add netstandard1.3 TFM to DependencyModel

### DIFF
--- a/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
+++ b/src/Microsoft.Extensions.DependencyModel/CompilationLibrary.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Extensions.DependencyModel
 
         public IReadOnlyList<string> Assemblies { get; }
 
+#if !NETSTANDARD1_3
         internal static ICompilationAssemblyResolver DefaultResolver { get; } = new CompositeCompilationAssemblyResolver(new ICompilationAssemblyResolver[]
         {
             new PackageCacheCompilationAssemblyResolver(),
@@ -45,5 +46,7 @@ namespace Microsoft.Extensions.DependencyModel
             }
             return assemblies;
         }
+#endif
+
     }
 }

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContext.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContext.cs
@@ -10,7 +10,9 @@ namespace Microsoft.Extensions.DependencyModel
 {
     public class DependencyContext
     {
+#if !NETSTANDARD1_3
         private static readonly Lazy<DependencyContext> _defaultContext = new Lazy<DependencyContext>(LoadDefault);
+#endif
 
         public DependencyContext(TargetInfo target,
             CompilationOptions compilationOptions,
@@ -46,7 +48,9 @@ namespace Microsoft.Extensions.DependencyModel
             RuntimeGraph = runtimeGraph.ToArray();
         }
 
+#if !NETSTANDARD1_3
         public static DependencyContext Default => _defaultContext.Value;
+#endif
 
         public TargetInfo Target { get; }
 
@@ -74,6 +78,7 @@ namespace Microsoft.Extensions.DependencyModel
                 );
         }
 
+#if !NETSTANDARD1_3
         private static DependencyContext LoadDefault()
         {
             return DependencyContextLoader.Default.Load(Assembly.GetEntryAssembly());
@@ -83,6 +88,7 @@ namespace Microsoft.Extensions.DependencyModel
         {
             return DependencyContextLoader.Default.Load(assembly);
         }
+#endif
 
         private class LibraryMergeEqualityComparer<T> : IEqualityComparer<T> where T : Library
         {

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextLoader.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextLoader.cs
@@ -7,6 +7,8 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.EnvironmentAbstractions;
 
+#if !NETSTANDARD1_3
+
 namespace Microsoft.Extensions.DependencyModel
 {
     public class DependencyContextLoader
@@ -131,3 +133,5 @@ namespace Microsoft.Extensions.DependencyModel
         }
     }
 }
+
+#endif

--- a/src/Microsoft.Extensions.DependencyModel/DependencyContextPaths.cs
+++ b/src/Microsoft.Extensions.DependencyModel/DependencyContextPaths.cs
@@ -1,5 +1,7 @@
 using System;
 
+#if !NETSTANDARD1_3
+
 namespace Microsoft.Extensions.DependencyModel
 {
     internal class DependencyContextPaths
@@ -31,7 +33,7 @@ namespace Microsoft.Extensions.DependencyModel
                 files != null && files.Length > 0 ? files[0] : null,
                 files != null && files.Length > 1 ? files[1] : null
                 );
-
         }
     }
 }
+#endif

--- a/src/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
+++ b/src/Microsoft.Extensions.DependencyModel/Resolution/AppBaseCompilationAssemblyResolver.cs
@@ -7,6 +7,8 @@ using System.IO;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.Extensions.EnvironmentAbstractions;
 
+#if !NETSTANDARD1_3
+
 namespace Microsoft.Extensions.DependencyModel.Resolution
 {
     public class AppBaseCompilationAssemblyResolver : ICompilationAssemblyResolver
@@ -115,3 +117,5 @@ namespace Microsoft.Extensions.DependencyModel.Resolution
         }
     }
 }
+
+#endif

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -13,6 +13,14 @@
   },
   "frameworks": {
     "net451": {},
+    "netstandard1.3": {
+      "imports": "portable-net45+wp80+win8+wpa81+dnxcore50",
+      "dependencies": {
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Dynamic.Runtime": "4.0.11",
+        "System.Linq": "4.1.0"
+      }
+    },
     "netstandard1.6": {
       "imports": "portable-net45+wp80+win8+wpa81+dnxcore50",
       "dependencies": {


### PR DESCRIPTION
So the MSBuild task can target netstandard1.3 and still use it to write the .deps.json file.

@pakrym @livarcocc 

/cc @brthor @piotrpMSFT 