### PR TITLE
Fix CI by not copying Microsoft.DotNet.PlatformAbstractions to stage0 since it is already loaded into the stage0 dotnet process.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -62,9 +62,6 @@
       <TaskDependenciesDlls Include="$(DotnetCliBuildDirectory)/bin/Microsoft.WindowsAzure.Storage.dll">
         <Name>Microsoft.WindowsAzure.Storage.dll</Name>
       </TaskDependenciesDlls>
-      <TaskDependenciesDlls Include="$(DotnetCliBuildDirectory)/bin/Microsoft.DotNet.PlatformAbstractions.dll">
-        <Name>Microsoft.DotNet.PlatformAbstractions.dll</Name>
-      </TaskDependenciesDlls>
     </ItemGroup>
 
     <!-- This is a work around to issue https://github.com/Microsoft/msbuild/issues/658 -->


### PR DESCRIPTION
Eventually we should also remove the copying of WindowsAzure.Storage.dll since the MSBuild bug is fixed. But since Publish isn't tested in Jenkins, I didn't want to do that here.  I just want to get our builds off the floor.

@livarcocc @brthor @piotrpMSFT 