### PR TITLE
Update xunit dependencies for CSharp_xunittest template

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "System.Runtime.Serialization.Primitives": "4.1.1",
-    "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc2-192208-24"
+    "xunit": "2.2.0-beta2-build3300",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "testRunner": "xunit",
   "frameworks": {


### PR DESCRIPTION
The current versions of `xunit` and `dotnet-test-xunit` do not work with a new `xunittest` project with the preview 2 tools. I have updated the version of the dependencies to match the ones mentioned in the [xunit documentation](http://xunit.github.io/docs/getting-started-dotnet-core.html) regarding preview 2 tools.