### PR TITLE
Remove whitespace from dotnet-new C# library template

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/Library.cs
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/Library.cs
@@ -5,7 +5,7 @@ namespace ClassLibrary
     public class Class1
     {
         public void Method1()
-        {    
+        {
         }
     }
 }


### PR DESCRIPTION
I noticed there was some extra whitespace in the file when I created a new library project via

```sh
dotnet new -t Lib
```

, so I went ahead and removed it in this PR.