### PR TITLE
Restore3 support for PackageReference

### DIFF
--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -20,7 +20,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Xml.XmlSerializer": "4.0.11",
     "WindowsAzure.Storage": "6.2.2-preview",
-    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.7",
+    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.9",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00038-160914",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -9,10 +9,10 @@
       "target": "project"
     },
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
-    "NuGet.Versioning": "3.6.0-beta.1.msbuild.7",
-    "NuGet.Packaging": "3.6.0-beta.1.msbuild.7",
-    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.7",
-    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.7"
+    "NuGet.Versioning": "3.6.0-beta.1.msbuild.9",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.9",
+    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.9",
+    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.9"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -8,9 +8,9 @@
     "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Configuration": "3.6.0-beta.1.msbuild.7",
-    "NuGet.Packaging": "3.6.0-beta.1.msbuild.7",
-    "NuGet.RuntimeModel": "3.6.0-beta.1.msbuild.7",
+    "NuGet.Configuration": "3.6.0-beta.1.msbuild.9",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.9",
+    "NuGet.RuntimeModel": "3.6.0-beta.1.msbuild.9",
     "System.Reflection.Metadata": "1.4.1-beta-24410-02"
   },
   "frameworks": {

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -20,7 +20,7 @@
     "Microsoft.Build.Targets": "0.1.0-preview-00038-160914",
     "Microsoft.Build": "0.1.0-preview-00038-160914",
     "System.Runtime.Serialization.Xml": "4.1.0",
-    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.7"
+    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.9"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/tool_nuget/project.json
+++ b/src/tool_nuget/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.7"
+    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.9"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
Updating NuGet dependencies

* Adds support for ``PackageReference`` in Restore3
* TFM conditionals will be added to targets/props files
* NuGet outputs are now written to ``$(BaseIntermediateOutputPath)``
* Lock file-> project.assets.json
* Targets -> projectName.nuget.g.targets
* Props-> projectName.nuget.g.props
* MSBuild package dependencies match the current CLI MSBuild dependencies