### PR TITLE
multi-proc test execution

### DIFF
--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -5,14 +5,14 @@
 
   <PropertyGroup>
     <BinaryToCorehostifyRelDir>runtimes/any/native</BinaryToCorehostifyRelDir>
-    <CoreSDKDir>$(RepoRoot)/resources/MSBuildImports</CoreSDKDir>
+    <MSBuildImportsDir>$(RepoRoot)/resources/MSBuildImports</MSBuildImportsDir>
   </PropertyGroup>
 
   <ItemGroup>
     <PublishOutputExtensions Include="$(ExeExtension);.dll;.pdb;.deps.json;.runtimeconfig.json" />
     <FilesToMove Include="$(BinaryToCorehostifyRelDir)/csc.exe;$(BinaryToCorehostifyRelDir)/MSBuild.exe;" />
     <BundledTools Include="csc;MSBuild;NuGet.CommandLine.XPlat;dotnet" />
-    <CoreSDKContent Include="$(CoreSDKDir)/**/*" />
+    <MSBuildImportsContent Include="$(MSBuildImportsDir)/**/*" />
   </ItemGroup>
 
   <Target Name="Compile" DependsOnTargets="Prepare;
@@ -165,7 +165,7 @@
             DestinationFiles="$(SdkOutputDirectory)/$(HostPolicyBaseName)" />
 
       <!-- copy core sdk -->
-      <Copy SourceFiles="@(CoreSDKContent)"
+      <Copy SourceFiles="@(MSBuildImportsContent)"
             DestinationFolder="$(SdkOutputDirectory)/%(RecursiveDir)" />
 
       <!-- Crossgen the Shared Framework -->

--- a/build/Microsoft.DotNet.Cli.Test.targets
+++ b/build/Microsoft.DotNet.Cli.Test.targets
@@ -10,7 +10,7 @@
   <Import Project="test/TestAssetProjects.targets" />
   <Import Project="test/TestProjects.targets" />
 
-  <Target Name="Test" 
+  <Target Name="Test"
           DependsOnTargets="PrepareTests;
                             BuildTestAssets;
                             BuildTests;">
@@ -27,13 +27,28 @@
       <TestTaskEnvironmentVariables Include="TEST_ARTIFACTS=$(TestArtifactsEnv)" />
     </ItemGroup>
 
-    <DotNetTest WorkingDirectory="%(TestProjects.ProjectDir)"
-                EnvironmentVariables="@(TestTaskEnvironmentVariables)"
-                ToolPath="$(Stage2Directory)"
-                Configuration="$(Configuration)"
-                NoBuild="True"
-                NoTrait="category=failing"
-                Xml="$(TestResultXmlDir)/%(TestProjects.OutputName)-testResults.xml" />
+    <PropertyGroup>
+      <RunTestEnvironmentVariables>@(TestTaskEnvironmentVariables)</RunTestEnvironmentVariables>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectsToTest Include="build/test/RunTest.proj">
+        <Properties>
+          CLIBuildDll=$(CLIBuildDll);
+          Configuration=$(Configuration);
+          EnvironmentVariables=$(RunTestEnvironmentVariables);
+          TestProjectName=%(TestProjects.OutputName);
+          TestResultXmlDir=$(TestResultXmlDir);
+          ToolPath=$(Stage2Directory);
+          WorkingDirectory=%(TestProjects.ProjectDir)
+        </Properties>
+      </ProjectsToTest>
+    </ItemGroup>
+
+    <MSBuild
+      BuildInParallel="True"
+      Projects="@(ProjectsToTest)">
+    </MSBuild>
   </Target>
 
   <Target Name="PrepareTests"
@@ -50,7 +65,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="BuildTests" 
+  <Target Name="BuildTests"
           DependsOnTargets="RestoreTests;
                             SetupTestProjectData;"
           Inputs="%(TestProjects.BuildInputs)"
@@ -70,18 +85,18 @@
     <CallTarget Targets="CleanTestProjectsLockFiles"/>
 
     <DotNetRestore  FallbackSource="$(TestPackagesDir)"
-                    ToolPath="$(DotnetUnderTest)" 
+                    ToolPath="$(DotnetUnderTest)"
                     WorkingDirectory="$(TestDirectory)" />
   </Target>
- 
-  <Target Name="CleanTestProjectsBinObj" 
-          DependsOnTargets="SetupRestoreTestsInputs;" 
+
+  <Target Name="CleanTestProjectsBinObj"
+          DependsOnTargets="SetupRestoreTestsInputs;"
           Inputs="@(RestoreTestsInputs)"
           Outputs="@(RestoreTestsInputs->'%(RelativeDir)project.lock.json')">
     <ItemGroup>
       <FilesToDelete Include="$(TestDirectory)**/bin/**/*.*" />
       <FilesToDelete Include="$(TestDirectory)**/obj/**/*.*" />
-    </ItemGroup>  
+    </ItemGroup>
 
     <Delete Files="@(FilesToDelete)" />
 
@@ -122,7 +137,7 @@
           Outputs="@(RestoreTestAssetProjectsInputs->'%(RelativeDir)/project.lock.json')">
 
     <DotNetRestore  FallbackSource="$(TestPackagesDir)"
-                    ToolPath="$(DotnetUnderTest)" 
+                    ToolPath="$(DotnetUnderTest)"
                     WorkingDirectory="$(RepoRoot)TestAssets/TestProjects/" />
   </Target>
 
@@ -136,23 +151,23 @@
     <ItemGroup>
       <TestAssetProjectsLockFiles Include="$(RepoRoot)/TestAssets/TestProjects/**/project.lock.json" />
     </ItemGroup>
-    <Delete Files="@(TestAssetProjectsLockFiles)" /> 
+    <Delete Files="@(TestAssetProjectsLockFiles)" />
   </Target>
 
   <Target Name="CleanTestProjectsLockFiles" >
     <ItemGroup>
       <TestProjectsLockFiles Include="$(RepoRoot)/test/**/project.lock.json" />
     </ItemGroup>
-    <Delete Files="@(TestProjectsLockFiles)" /> 
+    <Delete Files="@(TestProjectsLockFiles)" />
   </Target>
 
-  <Target Name="BuildDesktopTestAssetProjects" 
-          Condition=" '$(IsDesktopAvailable)' == 'True' " 
+  <Target Name="BuildDesktopTestAssetProjects"
+          Condition=" '$(IsDesktopAvailable)' == 'True' "
           DependsOnTargets="RestoreDesktopTestAssetProjects">
     <ItemGroup>
       <NoAutoBuildDesktopTestAssets Include="$(RepoRoot)TestAssets\DesktopTestProjects\**\.noautobuild" />
       <NoAutoBuildDesktopTestAssetProjects Include="%(NoAutoBuildDesktopTestAssets.RelativeDir)project.json" />
-      <BuildableDesktopTestAssetProjects Include="$(RepoRoot)TestAssets\DesktopTestProjects\**\project.json" 
+      <BuildableDesktopTestAssetProjects Include="$(RepoRoot)TestAssets\DesktopTestProjects\**\project.json"
                                          Exclude="@(NoAutoBuildDesktopTestAssetProjects)" />
     </ItemGroup>
 
@@ -167,14 +182,14 @@
   </Target>
 
   <Target Name="RestoreDesktopTestAssetProjects"
-          Condition=" '$(IsDesktopAvailable)' == 'True' " 
+          Condition=" '$(IsDesktopAvailable)' == 'True' "
           DependsOnTargets="CreateTestAssetPackageNuPkgs;
                             SetupRestoreDesktopTestAssetProjectsInputs;"
           Inputs="@(RestoreDesktopTestAssetProjectsInputs)"
           Outputs="@(RestoreDesktopTestAssetProjectsInputs->'%(RelativeDir)/project.lock.json')">
 
     <DotNetRestore  FallbackSource="$(TestPackagesDir)"
-                    ToolPath="$(DotnetUnderTest)" 
+                    ToolPath="$(DotnetUnderTest)"
                     WorkingDirectory="$(RepoRoot)TestAssets\DesktopTestProjects\" />
   </Target>
 
@@ -184,7 +199,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CreateTestAssetPackageNuPkgs" 
+  <Target Name="CreateTestAssetPackageNuPkgs"
           DependsOnTargets="BuildTestAssetPackageProjects;
                             SetupTestPackageProjectData;"
           Inputs="%(TestPackageProject.PackInputs)"
@@ -210,14 +225,14 @@
                   ToolPath="$(DotnetUnderTest)"
                   WorkingDirectory="%(BuildableTestAssetProjects.RelativeDir)" />
   </Target>
- 
-  <Target Name="RestoreTestAssetPackageProjects" 
+
+  <Target Name="RestoreTestAssetPackageProjects"
           DependsOnTargets="PrepareTests;
-                            SetupRestoreTestAssetPackageProjectsInputs;" 
+                            SetupRestoreTestAssetPackageProjectsInputs;"
           Inputs="@(RestoreTestAssetPackageProjectsInputs)"
           Outputs="@(RestoreTestAssetPackageProjectsInputs->'%(RelativeDir)/project.lock.json')">
 
-    <DotNetRestore  ToolPath="$(DotnetUnderTest)" 
+    <DotNetRestore  ToolPath="$(DotnetUnderTest)"
                     WorkingDirectory="$(RepoRoot)/TestAssets/TestPackages/" />
   </Target>
 

--- a/build/Microsoft.DotNet.Cli.Test.targets
+++ b/build/Microsoft.DotNet.Cli.Test.targets
@@ -78,7 +78,7 @@
 
   <Target Name="RestoreTests"
           DependsOnTargets="CreateTestAssetPackageNuPkgs;
-                            CleanTestProjectsBinObj;
+                            CleanTestProjectsBinObjProjectJson;
                             SetupRestoreTestsInputs;"
           Inputs="@(RestoreTestsInputs)"
           Outputs="@(RestoreTestsInputs->'%(RelativeDir)project.lock.json')">
@@ -89,13 +89,13 @@
                     WorkingDirectory="$(TestDirectory)" />
   </Target>
 
-  <Target Name="CleanTestProjectsBinObj"
+  <Target Name="CleanTestProjectsBinObjProjectJson"
           DependsOnTargets="SetupRestoreTestsInputs;"
           Inputs="@(RestoreTestsInputs)"
           Outputs="@(RestoreTestsInputs->'%(RelativeDir)project.lock.json')">
     <ItemGroup>
-      <FilesToDelete Include="$(TestDirectory)**/bin/**/*.*" />
-      <FilesToDelete Include="$(TestDirectory)**/obj/**/*.*" />
+      <FilesToDelete Include="$(TestDirectory)**/bin/**/project.json" />
+      <FilesToDelete Include="$(TestDirectory)**/obj/**/project.json" />
     </ItemGroup>
 
     <Delete Files="@(FilesToDelete)" />

--- a/build/test/RunTest.proj
+++ b/build/test/RunTest.proj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTarget="RunTest" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="DotNetTest" AssemblyFile="$(CLIBuildDll)" />
+
+  <Target Name="RunTest">
+    <DotNetTest WorkingDirectory="$(WorkingDirectory)"
+                EnvironmentVariables="$(EnvironmentVariables)"
+                ToolPath="$(ToolPath)"
+                Configuration="$(Configuration)"
+                NoBuild="True"
+                NoTrait="category=failing"
+                Xml="$(TestResultXmlDir)/$(TestProjectName)-testResults.xml" />
+  </Target>
+</Project>

--- a/build/test/RunTest.proj
+++ b/build/test/RunTest.proj
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTarget="RunTest" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- workaround for https://github.com/Microsoft/msbuild/issues/885 -->
+  <PropertyGroup>
+    <CLIBuildDll Condition=" '!Exists($(CLIBuildDll))' ">$([MSBuild]::Unescape($(CLIBuildDll)))</CLIBuildDll>
+  </PropertyGroup>
+
+
   <UsingTask TaskName="DotNetTest" AssemblyFile="$(CLIBuildDll)" />
 
   <Target Name="RunTest">

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -71,10 +71,10 @@ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 if ($NoBuild)
 {
     Write-Host "Not building due to --nobuild"
-    Write-Host "Command that would be run: 'dotnet build3 build.proj /p:Architecture=$Architecture $ExtraParameters'"
+    Write-Host "Command that would be run: 'dotnet build3 build.proj /m /p:Architecture=$Architecture $ExtraParameters'"
 }
 else
 {
-    dotnet build3 build.proj /p:Architecture=$Architecture $ExtraParameters
+    dotnet build3 build.proj /m /p:Architecture=$Architecture $ExtraParameters
     if($LASTEXITCODE -ne 0) { throw "Failed to build" } 
 }

--- a/run-build.sh
+++ b/run-build.sh
@@ -117,8 +117,8 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 echo "${args[@]}"
 
 if [ $BUILD -eq 1 ]; then
-    dotnet build3 build.proj /p:Architecture=$ARCHITECTURE "${args[@]}"
+    dotnet build3 build.proj /m /p:Architecture=$ARCHITECTURE "${args[@]}"
 else
     echo "Not building due to --nobuild"
-    echo "Command that would be run is: 'dotnet build3 build.proj /p:Architecture=$ARCHITECTURE ${args[@]}'"
+    echo "Command that would be run is: 'dotnet build3 build.proj /m /p:Architecture=$ARCHITECTURE ${args[@]}'"
 fi

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -6,7 +6,7 @@
   "dependencies": {
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-192208-24",
+    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
     "Microsoft.DotNet.InternalAbstractions": "1.0.0"
   },
   "testRunner": "xunit",

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -6,7 +6,7 @@
   "dependencies": {
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "Microsoft.DotNet.InternalAbstractions": "1.0.0"
   },
   "testRunner": "xunit",

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -31,14 +31,15 @@ namespace Microsoft.DotNet.Tests
 
             _firstDotnetNonVerbUseCommandResult = command.ExecuteWithCapturedOutput("--info");
             _firstDotnetVerbUseCommandResult = command.ExecuteWithCapturedOutput("new");
-
             _nugetCacheFolder = new DirectoryInfo(testNugetCache);
         }        
 
         [Fact]
         public void Using_dotnet_for_the_first_time_succeeds()
         {
-            _firstDotnetVerbUseCommandResult.Should().Pass();
+            _firstDotnetVerbUseCommandResult
+                .Should()
+                .Pass();
         }
 
         [Fact]
@@ -46,7 +47,9 @@ namespace Microsoft.DotNet.Tests
         {
             const string firstTimeNonVerbUseMessage = @".NET Command Line Tools";
 
-            _firstDotnetNonVerbUseCommandResult.StdOut.Should().StartWith(firstTimeNonVerbUseMessage);
+            _firstDotnetNonVerbUseCommandResult.StdOut
+                .Should()
+                .StartWith(firstTimeNonVerbUseMessage);
         }
 
         [Fact]
@@ -64,19 +67,25 @@ Configuring...
 -------------------
 A command is running to initially populate your local package cache, to improve restore speed and enable offline access. This command will take up to a minute to complete and will only happen once.";
 
-            _firstDotnetVerbUseCommandResult.StdOut.Should().StartWith(firstTimeUseWelcomeMessage);
+            _firstDotnetVerbUseCommandResult.StdOut
+                .Should()
+                .StartWith(firstTimeUseWelcomeMessage);
         }
 
     	[Fact]
     	public void It_restores_the_nuget_packages_to_the_nuget_cache_folder()
     	{
-            _nugetCacheFolder.Should().HaveFile($"{GetDotnetVersion()}.dotnetSentinel");            
+            _nugetCacheFolder
+                .Should()
+                .HaveFile($"{GetDotnetVersion()}.dotnetSentinel");            
     	}
 
         [Fact]
         public void It_creates_a_sentinel_file_under_the_nuget_cache_folder()
         {
-            _nugetCacheFolder.Should().HaveDirectory("microsoft.netcore.app");
+            _nugetCacheFolder
+                .Should()
+                .HaveDirectory("microsoft.netcore.app");
         }
 
     	private string GetDotnetVersion()


### PR DESCRIPTION
Takes advantage of new MSBuild by enabling parallel execution of tests. On my 8-proc machine, reduced time to execute tests from 10 mins to 6.5 mins.

/cc @brthor @eerhardt @livarcocc @rainersigwald