### PR TITLE
Support building with custom container name

### DIFF
--- a/build/Microsoft.DotNet.Cli.Publish.targets
+++ b/build/Microsoft.DotNet.Cli.Publish.targets
@@ -97,11 +97,13 @@
       AccountKey="$(CloudDropAccessToken)"
       AccountName="$(CloudDropAccountName)"
       ContainerName="$(ContainerName)"
-      Items="@(CliVersionBadgeToUpload)" />
+      Items="@(CliVersionBadgeToUpload)"
+      Overwrite="$(OverwriteOnPublish)" />
 
     <SetBlobPropertiesBasedOnFileType
       AccountKey="$(CloudDropAccessToken)"
       AccountName="$(CloudDropAccountName)"
+      ContainerName="$(ContainerName)"
       Items="@(CliVersionBadgeToUpload)" />
   </Target>
 </Project>

--- a/build_projects/dotnet-cli-build/SetBlobPropertiesBasedOnFileTypeTask.cs
+++ b/build_projects/dotnet-cli-build/SetBlobPropertiesBasedOnFileTypeTask.cs
@@ -19,15 +19,18 @@ namespace Microsoft.DotNet.Cli.Build
         public string AccountKey { get; set; }
 
         [Required]
+        public string ContainerName { get; set; }
+
+        [Required]
         public ITaskItem[] Items { get; set; }
 
         private AzurePublisher AzurePublisherTool
         {
             get
             {
-                if(_azurePublisher == null)
+                if (_azurePublisher == null)
                 {
-                    _azurePublisher = new AzurePublisher(AccountName, AccountKey);
+                    _azurePublisher = new AzurePublisher(AccountName, AccountKey, ContainerName);
                 }
 
                 return _azurePublisher;
@@ -42,7 +45,7 @@ namespace Microsoft.DotNet.Cli.Build
                 return false;
             }
 
-            foreach(var item in Items)
+            foreach (var item in Items)
             {
                 string relativeBlobPath = item.GetMetadata("RelativeBlobPath");
                 if (string.IsNullOrEmpty(relativeBlobPath))
@@ -53,7 +56,7 @@ namespace Microsoft.DotNet.Cli.Build
                 }
 
                 AzurePublisherTool.SetBlobPropertiesBasedOnFileType(relativeBlobPath);
-            }            
+            }
 
             return true;
         }


### PR DESCRIPTION
Currently, using a custom container name is supported for only some
publish steps.  This commit makes it supported for all publish steps.

This commit also ensures that the Overwrite property is specified on all
calls to the UploadToAzure task.

cc: @livarcocc @brthor 