### PR TITLE
Fix for #4018

### DIFF
--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -227,6 +227,9 @@
       <Delete Files="@(PdbsToClean)" />
 
       <!-- workaround for https://github.com/Microsoft/msbuild/issues/872 -->
+      <Copy SourceFiles="$(MSBuildTargetsDirectory)/MSBuild.exe"
+            DestinationFiles="$(SdkOutputDirectory)/MSBuild.exe" />
+
       <Copy SourceFiles="$(RepoRoot)/resources/MSBuild.exe.config"
             DestinationFiles="$(SdkOutputDirectory)/MSBuild.exe.config" />
 


### PR DESCRIPTION
#4018 broke Stage0 because Microsoft.Build.dll expects to find MSBuild.exe next to itself. This is a temporary workaround which bin-places MSBuild.exe into the root directory, unblocking MSBuild. Once this change is in it will again break Stage 0 because the stage0  version of Microsoft.Build.dll now has a higher assembly version number. Once that Stage 0 is in place I will follow up with another PR which rev's the dependencies of the build project and thereby stabilize Stage0.