### PR TITLE
Update version of routing to 1.0.1

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
@@ -15,6 +15,7 @@
       "version": "1.0.0-preview2-final",
       "type": "build"
     },
+    "Microsoft.AspNetCore.Routing": "1.0.1",
     "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Microsoft.AspNetCore.StaticFiles": "1.0.0",


### PR DESCRIPTION
This is needed because MVC still references 1.0.0.