### PR TITLE
CrossGen command, working code with some details pending

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.DotNet.Tools.Build;
 using Microsoft.DotNet.Tools.Build3;
 using Microsoft.DotNet.Tools.Compiler;
 using Microsoft.DotNet.Tools.Compiler.Csc;
+using Microsoft.DotNet.Tools.CrossGen;
 using Microsoft.DotNet.Tools.Help;
 using Microsoft.DotNet.Tools.Migrate;
 using Microsoft.DotNet.Tools.MSBuild;
@@ -37,6 +38,7 @@ namespace Microsoft.DotNet.Cli
         {
             ["build"] = BuildCommand.Run,
             ["compile-csc"] = CompileCscCommand.Run,
+            ["crossgen"] = CrossGenCommand.Run,
             ["help"] = HelpCommand.Run,
             ["new"] = NewCommand.Run,
             ["nuget"] = NuGetCommand.Run,

--- a/src/dotnet/commands/dotnet-crossgen/CrossGenContext.cs
+++ b/src/dotnet/commands/dotnet-crossgen/CrossGenContext.cs
@@ -1,0 +1,244 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.CrossGen.Outputs;
+using Microsoft.Extensions.DependencyModel;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+
+using static Microsoft.DotNet.Tools.CrossGen.Operations.FileNameConstants;
+
+namespace Microsoft.DotNet.Tools.CrossGen
+{
+    public class CrossGenContext
+    {
+        private readonly string _appName;
+        private readonly string _appDir;
+        private readonly bool _generatePDB;
+        private CrossGenTarget _crossGenTarget;
+
+        /// <summary>
+        /// Context taken straight out of the app's deps file,
+        /// This context determine what assets to crossgen
+        /// </summary>
+        private DependencyContext _depsFileContext;
+
+        /// <summary>
+        /// Context that is merged with the shared framework (if applicable)
+        /// This context is the actual context used on run time and is
+        /// used to determine runtime fallbacks
+        /// </summary>
+        private DependencyContext _runtimeContext;
+        
+        public CrossGenContext(string appName, string appDir, bool generatePDB)
+        {
+            _appName = appName;
+            _appDir = appDir;
+            _generatePDB = generatePDB;
+        }
+
+        public void Initialize()
+        {
+            var depsFilePath = Path.Combine(_appDir, $"{_appName}.deps.json");
+            if (!File.Exists(depsFilePath))
+            {
+                throw new CrossGenException($"Deps {depsFilePath} file not found");
+            }
+
+            string sharedFrameworkDir;
+            NuGetFramework framework;
+            string rid;
+            using (var reader = new DependencyContextJsonReader())
+            {
+                using (var fstream = new FileStream(depsFilePath, FileMode.Open))
+                {
+                    _depsFileContext = reader.Read(fstream);
+                }
+
+                if (_depsFileContext == null)
+                {
+                    throw new CrossGenException($"Unexpected error while reading {depsFilePath}");
+                }
+
+                var runtimeConfigPath = Path.Combine(_appDir, $"{_appName}.runtimeconfig.json");
+                RuntimeConfig runtimeConfig = null;
+                if (File.Exists(runtimeConfigPath))
+                {
+                    runtimeConfig = new RuntimeConfig(runtimeConfigPath);
+                }
+
+                if (runtimeConfig != null && runtimeConfig.IsPortable)
+                {
+                    // This is portable app
+                    Reporter.Verbose.WriteLine($"This is a portable app, runtime config file: {runtimeConfigPath}");
+                    sharedFrameworkDir = LocateSharedFramework(runtimeConfig.Framework);
+                    var shreadFrameworkDepsFile = Path.Combine(sharedFrameworkDir, $"{runtimeConfig.Framework.Name}.deps.json");
+                    if (!File.Exists(shreadFrameworkDepsFile))
+                    {
+                        throw new CrossGenException($"Cannot locate share framework's deps file {shreadFrameworkDepsFile}");
+                    }
+
+                    using (var fstream = new FileStream(shreadFrameworkDepsFile, FileMode.Open))
+                    {
+                        _runtimeContext = reader.Read(fstream);
+                    }
+
+                    // After merging, framework and rid would be gone. So do this pre-merge.
+                    framework = NuGetFramework.Parse(_runtimeContext.Target.Framework);
+                    rid = _runtimeContext.Target.Runtime;
+
+                    if (_runtimeContext == null)
+                    {
+                        throw new CrossGenException($"Unable to load shared framework context from {shreadFrameworkDepsFile}");
+                    }
+
+                    _runtimeContext = _depsFileContext.Merge(_runtimeContext);
+                }
+                else
+                {
+                    Reporter.Verbose.WriteLine($"This is a standalone app, runtime config file: {(runtimeConfig == null ? runtimeConfigPath : "None")}");
+                    sharedFrameworkDir = null;
+                    _runtimeContext = _depsFileContext;
+                    framework = NuGetFramework.Parse(_runtimeContext.Target.Framework);
+                    rid = _runtimeContext.Target.Runtime;
+                }
+            }
+
+            if (framework.Framework != ".NETCoreApp")
+            {
+                throw new CrossGenException($"App targets {_crossGenTarget.Framework.Framework} cannot be CrossGen'd, supported frameworks: [.NETCoreApp].");
+            }
+
+            _crossGenTarget = new CrossGenTarget(framework, rid, sharedFrameworkDir);
+
+            Reporter.Verbose.WriteLine($"CrossGen will be performed to target Framework: {_crossGenTarget.Framework}, RID: {_crossGenTarget.RuntimeIdentifier}");
+        }
+
+        public void ExecuteCrossGen(string crossGenExe, string diaSymReaderDll, string outputDir, CrossGenOutputStructure structure, bool overwriteHash)
+        {
+            if (_generatePDB && diaSymReaderDll == null)
+            {
+                diaSymReaderDll = FindDiaSymReader();
+            }
+
+            CrossGenHandler crossGenHandler;
+            switch (structure)
+            {
+                case CrossGenOutputStructure.APP:
+                    crossGenHandler = new AppCrossGenHandler(crossGenExe, diaSymReaderDll, _crossGenTarget, _depsFileContext, _runtimeContext, _appDir, outputDir, _generatePDB);
+                    break;
+                
+                case CrossGenOutputStructure.CACHE:
+                    crossGenHandler = new OptimizationCacheCrossGenHandler(crossGenExe, diaSymReaderDll, _crossGenTarget, _depsFileContext, _runtimeContext, _appDir, outputDir, _generatePDB, overwriteHash);
+                    break;
+
+                default:
+                    throw new CrossGenException($"Invalid output structure: {structure}");
+            }
+
+            crossGenHandler.ExecuteCrossGen();
+        }
+
+        private string FindDiaSymReader()
+        {
+            var targetRid = _crossGenTarget.RuntimeIdentifier;
+            var hostDepContext = DependencyContext.Default;
+            var ridFallback = hostDepContext.RuntimeGraph.FirstOrDefault(fallback => fallback.Runtime == _crossGenTarget.RuntimeIdentifier);
+            IEnumerable<string> ridList = new string[] { targetRid };
+            if (ridFallback == null)
+            {
+                Reporter.Verbose.WriteLine($"Runtime {targetRid} fallback is not defined.");
+                ridList = new string[] { targetRid };
+            }
+            else
+            {
+                ridList = ridList.Concat(ridFallback.Fallbacks);
+            }
+
+            var arch = RuntimeEnvironment.RuntimeArchitecture;
+            var diaSymReaderFileName = $"{DynamicLibPrefix}Microsoft.DiaSymReader.Native.{arch}{DynamicLibSuffix}";
+            var probeLocations = new string[] { Path.Combine(ApplicationEnvironment.ApplicationBasePath, diaSymReaderFileName) }.Concat(
+                    ridList.Select(rid => Path.Combine(ApplicationEnvironment.ApplicationBasePath, "runtimes", rid, "native", diaSymReaderFileName)));
+
+            // x64, aka amd64
+            if (arch == "x64")
+            {
+                var archSuffix = $".{arch}{DynamicLibSuffix}";
+                probeLocations = probeLocations.Concat(
+                                    probeLocations.Where(l => l.EndsWith(archSuffix))
+                                                    .Select(l => l.Substring(0, l.Length - archSuffix.Length) + $".amd64{DynamicLibSuffix}"));
+            }
+
+            var foundLocation = probeLocations.FirstOrDefault(l => File.Exists(l));
+
+            if (foundLocation == null)
+            {
+                throw new CrossGenException($"Failed to locate DiaSymReader for runtime {targetRid}");
+            }
+
+            Reporter.Verbose.WriteLine($"Found DiaSymReader {foundLocation}");
+            return foundLocation;
+        }
+
+        private string LocateSharedFramework(RuntimeConfigFramework framework)
+        {
+            var dotnetHome = Path.GetDirectoryName(new Muxer().MuxerPath);
+            var shareFrameworksDir = Path.Combine(dotnetHome, "shared", framework.Name);
+
+            if (!Directory.Exists(shareFrameworksDir))
+            {
+                throw new CrossGenException($"Shared framework {shareFrameworksDir} does not exist");
+            }
+
+            var version = framework.Version;
+            var exactMatch = Path.Combine(shareFrameworksDir, version);
+            if (Directory.Exists(exactMatch))
+            {
+                return exactMatch;
+            }
+            else
+            {
+                Reporter.Verbose.WriteLine($"Cannot find shared framework in: {exactMatch}, trying to auto roll forward.");
+                return AutoRollForward(shareFrameworksDir, version);
+            }
+        }
+
+        private string AutoRollForward(string root, string version)
+        {
+            var targetVersion = NuGetVersion.Parse(version);
+            var candidateNames = Directory.GetDirectories(root).Select(d => Path.GetFileName(d));
+
+            string bestMatch = null;
+            NuGetVersion bestMatchVersion = null;
+            foreach (var candidateName in candidateNames)
+            {
+                var currentVersion = NuGetVersion.Parse(candidateName);
+                if (currentVersion.Major == targetVersion.Major &&
+                    currentVersion.Minor == targetVersion.Minor &&
+                    currentVersion.CompareTo(targetVersion) > 0)
+                {
+                    if (bestMatchVersion == null || currentVersion.CompareTo(bestMatchVersion) < 0)
+                    {
+                        bestMatchVersion = currentVersion;
+                        bestMatch = candidateName;
+                    }
+                }
+            }
+
+            if (bestMatch == null)
+            {
+                throw new CrossGenException($"Unable to find shared framework candidate in {root}. Base version: {version}, available [{string.Join(", ", candidateNames)}]");
+            }
+
+            Reporter.Output.WriteLine($"Shared framework {bestMatch} would be used to crossgen.");
+
+            return Path.Combine(root, bestMatch);
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/CrossGenException.cs
+++ b/src/dotnet/commands/dotnet-crossgen/CrossGenException.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace Microsoft.DotNet.Tools.CrossGen
+{
+    public class CrossGenException : Exception
+    {
+        public CrossGenException(string msg, Exception innerException = null)
+            : base(msg, innerException) { }
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/CrossGenTarget.cs
+++ b/src/dotnet/commands/dotnet-crossgen/CrossGenTarget.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.Tools.CrossGen
+{
+    public class CrossGenTarget
+    {
+        public NuGetFramework Framework { get; private set; }
+        public string RuntimeIdentifier { get; private set; }
+        public string SharedFrameworkDir { get; private set; }
+
+        public bool IsPortable
+        {
+            get { return SharedFrameworkDir != null; }
+        }
+
+        public CrossGenTarget(NuGetFramework framework, string rid, string sharedFrameworkDir)
+        {
+            Framework = framework;
+            RuntimeIdentifier = rid;
+            SharedFrameworkDir = sharedFrameworkDir;
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/Operations/CrossGenCmdUtil.cs
+++ b/src/dotnet/commands/dotnet-crossgen/Operations/CrossGenCmdUtil.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.CrossGen.Operations
+{
+    /// <summary>
+    /// This is a wrapper of crossgen.exe native image generation utiltites
+    /// </summary>
+    public class CrossGenCmdUtil
+    {
+        private enum OutputType
+        {
+            dll, pdb
+        }
+
+        private static readonly string[] s_excludedLibraries =
+        {
+            "mscorlib.dll",
+            "mscorlib.ni.dll",
+            "System.Private.CoreLib.dll",
+            "System.Private.CoreLib.ni.dll"
+        };
+
+        private readonly string _jitPath;
+        private readonly string _crossgenPath;
+        private readonly string _diaSymReaderPath;
+        private readonly NativeImageType? _outputType;
+
+        public CrossGenCmdUtil(
+            string crossgenPath,
+            string jitPath,
+            string diaSymReaderPath,
+            NativeImageType? outputType = null)
+        {
+            _crossgenPath = crossgenPath;
+            _jitPath = jitPath;
+            _diaSymReaderPath = diaSymReaderPath;
+            _outputType = outputType;
+        }
+
+        public static bool ShouldExclude(string assemblyLocation)
+        {
+            var fileName = Path.GetFileName(assemblyLocation);
+            var exclude = s_excludedLibraries.Any(lib => string.Equals(lib, fileName, StringComparison.OrdinalIgnoreCase));
+            if (exclude)
+            {
+                Reporter.Verbose.WriteLine($"Excluding {assemblyLocation} for crossgen.");
+            }
+            return exclude;
+        }
+
+        public ICollection<string> CrossGenAssembly(string appPath, string assemblyLocation, IList<string> platformAssembliesPaths, string outputDirectory, bool generateSymbols)
+        {
+            Reporter.Verbose.WriteLine($"CrossGen'ing {assemblyLocation}");
+            var outputFiles = new List<string>();
+
+            var fileName = Path.GetFileName(assemblyLocation);
+            var module = fileName.Substring(0, fileName.Length - 4);
+            var crossgenArgs = string.Join(" ", GetArgs(appPath, assemblyLocation, module, platformAssembliesPaths, outputDirectory, false));
+            var cmd = Command.Create(new CommandSpec(_crossgenPath, crossgenArgs, CommandResolutionStrategy.None))
+                .WorkingDirectory(appPath)
+                // disable partial ngen
+                .EnvironmentVariable("COMPlus_PartialNGen", "0")
+                .CaptureStdOut()
+                .CaptureStdErr();
+
+            var result = cmd.Execute();
+
+            var niModuleLocation = GetOutputLocation(outputDirectory, module, OutputType.dll);
+            Reporter.Verbose.WriteLine(result.StdOut);
+            HandleCrossGenExeStdError(result.StdErr);
+            if (result.ExitCode != 0 || !File.Exists(niModuleLocation))
+            {
+                throw new CrossGenException($"Crossgen module {module} failed. Error code: {result.ExitCode}. Expected output location: {niModuleLocation}.");
+            }
+
+            outputFiles.Add(niModuleLocation);
+
+            if (generateSymbols)
+            {
+                var pdbArgs = string.Join(" ", GetArgs(appPath, assemblyLocation, module, platformAssembliesPaths, outputDirectory, true));
+                var pdbCmd = Command.Create(new CommandSpec(_crossgenPath, pdbArgs, CommandResolutionStrategy.None))
+                                .WorkingDirectory(appPath)
+                                .CaptureStdOut()
+                                .CaptureStdErr();
+
+                var pdbResult = pdbCmd.Execute();
+
+                var pdbLocation = GetOutputLocation(outputDirectory, module, OutputType.pdb);
+                Reporter.Verbose.WriteLine(result.StdOut);
+                HandleCrossGenExeStdError(result.StdErr);
+                if (pdbResult.ExitCode != 0 || !File.Exists(pdbLocation))
+                {
+                    throw new CrossGenException($"Symbol generation for module {module} failed. Error code: {pdbResult.ExitCode}. Expected output location: {pdbLocation}.");
+                }
+
+                outputFiles.Add(pdbLocation);
+            }
+
+            Reporter.Verbose.WriteLine($"Completed crossGen'ing {assemblyLocation}");
+            return outputFiles;
+        }
+
+        private List<string> GetArgs(string appPath, string assemblyLocation, string module, IList<string> platformAssembliesPaths, string outputDirectory, bool isSymbolGeneration)
+        {
+            var parameters = new List<string>();
+
+            if (platformAssembliesPaths != null && platformAssembliesPaths.Count > 0)
+            {
+                parameters.Add("-platform_assemblies_paths");
+                parameters.Add(string.Join(";", platformAssembliesPaths.Select(path => $"\"{path}\"")));
+            }
+
+            if (!string.IsNullOrEmpty(appPath))
+            {
+                parameters.Add("-App_Paths");
+                parameters.Add($"\"{appPath}\"");
+            }
+
+            parameters.Add("-JITPath");
+            parameters.Add(_jitPath);
+
+            var outputDllLocation = GetOutputLocation(outputDirectory, module, OutputType.dll);
+            if (isSymbolGeneration)
+            {
+                parameters.Add("-CreatePDB");
+                parameters.Add(GetOutputLocation(outputDirectory, module, OutputType.pdb));
+
+                parameters.Add("-DiasymreaderPath");
+                parameters.Add(_diaSymReaderPath);
+
+                parameters.Add(outputDllLocation);
+            }
+            else
+            {
+                if (_outputType.HasValue)
+                {
+                    switch (_outputType)
+                    {
+                        case NativeImageType.FragileNonVersionable:
+                            parameters.Add("-FragileNonVersionable");
+                            break;
+                        case NativeImageType.Ready2Run:
+                            parameters.Add("-readytorun");
+                            break;
+                    }
+                }
+
+                parameters.Add("-out");
+                parameters.Add(outputDllLocation);
+
+                parameters.Add(assemblyLocation);
+            }
+
+            return parameters;
+        }
+
+        private void HandleCrossGenExeStdError(string erroString)
+        {
+            // crossgen.exe would return a single \n in stdError even if it passes
+            var actualError = erroString.Trim();
+            if (actualError.Length > 0)
+            {
+                Reporter.Error.WriteLine(actualError);
+            }
+        }
+
+        private string GetOutputLocation(string outputDirectory, string module, OutputType type)
+        {
+            return Path.Combine(outputDirectory, $"{module}.{type}");
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/Operations/FileNameConstants.cs
+++ b/src/dotnet/commands/dotnet-crossgen/Operations/FileNameConstants.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.DotNet.Tools.CrossGen.Operations
+{
+    public static class FileNameConstants
+    {
+        public static readonly string DynamicLibPrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "" : "lib";
+
+        public static readonly string DynamicLibSuffix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".dll" :
+                                                         RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? ".dylib" : ".so";
+
+        public static readonly string JITLibName = $"{DynamicLibPrefix}clrjit{DynamicLibSuffix}";
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/Operations/NativeImageType.cs
+++ b/src/dotnet/commands/dotnet-crossgen/Operations/NativeImageType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Tools.CrossGen.Operations
+{
+    public enum NativeImageType
+    {
+        Ready2Run,
+        FragileNonVersionable
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/Operations/PEUtils.cs
+++ b/src/dotnet/commands/dotnet-crossgen/Operations/PEUtils.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Reflection.PortableExecutable;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.CrossGen.Operations
+{
+    public static class PEUtils
+    {
+        public static bool HasMetadata(string pathToFile)
+        {
+            var hasMetadata = false;
+            try
+            {
+                using (var inStream = File.OpenRead(pathToFile))
+                using (var peReader = new PEReader(inStream))
+                {
+                    hasMetadata = peReader.HasMetadata;
+                }
+            }
+            catch (BadImageFormatException) { }
+
+            if (!hasMetadata)
+            {
+                Reporter.Verbose.WriteLine($"No metadata was found for {pathToFile}");
+            }
+
+            return hasMetadata;
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/Outputs/AppCrossGenHandler.cs
+++ b/src/dotnet/commands/dotnet-crossgen/Outputs/AppCrossGenHandler.cs
@@ -1,0 +1,80 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.DependencyModel;
+
+namespace Microsoft.DotNet.Tools.CrossGen.Outputs
+{
+    public class AppCrossGenHandler : CrossGenHandler
+    {
+        public AppCrossGenHandler(
+            string crossGenExe,
+            string diaSymReaderDll,
+            CrossGenTarget crossGenTarget,
+            DependencyContext depsFileContext,
+            DependencyContext runtimeContext,
+            string appDir,
+            string outputDir,
+            bool generatePDB)
+            : base(crossGenExe, diaSymReaderDll, crossGenTarget, depsFileContext, runtimeContext, appDir, outputDir, generatePDB)
+        {
+        }
+
+        protected override string GetOutputDirFor(string sourcePathUsed, RuntimeLibrary lib, string assetPath)
+        {
+            var sourceDir = Path.GetDirectoryName(sourcePathUsed);
+            var sourceRelativeDir = sourceDir.Substring(AppDir.Length);
+            var i = 0;
+            for (; i < sourceRelativeDir.Length; i++)
+            {
+                if (sourceRelativeDir[i] != Path.AltDirectorySeparatorChar && sourceRelativeDir[i] != Path.DirectorySeparatorChar)
+                {
+                    break;
+                }
+            }
+            return Path.Combine(OutputRoot, sourceRelativeDir.Substring(i));
+        }
+
+        protected override void OnCrossGenCompleted()
+        {
+            // copy over any asset that wasn't generated during the CrossGen process
+            CopyOverDir(new string[] {});
+        }
+
+        // This method is written for simplicity not efficiency
+        private void CopyOverDir(IEnumerable<string> relativePath)
+        {
+            var sourceDirStack = new string[] { AppDir }.Concat(relativePath).ToArray();
+            var sourceDir = Path.Combine(sourceDirStack);
+            var destDirStack = new string[] { OutputRoot }.Concat(relativePath).ToArray();
+            var destDir = Path.Combine(destDirStack);
+
+            if (!Directory.Exists(destDir))
+            {
+                Reporter.Verbose.WriteLine($"CrossGenTool wrap up: creating directory {destDir}");
+                Directory.CreateDirectory(destDir);
+            }
+
+            foreach (var file in Directory.GetFiles(sourceDir))
+            {
+                var fileName = Path.GetFileName(file);
+                var destFileName = Path.Combine(destDir, fileName);
+                if (!File.Exists(destFileName))
+                {
+                    Reporter.Verbose.WriteLine($"CrossGenTool wrap up: copying over file {destFileName}");
+                    File.Copy(file, destFileName);
+                }
+            }
+
+            foreach (var dir in Directory.GetDirectories(sourceDir))
+            {
+                var dirName = Path.GetFileName(dir);
+                CopyOverDir(relativePath.Concat(new string[] {dirName} ));
+            }
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/Outputs/CrossGenHandler.cs
+++ b/src/dotnet/commands/dotnet-crossgen/Outputs/CrossGenHandler.cs
@@ -1,0 +1,237 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.CrossGen;
+using Microsoft.DotNet.Tools.CrossGen.Operations;
+using Microsoft.Extensions.DependencyModel;
+
+using static Microsoft.DotNet.Tools.CrossGen.Operations.FileNameConstants;
+
+namespace Microsoft.DotNet.Tools.CrossGen.Outputs
+{
+    public abstract class CrossGenHandler
+    {
+        private class CrossGenWorkCollection
+        {
+            public RuntimeLibrary Lib { get; private set; }
+            public ICollection<CrossGenWorkItem> WorkItems { get; private set; }
+
+            public CrossGenWorkCollection(RuntimeLibrary lib)
+            {
+                Lib = lib;
+                WorkItems = new List<CrossGenWorkItem>();
+            }
+        }
+
+        private class CrossGenWorkItem
+        {
+            public string Source { get; private set; }
+            public string DestinationDir { get; private set; }
+            public CrossGenWorkItem(string source, string destinationDir)
+            {
+                Source = source;
+                DestinationDir = destinationDir;
+            }
+        }
+
+        // use ready2run because this is a common cache location
+        // we can make this configurable if required
+        private const NativeImageType DefaultCrossGenType = NativeImageType.Ready2Run;
+        private readonly bool _generatePDB;
+        private readonly CrossGenCmdUtil _crossGenCmds;
+        private readonly IEnumerable<RuntimeLibrary> _libraries;
+        private readonly IEnumerable<string> _runtimeFallbacks;
+        private readonly CrossGenTarget _crossGenTarget;
+        private readonly ICollection<CrossGenWorkCollection> _workItems;
+
+        // Aggregate all the fallback directories and look them up by its runtime
+        // This property could actually be a Dictionary<string, string>
+        // because I am only expecting 1 fallback directory per runtime
+        private readonly IDictionary<string, HashSet<string>> _fallbackDirectories;
+
+        protected string OutputRoot { get; private set; }
+        protected string AppDir { get; private set; }
+
+        public CrossGenHandler(
+            string crossGenExe,
+            string diaSymReaderDll,
+            CrossGenTarget crossGenTarget,
+            DependencyContext depsFileContext,
+            DependencyContext runtimeContext,
+            string appDir,
+            string outputDir,
+            bool generatePDB)
+        {
+            AppDir = appDir;
+            OutputRoot = outputDir;
+            _generatePDB = generatePDB;
+            _crossGenTarget = crossGenTarget;
+            _workItems = new List<CrossGenWorkCollection>();
+            _fallbackDirectories = new Dictionary<string, HashSet<string>>();
+            _libraries = depsFileContext.RuntimeLibraries;
+
+            var runtimeGraph = runtimeContext.RuntimeGraph.FirstOrDefault(f => f.Runtime == _crossGenTarget.RuntimeIdentifier);
+            _runtimeFallbacks = runtimeGraph?.Fallbacks;
+
+            _crossGenCmds = GetCrossGenCmds(crossGenExe, diaSymReaderDll, crossGenTarget);
+        }
+
+        public void ExecuteCrossGen()
+        {
+            foreach (var lib in _libraries)
+            {
+                PrepareCrossGen(lib);
+            }
+
+            var platformAssembliesPaths = PopulatePlatformAssembliesPaths();
+
+            foreach (var lib in _workItems)
+            {
+                Reporter.Verbose.WriteLine($"CrossGen'ing {lib.Lib.Name}");
+                foreach (var item in lib.WorkItems)
+                {
+                    Directory.CreateDirectory(item.DestinationDir);
+                    _crossGenCmds.CrossGenAssembly(AppDir, item.Source, platformAssembliesPaths, item.DestinationDir, _generatePDB);
+                    Reporter.Verbose.WriteLine($"Done CrossGen'd asset {item.Source}, destination directory {item.DestinationDir}");
+                }
+                Reporter.Verbose.WriteLine($"Finished crossGen'ing {lib.Lib.Name}");
+                OnCrossGenCompletedFor(lib.Lib);
+            }
+            OnCrossGenCompleted();
+        }
+
+        /// <summary>
+        /// Go through the library to determine what assets to crossgen and also include all the asset directories
+        /// into platform assemblies path
+        /// </summary>
+        private void PrepareCrossGen(RuntimeLibrary lib)
+        {
+            if (ShouldCrossGenLib(lib))
+            {
+                var workItemsForLib = new CrossGenWorkCollection(lib);
+                Reporter.Verbose.WriteLine($"Looking for assets to CrossGen for library {lib.Name}.{lib.Version}");
+                foreach (var assetGroup in lib.RuntimeAssemblyGroups)
+                {
+                    var runtime = assetGroup.Runtime;
+
+                    if (!string.IsNullOrEmpty(runtime) && runtime != _crossGenTarget.RuntimeIdentifier && !_runtimeFallbacks.Contains(runtime))
+                    {
+                        Reporter.Verbose.WriteLine($"Skipping assets [{string.Join(", ", assetGroup.AssetPaths)}] because targeted runtime was {runtime}");
+                    }
+                    else
+                    {
+                        foreach (var assetPath in assetGroup.AssetPaths.Where(p => p.EndsWith(".dll")))
+                        {
+                            var fileName = Path.GetFileName(assetPath);
+                            var sourcePath = Path.Combine(AppDir, fileName);
+
+                            if (!File.Exists(sourcePath))
+                            {
+                                sourcePath = Path.Combine(AppDir, assetPath);
+                                if (!File.Exists(sourcePath))
+                                {
+                                    throw new CrossGenException($"Unable to locate asset {assetPath}");
+                                }
+                            }
+
+                            // skip native
+                            if (PEUtils.HasMetadata(sourcePath))
+                            {
+                                AddFallbackDirectory(runtime, Path.GetDirectoryName(sourcePath));
+                                if (!CrossGenCmdUtil.ShouldExclude(sourcePath))
+                                {
+                                    var outputDir = GetOutputDirFor(sourcePath, lib, assetPath);
+                                    workItemsForLib.WorkItems.Add(new CrossGenWorkItem(sourcePath, outputDir));
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (workItemsForLib.WorkItems.Count > 0)
+                {
+                    _workItems.Add(workItemsForLib);
+                }
+            }
+        }
+
+        private CrossGenCmdUtil GetCrossGenCmds(string crossGenExe, string diaSymReaderDll, CrossGenTarget crossGenTarget)
+        {
+            // TODO: Actually, we could support this if we really want to, we just need to copy files to to same directory
+            if (_generatePDB)
+            {
+                var versionInfo = FileVersionInfo.GetVersionInfo(crossGenExe);
+                if (versionInfo.FileMajorPart <= 1 && versionInfo.FileMinorPart == 0)
+                {
+                    throw new CrossGenException($"Generate PDB is not supported for {crossGenExe}, version: {versionInfo.FileMajorPart}.{versionInfo.FileMinorPart} < 1.1.0");
+                }
+            }
+
+            var jitPath = Path.Combine(AppDir, JITLibName);
+            if (!File.Exists(jitPath))
+            {
+                jitPath = Path.Combine(crossGenTarget.SharedFrameworkDir, JITLibName);
+                if (!File.Exists(jitPath))
+                {
+                    throw new CrossGenException($"Unable to resolve jit path. It should either be in the app directory \"{AppDir}\" or shared framework directory \"{crossGenTarget.SharedFrameworkDir}\".");
+                }
+            }
+
+            string diaSymReaderPath = _generatePDB ? diaSymReaderDll : null;
+            return new CrossGenCmdUtil(crossGenExe, jitPath, diaSymReaderPath, DefaultCrossGenType);
+        }
+
+        private void AddFallbackDirectory(string rid, string dir)
+        {
+            var fallbackKey = string.IsNullOrEmpty(rid) ? string.Empty : rid;
+            HashSet<string> dirs;
+            if (!_fallbackDirectories.TryGetValue(fallbackKey, out dirs))
+            {
+                dirs = new HashSet<string>();
+                _fallbackDirectories.Add(fallbackKey, dirs);
+            }
+            dirs.Add(dir);
+        }
+
+        private IList<string> PopulatePlatformAssembliesPaths()
+        {
+            var runtimesFallbacks = _runtimeFallbacks ?? new string[] { };
+            runtimesFallbacks = runtimesFallbacks.Concat(new string[] { string.Empty });
+
+            var platformAssembliesPaths = new List<string>();
+
+            foreach (var runtime in runtimesFallbacks)
+            {
+                if (_fallbackDirectories.ContainsKey(runtime))
+                {
+                    var dirs = _fallbackDirectories[runtime];
+                    platformAssembliesPaths.AddRange(dirs);
+                }
+            }
+
+            if (_crossGenTarget.SharedFrameworkDir != null)
+            {
+                platformAssembliesPaths.Add(_crossGenTarget.SharedFrameworkDir);
+            }
+
+            Reporter.Verbose.WriteLine($"App closure: [{string.Join(", ", platformAssembliesPaths)}]");
+            return platformAssembliesPaths;
+        }
+
+        private string GetFallbackDirForManaged(string rid)
+        {
+            return Path.Combine(AppDir, "runtimes", rid, "lib");
+        }
+
+        protected virtual bool ShouldCrossGenLib(RuntimeLibrary lib) { return true; }
+        protected virtual void OnCrossGenCompletedFor(RuntimeLibrary lib) { }
+        protected virtual void OnCrossGenCompleted() { }
+        protected abstract string GetOutputDirFor(string sourcePathUsed, RuntimeLibrary lib, string assetPath);
+
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/Outputs/CrossGenOutputStructure.cs
+++ b/src/dotnet/commands/dotnet-crossgen/Outputs/CrossGenOutputStructure.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Tools.CrossGen.Outputs
+{
+    public enum CrossGenOutputStructure
+    {
+        APP, CACHE
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/Outputs/OptimizationCacheCrossGenHandler.cs
+++ b/src/dotnet/commands/dotnet-crossgen/Outputs/OptimizationCacheCrossGenHandler.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.DependencyModel;
+
+namespace Microsoft.DotNet.Tools.CrossGen.Outputs
+{
+    /// <summary>
+    /// NuGet logic warning: Move out if/when needed
+    /// </summary>
+    public class OptimizationCacheCrossGenHandler : CrossGenHandler
+    {
+        // looks like the hash value "{Algorithm}-{value}" should be handled as an opaque string
+        private const string Sha512PropertyName = "sha512";
+        private readonly string _archName;
+        private readonly bool _overwriteOnConflict;
+        private IDictionary<string, string> _libShaValues;
+
+        public OptimizationCacheCrossGenHandler(
+            string crossGenExe,
+            string diaSymReaderDll,
+            CrossGenTarget crossGenTarget,
+            DependencyContext depsFileContext,
+            DependencyContext runtimeContext,
+            string appDir,
+            string outputDir,
+            bool generatePDB,
+            bool overwriteOnConflict)
+            : base(crossGenExe, diaSymReaderDll, crossGenTarget, depsFileContext, runtimeContext, appDir, outputDir, generatePDB)
+        {
+            _archName = crossGenTarget.RuntimeIdentifier.Split(new char[]{'-'}).Last();
+            _overwriteOnConflict = overwriteOnConflict;
+            _libShaValues = new Dictionary<string, string>();
+        }
+
+        protected override string GetOutputDirFor(string sourcePathUsed, RuntimeLibrary lib, string assetPath)
+        {
+            var libRoot = GetOutputRootForLib(lib);
+            var targetLocation = Path.Combine(libRoot, assetPath);
+            return Path.GetDirectoryName(targetLocation);
+        }
+
+        protected override bool ShouldCrossGenLib(RuntimeLibrary lib)
+        {
+            // calculate/verify sha value ahead of time so the process can bail out completely
+            // without affect the cache if there's an error
+            var sha = GetShaValueToWrite(lib);
+            if (sha != null)
+            {
+                _libShaValues.Add(lib.Name, sha);
+            }
+
+            return lib.Serviceable;
+        }
+
+        protected override void OnCrossGenCompletedFor(RuntimeLibrary lib)
+        {
+            string sha;
+            _libShaValues.TryGetValue(lib.Name, out sha);
+            if (sha != null)
+            {
+                var shaLocation = GetShaLocation(lib);
+                File.WriteAllText(shaLocation, sha);
+            }
+
+            // TODO: Copy everything needed.
+            // aspnet/BuildTools/DependenciesPackager
+        }
+
+        private string GetShaLocation(RuntimeLibrary lib)
+        {
+            var libRoot = GetOutputRootForLib(lib);
+            return Path.Combine(libRoot, $"{lib.Name}.{lib.Version}.nupkg.sha512");
+        }
+
+        private string GetShaValueToWrite(RuntimeLibrary lib)
+        {
+            var libHashString = lib.Hash;
+            if (!libHashString.StartsWith($"{Sha512PropertyName}-"))
+            {
+                throw new CrossGenException($"Unsupported Hash value for package {lib.Name}.{lib.Version}, value: {libHashString}");
+            }
+            var newShaValue = libHashString.Substring(Sha512PropertyName.Length + 1);
+
+            var targetLibShaFile = GetShaLocation(lib);
+            
+            if (!File.Exists(targetLibShaFile) || ShouldOverwrite(lib, targetLibShaFile, newShaValue))
+            {
+                // We don't have to write until we need to
+                return newShaValue;
+            }
+
+            return null;
+        }
+
+        private bool ShouldOverwrite(RuntimeLibrary lib, string targetLibShaFile, string newShaValue)
+        {
+            var oldShaValue = File.ReadAllText(targetLibShaFile);
+            if (oldShaValue == newShaValue)
+            {
+                return false;
+            }
+            else if (_overwriteOnConflict)
+            {
+                Reporter.Output.WriteLine($"[INFO] Hash mismatch found for {lib.Name}.{lib.Version}. Overwriting existing hash file. This might causes cache misses for other applications.");
+                return true;
+            }
+            else
+            {
+                throw new CrossGenException($"Hash mismatch found for {lib.Name}.{lib.Version}.");
+            }
+        }
+
+        private string GetOutputRootForLib(RuntimeLibrary lib)
+        {
+            return Path.Combine(OutputRoot, _archName, lib.Name, lib.Version);
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-crossgen/Program.cs
+++ b/src/dotnet/commands/dotnet-crossgen/Program.cs
@@ -1,0 +1,128 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.CrossGen.Outputs;
+
+namespace Microsoft.DotNet.Tools.CrossGen
+{
+    public static class CrossGenCommand
+    {
+        public static int Run(string[] args)
+        {
+            var app = new CommandLineApplication();
+            app.Name = "dotnet crossgen";
+            app.FullName = ".NET CrossGen Tool";
+            app.Description = "Tool for priming the dotnet optimization cache with crossgen'd assemblies";
+            app.HelpOption("-h|--help");
+
+            var appNameParam = app.Option("--appName <APPNAME>", "Name of the app", CommandOptionType.SingleValue);
+            var appRootParam = app.Option("--appRoot <DIR>", "App directory", CommandOptionType.SingleValue);
+
+            var outputDirParam = app.Option("--outputDir <DIR>", "(Optional) Directory to write the output cache to, default is DOTNET_HOSTING_OPTIMIZATION_CACHE", CommandOptionType.SingleValue);
+            var outputStructureParam = app.Option("--output-structure", "(Optional) Structure of the output. \"APP\" - Default option, obtain app's directory structure; \"CACHE\" - Arrange the crossgen'd assemblies in the structure of the optimization cache.", CommandOptionType.SingleValue);
+            var crossGenExeLocationParam = app.Option("--crossgenExe <FILE>", "(Optional) Location of crossgen executable.", CommandOptionType.SingleValue);
+            var generatePDBParam = app.Option("--generatePDB", "(Optional) Option to generate PDB", CommandOptionType.NoValue);
+            var diaSymReaderLocationParam = app.Option("--diasymreader <FILE>", "(Optional) Location of diasymreader", CommandOptionType.SingleValue);
+            var overwriteHashParam = app.Option("--overwrite-on-conflict", "(Optional) Used in CACHE output mode only. If a package hash value conflicts with existing cache, the program will exit unless this option is given.", CommandOptionType.NoValue);
+
+            app.OnExecute( () => {
+                VerifyRequired(crossGenExeLocationParam);
+                VerifyPathIfGiven(crossGenExeLocationParam);
+                var crossGenExeLocation = crossGenExeLocationParam.Value();
+
+                appNameParam.VerifyRequired();
+                var appName = appNameParam.Value();
+
+                appRootParam.VerifyRequired();
+                var appRoot = appRootParam.Value();
+                if (!Directory.Exists(appRoot))
+                {
+                    throw new CrossGenException($"App root \"{appRoot}\" is not valid directory.");
+                }
+
+                var generatePDB = generatePDBParam.HasValue();
+
+                if (generatePDB)
+                {
+                    VerifyPathIfGiven(diaSymReaderLocationParam);
+                }
+                var diaSymReaderLocation = diaSymReaderLocationParam.Value();
+
+                string outputDir;
+                if (outputDirParam.HasValue())
+                {
+                    outputDir = outputDirParam.Value();
+                }
+                else
+                {
+                    outputDir = Environment.GetEnvironmentVariable("DOTNET_HOSTING_OPTIMIZATION_CACHE");
+                    if (string.IsNullOrEmpty(outputDir))
+                    {
+                        throw new CrossGenException($"Please either set DOTNET_HOSTING_OPTIMIZATION_CACHE environmental variable or provide --outputDir parameter");
+                    }
+                }
+                
+                CrossGenOutputStructure outputStructure;
+                if (outputStructureParam.HasValue())
+                {
+                    if (!Enum.TryParse(outputStructureParam.Value(), true, out outputStructure))
+                    {
+                        throw new CrossGenException($"Invalid output structure {outputStructureParam.Value()}");
+                    }
+                }
+                else
+                {
+                    outputStructure = CrossGenOutputStructure.APP;
+                }
+
+                var overwriteHash = overwriteHashParam.HasValue();
+
+                var crossGenContext = new CrossGenContext(appName, appRoot, generatePDB);
+                crossGenContext.Initialize();
+                crossGenContext.ExecuteCrossGen(crossGenExeLocation, diaSymReaderLocation, outputDir, outputStructure, overwriteHash);
+
+                Reporter.Output.WriteLine($"CrossGen successful for {appName}");
+                return 0;
+            });
+
+
+            try
+            {
+                return app.Execute(args);
+            }
+            catch (Exception ex)
+            {
+#if DEBUG
+                Reporter.Error.WriteLine(ex.ToString());
+#else
+                Reporter.Error.WriteLine(ex.Message);
+#endif
+                return 1;
+            }
+        }
+
+        private static void VerifyPathIfGiven(this CommandOption option)
+        {
+            if (option.HasValue())
+            {
+                var path = option.Value();
+                if (!File.Exists(path))
+                {
+                    throw new CrossGenException($"--{option.LongName} cannot be located at {path}");
+                }
+            }
+        }
+
+        private static void VerifyRequired(this CommandOption option)
+        {
+            if (!option.HasValue())
+            {
+                throw new CrossGenException($"Missing required parameter --{option.LongName}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Feature:

Given a published dotnet application, this tool can generate crossgen'd assemblies and arrange them in on of the two following folder structure

1. App - Make a copy of the application except all dotnet assemblies are crossgen'd
2. Optimization Cache - Populate into a structure that can be used as DOTNET_HOSTING_OPTIMIZATION_CACHE. (This feature is incomplete, right now it outputs the crossgen'd assemblies and sha file only. The rest of the structure still needs to be populated.)

Note that because this is a WIP feature, currently the user have to specify where crossgen.exe is

### How was runtime environments determined?
**Self contained:** deps.json provides RID
**Portable:** RID would be determined by detecting the RID of the current CLI. Framework would be determined by going into the shared framework directory and auto-roll-forward if necessary.

### Pending issues

1. This app does not currently generate complete DOTNET_HOSTING_OPTIMIZATION_CACHE hive. Only the crossgen'd assembly and sha file.

2. How important is the GeneratePDB option? Currently it only supports crossgen.exe version 1.1 and up. I can add logic to support GeneratePDB pre-1.1 if required but it would be a bit more messy.

3. We don't know how crossgen.exe would be shipped. Currently the command requires the location of crossgen.exe to be passed in.