### PR TITLE
Update msbuild

### DIFF
--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -21,7 +21,7 @@
     "System.Xml.XmlSerializer": "4.0.11",
     "WindowsAzure.Storage": "6.2.2-preview",
     "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.7",
-    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00034-160909",
+    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00038-160914",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -68,7 +68,7 @@
       "exclude": "compile"
     },
 
-    "Microsoft.Build": "0.1.0-preview-00034-160909",
+    "Microsoft.Build": "0.1.0-preview-00038-160914",
 
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -13,12 +13,12 @@
     "tool_nuget": "1.0.0-preview3-*",
     "tool_msbuild": "1.0.0-preview3-*",
 
-    "MSBuild": "0.1.0-preview-00034-160909",
-    "Microsoft.Build.Framework": "0.1.0-preview-00034-160909",
-    "Microsoft.Build.Tasks.Core": "0.1.0-preview-00034-160909",
-    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00034-160909",
-    "Microsoft.Build.Targets": "0.1.0-preview-00034-160909",
-    "Microsoft.Build": "0.1.0-preview-00034-160909",
+    "MSBuild": "0.1.0-preview-00038-160914",
+    "Microsoft.Build.Framework": "0.1.0-preview-00038-160914",
+    "Microsoft.Build.Tasks.Core": "0.1.0-preview-00038-160914",
+    "Microsoft.Build.Utilities.Core": "0.1.0-preview-00038-160914",
+    "Microsoft.Build.Targets": "0.1.0-preview-00038-160914",
+    "Microsoft.Build": "0.1.0-preview-00038-160914",
     "System.Runtime.Serialization.Xml": "4.1.0",
     "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.7"
   },

--- a/src/tool_msbuild/project.json
+++ b/src/tool_msbuild/project.json
@@ -8,8 +8,8 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "MSBuild": "0.1.0-preview-00034-160909",
-    "Microsoft.Build.Targets": "0.1.0-preview-00034-160909",
+    "MSBuild": "0.1.0-preview-00038-160914",
+    "Microsoft.Build.Targets": "0.1.0-preview-00038-160914",
     "Microsoft.Net.Compilers.netcore": "1.3.0",
     "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",
     "Microsoft.Cci": "4.0.0-rc3-24128-00",


### PR DESCRIPTION
Update msbuild to latest to make the common portion of cross-targeting targets available.

@brthor @livarcocc @eerhardt
