### PR TITLE
Create a `dotnet msbuild` command and fill out the applicable command line arguments to `dotnet build3`.

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -168,6 +168,8 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.DotNet.Tools.Test
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dotnet-vstest.Tests", "test\dotnet-vstest.Tests\dotnet-vstest.Tests.xproj", "{9F5AE280-A040-4160-9799-6504D907742D}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "dotnet-msbuild.Tests", "test\dotnet-msbuild.Tests\dotnet-msbuild.Tests.xproj", "{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -964,6 +966,22 @@ Global
 		{9F5AE280-A040-4160-9799-6504D907742D}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
 		{9F5AE280-A040-4160-9799-6504D907742D}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
 		{9F5AE280-A040-4160-9799-6504D907742D}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.Debug|x64.Build.0 = Debug|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.MinSizeRel|Any CPU.ActiveCfg = Debug|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.MinSizeRel|Any CPU.Build.0 = Debug|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.MinSizeRel|x64.ActiveCfg = Debug|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.MinSizeRel|x64.Build.0 = Debug|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.Release|x64.ActiveCfg = Release|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.Release|x64.Build.0 = Release|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.RelWithDebInfo|Any CPU.ActiveCfg = Release|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.RelWithDebInfo|Any CPU.Build.0 = Release|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.RelWithDebInfo|x64.ActiveCfg = Release|Any CPU
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6}.RelWithDebInfo|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1026,5 +1044,6 @@ Global
 		{1F2EF070-AC5F-4078-AFB0-65745AC691B9} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 		{6D028154-5518-4A56-BAD6-938A90E5BCF6} = {ED2FE3E2-F7E7-4389-8231-B65123F2076F}
 		{9F5AE280-A040-4160-9799-6504D907742D} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
+		{2FFCBDF0-BA36-4393-8DDB-1AE04AEA3CD6} = {17735A9D-BFD9-4585-A7CB-3208CA6EA8A7}
 	EndGlobalSection
 EndGlobal

--- a/TestAssets/TestProjects/MSBuildBareBonesProject/BareBones.proj
+++ b/TestAssets/TestProjects/MSBuildBareBonesProject/BareBones.proj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="SayHello">
+    <Message Text="Hello, from MSBuild!" />
+  </Target>
+
+  <Target Name="SayGoodbye">
+    <Message Text="Goodbye, from MSBuild. :'(" />
+  </Target>
+
+  <Target Name="SayThis">
+    <Message Text="You want me to say '$(This)'" />
+  </Target>
+
+</Project>

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -15,6 +15,8 @@ using Microsoft.DotNet.Tools.Build3;
 using Microsoft.DotNet.Tools.Compiler;
 using Microsoft.DotNet.Tools.Compiler.Csc;
 using Microsoft.DotNet.Tools.Help;
+using Microsoft.DotNet.Tools.Migrate;
+using Microsoft.DotNet.Tools.MSBuild;
 using Microsoft.DotNet.Tools.New;
 using Microsoft.DotNet.Tools.NuGet;
 using Microsoft.DotNet.Tools.Pack3;
@@ -24,7 +26,6 @@ using Microsoft.DotNet.Tools.Restore3;
 using Microsoft.DotNet.Tools.Run;
 using Microsoft.DotNet.Tools.Test;
 using Microsoft.DotNet.Tools.VSTest;
-using Microsoft.DotNet.Tools.Migrate;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -5,13 +5,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.Loader;
 using System.Text;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.DotNet.ProjectModel.Server;
 using Microsoft.DotNet.Tools.Build;
+using Microsoft.DotNet.Tools.Build3;
 using Microsoft.DotNet.Tools.Compiler;
 using Microsoft.DotNet.Tools.Compiler.Csc;
 using Microsoft.DotNet.Tools.Help;
@@ -44,6 +44,7 @@ namespace Microsoft.DotNet.Cli
             ["run"] = RunCommand.Run,
             ["test"] = TestCommand.Run,
             ["build3"] = Build3Command.Run,
+            ["msbuild"] = MSBuildCommand.Run,
             ["run3"] = Run3Command.Run,
             ["restore3"] = Restore3Command.Run,
             ["vstest"] = VSTestCommand.Run,

--- a/src/dotnet/commands/dotnet-build3/Program.cs
+++ b/src/dotnet/commands/dotnet-build3/Program.cs
@@ -1,19 +1,87 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
-using System;
-using System.Diagnostics;
-using System.IO;
-using System.Reflection;
 
-namespace Microsoft.DotNet.Cli
+namespace Microsoft.DotNet.Tools.Build3
 {
     public class Build3Command
     {
         public static int Run(string[] args)
         {
-            return new MSBuildForwardingApp(args).Execute();
+            DebugHelper.HandleDebugSwitch(ref args);
+
+            CommandLineApplication app = new CommandLineApplication(throwOnUnexpectedArg: false);
+            app.Name = "dotnet build3";
+            app.FullName = ".NET Builder";
+            app.Description = "Builder for the .NET Platform. Delegates to the MSBuild 'Build' target in the project file.";
+            app.AllowArgumentSeparator = true;
+            app.HelpOption("-h|--help");
+
+            CommandArgument projectArgument = app.Argument("<PROJECT>",
+                "The MSBuild project file to build. If a project file is not specified," +
+                " MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file.");
+
+            CommandOption outputOption = app.Option("-o|--output <OUTPUT_DIR>", "Directory in which to place outputs", CommandOptionType.SingleValue);
+            CommandOption frameworkOption = app.Option("-f|--framework <FRAMEWORK>", "Compile a specific framework", CommandOptionType.SingleValue);
+            CommandOption configurationOption = app.Option("-c|--configuration <CONFIGURATION>", "Configuration under which to build", CommandOptionType.SingleValue);
+            CommandOption versionSuffixOption = app.Option("--version-suffix <VERSION_SUFFIX>", "Defines the value for the $(VersionSuffix) property in the project", CommandOptionType.SingleValue);
+
+            CommandOption noIncrementalOption = app.Option("--no-incremental", "Set this flag to turn off incremental build", CommandOptionType.NoValue);
+            CommandOption noDependenciesOption = app.Option("--no-dependencies", "Set this flag to ignore project to project references and only build the root project", CommandOptionType.NoValue);
+
+            app.OnExecute(() =>
+            {
+                List<string> msbuildArgs = new List<string>();
+
+                if (!string.IsNullOrEmpty(projectArgument.Value))
+                {
+                    msbuildArgs.Add(projectArgument.Value);
+                }
+
+                if (noIncrementalOption.HasValue())
+                {
+                    msbuildArgs.Add("/t:Rebuild");
+                }
+                else
+                {
+                    msbuildArgs.Add("/t:Build");
+                }
+
+                if (outputOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:OutputPath={outputOption.Value()}");
+                }
+
+                if (frameworkOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:TargetFramework={frameworkOption.Value()}");
+                }
+
+                if (configurationOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:Configuration={configurationOption.Value()}");
+                }
+
+                if (versionSuffixOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:VersionSuffix={versionSuffixOption.Value()}");
+                }
+
+                if (noDependenciesOption.HasValue())
+                {
+                    msbuildArgs.Add("/p:BuildProjectReferences=false");
+                }
+
+                msbuildArgs.AddRange(app.RemainingArguments);
+
+                return new MSBuildForwardingApp(msbuildArgs).Execute();
+            });
+
+            return app.Execute(args);
         }
     }
 }

--- a/src/dotnet/commands/dotnet-build3/Program.cs
+++ b/src/dotnet/commands/dotnet-build3/Program.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.MSBuild;
 
 namespace Microsoft.DotNet.Tools.Build3
 {

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.PlatformAbstractions;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.DotNet.Cli.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
 
-namespace Microsoft.DotNet.Cli
+namespace Microsoft.DotNet.Tools.MSBuild
 {
     public class MSBuildForwardingApp
     {

--- a/src/dotnet/commands/dotnet-msbuild/Program.cs
+++ b/src/dotnet/commands/dotnet-msbuild/Program.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.DotNet.Cli
+namespace Microsoft.DotNet.Tools.MSBuild
 {
     public class MSBuildCommand
     {

--- a/src/dotnet/commands/dotnet-msbuild/Program.cs
+++ b/src/dotnet/commands/dotnet-msbuild/Program.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Cli
+{
+    public class MSBuildCommand
+    {
+        public static int Run(string[] args)
+        {
+            return new MSBuildForwardingApp(args).Execute();
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-pack3/Pack3Command.cs
+++ b/src/dotnet/commands/dotnet-pack3/Pack3Command.cs
@@ -1,11 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.MSBuild;
 
 namespace Microsoft.DotNet.Tools.Pack3
 {

--- a/src/dotnet/commands/dotnet-restore3/Program.cs
+++ b/src/dotnet/commands/dotnet-restore3/Program.cs
@@ -1,11 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
-using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.MSBuild;
 
 namespace Microsoft.DotNet.Tools.Restore3
 {

--- a/src/dotnet/commands/dotnet-run3/Run3Command.cs
+++ b/src/dotnet/commands/dotnet-run3/Run3Command.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Execution;
-using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.MSBuild;
 
 namespace Microsoft.DotNet.Tools.Run
 {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/MSBuildCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/MSBuildCommand.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public sealed class MSBuildCommand : TestCommand
+    {
+        public MSBuildCommand()
+            : base("dotnet")
+        {
+        }
+
+        public override CommandResult Execute(string args = "")
+        {
+            args = $"msbuild {args}";
+            return base.Execute(args);
+        }
+
+        public override CommandResult ExecuteWithCapturedOutput(string args = "")
+        {
+            args = $"msbuild {args}";
+            return base.ExecuteWithCapturedOutput(args);
+        }
+    }
+}

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Build3.Tests
+{
+    public class GivenDotnetMSBuildBuildsProjects : TestBase
+    {
+        [Fact]
+        public void ItRunsSpecifiedTargetsWithPropertiesCorrectly()
+        {
+            var testInstance = TestAssetsManager
+                .CreateTestInstance("MSBuildBareBonesProject");
+
+            var testProjectDirectory = testInstance.TestRoot;
+
+            new MSBuildCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("/t:SayHello")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello, from MSBuild!");
+
+            new MSBuildCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("/t:SayGoodbye")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Goodbye, from MSBuild. :'(");
+
+            new MSBuildCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("/t:SayThis /p:This=GreatScott")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("You want me to say 'GreatScott'");
+        }
+    }
+}

--- a/test/dotnet-msbuild.Tests/dotnet-msbuild.Tests.xproj
+++ b/test/dotnet-msbuild.Tests/dotnet-msbuild.Tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.23107" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.23107</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>2ffcbdf0-ba36-4393-8ddb-1ae04aea3cd6</ProjectGuid>
+    <RootNamespace>Microsoft.DotNet.Cli.MSBuild.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/dotnet-msbuild.Tests/project.json
+++ b/test/dotnet-msbuild.Tests/project.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0.0-*",
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.1"
+    },
+    "System.Runtime.Serialization.Primitives": "4.1.1",
+    "Microsoft.DotNet.Tools.Tests.Utilities": {
+      "target": "project"
+    },
+    "xunit": "2.2.0-beta3-build3330",
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.4",
+        "portable-net451+win8"
+      ]
+    }
+  },
+  "testRunner": "xunit"
+}


### PR DESCRIPTION
Fix #4203

@livarcocc @brthor @Sridhar-MS 

/cc @dotnet/msbuild - FYI to review the mappings between `dotnet build` args to MSBuild concepts.