### PR TITLE
bump nuget to 3.6.0-beta.1.msbuild.16

### DIFF
--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -20,7 +20,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Xml.XmlSerializer": "4.0.11",
     "WindowsAzure.Storage": "6.2.2-preview",
-    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.15",
+    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.16",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00039-160922",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -9,10 +9,10 @@
       "target": "project"
     },
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
-    "NuGet.Versioning": "3.6.0-beta.1.msbuild.15",
-    "NuGet.Packaging": "3.6.0-beta.1.msbuild.15",
-    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.15",
-    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.15"
+    "NuGet.Versioning": "3.6.0-beta.1.msbuild.16",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.16",
+    "NuGet.Frameworks": "3.6.0-beta.1.msbuild.16",
+    "NuGet.ProjectModel": "3.6.0-beta.1.msbuild.16"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -8,9 +8,9 @@
     "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Configuration": "3.6.0-beta.1.msbuild.15",
-    "NuGet.Packaging": "3.6.0-beta.1.msbuild.15",
-    "NuGet.RuntimeModel": "3.6.0-beta.1.msbuild.15",
+    "NuGet.Configuration": "3.6.0-beta.1.msbuild.16",
+    "NuGet.Packaging": "3.6.0-beta.1.msbuild.16",
+    "NuGet.RuntimeModel": "3.6.0-beta.1.msbuild.16",
     "System.Reflection.Metadata": "1.4.1-beta-24410-02"
   },
   "frameworks": {

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -27,7 +27,7 @@
     "Microsoft.Build": "0.1.0-preview-00039-160922",
     "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60922-08",
     "System.Runtime.Serialization.Xml": "4.1.1",
-    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.15",
+    "NuGet.Build.Tasks": "3.6.0-beta.1.msbuild.16",
     "Microsoft.TestPlatform.CLI": "15.0.0-preview-20160915-01"
   },
   "frameworks": {

--- a/src/tool_nuget/project.json
+++ b/src/tool_nuget/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.15"
+    "NuGet.CommandLine.XPlat": "3.6.0-beta.1.msbuild.16"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
this includes @emgarten 's fix for generating the *.g.props and *.g.targets with the file extension included in the name.

CC: @eerhardt @livarcocc @rrelyea @emgarten @joelverhagen 
