### PR TITLE
Download stage0 from the correct channel

### DIFF
--- a/init-tools.ps1
+++ b/init-tools.ps1
@@ -11,7 +11,7 @@ $RepoRoot = "$PSScriptRoot"
 # Install a stage 0
 Write-Host "Installing .NET Core CLI Stage 0 from branchinfo channel"
     
-& "$RepoRoot\scripts\obtain\dotnet-install.ps1" -Channel feature-msbuild -Architecture $Architecture -Verbose
+& "$RepoRoot\scripts\obtain\dotnet-install.ps1" -Channel $env:CHANNEL -Architecture $Architecture -Verbose
 if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
 # Put the stage0 on the path

--- a/init-tools.sh
+++ b/init-tools.sh
@@ -14,7 +14,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-$DIR/scripts/obtain/dotnet-install.sh --channel feature-msbuild --verbose
+$DIR/scripts/obtain/dotnet-install.sh --channel $CHANNEL --verbose
 
 __init_tools_log=$DIR/init-tools.log
 __BUILD_TOOLS_CLI_VERSION=$(cat "$DIR/BuildToolsCliVersion.txt")


### PR DESCRIPTION
Now that the rel/1.0.0 has been bootstrapped using the 'feature-msbuild' channel, the correct channel needs to be passed to the install scripts.

cc @livarcocc @brthor @eerhardt 