### PR TITLE
Fix tools with trailing backslashes in additionalProbingPath

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectDependenciesCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectDependenciesCommandResolver.cs
@@ -95,14 +95,14 @@ namespace Microsoft.DotNet.Cli.Utils
             }
 
             var toolLibrary = GetToolLibraryForContext(projectContext, commandName);
-            var nugetPackagesRoot = PathUtility.EnsureNoTrailingDirectorySeparator(projectContext.PackagesDirectory);
+            var normalizedNugetPackagesRoot = PathUtility.EnsureNoTrailingDirectorySeparator(projectContext.PackagesDirectory);
 
             return _packagedCommandSpecFactory.CreateCommandSpecFromLibrary(
                         toolLibrary,
                         commandName,
                         commandArguments,
                         allowedExtensions,
-                        nugetPackagesRoot,
+                        normalizedNugetPackagesRoot,
                         s_commandResolutionStrategy,
                         depsFilePath,
                         runtimeConfigPath);

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectDependenciesCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectDependenciesCommandResolver.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Common;
 using NuGet.Frameworks;
 using NuGet.ProjectModel;
 
@@ -94,13 +95,14 @@ namespace Microsoft.DotNet.Cli.Utils
             }
 
             var toolLibrary = GetToolLibraryForContext(projectContext, commandName);
+            var nugetPackagesRoot = PathUtility.EnsureNoTrailingDirectorySeparator(projectContext.PackagesDirectory);
 
             return _packagedCommandSpecFactory.CreateCommandSpecFromLibrary(
                         toolLibrary,
                         commandName,
                         commandArguments,
                         allowedExtensions,
-                        projectContext.PackagesDirectory,
+                        nugetPackagesRoot,
                         s_commandResolutionStrategy,
                         depsFilePath,
                         runtimeConfigPath);

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.DotNet.InternalAbstractions;
 using Microsoft.DotNet.ProjectModel;
+using Microsoft.DotNet.Tools.Common;
 using Microsoft.Extensions.DependencyModel;
 using NuGet.Frameworks;
 using NuGet.LibraryModel;
@@ -95,7 +96,7 @@ namespace Microsoft.DotNet.Cli.Utils
             IEnumerable<string> args,
             ProjectContext projectContext)
         {
-            var nugetPackagesRoot = projectContext.PackagesDirectory;
+            var nugetPackagesRoot = PathUtility.EnsureNoTrailingDirectorySeparator(projectContext.PackagesDirectory);
 
             var lockFile = GetToolLockFile(toolLibraryRange, nugetPackagesRoot);
 

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Cli.Utils
             IEnumerable<string> args,
             ProjectContext projectContext)
         {
-            var nugetPackagesRoot = PathUtility.EnsureNoTrailingDirectorySeparator(projectContext.PackagesDirectory);
+            var nugetPackagesRoot = projectContext.PackagesDirectory;
 
             var lockFile = GetToolLockFile(toolLibraryRange, nugetPackagesRoot);
 
@@ -112,12 +112,14 @@ namespace Microsoft.DotNet.Cli.Utils
             var depsFileRoot = Path.GetDirectoryName(lockFile.Path);
             var depsFilePath = GetToolDepsFilePath(toolLibraryRange, lockFile, depsFileRoot);
 
+            var normalizedNugetPackagesRoot = PathUtility.EnsureNoTrailingDirectorySeparator(nugetPackagesRoot);
+
             return _packagedCommandSpecFactory.CreateCommandSpecFromLibrary(
                     toolLibrary,
                     commandName,
                     args,
                     _allowedCommandExtensions,
-                    projectContext.PackagesDirectory,
+                    normalizedNugetPackagesRoot,
                     s_commandResolutionStrategy,
                     depsFilePath,
                     null);


### PR DESCRIPTION
Tools became broken at some point because a trailing backslash is getting passed to the host as additionalProbingPath.

This should fix it:
@livarcocc @prafullbhosale @mlorbetske 
