### PR TITLE
Add support for user runtimeconfig

### DIFF
--- a/src/Microsoft.DotNet.Core.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
+++ b/src/Microsoft.DotNet.Core.Build.Tasks/GenerateRuntimeConfigurationFiles.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
 
         public string RuntimeConfigDevPath { get; set; }
 
-        public string RawRuntimeOptions { get; set; }
+        public string UserRuntimeConfig { get; set; }
 
         private LockFile LockFile { get; set; }
 
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             config.RuntimeOptions = new RuntimeOptions();
 
             AddFramework(config.RuntimeOptions);
-            AddRuntimeOptions(config.RuntimeOptions);
+            AddUserRuntimeOptions(config.RuntimeOptions);
 
             WriteToJsonFile(RuntimeConfigPath, config);
         }
@@ -76,14 +76,16 @@ namespace Microsoft.DotNet.Core.Build.Tasks
             }
         }
 
-        private void AddRuntimeOptions(RuntimeOptions runtimeOptions)
+        private void AddUserRuntimeOptions(RuntimeOptions runtimeOptions)
         {
-            if (string.IsNullOrEmpty(RawRuntimeOptions))
+            if (string.IsNullOrEmpty(UserRuntimeConfig) || !File.Exists(UserRuntimeConfig))
             {
                 return;
             }
 
-            var runtimeOptionsFromProject = JObject.Parse(RawRuntimeOptions);
+            var rawRuntimeOptions = File.ReadAllText(UserRuntimeConfig);
+
+            var runtimeOptionsFromProject = JObject.Parse(rawRuntimeOptions);
             foreach (var runtimeOption in runtimeOptionsFromProject)
             {
                 runtimeOptions.RawOptions.Add(runtimeOption.Key, runtimeOption.Value);

--- a/src/dotnet/Microsoft.DotNet.Core.Sdk.targets
+++ b/src/dotnet/Microsoft.DotNet.Core.Sdk.targets
@@ -7,7 +7,7 @@
 
 	<!-- If the build task directory doesn't exist (since we aren't in a NuGet package), load the task assembly in the tools path -->
     <MicrosoftDotNetCoreBuildTasksDirectory Condition=" !Exists('$(MicrosoftDotNetCoreBuildTasksDirectory)') ">$(MSBuildToolsPath)/</MicrosoftDotNetCoreBuildTasksDirectory>
-</PropertyGroup>
+  </PropertyGroup>
 
   <PropertyGroup>
     <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two
@@ -20,6 +20,7 @@
 
   <PropertyGroup>
     <GenerateRuntimeConfigurationFiles Condition=" '$(GenerateRuntimeConfigurationFiles)' == '' and '$(OutputType)' == 'exe' ">true</GenerateRuntimeConfigurationFiles>
+    <UserRuntimeConfig Condition=" '$(UserRuntimeConfig)' == '' ">$(MSBuildProjectDirectory)/runtimeconfig.template.json</UserRuntimeConfig>
     <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">1.0.0</VersionPrefix>
     <VersionSuffix Condition=" '$(VersionSuffix)' == '' "></VersionSuffix>
     <Version Condition=" '$(Version)' == '' and '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
@@ -63,13 +64,10 @@
   <Target Name="GenerateRuntimeConfigurationFiles"
         Condition=" '$(GenerateRuntimeConfigurationFiles)' == 'true'">
 
-    <!--
-    TODO: Get RawRuntimeOptions from where it lives in the MSBuild world
-    -->
     <GenerateRuntimeConfigurationFiles LockFilePath="$(MSBuildProjectDirectory)/project.lock.json"
                                        RuntimeConfigPath="$(TargetDir)/$(AssemblyName).runtimeconfig.json"
                                        RuntimeConfigDevPath="$(TargetDir)/$(AssemblyName).runtimeconfig.dev.json"
-                                       RawRuntimeOptions="" />
+                                       UserRuntimeConfig="$(UserRuntimeConfig)" />
 
   </Target>
 


### PR DESCRIPTION
@eerhardt @piotrpMSFT @livarcocc 

We'll need this for migration. 

This adds runtimeconfig.template.json in the user's project directory as an optional/overridable location for placing the equivalent of runtimeOptions in `project.json` today.

I was unable to use the RawRuntimeOptions @eerhardt because reading files in msbuild produces an item for each line, which is difficult to parse into json.

