### PR TITLE
[WIP] Adding Restore3 command

### DIFF
--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -20,7 +20,8 @@
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Xml.XmlSerializer": "4.0.11",
     "WindowsAzure.Storage": "6.2.2-preview",
-    "NuGet.CommandLine.XPlat": "3.5.0-rc1-1697",
+    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.1",
+    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.1",
     "Microsoft.Build.Framework": "0.1.0-preview-00029-160805",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00029-160805",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"

--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -20,7 +20,6 @@
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Xml.XmlSerializer": "4.0.11",
     "WindowsAzure.Storage": "6.2.2-preview",
-    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.1",
     "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.1",
     "Microsoft.Build.Framework": "0.1.0-preview-00029-160805",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00029-160805",

--- a/resources/MSBuildImports/15.0/Microsoft.Common.targets/ImportAfter/Microsoft.NuGet.ImportAfter.targets
+++ b/resources/MSBuildImports/15.0/Microsoft.Common.targets/ImportAfter/Microsoft.NuGet.ImportAfter.targets
@@ -14,4 +14,10 @@ Copyright (c) .NET Foundation. All rights reserved.
     <NuGetTargets Condition="'$(NuGetTargets)'==''">$(MSBuildExtensionsPath)\Microsoft.NuGet.targets</NuGetTargets>
   </PropertyGroup>
   <Import Condition="Exists('$(NuGetTargets)')" Project="$(NuGetTargets)" />
+
+  <!-- Import NuGet.targets for Restore -->
+  <PropertyGroup>
+    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildExtensionsPath)\NuGet.targets</NuGetRestoreTargets>
+  </PropertyGroup>
+  <Import Condition="Exists('$(NuGetRestoreTargets)')" Project="$(NuGetRestoreTargets)" />
 </Project>

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -9,10 +9,10 @@
       "target": "project"
     },
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914",
-    "NuGet.Versioning": "3.5.0-rc1-1697",
-    "NuGet.Packaging": "3.5.0-rc1-1697",
-    "NuGet.Frameworks": "3.5.0-rc1-1697",
-    "NuGet.ProjectModel": "3.5.0-rc1-1697"
+    "NuGet.Versioning": "3.6.0-beta.1.msbuild.1",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.1",
+    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.1",
+    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.1"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -8,9 +8,9 @@
     "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000914",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Configuration": "3.5.0-rc1-1697",
-    "NuGet.Packaging": "3.5.0-rc1-1697",
-    "NuGet.RuntimeModel": "3.5.0-rc1-1697",
+    "NuGet.Configuration": "3.6.0-beta.1.msbuild.1",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.1",
+    "NuGet.RuntimeModel": "3.6.0-beta.1.msbuild.1",
     "System.Reflection.Metadata": "1.3.0"
   },
   "frameworks": {

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -17,6 +17,7 @@ using Microsoft.DotNet.Tools.Help;
 using Microsoft.DotNet.Tools.New;
 using Microsoft.DotNet.Tools.Publish;
 using Microsoft.DotNet.Tools.Restore;
+using Microsoft.DotNet.Tools.Restore3;
 using Microsoft.DotNet.Tools.Run;
 using Microsoft.DotNet.Tools.Test;
 using NuGet.Frameworks;
@@ -37,7 +38,8 @@ namespace Microsoft.DotNet.Cli
             ["run"] = RunCommand.Run,
             ["test"] = TestCommand.Run,
             ["build3"] = Build3Command.Run,
-            ["run3"] = Run3Command.Run
+            ["run3"] = Run3Command.Run,
+            ["restore3"] = Restore3Command.Run,
         };
 
         public static int Main(string[] args)

--- a/src/dotnet/commands/dotnet-build3/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-build3/MSBuildForwardingApp.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli
         private const string s_msbuildExeName = "MSBuild.exe";
         private readonly ForwardingApp _forwardingApp;
 
-        public MSBuildForwardingApp(string[] argsToForward)
+        public MSBuildForwardingApp(IEnumerable<string> argsToForward)
         {
             _forwardingApp = new ForwardingApp(
                 GetMSBuildExePath(),

--- a/src/dotnet/commands/dotnet-restore3/Program.cs
+++ b/src/dotnet/commands/dotnet-restore3/Program.cs
@@ -1,0 +1,111 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.Restore3
+{
+    public class Restore3Command
+    {
+        public static int Run(string[] args)
+        {
+            DebugHelper.HandleDebugSwitch(ref args);
+
+            CommandLineApplication cmd = new CommandLineApplication(throwOnUnexpectedArg: false)
+            {
+                Name = "restore3",
+                FullName = "restore3",
+                Description = "restore for msbuild"
+            };
+
+            cmd.HelpOption("-h|--help");
+
+            var argRoot = cmd.Argument(
+                    "[root]",
+                    "Optional path to a project file or MSBuild arguments.",
+                    multipleValues: true);
+
+            var sourceOption = cmd.Option(
+                    "-s|--source <source>",
+                    "Specifies a NuGet package source to use during the restore.",
+                    CommandOptionType.MultipleValue);
+
+            var packagesOption = cmd.Option(
+                    "--packages <packagesDirectory>",
+                    "Directory to install packages in.",
+                    CommandOptionType.SingleValue);
+
+            var disableParallelOption = cmd.Option(
+                    "--disable-parallel",
+                    "Disables restoring multiple projects in parallel.",
+                    CommandOptionType.NoValue);
+
+            var configFileOption = cmd.Option(
+                    "--configfile <file>",
+                    "The NuGet configuration file to use.",
+                    CommandOptionType.SingleValue);
+
+            var noCacheOption = cmd.Option(
+                    "--no-cache",
+                    "Do not cache packages and http requests.",
+                    CommandOptionType.NoValue);
+
+            var ignoreFailedSourcesOption = cmd.Option(
+                    "--ignore-failed-sources",
+                    "Treat package source failures as warnings.",
+                    CommandOptionType.NoValue);
+
+            cmd.OnExecute(() =>
+            {
+                var msbuildArgs = new List<string>()
+                {
+                     "/t:Restore"
+                };
+
+                if (sourceOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:RestoreSources={string.Join(";", sourceOption.Values)}");
+                }
+
+                if (packagesOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:RestorePackagesPath={packagesOption.Value()}");
+                }
+
+                if (disableParallelOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:RestoreDisableParallel=true");
+                }
+
+                if (configFileOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:RestoreConfigFile={configFileOption.Value()}");
+                }
+
+                if (noCacheOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:RestoreNoCache=true");
+                }
+
+                if (ignoreFailedSourcesOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:RestoreIgnoreFailedSources=true");
+                }
+
+                // Add in arguments
+                msbuildArgs.AddRange(argRoot.Values);
+
+                // Add remaining arguments that the parser did not understand
+                msbuildArgs.AddRange(cmd.RemainingArguments);
+
+                return new MSBuildForwardingApp(msbuildArgs).Execute();
+            });
+
+            return cmd.Execute(args);
+        }
+    }
+}

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -26,6 +26,8 @@
     }
   },
   "dependencies": {
+    "NuGet.Commandline.XPlat": "3.6.0-beta.1.msbuild.1",
+    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.1",
     "Newtonsoft.Json": "9.0.1",
     "System.Text.Encoding.CodePages": "4.0.1",
     "System.Diagnostics.FileVersionInfo": "4.0.0",
@@ -60,8 +62,8 @@
       "exclude": "compile"
     },
 
-    "Microsoft.Build": "0.1.0-preview-00029-160805", 
-    "Microsoft.Build.Framework": "0.1.0-preview-00029-160805", 
+    "Microsoft.Build": "0.1.0-preview-00029-160805",
+    "Microsoft.Build.Framework": "0.1.0-preview-00029-160805",
 
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
   },

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -26,8 +26,6 @@
     }
   },
   "dependencies": {
-    "NuGet.Commandline.XPlat": "3.6.0-beta.1.msbuild.1",
-    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.1",
     "Newtonsoft.Json": "9.0.1",
     "System.Text.Encoding.CodePages": "4.0.1",
     "System.Diagnostics.FileVersionInfo": "4.0.0",

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -18,7 +18,8 @@
     "Microsoft.Build.Tasks.Core": "0.1.0-preview-00029-160805",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00029-160805",
     "Microsoft.Build.Targets": "0.1.0-preview-00029-160805",
-    "Microsoft.Build": "0.1.0-preview-00029-160805"
+    "Microsoft.Build": "0.1.0-preview-00029-160805",
+    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.1"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/tool_nuget/project.json
+++ b/src/tool_nuget/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.0"
     },
-    "NuGet.CommandLine.XPlat": "3.5.0-rc1-1697"
+    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.1"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -20,10 +20,10 @@
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
-    "NuGet.Versioning": "3.5.0-rc1-1697",
-    "NuGet.Packaging": "3.5.0-rc1-1697",
-    "NuGet.Frameworks": "3.5.0-rc1-1697",
-    "NuGet.ProjectModel": "3.5.0-rc1-1697",
+    "NuGet.Versioning": "3.6.0-beta.1.msbuild.1",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.1",
+    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.1",
+    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.1",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },


### PR DESCRIPTION
This change adds the NuGet.Build.Tasks package containing NuGet's MSBuild task for restore. The Restore3 command will call the Restore target in NuGet.targets and convert the command line parameters into MSBuild properties.

