### PR TITLE
Added clean3 verb for msbuild based projects.

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.DotNet.ProjectModel.Server;
 using Microsoft.DotNet.Tools.Build;
 using Microsoft.DotNet.Tools.Build3;
+using Microsoft.DotNet.Tools.Clean3;
 using Microsoft.DotNet.Tools.Compiler;
 using Microsoft.DotNet.Tools.Compiler.Csc;
 using Microsoft.DotNet.Tools.Help;
@@ -47,6 +48,7 @@ namespace Microsoft.DotNet.Cli
             ["run"] = RunCommand.Run,
             ["test"] = TestCommand.Run,
             ["build3"] = Build3Command.Run,
+            ["clean3"] = Clean3Command.Run,
             ["msbuild"] = MSBuildCommand.Run,
             ["run3"] = Run3Command.Run,
             ["restore3"] = Restore3Command.Run,

--- a/src/dotnet/commands/dotnet-clean3/Program.cs
+++ b/src/dotnet/commands/dotnet-clean3/Program.cs
@@ -1,0 +1,68 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.MSBuild;
+
+namespace Microsoft.DotNet.Tools.Clean3
+{
+    public class Clean3Command
+    {
+        public static int Run(string[] args)
+        {
+            DebugHelper.HandleDebugSwitch(ref args);
+
+            CommandLineApplication app = new CommandLineApplication(throwOnUnexpectedArg: false)
+            {
+                Name = "dotnet clean3",
+                FullName = ".NET Clean Command",
+                Description = "Command to clean previously generated build outputs.",
+                AllowArgumentSeparator = true
+            };
+            app.HelpOption("-h|--help");
+
+            CommandArgument projectArgument = app.Argument("<PROJECT>",
+                "The MSBuild project file to build. If a project file is not specified," +
+                " MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file.");
+
+            CommandOption outputOption = app.Option("-o|--output <OUTPUT_DIR>", "Directory in which the build outputs have been placed", CommandOptionType.SingleValue);
+            CommandOption frameworkOption = app.Option("-f|--framework <FRAMEWORK>", "Clean a specific framework", CommandOptionType.SingleValue);
+            CommandOption configurationOption = app.Option("-c|--configuration <CONFIGURATION>", "Clean a specific configuration", CommandOptionType.SingleValue);
+
+            app.OnExecute(() =>
+            {
+                List<string> msbuildArgs = new List<string>();
+
+                if (!string.IsNullOrEmpty(projectArgument.Value))
+                {
+                    msbuildArgs.Add(projectArgument.Value);
+                }
+
+                msbuildArgs.Add("/t:Clean");
+
+                if (outputOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:OutputPath={outputOption.Value()}");
+                }
+
+                if (frameworkOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:TargetFramework={frameworkOption.Value()}");
+                }
+
+                if (configurationOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:Configuration={configurationOption.Value()}");
+                }
+
+                msbuildArgs.AddRange(app.RemainingArguments);
+
+                return new MSBuildForwardingApp(msbuildArgs).Execute();
+            });
+
+            return app.Execute(args);
+        }
+    }
+}

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 
@@ -9,7 +10,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
     public class GivenDotNetUsesMSBuild : TestBase
     {
         [Fact]
-        public void ItCanNewRestoreBuildRunMSBuildProject()
+        public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
             using (DisposableDirectory directory = Temp.CreateDirectory())
             {
@@ -41,6 +42,17 @@ namespace Microsoft.DotNet.Tests.EndToEnd
                     .Pass()
                     .And
                     .HaveStdOutContaining("Hello World!");
+
+                var binDirectory = new DirectoryInfo(projectDirectory).Sub("bin");
+                binDirectory.Should().HaveFilesMatching("*.dll", SearchOption.AllDirectories);
+
+                new Clean3Command()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute()
+                    .Should()
+                    .Pass();
+
+                binDirectory.Should().NotHaveFilesMatching("*.dll", SearchOption.AllDirectories);
             }
         }
 

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/DirectoryInfoAssertions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/DirectoryInfoAssertions.cs
@@ -56,6 +56,15 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return new AndConstraint<DirectoryInfoAssertions>(this);
         }
 
+        public AndConstraint<DirectoryInfoAssertions> HaveFilesMatching(string expectedFilesSearchPattern, SearchOption searchOption)
+        {
+            var matchingFileExists = _dirInfo.EnumerateFiles(expectedFilesSearchPattern, searchOption).Any();
+            Execute.Assertion.ForCondition(matchingFileExists == true)
+                .FailWith("Expected directory {0} to contain files matching {1}, but no matching file exists.",
+                    _dirInfo.FullName, expectedFilesSearchPattern);
+            return new AndConstraint<DirectoryInfoAssertions>(this);
+        }
+
         public AndConstraint<DirectoryInfoAssertions> NotHaveFiles(IEnumerable<string> expectedFiles)
         {
             foreach (var expectedFile in expectedFiles)
@@ -63,6 +72,15 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 NotHaveFile(expectedFile);
             }
 
+            return new AndConstraint<DirectoryInfoAssertions>(this);
+        }
+
+        public AndConstraint<DirectoryInfoAssertions> NotHaveFilesMatching(string expectedFilesSearchPattern, SearchOption searchOption)
+        {
+            var matchingFileCount = _dirInfo.EnumerateFiles(expectedFilesSearchPattern, searchOption).Count();
+            Execute.Assertion.ForCondition(matchingFileCount == 0)
+                .FailWith("Found {0} files that should not exist in directory {1}. No file matching {2} should exist.",
+                    matchingFileCount, _dirInfo.FullName, expectedFilesSearchPattern);
             return new AndConstraint<DirectoryInfoAssertions>(this);
         }
 

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/Clean3Command.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/Clean3Command.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.DotNet.Cli.Utils;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.ProjectModel;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public sealed class Clean3Command : TestCommand
+    {
+        public Clean3Command()
+            : base("dotnet")
+        {
+        }
+
+        public override CommandResult Execute(string args = "")
+        {
+            args = $"clean3 {args}";
+            return base.Execute(args);
+        }
+
+        public override CommandResult ExecuteWithCapturedOutput(string args = "")
+        {
+            args = $"clean3 {args}";
+            return base.ExecuteWithCapturedOutput(args);
+        }
+    }
+}


### PR DESCRIPTION
Added a `clean3` verb to execute the `Clean` msbuild target, using `build3` as template.

Don't fully know how to test it in isolation without testing the actual target's logic (file-exists-check), but added it to E2E tests which passes.