### PR TITLE
Pass debugType thru to the command line compiler

### DIFF
--- a/src/dotnet/commands/dotnet-compile-csc/Program.cs
+++ b/src/dotnet/commands/dotnet-compile-csc/Program.cs
@@ -198,19 +198,17 @@ namespace Microsoft.DotNet.Tools.Compiler.Csc
                 commonArgs.Add("-t:library");
             }
 
+            string debugType;
             if (string.IsNullOrEmpty(options.DebugType))
             {
-                commonArgs.Add(RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                    ? "-debug:full"
-                    : "-debug:portable");
+                debugType = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "full" : "portable";
             }
             else
             {
-                commonArgs.Add(options.DebugType == "portable"
-                    ? "-debug:portable"
-                    : "-debug:full");
+                debugType = options.DebugType;
             }
 
+            commonArgs.Add("-debug:" + debugType);
             return commonArgs;
         }
 


### PR DESCRIPTION
dotnet cli shouldn't automatically treat invalid value of "debugType" project setting as "full". Instead it should either pass the value as is to the compiler, which already reports a good error message (this PR), or report error itself.

This change indirectly enables "debugType" to be "embedded". See https://github.com/dotnet/roslyn/issues/12390 for background. 

