### PR TITLE
Replace Microsoft.Net.Compilers.Targets.NetCore

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,6 +6,8 @@
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" />
+    <!-- Temporary -->
+    <add key="roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,8 +6,6 @@
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" />
-    <!-- Temporary -->
-    <add key="roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/TestAssets/TestProjects/AppWithNet46AndRoslyn/project.json
+++ b/TestAssets/TestProjects/AppWithNet46AndRoslyn/project.json
@@ -3,7 +3,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60920-07"
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60922-08"
   },
   "frameworks": {
     "net46": {}

--- a/TestAssets/TestProjects/AppWithNet46AndRoslyn/project.json
+++ b/TestAssets/TestProjects/AppWithNet46AndRoslyn/project.json
@@ -3,7 +3,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "1.3.0"
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60920-07"
   },
   "frameworks": {
     "net46": {}

--- a/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
@@ -4,7 +4,7 @@
     "preserveCompilationContext": true
   },
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "1.3.0"
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60920-07"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
@@ -4,7 +4,7 @@
     "preserveCompilationContext": true
   },
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60920-07"
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60922-08"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -4,7 +4,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "1.3.0",
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60920-07",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -4,7 +4,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60920-07",
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60922-08",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -10,7 +10,7 @@
     "Microsoft.DotNet.Compiler.Common": {
       "target": "project"
     },
-    "Microsoft.CodeAnalysis.CSharp.Workspaces": "1.3.0",
+    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta6-60920-07",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {

--- a/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Workspaces/project.json
@@ -10,7 +10,7 @@
     "Microsoft.DotNet.Compiler.Common": {
       "target": "project"
     },
-    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta6-60920-07",
+    "Microsoft.CodeAnalysis.CSharp.Workspaces": "2.0.0-beta6-60922-08",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },
   "frameworks": {

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -32,13 +32,8 @@ namespace Microsoft.DotNet.Tools.MSBuild
             return new Dictionary<string, string>
             {
                 { "MSBuildExtensionsPath", AppContext.BaseDirectory },
-                { "DotnetHostPath", GetHostPath() },
+                { "CscToolExe", GetRunCscPath() }
             };
-        }
-
-        private static string GetHostPath()
-        {
-            return new Muxer().MuxerPath;
         }
 
         private static string GetMSBuildExePath()
@@ -46,6 +41,12 @@ namespace Microsoft.DotNet.Tools.MSBuild
             return Path.Combine(
                 AppContext.BaseDirectory,
                 s_msbuildExeName);
+        }
+
+        private static string GetRunCscPath()
+        {
+            var scriptExtension = RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows ? ".cmd" : ".sh";
+            return Path.Combine(AppContext.BaseDirectory, $"RunCsc{scriptExtension}");
         }
     }
 }

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -4,8 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli;
-using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.MSBuild
 {
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         private static string GetRunCscPath()
         {
-            var scriptExtension = RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows ? ".cmd" : ".sh";
+            var scriptExtension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".cmd" : ".sh";
             return Path.Combine(AppContext.BaseDirectory, $"RunCsc{scriptExtension}");
         }
     }

--- a/src/redist/RunCsc.cmd
+++ b/src/redist/RunCsc.cmd
@@ -1,0 +1,6 @@
+@echo off
+
+REM Copyright (c) .NET Foundation and contributors. All rights reserved.
+REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+%~dp0..\..\dotnet %~dp0csc.exe %*

--- a/src/redist/RunCsc.sh
+++ b/src/redist/RunCsc.sh
@@ -14,4 +14,4 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-$DIR/../../dotnet $DIR/csc.exe $@
+"$DIR/../../dotnet" "$DIR/csc.exe" "$@"

--- a/src/redist/RunCsc.sh
+++ b/src/redist/RunCsc.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+$DIR/../../dotnet $DIR/csc.exe $@

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -25,7 +25,7 @@
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00039-160922",
     "Microsoft.Build.Targets": "0.1.0-preview-00039-160922",
     "Microsoft.Build": "0.1.0-preview-00039-160922",
-    "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60920-07",
+    "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60922-08",
     "System.Runtime.Serialization.Xml": "4.1.1",
     "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.9",
     "Microsoft.TestPlatform.CLI": "15.0.0-preview-20160915-01"

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -3,11 +3,11 @@
   "buildOptions": {
     "emitEntryPoint": true,
     "copyToOutput": {
-      "include": "RunCsc.sh"
+      "include": ["RunCsc.sh", "RunCsc.cmd"]
     }
   },
   "publishOptions": {
-    "include": "RunCsc.sh"
+    "include": ["RunCsc.sh", "RunCsc.cmd"]
   },
   "dependencies": {
     "Microsoft.NETCore.App": {

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -1,7 +1,13 @@
 {
   "version": "1.0.0-preview3-*",
   "buildOptions": {
-    "emitEntryPoint": true
+    "emitEntryPoint": true,
+    "copyToOutput": {
+      "include": "RunCsc.sh"
+    }
+  },
+  "publishOptions": {
+    "include": "RunCsc.sh"
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
@@ -19,6 +25,7 @@
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00039-160922",
     "Microsoft.Build.Targets": "0.1.0-preview-00039-160922",
     "Microsoft.Build": "0.1.0-preview-00039-160922",
+    "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60920-07",
     "System.Runtime.Serialization.Xml": "4.1.1",
     "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.9",
     "Microsoft.TestPlatform.CLI": "15.0.0-preview-20160915-01"

--- a/src/tool_csc/project.json
+++ b/src/tool_csc/project.json
@@ -8,8 +8,8 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "Microsoft.CodeAnalysis.CSharp": "1.3.0",
-    "Microsoft.Net.Compilers.netcore": "1.3.0",
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60920-07",
+    "Microsoft.Net.Compilers.netcore": "2.0.0-beta6-60920-07",
     "Microsoft.DiaSymReader.Native": "1.4.0-rc2"
   },
   "frameworks": {

--- a/src/tool_csc/project.json
+++ b/src/tool_csc/project.json
@@ -8,8 +8,8 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60920-07",
-    "Microsoft.Net.Compilers.netcore": "2.0.0-beta6-60920-07",
+    "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60922-08",
+    "Microsoft.Net.Compilers.netcore": "2.0.0-beta6-60922-08",
     "Microsoft.DiaSymReader.Native": "1.4.0-rc2"
   },
   "frameworks": {

--- a/src/tool_msbuild/project.json
+++ b/src/tool_msbuild/project.json
@@ -10,8 +10,8 @@
     },
     "MSBuild": "0.1.0-preview-00039-160922",
     "Microsoft.Build.Targets": "0.1.0-preview-00039-160922",
-    "Microsoft.Net.Compilers.netcore": "1.3.0",
-    "Microsoft.Net.Compilers.Targets.NetCore": "0.1.5-dev",
+    "Microsoft.Net.Compilers.netcore": "2.0.0-beta6-60920-07",
+    "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60920-07",
     "Microsoft.Cci": "4.0.0-rc3-24128-00",
     "Microsoft.Composition": "1.0.30",
     "Microsoft.NuGet.Build.Tasks": "1.0.0-alpha-000002"

--- a/src/tool_msbuild/project.json
+++ b/src/tool_msbuild/project.json
@@ -10,11 +10,11 @@
     },
     "MSBuild": "0.1.0-preview-00039-160922",
     "Microsoft.Build.Targets": "0.1.0-preview-00039-160922",
-    "Microsoft.Net.Compilers.netcore": "2.0.0-beta6-60920-07",
-    "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60920-07",
+    "Microsoft.Net.Compilers.netcore": "2.0.0-beta6-60922-08",
+    "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60922-08",
     "Microsoft.Cci": "4.0.0-rc3-24128-00",
     "Microsoft.Composition": "1.0.30",
-    "Microsoft.NuGet.Build.Tasks": "1.0.0-alpha-000003"
+    "Microsoft.NuGet.Build.Tasks": "1.0.0-alpha-000004"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/tool_msbuild/project.json
+++ b/src/tool_msbuild/project.json
@@ -14,7 +14,7 @@
     "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60920-07",
     "Microsoft.Cci": "4.0.0-rc3-24128-00",
     "Microsoft.Composition": "1.0.30",
-    "Microsoft.NuGet.Build.Tasks": "1.0.0-alpha-000002"
+    "Microsoft.NuGet.Build.Tasks": "1.0.0-alpha-000003"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
Updating csc to 2.0.0-beta and replace Microsoft.Net.Compilers.Targets.NetCore package with Microsoft.CodeAnalysis.Build.Tasks

cc @eerhardt @brthor @Sridhar-MS @piotrpMSFT 