### PR TITLE
Populate .deps.json path property with path property from lock file

### DIFF
--- a/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.0"
     },
-    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000914"
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-003395"
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netstandard1.6": {

--- a/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "xunit": "2.2.0-beta3-build3330"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
@@ -8,7 +8,7 @@
     "System.Linq.Expressions": "4.1.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "Microsoft.DotNet.InternalAbstractions": {
       "target": "project"
     }

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/project.json
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/project.json
@@ -8,7 +8,7 @@
     "NETStandard.Library": "1.6.0",
     "System.Diagnostics.Process": "4.1.0",
     "System.Reflection.TypeExtensions": "4.1.0",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -23,7 +23,7 @@
     "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.1",
     "Microsoft.Build.Framework": "0.1.0-preview-00029-160805",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00029-160805",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/build_projects/shared-build-targets-utils/project.json
+++ b/build_projects/shared-build-targets-utils/project.json
@@ -12,7 +12,7 @@
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"
     },
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netstandard1.6": {

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -8,7 +8,7 @@
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919",
     "NuGet.Versioning": "3.6.0-beta.1.msbuild.1",
     "NuGet.Packaging": "3.6.0-beta.1.msbuild.1",
     "NuGet.Frameworks": "3.6.0-beta.1.msbuild.1",

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -11,7 +11,7 @@
       "target": "project"
     },
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.0",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
@@ -146,8 +146,8 @@ namespace Microsoft.Extensions.DependencyModel
                     export.NativeLibraryGroups.Select(CreateRuntimeAssetGroup).ToArray(),
                     export.ResourceAssemblies.Select(CreateResourceAssembly),
                     libraryDependencies,
-                    serviceable
-                    );
+                    serviceable,
+                    GetLibraryPath(export.Library));
             }
             else
             {
@@ -168,8 +168,26 @@ namespace Microsoft.Extensions.DependencyModel
                     export.Library.Hash,
                     assemblies,
                     libraryDependencies,
-                    serviceable);
+                    serviceable,
+                    GetLibraryPath(export.Library));
             }
+        }
+
+        private string GetLibraryPath(LibraryDescription description)
+        {
+            var packageDescription = description as PackageDescription;
+
+            if (packageDescription != null)
+            {
+                // This is the relative path appended to a NuGet packages directory to find the directory containing
+                // the package assets. This string should mastered only byNuGet, but has the format:
+                // {lowercase-package-ID}/{lowercase-package-version}
+                // 
+                // For example: newtonsoft.json/9.0.1
+                return packageDescription.PackageLibrary?.Path;
+            }
+
+            return null;
         }
 
         private RuntimeAssetGroup CreateRuntimeAssetGroup(LibraryAssetGroup libraryAssetGroup)

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePackageLibrary.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFilePackageLibrary.cs
@@ -17,5 +17,7 @@ namespace Microsoft.DotNet.ProjectModel.Graph
         public string Sha512 { get; set; }
 
         public IList<string> Files { get; set; } = new List<string>();
+
+        public string Path { get; set; }
     }
 }

--- a/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Graph/LockFileReader.cs
@@ -144,6 +144,9 @@ namespace Microsoft.DotNet.ProjectModel.Graph
 
                 var type = _symbols.GetString(value.Value<string>("type"));
 
+                var pathValue = value["path"];
+                var path = pathValue == null ? null : ReadString(pathValue);
+
                 if (type == null || string.Equals(type, "package", StringComparison.OrdinalIgnoreCase))
                 {
                     lockFile.PackageLibraries.Add(new LockFilePackageLibrary
@@ -152,7 +155,8 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                         Version = version,
                         IsServiceable = ReadBool(value, "serviceable", defaultValue: false),
                         Sha512 = ReadString(value["sha512"]),
-                        Files = ReadPathArray(value["files"], ReadString)
+                        Files = ReadPathArray(value["files"], ReadString),
+                        Path = path
                     });
                 }
                 else if (type == "project")
@@ -162,9 +166,8 @@ namespace Microsoft.DotNet.ProjectModel.Graph
                         Name = name,
                         Version = version
                     };
-
-                    var pathValue = value["path"];
-                    projectLibrary.Path = pathValue == null ? null : ReadString(pathValue);
+                    
+                    projectLibrary.Path = path;
 
                     var buildTimeDependencyValue = value["msbuildProject"];
                     projectLibrary.MSBuildProject = buildTimeDependencyValue == null ? null : ReadString(buildTimeDependencyValue);

--- a/src/Microsoft.DotNet.ProjectModel/MSBuildProjectDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/MSBuildProjectDescription.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.DotNet.ProjectModel.Graph;
 
 namespace Microsoft.DotNet.ProjectModel

--- a/src/Microsoft.DotNet.ProjectModel/ProjectDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/ProjectDescription.cs
@@ -19,7 +19,8 @@ namespace Microsoft.DotNet.ProjectModel
                   framework: null,
                   resolved: false,
                   compatible: false)
-        { }
+        {
+        }
 
         public ProjectDescription(
             LibraryRange libraryRange,

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -5,8 +5,8 @@
   },
   "description": "Types to model a .NET Project",
   "dependencies": {
-    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000914",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914",
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000919",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919",
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Configuration": "3.6.0-beta.1.msbuild.1",
     "NuGet.Packaging": "3.6.0-beta.1.msbuild.1",

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -63,7 +63,7 @@
     "Microsoft.Build": "0.1.0-preview-00029-160805",
     "Microsoft.Build.Framework": "0.1.0-preview-00029-160805",
 
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -19,8 +19,8 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -20,8 +20,8 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Kestrel.Tests/project.json
+++ b/test/Kestrel.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -35,8 +35,8 @@
     },
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -16,7 +16,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Configurer.UnitTests/project.json
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/project.json
@@ -21,7 +21,7 @@
     "FluentAssertions": "4.0.0",
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
@@ -15,7 +15,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.ProjectModel.Tests/LockFileReaderTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/LockFileReaderTests.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using Microsoft.DotNet.ProjectModel.Graph;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.ProjectModel.Tests
+{
+    public class LockFileReaderTests : TestBase
+    {
+        [Fact]
+        public void ReadsAllLibraryPropertiesWhenPathIsPresent()
+        {
+            // Arrange
+            var lockFileJson = @"
+            {
+              ""libraries"": {
+                ""PackageA/1.0.1-Alpha"": {
+                  ""sha512"": ""FAKE-HASH"",
+                  ""type"": ""package"",
+                  ""serviceable"": true,
+                  ""files"": [
+                    ""a.txt"",
+                    ""foo/b.txt""
+                  ],
+                  ""path"": ""PackageA/1.0.1-beta-PATH""
+                },
+                ""ProjectA/1.0.2-Beta"": {
+                  ""type"": ""project"",
+                  ""path"": ""ProjectA-PATH"",
+                  ""msbuildProject"": ""some-msbuild""
+                }
+              }
+            }";
+
+            var lockFileStream = new MemoryStream(Encoding.UTF8.GetBytes(lockFileJson));
+            var lockFileReader = new LockFileReader();
+
+            // Act
+            var lockFile = lockFileReader.ReadLockFile(
+                lockFilePath: null,
+                stream: lockFileStream,
+                designTime: true);
+
+            // Assert
+            lockFile.PackageLibraries.Should().HaveCount(1);
+            var package = lockFile.PackageLibraries.First();
+            package.Name.Should().Be("PackageA");
+            package.Version.ToString().Should().Be("1.0.1-Alpha");
+            package.Sha512.Should().Be("FAKE-HASH");
+            package.IsServiceable.Should().BeTrue();
+            package.Files.Should().HaveCount(2);
+            package.Files[0].Should().Be("a.txt");
+            package.Files[1].Should().Be(Path.Combine("foo", "b.txt"));
+            package.Path.Should().Be("PackageA/1.0.1-beta-PATH");
+
+            lockFile.ProjectLibraries.Should().HaveCount(1);
+            var project = lockFile.ProjectLibraries.First();
+            project.Name.Should().Be("ProjectA");
+            project.Version.ToString().Should().Be("1.0.2-Beta");
+            project.Path.Should().Be("ProjectA-PATH");
+        }
+
+        [Fact]
+        public void ReadsAllLibraryPropertiesWhenPathIsNotPresent()
+        {
+            // Arrange
+            var lockFileJson = @"
+            {
+              ""libraries"": {
+                ""PackageA/1.0.1-Alpha"": {
+                  ""sha512"": ""FAKE-HASH"",
+                  ""type"": ""package"",
+                  ""serviceable"": true,
+                  ""files"": [
+                    ""a.txt"",
+                    ""foo/b.txt""
+                  ]
+                },
+                ""ProjectA/1.0.2-Beta"": {
+                  ""type"": ""project"",
+                  ""msbuildProject"": ""some-msbuild""
+                }
+              }
+            }";
+
+            var lockFileStream = new MemoryStream(Encoding.UTF8.GetBytes(lockFileJson));
+            var lockFileReader = new LockFileReader();
+
+            // Act
+            var lockFile = lockFileReader.ReadLockFile(
+                lockFilePath: null,
+                stream: lockFileStream,
+                designTime: true);
+
+            // Assert
+            lockFile.PackageLibraries.Should().HaveCount(1);
+            var package = lockFile.PackageLibraries.First();
+            package.Name.Should().Be("PackageA");
+            package.Version.ToString().Should().Be("1.0.1-Alpha");
+            package.Sha512.Should().Be("FAKE-HASH");
+            package.IsServiceable.Should().BeTrue();
+            package.Files.Should().HaveCount(2);
+            package.Files[0].Should().Be("a.txt");
+            package.Files[1].Should().Be(Path.Combine("foo", "b.txt"));
+            package.Path.Should().BeNull();
+
+            lockFile.ProjectLibraries.Should().HaveCount(1);
+            var project = lockFile.ProjectLibraries.First();
+            project.Name.Should().Be("ProjectA");
+            project.Version.ToString().Should().Be("1.0.2-Beta");
+            project.Path.Should().BeNull();
+        }
+    }
+}

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -21,7 +21,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -7,14 +7,14 @@
   "dependencies": {
     "FluentAssertions": "4.0.0",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "Microsoft.DotNet.TestFramework": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": { "target": "project" },
     "Microsoft.DotNet.ProjectModel": { "target": "project" },
     "Microsoft.DotNet.InternalAbstractions": {
       "target": "project"
     },
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Performance/project.json
+++ b/test/Performance/project.json
@@ -17,7 +17,7 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028"
   },
   "frameworks": {

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -15,7 +15,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
@@ -19,7 +19,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "FluentAssertions": "4.2.2"
   },
   "frameworks": {

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
@@ -14,7 +14,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "FluentAssertions": "4.2.2",
     "moq.netcore": "4.4.0-beta8"
   },

--- a/test/binding-redirects.Tests/project.json
+++ b/test/binding-redirects.Tests/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/crossgen.Tests/project.json
+++ b/test/crossgen.Tests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-build3.Tests/project.json
+++ b/test/dotnet-build3.Tests/project.json
@@ -10,7 +10,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-compile-fsc.Tests/project.json
+++ b/test/dotnet-compile-fsc.Tests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -30,7 +30,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet-new.Tests/project.json
+++ b/test/dotnet-new.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -14,7 +14,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -14,7 +14,7 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
   },
   "frameworks": {

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -14,7 +14,7 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-run.UnitTests/project.json
+++ b/test/dotnet-run.UnitTests/project.json
@@ -14,7 +14,7 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "moq.netcore": "4.4.0-beta8",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -19,8 +19,8 @@
     "System.Net.Sockets": "4.1.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -14,7 +14,7 @@
       "exclude": "Compile"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -17,8 +17,8 @@
       "type": "build"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000914"
+    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
This is step #3 in this NuGet issue: https://github.com/NuGet/Home/issues/2522. This work is also tracked by this CLI issue: https://github.com/dotnet/cli/issues/2874.

This PR adds a `"path"` property to the `"libraries"` entries in the `.deps.json` file. For packages, this is the relative path appended to the global packages folder (or fallback folder) to access the package's assets. For projects and other library types, this value is null.

After this work, the .NET Core host process needs to be modified to prefer this property over the concatenation of the package ID and version.