### PR TITLE
Set the "hashPath" when building the .deps.json file

### DIFF
--- a/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.0"
     },
-    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000919"
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000919"
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netstandard1.6": {

--- a/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "xunit": "2.2.0-beta3-build3330"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
@@ -8,7 +8,7 @@
     "System.Linq.Expressions": "4.1.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "Microsoft.DotNet.InternalAbstractions": {
       "target": "project"
     }

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/project.json
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/project.json
@@ -8,7 +8,7 @@
     "NETStandard.Library": "1.6.0",
     "System.Diagnostics.Process": "4.1.0",
     "System.Reflection.TypeExtensions": "4.1.0",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -20,10 +20,10 @@
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Xml.XmlSerializer": "4.0.11",
     "WindowsAzure.Storage": "6.2.2-preview",
-    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.1",
+    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.4",
     "Microsoft.Build.Framework": "0.1.0-preview-00033-160829",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00033-160829",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/build_projects/shared-build-targets-utils/project.json
+++ b/build_projects/shared-build-targets-utils/project.json
@@ -12,7 +12,7 @@
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"
     },
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netstandard1.6": {

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -8,11 +8,11 @@
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919",
-    "NuGet.Versioning": "3.6.0-beta.1.msbuild.1",
-    "NuGet.Packaging": "3.6.0-beta.1.msbuild.1",
-    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.1",
-    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.1"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
+    "NuGet.Versioning": "3.6.0-beta.1.msbuild.4",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.4",
+    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.4",
+    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.4"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -11,7 +11,7 @@
       "target": "project"
     },
     "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.0",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
+++ b/src/Microsoft.DotNet.ProjectModel/DependencyContextBuilder.cs
@@ -147,7 +147,8 @@ namespace Microsoft.Extensions.DependencyModel
                     export.ResourceAssemblies.Select(CreateResourceAssembly),
                     libraryDependencies,
                     serviceable,
-                    GetLibraryPath(export.Library));
+                    GetLibraryPath(export.Library),
+                    GetLibraryHashPath(export.Library));
             }
             else
             {
@@ -169,7 +170,8 @@ namespace Microsoft.Extensions.DependencyModel
                     assemblies,
                     libraryDependencies,
                     serviceable,
-                    GetLibraryPath(export.Library));
+                    GetLibraryPath(export.Library),
+                    GetLibraryHashPath(export.Library));
             }
         }
 
@@ -180,11 +182,22 @@ namespace Microsoft.Extensions.DependencyModel
             if (packageDescription != null)
             {
                 // This is the relative path appended to a NuGet packages directory to find the directory containing
-                // the package assets. This string should mastered only byNuGet, but has the format:
-                // {lowercase-package-ID}/{lowercase-package-version}
-                // 
-                // For example: newtonsoft.json/9.0.1
+                // the package assets. This string should only be mastered by NuGet.
                 return packageDescription.PackageLibrary?.Path;
+            }
+
+            return null;
+        }
+
+        private string GetLibraryHashPath(LibraryDescription description)
+        {
+            var packageDescription = description as PackageDescription;
+
+            if (packageDescription != null)
+            {
+                // This hash path appended to the package path (much like package assets). This string should only be
+                // mastered by NuGet.
+                return packageDescription.HashPath;
             }
 
             return null;

--- a/src/Microsoft.DotNet.ProjectModel/PackageDescription.cs
+++ b/src/Microsoft.DotNet.ProjectModel/PackageDescription.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.ProjectModel
     {
         public PackageDescription(
             string path,
+            string hashPath,
             LockFilePackageLibrary package,
             LockFileTargetLibrary lockFileLibrary,
             IEnumerable<LibraryRange> dependencies,
@@ -27,8 +28,11 @@ namespace Microsoft.DotNet.ProjectModel
                   compatible: compatible,
                   framework: null)
         {
+            HashPath = hashPath;
             PackageLibrary = package;
         }
+
+        public string HashPath { get; }
 
         public LockFilePackageLibrary PackageLibrary { get; }
 

--- a/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
+++ b/src/Microsoft.DotNet.ProjectModel/Resolution/PackageDependencyProvider.cs
@@ -17,6 +17,7 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
     public class PackageDependencyProvider
     {
         private readonly FallbackPackagePathResolver _packagePathResolver;
+        private readonly VersionFolderPathResolver _versionFolderPathResolver;
         private readonly FrameworkReferenceResolver _frameworkReferenceResolver;
 
         public PackageDependencyProvider(INuGetPathContext nugetPathContext, FrameworkReferenceResolver frameworkReferenceResolver)
@@ -24,6 +25,9 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
             if (nugetPathContext != null)
             {
                 _packagePathResolver = new FallbackPackagePathResolver(nugetPathContext);
+
+                // This resolver is only used for building file names, so that base path is not required.
+                _versionFolderPathResolver = new VersionFolderPathResolver(path: null);
             }
 
             _frameworkReferenceResolver = frameworkReferenceResolver;
@@ -48,6 +52,12 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
             var path = _packagePathResolver?.GetPackageDirectory(package.Name, package.Version);
             bool exists = path != null;
 
+            string hashPath = null;
+            if (_versionFolderPathResolver != null)
+            {
+                hashPath = _versionFolderPathResolver.GetHashFileName(package.Name, package.Version);
+            }
+
             if (exists)
             {
                 // If the package's compile time assemblies is for a portable profile then, read the assembly metadata
@@ -57,6 +67,7 @@ namespace Microsoft.DotNet.ProjectModel.Resolution
 
             var packageDescription = new PackageDescription(
                 path,
+                hashPath,
                 package,
                 targetLibrary,
                 dependencies,

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -5,12 +5,12 @@
   },
   "description": "Types to model a .NET Project",
   "dependencies": {
-    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000919",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919",
+    "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Configuration": "3.6.0-beta.1.msbuild.1",
-    "NuGet.Packaging": "3.6.0-beta.1.msbuild.1",
-    "NuGet.RuntimeModel": "3.6.0-beta.1.msbuild.1",
+    "NuGet.Configuration": "3.6.0-beta.1.msbuild.4",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.4",
+    "NuGet.RuntimeModel": "3.6.0-beta.1.msbuild.4",
     "System.Reflection.Metadata": "1.4.1-beta-24410-02"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.Tools.Test/project.json
+++ b/src/Microsoft.DotNet.Tools.Test/project.json
@@ -25,7 +25,7 @@
     "Microsoft.DotNet.InternalAbstractions": {
   	  "target": "project"
   	},
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
 
   "frameworks": {

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -71,7 +71,7 @@
     "Microsoft.Build": "0.1.0-preview-00033-160829",
     "Microsoft.Build.Framework": "0.1.0-preview-00033-160829",
 
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -20,7 +20,7 @@
     "Microsoft.Build.Targets": "0.1.0-preview-00033-160829",
     "Microsoft.Build": "0.1.0-preview-00033-160829",
     "System.Runtime.Serialization.Xml": "4.1.0",
-    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.1"
+    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.4"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/tool_nuget/project.json
+++ b/src/tool_nuget/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.0"
     },
-    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.1"
+    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.4"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -19,8 +19,8 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -20,8 +20,8 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Kestrel.Tests/project.json
+++ b/test/Kestrel.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -20,10 +20,10 @@
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
-    "NuGet.Versioning": "3.6.0-beta.1.msbuild.1",
-    "NuGet.Packaging": "3.6.0-beta.1.msbuild.1",
-    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.1",
-    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.1",
+    "NuGet.Versioning": "3.6.0-beta.1.msbuild.4",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.4",
+    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.4",
+    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.4",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
@@ -35,8 +35,8 @@
     },
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -16,7 +16,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Configurer.UnitTests/project.json
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/project.json
@@ -21,7 +21,7 @@
     "FluentAssertions": "4.0.0",
     "moq.netcore": "4.4.0-beta8",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "FluentAssertions": "4.0.0",
     "moq.netcore": "4.4.0-beta8",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
@@ -15,7 +15,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.ProjectModel.Tests/LibraryExporterPackageTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/LibraryExporterPackageTests.cs
@@ -17,10 +17,16 @@ namespace Microsoft.DotNet.ProjectModel.Tests
     public class LibraryExporterPackageTests
     {
         private const string PackagePath = "PackagePath";
+        private const string HashPath = "PackageHashPath";
 
-        private PackageDescription CreateDescription(LockFileTargetLibrary target = null, LockFilePackageLibrary package = null)
+        private PackageDescription CreateDescription(
+            LockFileTargetLibrary target = null,
+            LockFilePackageLibrary package = null,
+            string hashPath = null)
         {
-            return new PackageDescription(PackagePath,
+            return new PackageDescription(
+                PackagePath,
+                hashPath ?? HashPath,
                 package ?? new LockFilePackageLibrary(),
                 target ?? new LockFileTargetLibrary(),
                 new List<LibraryRange>(), compatible: true, resolved: true);

--- a/test/Microsoft.DotNet.ProjectModel.Tests/PackageDependencyProviderTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/PackageDependencyProviderTests.cs
@@ -45,6 +45,36 @@ namespace Microsoft.DotNet.ProjectModel.Tests
         }
 
         [Fact]
+        public void GetDescriptionShouldGenerateHashFileName()
+        {
+            // Arrange
+            var provider = new PackageDependencyProvider(
+                NuGetPathContext.Create("/foo/packages"),
+                new FrameworkReferenceResolver("/foo/references"));
+            var package = new LockFilePackageLibrary();
+            package.Name = "Something";
+            package.Version = NuGetVersion.Parse("1.0.0-Beta");
+            package.Files.Add("lib/dotnet/_._");
+            package.Files.Add("runtimes/any/native/Microsoft.CSharp.CurrentVersion.targets");
+            package.Path = "SomePath";
+
+            var target = new LockFileTargetLibrary();
+            target.Name = "Something";
+            target.Version = package.Version;
+
+            target.RuntimeAssemblies.Add("lib/dotnet/_._");
+            target.CompileTimeAssemblies.Add("lib/dotnet/_._");
+            target.NativeLibraries.Add("runtimes/any/native/Microsoft.CSharp.CurrentVersion.targets");
+
+            // Act
+            var p = provider.GetDescription(NuGetFramework.Parse("netcoreapp1.0"), package, target);
+
+            // Assert
+            p.PackageLibrary.Path.Should().Be("SomePath");
+            p.HashPath.Should().Be("something.1.0.0-beta.nupkg.sha512");
+        }
+
+        [Fact]
         public void GetDescriptionShouldNotModifyTarget()
         {
             var provider = new PackageDependencyProvider(

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -21,7 +21,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -7,14 +7,14 @@
   "dependencies": {
     "FluentAssertions": "4.0.0",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "Microsoft.DotNet.TestFramework": { "target": "project" },
     "Microsoft.DotNet.Cli.Utils": { "target": "project" },
     "Microsoft.DotNet.ProjectModel": { "target": "project" },
     "Microsoft.DotNet.InternalAbstractions": {
       "target": "project"
     },
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Performance/project.json
+++ b/test/Performance/project.json
@@ -17,7 +17,7 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028"
   },
   "frameworks": {

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -15,7 +15,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
@@ -19,7 +19,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "FluentAssertions": "4.2.2"
   },
   "frameworks": {

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
@@ -14,7 +14,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "FluentAssertions": "4.2.2",
     "moq.netcore": "4.4.0-beta8"
   },

--- a/test/binding-redirects.Tests/project.json
+++ b/test/binding-redirects.Tests/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "Microsoft.NETCore.Platforms": "1.0.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/crossgen.Tests/project.json
+++ b/test/crossgen.Tests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-build3.Tests/project.json
+++ b/test/dotnet-build3.Tests/project.json
@@ -10,7 +10,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-compile-fsc.Tests/project.json
+++ b/test/dotnet-compile-fsc.Tests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -30,7 +30,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet-migrate.Tests/project.json
+++ b/test/dotnet-migrate.Tests/project.json
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-318883-21",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "FluentAssertions": "4.0.0",
     "moq.netcore": "4.4.0-beta8",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-new.Tests/project.json
+++ b/test/dotnet-new.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-nuget.UnitTests/project.json
+++ b/test/dotnet-nuget.UnitTests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "moq.netcore": "4.4.0-beta8"
   },
   "frameworks": {

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -14,7 +14,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -14,7 +14,7 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
   },
   "frameworks": {

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -14,7 +14,7 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -13,7 +13,7 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-run.UnitTests/project.json
+++ b/test/dotnet-run.UnitTests/project.json
@@ -14,7 +14,7 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "moq.netcore": "4.4.0-beta8",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -22,8 +22,8 @@
     "System.Net.Sockets": "4.1.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -17,7 +17,7 @@
       "exclude": "Compile"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "moq.netcore": "4.4.0-beta8",
     "FluentAssertions": "4.2.2"
   },

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -17,8 +17,8 @@
       "type": "build"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-330423-54",
-    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000919"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
+    "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
1. Set the "hashPath" when building the .deps.json file
1. Use newer versions of `PlatformAbstractions`, `DependencyModel`, and `dotnet-test-xunit`

This is progress for this work item: https://github.com/NuGet/Home/issues/2522.

/cc @eerhardt @livarcocc @piotrpMSFT @gkhanna79 @emgarten 