### PR TITLE
added pack3 command to call msbuild target

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -15,6 +15,7 @@ using Microsoft.DotNet.Tools.Compiler;
 using Microsoft.DotNet.Tools.Compiler.Csc;
 using Microsoft.DotNet.Tools.Help;
 using Microsoft.DotNet.Tools.New;
+using Microsoft.DotNet.Tools.Pack3;
 using Microsoft.DotNet.Tools.Publish;
 using Microsoft.DotNet.Tools.Restore;
 using Microsoft.DotNet.Tools.Restore3;
@@ -40,6 +41,7 @@ namespace Microsoft.DotNet.Cli
             ["build3"] = Build3Command.Run,
             ["run3"] = Run3Command.Run,
             ["restore3"] = Restore3Command.Run,
+            ["pack3"] = Pack3Command.Run,
         };
 
         public static int Main(string[] args)

--- a/src/dotnet/commands/dotnet-pack3/Pack3Command.cs
+++ b/src/dotnet/commands/dotnet-pack3/Pack3Command.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.Pack3
+{
+    public class Pack3Command
+    {
+        public static int Run(string[] args)
+        {
+            DebugHelper.HandleDebugSwitch(ref args);
+
+            CommandLineApplication cmd = new CommandLineApplication(throwOnUnexpectedArg: false)
+            {
+                Name = "pack3",
+                FullName = "pack3",
+                Description = "pack for msbuild"
+            };
+
+            cmd.HelpOption("-h|--help");
+
+            var output = cmd.Option("-o|--output <OUTPUT_DIR>",
+                "Directory in which to place outputs",
+                CommandOptionType.SingleValue);
+            var noBuild = cmd.Option("--no-build",
+                "Do not build project before packing", 
+                CommandOptionType.NoValue);
+            var configuration = cmd.Option("-c|--configuration <CONFIGURATION>",
+                "Configuration under which to build", 
+                CommandOptionType.SingleValue);
+            var versionSuffix = cmd.Option("--version-suffix <VERSION_SUFFIX>",
+                "Defines what `*` should be replaced with in version field in project.json",
+                CommandOptionType.SingleValue);
+            var serviceable = cmd.Option("-s|--serviceable", 
+                "Set the serviceable flag in the package", 
+                CommandOptionType.NoValue);
+            var argRoot = cmd.Argument("<PROJECT>",
+                "The project to pack, defaults to the project file in the current directory. Can be a path to any project file",
+                multipleValues:true);
+
+            cmd.OnExecute(() =>
+            {
+                var msbuildArgs = new List<string>()
+                {
+                     "/t:pack"
+                };
+
+                if (noBuild.HasValue())
+                {
+                    msbuildArgs.Add($"/p:NoBuild=true");
+                }
+
+                if (output.HasValue())
+                {
+                    msbuildArgs.Add($"/p:PackageOutputPath={output.Value()}");
+                }
+
+                if (configuration.HasValue())
+                {
+                    msbuildArgs.Add($"/p:Configuration={configuration.Value()}");
+                }
+
+                if (versionSuffix.HasValue())
+                {
+                    msbuildArgs.Add($"/p:VersionSuffix={versionSuffix.Value()}");
+                }
+
+                if (serviceable.HasValue())
+                {
+                    msbuildArgs.Add($"/p:Serviceable=true");
+                }
+
+                msbuildArgs.AddRange(argRoot.Values);
+
+                msbuildArgs.AddRange(cmd.RemainingArguments);
+                return new MSBuildForwardingApp(msbuildArgs).Execute();
+            });
+
+            return cmd.Execute(args);
+        }
+    }
+}


### PR DESCRIPTION
This change adds on top of the  NuGet.Build.Tasks package to add support NuGet's MSBuild task for pack. The Pack3 command will call the pack target in Pack.targets and convert the command line parameters into MSBuild properties.

CC: @rrelyea @emgarten @piotrpMSFT @eerhardt 