### PR TITLE
Double quoting the path to the host and to csc.dll in RunCsc.cmd

### DIFF
--- a/src/redist/RunCsc.cmd
+++ b/src/redist/RunCsc.cmd
@@ -3,4 +3,4 @@
 REM Copyright (c) .NET Foundation and contributors. All rights reserved.
 REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-%~dp0..\..\dotnet %~dp0csc.exe %*
+"%~dp0..\..\dotnet" "%~dp0csc.exe" %*


### PR DESCRIPTION
Double quoting the path to the host and to csc.dll in RunCsc.cmd so that it works when the CLI is in a path with spaces.

I still need to figure out how to do the quoting of arguments, but given that this will break anyone using the MSIs, I decided to get this in first. I opened a issue for the double quoting of the arguments.

https://github.com/dotnet/cli/issues/4266

@eerhardt @brthor @Sridhar-MS 