### PR TITLE
Update 1.0.0-preview2.1 branch to the 1.1 shared framework

### DIFF
--- a/Documentation/cli-installation-scenarios.md
+++ b/Documentation/cli-installation-scenarios.md
@@ -365,7 +365,7 @@ ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-123456=1
 ```
 
-Installing 1.0.4-234567 (RTM) on top of that
+Installing 1.1.0-preview1-24528-02-234567 (RTM) on top of that
 
 ```
 RF+ HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.0-rc1=1
@@ -381,10 +381,10 @@ RF+ HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]
 RF+ HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-rc2=1
 RF+ HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3=1
 NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-123456=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc1=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc2=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-234567=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc1=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc2=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-234567=1
 ```
 
 Removing 1.0.3-123456
@@ -403,10 +403,10 @@ RF- HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]
 RF- HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-rc2=1
 RF- HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3=1
 DEL HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-123456=1
-NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc1=1
-NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc2=1
-NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4=1
-NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-234567=1
+NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc1=1
+NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc2=1
+NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02=1
+NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-234567=1
 ```
 
 #### Scenario 2
@@ -432,9 +432,9 @@ NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-rc1=1 (first back-incompatible version)
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-rc2=1
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc1=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc2=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc1=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc2=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02=1
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-rc1=1
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-rc2=1
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0=1

--- a/Documentation/cli-installation-scenarios.md
+++ b/Documentation/cli-installation-scenarios.md
@@ -365,7 +365,7 @@ ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-123456=1
 ```
 
-Installing 1.1.0-preview1-24528-02-234567 (RTM) on top of that
+Installing 1.0.4-234567 (RTM) on top of that
 
 ```
 RF+ HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.0-rc1=1
@@ -381,10 +381,10 @@ RF+ HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]
 RF+ HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-rc2=1
 RF+ HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3=1
 NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-123456=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc1=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc2=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-234567=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc1=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc2=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-234567=1
 ```
 
 Removing 1.0.3-123456
@@ -403,10 +403,10 @@ RF- HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]
 RF- HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-rc2=1
 RF- HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3=1
 DEL HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-123456=1
-NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc1=1
-NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc2=1
-NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02=1
-NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-234567=1
+NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc1=1
+NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc2=1
+NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4=1
+NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-234567=1
 ```
 
 #### Scenario 2
@@ -432,9 +432,9 @@ NOP HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-rc1=1 (first back-incompatible version)
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3-rc2=1
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.3=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc1=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02-rc2=1
-ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-preview1-24528-02=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc1=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4-rc2=1
+ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.0.4=1
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-rc1=1
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0-rc2=1
 ADD HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x86\sdk\[REG_DWORD]1.1.0=1

--- a/TestAssets/DesktopTestProjects/AppWithDirectDependencyDesktopAndPortable/project.json
+++ b/TestAssets/DesktopTestProjects/AppWithDirectDependencyDesktopAndPortable/project.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       },
       "imports": [

--- a/TestAssets/DesktopTestProjects/AppWithDirectDependencyDesktopAndPortable/project.json
+++ b/TestAssets/DesktopTestProjects/AppWithDirectDependencyDesktopAndPortable/project.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       },
       "imports": [

--- a/TestAssets/DesktopTestProjects/AppWithDirectDependencyDesktopAndPortable/project.json
+++ b/TestAssets/DesktopTestProjects/AppWithDirectDependencyDesktopAndPortable/project.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       },
       "imports": [

--- a/TestAssets/DesktopTestProjects/DesktopAppWithNativeDep/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopAppWithNativeDep/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "PackageWithFakeNativeDep": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.0.1"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024"
   },
   "buildOptions": {
     "emitEntryPoint": true

--- a/TestAssets/DesktopTestProjects/DesktopAppWithNativeDep/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopAppWithNativeDep/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "PackageWithFakeNativeDep": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00"
   },
   "buildOptions": {
     "emitEntryPoint": true

--- a/TestAssets/DesktopTestProjects/DesktopAppWithNativeDep/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopAppWithNativeDep/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "PackageWithFakeNativeDep": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001086-00"
   },
   "buildOptions": {
     "emitEntryPoint": true

--- a/TestAssets/DesktopTestProjects/DesktopAppWithRuntimes/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopAppWithRuntimes/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc3-24206-00"
+    "Microsoft.NETCore.Windows.ApiSets": "1.1.0-preview1-001024-rc3-24206-00"
   },
   "buildOptions": {
     "emitEntryPoint": true

--- a/TestAssets/DesktopTestProjects/DesktopAppWithRuntimes/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopAppWithRuntimes/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.NETCore.Windows.ApiSets": "1.1.0-preview1-001073-00-rc3-24206-00"
+    "Microsoft.NETCore.Windows.ApiSets": "1.0.2-beta-24523-00"
   },
   "buildOptions": {
     "emitEntryPoint": true

--- a/TestAssets/DesktopTestProjects/DesktopAppWithRuntimes/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopAppWithRuntimes/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "Microsoft.NETCore.Windows.ApiSets": "1.1.0-preview1-001024-rc3-24206-00"
+    "Microsoft.NETCore.Windows.ApiSets": "1.1.0-preview1-001073-00-rc3-24206-00"
   },
   "buildOptions": {
     "emitEntryPoint": true

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.0.1"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001086-00"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001086-00"
   },
   "buildOptions": {
     "platform": "anycpu32bitpreferred",

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.0.1"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024"
   },
   "buildOptions": {
     "platform": "anycpu32bitpreferred",

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00"
   },
   "buildOptions": {
     "platform": "anycpu32bitpreferred",

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.0.1"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001086-00"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/DesktopTestProjects/LibraryWithDirectDependencyDesktopAndPortable/project.json
+++ b/TestAssets/DesktopTestProjects/LibraryWithDirectDependencyDesktopAndPortable/project.json
@@ -9,7 +9,7 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       },
       "imports": [
         "portable-net45+win8",

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedDependency/project.json
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedDependency/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "ThisIsNotARealDependencyAndIfSomeoneGoesAndAddsAProjectWithThisNameIWillFindThemAndPunishThem": {
       "target": "project"

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedDependency/project.json
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedDependency/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "ThisIsNotARealDependencyAndIfSomeoneGoesAndAddsAProjectWithThisNameIWillFindThemAndPunishThem": {
       "target": "project"

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedDependency/project.json
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedDependency/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "ThisIsNotARealDependencyAndIfSomeoneGoesAndAddsAProjectWithThisNameIWillFindThemAndPunishThem": {
       "target": "project"

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "EmptyLibrary": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "EmptyLibrary": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "EmptyLibrary": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
@@ -3,7 +3,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       }
     },
     "dnx451": {}

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
@@ -3,7 +3,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       }
     },
     "dnx451": {}

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
@@ -3,7 +3,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       }
     },
     "dnx451": {}

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyLibrary/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyLibrary/project.json
@@ -5,7 +5,7 @@
     "netstandard1.3": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyNetCoreApp/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyNetCoreApp/project.json
@@ -6,7 +6,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         },
         "Newtonsoft.Json": "8.0.3"
       }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyNetCoreApp/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyNetCoreApp/project.json
@@ -6,7 +6,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         },
         "Newtonsoft.Json": "8.0.3"
       }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyNetCoreApp/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyNetCoreApp/project.json
@@ -6,7 +6,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         },
         "Newtonsoft.Json": "8.0.3"
       }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
@@ -3,7 +3,7 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       }
     }
   },

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
@@ -3,7 +3,7 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       }
     }
   },

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
@@ -3,7 +3,7 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       }
     }
   },

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "Microsoft.Web.Administration": "7.0.0"
   },
   "frameworks": {

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "Microsoft.Web.Administration": "7.0.0"
   },
   "frameworks": {

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "Microsoft.Web.Administration": "7.0.0"
   },
   "frameworks": {

--- a/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
+++ b/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
+++ b/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
+++ b/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestPackages/ToolWithOutputName/project.json
+++ b/TestAssets/TestPackages/ToolWithOutputName/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     }

--- a/TestAssets/TestPackages/ToolWithOutputName/project.json
+++ b/TestAssets/TestPackages/ToolWithOutputName/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     }

--- a/TestAssets/TestPackages/ToolWithOutputName/project.json
+++ b/TestAssets/TestPackages/ToolWithOutputName/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     }

--- a/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.Extensions.DependencyModel": {
       "target": "project"

--- a/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.Extensions.DependencyModel": {
       "target": "project"

--- a/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.Extensions.DependencyModel": {
       "target": "project"

--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"

--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"

--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },

--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestPackages/dotnet-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-portable/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     }

--- a/TestAssets/TestPackages/dotnet-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-portable/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     }

--- a/TestAssets/TestPackages/dotnet-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-portable/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithAppDependency/TestApp1/project.json
+++ b/TestAssets/TestProjects/AppWithAppDependency/TestApp1/project.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithAppDependency/TestApp1/project.json
+++ b/TestAssets/TestProjects/AppWithAppDependency/TestApp1/project.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithAppDependency/TestApp1/project.json
+++ b/TestAssets/TestProjects/AppWithAppDependency/TestApp1/project.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithAppDependency/TestApp2/project.json
+++ b/TestAssets/TestProjects/AppWithAppDependency/TestApp2/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithAppDependency/TestApp2/project.json
+++ b/TestAssets/TestProjects/AppWithAppDependency/TestApp2/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithAppDependency/TestApp2/project.json
+++ b/TestAssets/TestProjects/AppWithAppDependency/TestApp2/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
+++ b/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
+++ b/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
+++ b/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001073-00",
+      "version": "1.1.0-preview1-001086-00",
       "type": "platform"
     }
   },

--- a/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001024",
+      "version": "1.1.0-preview1-001073-00",
       "type": "platform"
     }
   },

--- a/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.2-servicing-004528-00",
+      "version": "1.1.0-preview1-001024",
       "type": "platform"
     }
   },

--- a/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "dotnet-hello": {
       "version": "1.0.0",
       "target": "package"

--- a/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "dotnet-hello": {
       "version": "1.0.0",
       "target": "package"

--- a/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "dotnet-hello": {
       "version": "1.0.0",
       "target": "package"

--- a/TestAssets/TestProjects/AppWithDirectDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependency/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "dotnet-hello": {
       "version": "1.0.0",
       "target": "package"

--- a/TestAssets/TestProjects/AppWithDirectDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependency/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "dotnet-hello": {
       "version": "1.0.0",
       "target": "package"

--- a/TestAssets/TestProjects/AppWithDirectDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependency/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "dotnet-hello": {
       "version": "1.0.0",
       "target": "package"

--- a/TestAssets/TestProjects/AppWithDirectDependencyAndTypeBuild/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependencyAndTypeBuild/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001073-00",
+      "version": "1.1.0-preview1-001086-00",
       "type": "platform"
     },
     "xunit.core": "2.1.0",

--- a/TestAssets/TestProjects/AppWithDirectDependencyAndTypeBuild/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependencyAndTypeBuild/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001024",
+      "version": "1.1.0-preview1-001073-00",
       "type": "platform"
     },
     "xunit.core": "2.1.0",

--- a/TestAssets/TestProjects/AppWithDirectDependencyAndTypeBuild/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependencyAndTypeBuild/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.2-servicing-004528-00",
+      "version": "1.1.0-preview1-001024",
       "type": "platform"
     },
     "xunit.core": "2.1.0",

--- a/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
@@ -8,7 +8,7 @@
       "target": "package"
     },
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001073-00",
+      "version": "1.1.0-preview1-001086-00",
       "type": "platform"
     }
   },

--- a/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
@@ -8,7 +8,7 @@
       "target": "package"
     },
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001024",
+      "version": "1.1.0-preview1-001073-00",
       "type": "platform"
     }
   },

--- a/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
@@ -8,7 +8,7 @@
       "target": "package"
     },
     "Microsoft.NETCore.App": {
-      "version": "1.0.2-servicing-004528-00",
+      "version": "1.1.0-preview1-001024",
       "type": "platform"
     }
   },

--- a/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
+++ b/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
+++ b/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
+++ b/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/AppWithToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithToolDependency/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/AppWithToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithToolDependency/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/AppWithToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithToolDependency/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/CompileFail/project.json
+++ b/TestAssets/TestProjects/CompileFail/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/CompileFail/project.json
+++ b/TestAssets/TestProjects/CompileFail/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/CompileFail/project.json
+++ b/TestAssets/TestProjects/CompileFail/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json
+++ b/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     }

--- a/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json
+++ b/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     }

--- a/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json
+++ b/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     }

--- a/TestAssets/TestProjects/DependencyContextFromTool/project.json
+++ b/TestAssets/TestProjects/DependencyContextFromTool/project.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     }

--- a/TestAssets/TestProjects/DependencyContextFromTool/project.json
+++ b/TestAssets/TestProjects/DependencyContextFromTool/project.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     }

--- a/TestAssets/TestProjects/DependencyContextFromTool/project.json
+++ b/TestAssets/TestProjects/DependencyContextFromTool/project.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     }

--- a/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
@@ -9,7 +9,7 @@
     "netstandard1.6": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     },
     "net451": {}

--- a/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
@@ -5,7 +5,7 @@
     "preserveCompilationContext": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
@@ -5,7 +5,7 @@
     "preserveCompilationContext": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
@@ -5,7 +5,7 @@
     "preserveCompilationContext": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppPortable/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppPortable/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "DependencyContextValidator": "1.0.0-*"
   },

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppPortable/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppPortable/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "DependencyContextValidator": "1.0.0-*"
   },

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppPortable/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppPortable/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "DependencyContextValidator": "1.0.0-*"
   },

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppPortableDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppPortableDeps/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "DependencyContextValidator": "1.0.0-*"
   },

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppPortableDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppPortableDeps/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "DependencyContextValidator": "1.0.0-*"
   },

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppPortableDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppPortableDeps/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "DependencyContextValidator": "1.0.0-*"
   },

--- a/TestAssets/TestProjects/EndToEndTestApp/project.json
+++ b/TestAssets/TestProjects/EndToEndTestApp/project.json
@@ -14,7 +14,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "packOptions": {
     "files": {

--- a/TestAssets/TestProjects/EndToEndTestApp/project.json
+++ b/TestAssets/TestProjects/EndToEndTestApp/project.json
@@ -14,7 +14,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "packOptions": {
     "files": {

--- a/TestAssets/TestProjects/EndToEndTestApp/project.json
+++ b/TestAssets/TestProjects/EndToEndTestApp/project.json
@@ -14,7 +14,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "packOptions": {
     "files": {

--- a/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "tools": {
     "dotnet-compile-fsc": {

--- a/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "tools": {
     "dotnet-compile-fsc": {

--- a/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "tools": {
     "dotnet-compile-fsc": {

--- a/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
@@ -14,7 +14,7 @@
       "version": "1.0.0-*",
       "target": "project"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509"
   },
   "tools": {

--- a/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
@@ -14,7 +14,7 @@
       "version": "1.0.0-*",
       "target": "project"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509"
   },
   "tools": {

--- a/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
@@ -14,7 +14,7 @@
       "version": "1.0.0-*",
       "target": "project"
     },
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509"
   },
   "tools": {

--- a/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "tools": {
     "dotnet-compile-fsc": {

--- a/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "tools": {
     "dotnet-compile-fsc": {

--- a/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "tools": {
     "dotnet-compile-fsc": {

--- a/TestAssets/TestProjects/FSharpTestProjects/TestLibrary/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestLibrary/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "tools": {
     "dotnet-compile-fsc": {

--- a/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
@@ -18,7 +18,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       },
       "imports": [

--- a/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
@@ -18,7 +18,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       },
       "imports": [

--- a/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
@@ -18,7 +18,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       },
       "imports": [

--- a/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
@@ -16,7 +16,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       },
       "imports": [
         "dnxcore50",

--- a/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
@@ -16,7 +16,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       },
       "imports": [
         "dnxcore50",

--- a/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
@@ -16,7 +16,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       },
       "imports": [
         "dnxcore50",

--- a/TestAssets/TestProjects/LibraryWithOutputAssemblyName/project.json
+++ b/TestAssets/TestProjects/LibraryWithOutputAssemblyName/project.json
@@ -3,7 +3,7 @@
     "outputName": "MyLibrary"
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
+++ b/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
+++ b/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
+++ b/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetApp/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetApp/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetApp/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP0/project.json
@@ -9,7 +9,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP0/project.json
@@ -9,7 +9,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP0/project.json
@@ -9,7 +9,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP1/project.json
@@ -6,7 +6,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP1/project.json
@@ -6,7 +6,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP1/project.json
@@ -6,7 +6,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP2/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP2/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP2/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     }
   },
   "frameworks": {

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
@@ -9,14 +9,14 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01"
+        "NETStandard.Library": "1.6.1-preview1-24528-02",
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24528-02"
       }
     }
   },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
@@ -13,14 +13,14 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01"
+        "NETStandard.Library": "1.6.1-preview1-24528-02",
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24528-02"
       }
     }
   },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP1/project.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP1/project.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP1/project.json
@@ -10,13 +10,13 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP2/project.json
@@ -6,7 +6,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP2/project.json
@@ -6,7 +6,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP2/project.json
@@ -6,13 +6,13 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
@@ -13,14 +13,14 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01"
+        "NETStandard.Library": "1.6.1-preview1-24528-02",
+        "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24528-02"
       }
     }
   },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP1/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP1/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP1/project.json
@@ -13,13 +13,13 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP2/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP2/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP2/project.json
@@ -13,13 +13,13 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP3/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP3/project.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP3/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP3/project.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP3/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP3/project.json
@@ -10,13 +10,13 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP4/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP4/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP4/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP4/project.json
@@ -13,7 +13,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP4/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP4/project.json
@@ -13,13 +13,13 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP5/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP5/project.json
@@ -6,7 +6,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP5/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP5/project.json
@@ -6,7 +6,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP5/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP5/project.json
@@ -6,13 +6,13 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP6/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP6/project.json
@@ -6,7 +6,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP6/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP6/project.json
@@ -6,7 +6,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     },

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP6/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP6/project.json
@@ -6,13 +6,13 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PortableTests/PortableApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableApp/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     }

--- a/TestAssets/TestProjects/PortableTests/PortableApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableApp/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     }

--- a/TestAssets/TestProjects/PortableTests/PortableApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableApp/project.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     }

--- a/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         }
       }
     }

--- a/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       }
     }

--- a/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         }
       }
     }

--- a/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         },
         "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
         "Libuv": "1.9.0-rc2-20896"

--- a/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         },
         "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
         "Libuv": "1.9.0-rc2-20896"

--- a/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         },
         "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
         "Libuv": "1.9.0-rc2-20896"

--- a/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
@@ -5,7 +5,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       }
     }
   },

--- a/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
@@ -5,7 +5,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       }
     }
   },

--- a/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
@@ -5,7 +5,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       }
     }
   },

--- a/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001086-00",
     "xunit": "2.1.0"
   },
   "frameworks": {
@@ -15,7 +15,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         },
         "System.Linq.Expressions": "4.1.0",
         "System.Runtime.Serialization.Primitives": "4.1.1"

--- a/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00",
     "xunit": "2.1.0"
   },
   "frameworks": {
@@ -15,7 +15,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001024"
+          "version": "1.1.0-preview1-001073-00"
         },
         "System.Linq.Expressions": "4.1.0",
         "System.Runtime.Serialization.Primitives": "4.1.1"

--- a/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "Microsoft.NETCore.Platforms": "1.0.1",
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024",
     "xunit": "2.1.0"
   },
   "frameworks": {
@@ -15,7 +15,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001024"
         },
         "System.Linq.Expressions": "4.1.0",
         "System.Runtime.Serialization.Primitives": "4.1.1"

--- a/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Linq.Expressions": "4.1.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",

--- a/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Linq.Expressions": "4.1.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",

--- a/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Linq.Expressions": "4.1.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",

--- a/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
+++ b/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
@@ -7,7 +7,7 @@
     "Microsoft.Data.OData": "5.6.4",
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "TestLibraryWithResources": {
       "target": "project"

--- a/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
+++ b/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
@@ -7,7 +7,7 @@
     "Microsoft.Data.OData": "5.6.4",
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "TestLibraryWithResources": {
       "target": "project"

--- a/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
+++ b/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
@@ -7,7 +7,7 @@
     "Microsoft.Data.OData": "5.6.4",
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "TestLibraryWithResources": {
       "target": "project"

--- a/TestAssets/TestProjects/ResourcesTests/TestLibraryWithResources/project.json
+++ b/TestAssets/TestProjects/ResourcesTests/TestLibraryWithResources/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
@@ -7,7 +7,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-preview1-001024",
+          "version": "1.1.0-preview1-001073-00",
           "type": "platform"
         }
       }

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
@@ -7,7 +7,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-preview1-001073-00",
+          "version": "1.1.0-preview1-001086-00",
           "type": "platform"
         }
       }

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
@@ -7,7 +7,7 @@
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.2-servicing-004528-00",
+          "version": "1.1.0-preview1-001024",
           "type": "platform"
         }
       }

--- a/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "TestLibrary": "1.0.0-*",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "TestLibrary": "1.0.0-*",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "TestLibrary": "1.0.0-*",
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppCompilationContext/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppCompilationContext/TestLibrary/project.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/TestAppSimple/project.json
+++ b/TestAssets/TestProjects/TestAppSimple/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppSimple/project.json
+++ b/TestAssets/TestProjects/TestAppSimple/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppSimple/project.json
+++ b/TestAssets/TestProjects/TestAppSimple/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/TestAppWithArgs/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/TestAppWithArgs/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/TestAppWithArgs/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithBuildDependency/App/project.json
+++ b/TestAssets/TestProjects/TestAppWithBuildDependency/App/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "LibraryWithBuildDependency": {
       "target": "project"

--- a/TestAssets/TestProjects/TestAppWithBuildDependency/App/project.json
+++ b/TestAssets/TestProjects/TestAppWithBuildDependency/App/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "LibraryWithBuildDependency": {
       "target": "project"

--- a/TestAssets/TestProjects/TestAppWithBuildDependency/App/project.json
+++ b/TestAssets/TestProjects/TestAppWithBuildDependency/App/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "LibraryWithBuildDependency": {
       "target": "project"

--- a/TestAssets/TestProjects/TestAppWithBuildDependency/LibraryWithBuildDependency/project.json
+++ b/TestAssets/TestProjects/TestAppWithBuildDependency/LibraryWithBuildDependency/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.Net.Compilers": {
       "type": "build",

--- a/TestAssets/TestProjects/TestAppWithBuildDependency/LibraryWithBuildDependency/project.json
+++ b/TestAssets/TestProjects/TestAppWithBuildDependency/LibraryWithBuildDependency/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.Net.Compilers": {
       "type": "build",

--- a/TestAssets/TestProjects/TestAppWithBuildDependency/LibraryWithBuildDependency/project.json
+++ b/TestAssets/TestProjects/TestAppWithBuildDependency/LibraryWithBuildDependency/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.Net.Compilers": {
       "type": "build",

--- a/TestAssets/TestProjects/TestAppWithContentPackage/project.json
+++ b/TestAssets/TestProjects/TestAppWithContentPackage/project.json
@@ -5,7 +5,7 @@
     "outputName": "AppWithContentPackage"
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "SharedContentA": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/TestAppWithContentPackage/project.json
+++ b/TestAssets/TestProjects/TestAppWithContentPackage/project.json
@@ -5,7 +5,7 @@
     "outputName": "AppWithContentPackage"
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "SharedContentA": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/TestAppWithContentPackage/project.json
+++ b/TestAssets/TestProjects/TestAppWithContentPackage/project.json
@@ -5,7 +5,7 @@
     "outputName": "AppWithContentPackage"
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "SharedContentA": "1.0.0-*"
   },
   "frameworks": {

--- a/TestAssets/TestProjects/TestAppWithContents/project.json
+++ b/TestAssets/TestProjects/TestAppWithContents/project.json
@@ -7,7 +7,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithContents/project.json
+++ b/TestAssets/TestProjects/TestAppWithContents/project.json
@@ -7,7 +7,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithContents/project.json
+++ b/TestAssets/TestProjects/TestAppWithContents/project.json
@@ -7,7 +7,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
@@ -9,7 +9,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
@@ -9,7 +9,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
@@ -9,7 +9,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestLibrary/project.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
+++ b/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "Microsoft.CSharp": "4.0.1",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",

--- a/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
+++ b/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "Microsoft.CSharp": "4.0.1",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",

--- a/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
+++ b/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "Microsoft.CSharp": "4.0.1",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",

--- a/TestAssets/TestProjects/TestAppWithScripts/project.json
+++ b/TestAssets/TestProjects/TestAppWithScripts/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithScripts/project.json
+++ b/TestAssets/TestProjects/TestAppWithScripts/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithScripts/project.json
+++ b/TestAssets/TestProjects/TestAppWithScripts/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
@@ -9,7 +9,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
@@ -9,7 +9,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
@@ -9,7 +9,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary/project.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
@@ -8,7 +8,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibraryWithAppDependency/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibraryWithAppDependency/project.json
@@ -5,7 +5,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
+++ b/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
+++ b/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
+++ b/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
@@ -9,7 +9,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
@@ -9,7 +9,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
@@ -9,7 +9,7 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryGreater/project.json
+++ b/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryGreater/project.json
@@ -7,7 +7,7 @@
     "net451": {},
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       },
       "imports": "portable-net45+win8"
     }

--- a/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
+++ b/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
@@ -13,7 +13,7 @@
     "net451": {},
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       },
       "imports": "portable-net45+win8"
     }

--- a/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
+++ b/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
@@ -13,7 +13,7 @@
     "net451": {},
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       },
       "imports": "portable-net45+win8"
     }

--- a/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
+++ b/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
@@ -13,7 +13,7 @@
     "net451": {},
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       },
       "imports": "portable-net45+win8"
     }

--- a/TestAssets/TestProjects/TestLibraryWithAnalyzer/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithAnalyzer/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
+    "NETStandard.Library": "1.6.1-preview1-24528-02",
     "System.Runtime.Analyzers": {
       "version": "1.1.0",
       "type": "build"

--- a/TestAssets/TestProjects/TestLibraryWithConfiguration/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithConfiguration/project.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "configurations": {
     "Test": {}

--- a/TestAssets/TestProjects/TestLibraryWithDeprecatedProjectFile/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithDeprecatedProjectFile/project.json
@@ -5,7 +5,7 @@
   },
   "packInclude": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
@@ -28,7 +28,7 @@
     "netstandard1.5": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/TestAssets/TestProjects/TestLibraryWithXmlDoc/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithXmlDoc/project.json
@@ -4,7 +4,7 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
@@ -5,7 +5,7 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
@@ -5,7 +5,7 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
@@ -5,7 +5,7 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
@@ -5,7 +5,7 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       }
     },
     "netcore50": {

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
@@ -5,7 +5,7 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       }
     },
     "netcore50": {

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
@@ -5,7 +5,7 @@
     "netcoreapp1.0": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       }
     },
     "netcore50": {

--- a/TestAssets/TestProjects/TestMscorlibReference/project.json
+++ b/TestAssets/TestProjects/TestMscorlibReference/project.json
@@ -4,7 +4,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestMscorlibReference/project.json
+++ b/TestAssets/TestProjects/TestMscorlibReference/project.json
@@ -4,7 +4,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestMscorlibReference/project.json
+++ b/TestAssets/TestProjects/TestMscorlibReference/project.json
@@ -4,7 +4,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestProjectContextBuildAllDedupe/project.json
+++ b/TestAssets/TestProjects/TestProjectContextBuildAllDedupe/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001073-00",
+      "version": "1.1.0-preview1-001086-00",
       "type": "platform"
     }
   },

--- a/TestAssets/TestProjects/TestProjectContextBuildAllDedupe/project.json
+++ b/TestAssets/TestProjects/TestProjectContextBuildAllDedupe/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001024",
+      "version": "1.1.0-preview1-001073-00",
       "type": "platform"
     }
   },

--- a/TestAssets/TestProjects/TestProjectContextBuildAllDedupe/project.json
+++ b/TestAssets/TestProjects/TestProjectContextBuildAllDedupe/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.2-servicing-004528-00",
+      "version": "1.1.0-preview1-001024",
       "type": "platform"
     }
   },

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "L11": "1.0.0-*",
     "L12": "1.0.0-*",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "L11": "1.0.0-*",
     "L12": "1.0.0-*",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "L11": "1.0.0-*",
     "L12": "1.0.0-*",
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L11/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L11/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "L12": "1.0.0-*",
     "L21": "1.0.0-*",
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L12/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L12/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "L22": "1.0.0-*",
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L21/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L21/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L22/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L22/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestProjectWithResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithResource/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestProjectWithResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithResource/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestProjectWithResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithResource/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestRuleSet/TestLibraryWithRuleSet/project.json
+++ b/TestAssets/TestProjects/TestRuleSet/TestLibraryWithRuleSet/project.json
@@ -6,7 +6,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
+    "NETStandard.Library": "1.6.1-preview1-24528-02",
     "System.Runtime.Analyzers": {
       "version": "1.1.0",
       "type": "build"

--- a/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
+++ b/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
@@ -5,7 +5,7 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
+++ b/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
@@ -5,7 +5,7 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
+++ b/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
@@ -5,7 +5,7 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/TestAssets/TestProjects/TestSystemCoreReference/project.json
+++ b/TestAssets/TestProjects/TestSystemCoreReference/project.json
@@ -4,7 +4,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestSystemCoreReference/project.json
+++ b/TestAssets/TestProjects/TestSystemCoreReference/project.json
@@ -4,7 +4,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestSystemCoreReference/project.json
+++ b/TestAssets/TestProjects/TestSystemCoreReference/project.json
@@ -4,7 +4,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestSystemReference/project.json
+++ b/TestAssets/TestProjects/TestSystemReference/project.json
@@ -4,7 +4,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestSystemReference/project.json
+++ b/TestAssets/TestProjects/TestSystemReference/project.json
@@ -4,7 +4,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
       }
     },
     "net451": {

--- a/TestAssets/TestProjects/TestSystemReference/project.json
+++ b/TestAssets/TestProjects/TestSystemReference/project.json
@@ -4,7 +4,7 @@
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001024"
       }
     },
     "net451": {

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/AnsiColorExtensions.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/AnsiColorExtensions.cs
@@ -7,46 +7,46 @@ namespace Microsoft.DotNet.Cli.Build.Framework
     {
         public static string Black(this string text)
         {
-            return "\x1B[30m" + text + "\x1B[39m";
+            return text;
         }
 
         public static string Red(this string text)
         {
-            return "\x1B[31m" + text + "\x1B[39m";
+            return text;
         }
         public static string Green(this string text)
         {
-            return "\x1B[32m" + text + "\x1B[39m";
+            return text;
         }
 
         public static string Yellow(this string text)
         {
-            return "\x1B[33m" + text + "\x1B[39m";
+            return text;
         }
 
         public static string Blue(this string text)
         {
-            return "\x1B[34m" + text + "\x1B[39m";
+            return text;
         }
 
         public static string Magenta(this string text)
         {
-            return "\x1B[35m" + text + "\x1B[39m";
+            return text;
         }
 
         public static string Cyan(this string text)
         {
-            return "\x1B[36m" + text + "\x1B[39m";
+            return text;
         }
 
         public static string White(this string text)
         {
-            return "\x1B[37m" + text + "\x1B[39m";
+            return text;
         }
 
         public static string Bold(this string text)
         {
-            return "\x1B[1m" + text + "\x1B[22m";
+            return text;
         }
     }
 }

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/project.json
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/project.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
+    "NETStandard.Library": "1.6.1-preview1-24528-02",
     "System.Diagnostics.Process": "4.1.0",
     "System.Reflection.TypeExtensions": "4.1.0"
   },

--- a/build_projects/dotnet-cli-build/CliDependencyVersions.cs
+++ b/build_projects/dotnet-cli-build/CliDependencyVersions.cs
@@ -7,9 +7,9 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class CliDependencyVersions
     {
-        public static readonly string SharedFrameworkVersion = "1.1.0-preview1-001073-00";
-        public static readonly string SharedHostVersion = "1.1.0-preview1-001073-00";
-        public static readonly string HostFxrVersion = "1.1.0-preview1-001073-00";
+        public static readonly string SharedFrameworkVersion = "1.1.0-preview1-001086-00";
+        public static readonly string SharedHostVersion = "1.1.0-preview1-001086-00";
+        public static readonly string HostFxrVersion = "1.1.0-preview1-001086-00";
 
         public static readonly string SharedFrameworkChannel = "release/1.1.0";
         public static readonly string SharedHostChannel = "release/1.1.0";

--- a/build_projects/dotnet-cli-build/CliDependencyVersions.cs
+++ b/build_projects/dotnet-cli-build/CliDependencyVersions.cs
@@ -7,9 +7,9 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class CliDependencyVersions
     {
-        public static readonly string SharedFrameworkVersion = "1.1.0-preview1-001024";
-        public static readonly string SharedHostVersion = "1.1.0-preview1-001024";
-        public static readonly string HostFxrVersion = "1.1.0-preview1-001024";
+        public static readonly string SharedFrameworkVersion = "1.1.0-preview1-001073-00";
+        public static readonly string SharedHostVersion = "1.1.0-preview1-001073-00";
+        public static readonly string HostFxrVersion = "1.1.0-preview1-001073-00";
 
         public static readonly string SharedFrameworkChannel = "release/1.1.0";
         public static readonly string SharedHostChannel = "release/1.1.0";

--- a/build_projects/dotnet-cli-build/CliDependencyVersions.cs
+++ b/build_projects/dotnet-cli-build/CliDependencyVersions.cs
@@ -7,12 +7,12 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class CliDependencyVersions
     {
-        public static readonly string SharedFrameworkVersion = "1.0.2-servicing-004528-00";
-        public static readonly string SharedHostVersion = "1.0.2-servicing-004528-00";
-        public static readonly string HostFxrVersion = "1.0.2-servicing-004528-00";
+        public static readonly string SharedFrameworkVersion = "1.1.0-preview1-001024";
+        public static readonly string SharedHostVersion = "1.1.0-preview1-001024";
+        public static readonly string HostFxrVersion = "1.1.0-preview1-001024";
 
-        public static readonly string SharedFrameworkChannel = "preview";
-        public static readonly string SharedHostChannel = "preview";
-        public static readonly string HostFxrChannel = "preview";
+        public static readonly string SharedFrameworkChannel = "release/1.1.0";
+        public static readonly string SharedHostChannel = "release/1.1.0";
+        public static readonly string HostFxrChannel = "release/1.1.0";
     }
 }

--- a/build_projects/dotnet-cli-build/CompileTargets.cs
+++ b/build_projects/dotnet-cli-build/CompileTargets.cs
@@ -46,12 +46,14 @@ namespace Microsoft.DotNet.Cli.Build
             { "osx.10.11-x64", "osx.10.10-x64" },
             { "ubuntu.14.04-x64", "ubuntu.14.04-x64" },
             { "ubuntu.16.04-x64", "ubuntu.16.04-x64" },
+            { "ubuntu.16.10-x64", "ubuntu.16.10-x64" },
             { "centos.7-x64", "rhel.7-x64" },
             { "rhel.7-x64", "rhel.7-x64" },
             { "rhel.7.2-x64", "rhel.7-x64" },
             { "debian.8-x64", "debian.8-x64" },
             { "fedora.23-x64", "fedora.23-x64" },
-            { "opensuse.13.2-x64", "opensuse.13.2-x64" }
+            { "opensuse.13.2-x64", "opensuse.13.2-x64" },
+            { "opensuse.42.1-x64", "opensuse.42.1-x64" }
         };
 
         public const string SharedFrameworkName = "Microsoft.NETCore.App";
@@ -201,6 +203,7 @@ namespace Microsoft.DotNet.Cli.Build
             var compilersDeps = Path.Combine(sdkOutputDirectory, "compilers.deps.json");
             var compilersRuntimeConfig = Path.Combine(sdkOutputDirectory, "compilers.runtimeconfig.json");
 
+            RemoveAssetFromDepsPackages(compilersDeps, "runtime", "compilers.dll");
 
             var binaryToCorehostifyRelDir = Path.Combine("runtimes", "any", "native");
             var binaryToCorehostifyOutDir = Path.Combine(sdkOutputDirectory, binaryToCorehostifyRelDir);

--- a/build_projects/dotnet-cli-build/CompileTargets.cs
+++ b/build_projects/dotnet-cli-build/CompileTargets.cs
@@ -46,14 +46,12 @@ namespace Microsoft.DotNet.Cli.Build
             { "osx.10.11-x64", "osx.10.10-x64" },
             { "ubuntu.14.04-x64", "ubuntu.14.04-x64" },
             { "ubuntu.16.04-x64", "ubuntu.16.04-x64" },
-            { "ubuntu.16.10-x64", "ubuntu.16.10-x64" },
             { "centos.7-x64", "rhel.7-x64" },
             { "rhel.7-x64", "rhel.7-x64" },
             { "rhel.7.2-x64", "rhel.7-x64" },
             { "debian.8-x64", "debian.8-x64" },
             { "fedora.23-x64", "fedora.23-x64" },
-            { "opensuse.13.2-x64", "opensuse.13.2-x64" },
-            { "opensuse.42.1-x64", "opensuse.42.1-x64" }
+            { "opensuse.13.2-x64", "opensuse.13.2-x64" }
         };
 
         public const string SharedFrameworkName = "Microsoft.NETCore.App";

--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -5,8 +5,8 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01",
+    "NETStandard.Library": "1.6.1-preview1-24528-02",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24528-02",
     "Microsoft.CSharp": "4.0.1",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-        public static readonly string CoreCLRVersion = "1.0.5-servicing-24603-01";
-        public static readonly string JitVersion = "1.0.5-servicing-24603-01";
+        public static readonly string CoreCLRVersion = "1.1.0-preview1-24528-02";
+        public static readonly string JitVersion = "1.1.0-preview1-24528-02";
     }
 }

--- a/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
+++ b/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Cli.Build
         public static async Task DownloadFile(string blobFilePath, string localDownloadPath)
         {
             var blobUrl = $"{s_dotnetBlobRootUrl}{blobFilePath}";
-
+            Console.WriteLine($"Downloading {blobUrl} to {localDownloadPath}.");
             using (var client = new HttpClient())
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, blobUrl);

--- a/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
+++ b/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
@@ -187,7 +187,7 @@ namespace Microsoft.DotNet.Cli.Build
         public static async Task DownloadFile(string blobFilePath, string localDownloadPath)
         {
             var blobUrl = $"{s_dotnetBlobRootUrl}{blobFilePath}";
-            Console.WriteLine($"Downloading {blobUrl} to {localDownloadPath}.");
+
             using (var client = new HttpClient())
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, blobUrl);

--- a/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/HostVersion.cs
@@ -16,9 +16,9 @@ namespace Microsoft.DotNet.Cli.Build
 
         // Version constants without suffix
         public override int Major => 1;
-        public override int Minor => 0;
-        public override int Patch => 1;
-        public override string ReleaseSuffix => "rc3";
+        public override int Minor => 1;
+        public override int Patch => 0;
+        public override string ReleaseSuffix => "preview1";
         public string LatestHostVersionNoSuffix => $"{Major}.{Minor}.{Patch}";
         public string LatestHostFxrVersionNoSuffix => $"{Major}.{Minor}.{Patch}";
         public string LatestHostPolicyVersionNoSuffix => $"{Major}.{Minor}.{Patch}";

--- a/build_projects/shared-build-targets-utils/project.json
+++ b/build_projects/shared-build-targets-utils/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "description": "Build scripts for dotnet-cli",
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
+    "NETStandard.Library": "1.6.1-preview1-24528-02",
     "Microsoft.CSharp": "4.0.1",
     "System.Dynamic.Runtime": "4.0.11",
     "System.Reflection.Metadata": "1.3.0",

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -5,9 +5,9 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
+    "NETStandard.Library": "1.6.1-preview1-24528-02",
     "Microsoft.CSharp": "4.0.1",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.0.5-servicing-24603-01",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24528-02",
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"

--- a/src/Microsoft.DotNet.Archive/project.json
+++ b/src/Microsoft.DotNet.Archive/project.json
@@ -5,7 +5,7 @@
   },
   "description": "Archive and compression types.",
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
+    "NETStandard.Library": "1.6.1-preview1-24528-02",
     "System.Linq.Parallel": "4.0.1"
   },
   "frameworks": {

--- a/src/compilers/project.json
+++ b/src/compilers/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.Net.Compilers.netcore": "1.3.0",

--- a/src/compilers/project.json
+++ b/src/compilers/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.Net.Compilers.netcore": "1.3.0",

--- a/src/compilers/project.json
+++ b/src/compilers/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.Net.Compilers.netcore": "1.3.0",

--- a/src/dotnet-archive/project.json
+++ b/src/dotnet-archive/project.json
@@ -14,7 +14,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     }
   },
   "frameworks": {

--- a/src/dotnet-archive/project.json
+++ b/src/dotnet-archive/project.json
@@ -14,7 +14,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     }
   },
   "frameworks": {

--- a/src/dotnet-archive/project.json
+++ b/src/dotnet-archive/project.json
@@ -14,7 +14,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     }
   },
   "frameworks": {

--- a/src/dotnet-compile-fsc/project.json
+++ b/src/dotnet-compile-fsc/project.json
@@ -24,7 +24,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     }
   },
   "frameworks": {

--- a/src/dotnet-compile-fsc/project.json
+++ b/src/dotnet-compile-fsc/project.json
@@ -24,7 +24,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     }
   },
   "frameworks": {

--- a/src/dotnet-compile-fsc/project.json
+++ b/src/dotnet-compile-fsc/project.json
@@ -24,7 +24,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     }
   },
   "frameworks": {

--- a/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
@@ -10,7 +10,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       },
       "imports": "dnxcore50"

--- a/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
@@ -6,11 +6,11 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001073-00"
         }
       },
       "imports": "dnxcore50"

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
@@ -7,7 +7,7 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24528-02"
+        "NETStandard.Library": "1.6.1-preview1-24529-03"
       }
     }
   }

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
@@ -7,7 +7,7 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1-preview1-24528-02"
       }
     }
   }

--- a/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
@@ -3,7 +3,7 @@
 
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001073-00",
+      "version": "1.1.0-preview1-001086-00",
       "type": "platform"
     },
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",

--- a/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
@@ -3,7 +3,7 @@
 
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.1",
+      "version": "1.1.0-preview1-001073-00",
       "type": "platform"
     },
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -14,7 +14,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         }
       },
       "imports": [

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -10,11 +10,11 @@
   },
   "testRunner": "xunit",
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001073-00"
         }
       },
       "imports": [

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
@@ -18,7 +18,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001073-00"
+          "version": "1.1.0-preview1-001086-00"
         },
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160629"
       }

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
@@ -18,7 +18,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2-servicing-004528-00"
+          "version": "1.1.0-preview1-001073-00"
         },
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160629"
       }

--- a/src/dotnet/commands/dotnet-new/FSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Lib/project.json.template
@@ -15,7 +15,7 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library":"1.6.1-preview1-24528-02",
+        "NETStandard.Library":"1.6.1-preview1-24529-03",
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160629"
       }
     }

--- a/src/dotnet/commands/dotnet-new/FSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Lib/project.json.template
@@ -15,7 +15,7 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library":"1.6.0",
+        "NETStandard.Library":"1.6.1-preview1-24528-02",
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160629"
       }
     }

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -2,6 +2,7 @@
   "version": "1.0.0-preview2-*",
   "buildOptions": {
     "emitEntryPoint": true,
+    "keyFile": "../../tools/Key.snk",
     "embed": {
       "include": [
         "commands/dotnet-new/CSharp_Console.zip",

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -50,7 +50,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0",

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -50,7 +50,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0",

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -2,7 +2,6 @@
   "version": "1.0.0-preview2-*",
   "buildOptions": {
     "emitEntryPoint": true,
-    "keyFile": "../../tools/Key.snk",
     "embed": {
       "include": [
         "commands/dotnet-new/CSharp_Console.zip",
@@ -51,7 +50,7 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Diagnostics.TextWriterTraceListener": "4.0.0",

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/ArgumentsReflector/project.json
+++ b/test/ArgumentsReflector/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     }
   },
   "frameworks": {

--- a/test/ArgumentsReflector/project.json
+++ b/test/ArgumentsReflector/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     }
   },
   "frameworks": {

--- a/test/ArgumentsReflector/project.json
+++ b/test/ArgumentsReflector/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     }
   },
   "frameworks": {

--- a/test/EndToEnd/EndToEndTest.cs
+++ b/test/EndToEnd/EndToEndTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
 {
     public class EndToEndTest : TestBase
     {
-        private static readonly string NetCoreAppTfm = "netcoreapp1.0";
+        private static readonly string NetCoreAppTfm = "netcoreapp1.1";
         private static readonly string s_expectedOutput = "Hello World!" + Environment.NewLine;
         private static readonly string s_testdirName = "e2etestroot";
         private static readonly string s_outputdirName = "test space/bin";

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/Kestrel.Tests/project.json
+++ b/test/Kestrel.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Kestrel.Tests/project.json
+++ b/test/Kestrel.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Kestrel.Tests/project.json
+++ b/test/Kestrel.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Microsoft.DotNet.Configurer.UnitTests/project.json
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "Microsoft.DotNet.Configurer": {

--- a/test/Microsoft.DotNet.Configurer.UnitTests/project.json
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "Microsoft.DotNet.Configurer": {

--- a/test/Microsoft.DotNet.Configurer.UnitTests/project.json
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "Microsoft.DotNet.Configurer": {

--- a/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.DotNet.ProjectModel.Loader": {
       "target": "project"

--- a/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.DotNet.ProjectModel.Loader": {
       "target": "project"

--- a/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.DotNet.ProjectModel.Loader": {
       "target": "project"

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/Microsoft.Extensions.DependencyModel.Tests/FunctionalTests.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/FunctionalTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.DependencyModel
             // project dependency
             result.Should().HaveStdOutContaining("Runtime DependencyContextValidator:DependencyContextValidator");
             // system assembly
-            result.Should().HaveStdOutContaining("Runtime System.Linq:System.Linq");
+            result.StdOut.Should().ContainEquivalentOf("Runtime system.linq:System.Linq");
         }
 
         private void ValidateCompilationLibraries(CommandResult result, string appname)

--- a/test/Microsoft.Extensions.DependencyModel.Tests/project.json
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Microsoft.Extensions.DependencyModel.Tests/project.json
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Microsoft.Extensions.DependencyModel.Tests/project.json
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/Performance/project.json
+++ b/test/Performance/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/Performance/project.json
+++ b/test/Performance/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/Performance/project.json
+++ b/test/Performance/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.ProjectModel": {

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.Extensions.Testing.Abstractions": {
       "target": "project"

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.Extensions.Testing.Abstractions": {
       "target": "project"

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.Extensions.Testing.Abstractions": {
       "target": "project"

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.Extensions.Testing.Abstractions": {
       "target": "project"

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.Extensions.Testing.Abstractions": {
       "target": "project"

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.Extensions.Testing.Abstractions": {
       "target": "project"

--- a/test/TestingAbstractions/TestAppWithFullPdbs/project.json
+++ b/test/TestingAbstractions/TestAppWithFullPdbs/project.json
@@ -4,7 +4,7 @@
     "debugType": "full"
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/test/TestingAbstractions/TestAppWithPortablePdbs/project.json
+++ b/test/TestingAbstractions/TestAppWithPortablePdbs/project.json
@@ -4,7 +4,7 @@
     "debugType": "portable"
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
+    "NETStandard.Library": "1.6.1-preview1-24528-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/test/binding-redirects.Tests/project.json
+++ b/test/binding-redirects.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001086-00",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     }

--- a/test/binding-redirects.Tests/project.json
+++ b/test/binding-redirects.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "Microsoft.NETCore.Platforms": "1.0.1",
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     }

--- a/test/binding-redirects.Tests/project.json
+++ b/test/binding-redirects.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-001073-00",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     }

--- a/test/crossgen.Tests/project.json
+++ b/test/crossgen.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/crossgen.Tests/project.json
+++ b/test/crossgen.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/crossgen.Tests/project.json
+++ b/test/crossgen.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-compile-fsc.Tests/project.json
+++ b/test/dotnet-compile-fsc.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/dotnet-compile-fsc.Tests/project.json
+++ b/test/dotnet-compile-fsc.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/dotnet-compile-fsc.Tests/project.json
+++ b/test/dotnet-compile-fsc.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"

--- a/test/dotnet-new.Tests/project.json
+++ b/test/dotnet-new.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/dotnet-new.Tests/project.json
+++ b/test/dotnet-new.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/dotnet-new.Tests/project.json
+++ b/test/dotnet-new.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.IO.Compression.ZipFile": "4.0.1",

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.IO.Compression.ZipFile": "4.0.1",

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.IO.Compression.ZipFile": "4.0.1",

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "dotnet": {
       "target": "project"

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "dotnet": {
       "target": "project"

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "dotnet": {
       "target": "project"

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.TestFramework": {

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.TestFramework": {

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.TestFramework": {

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-run.UnitTests/project.json
+++ b/test/dotnet-run.UnitTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "dotnet": {

--- a/test/dotnet-run.UnitTests/project.json
+++ b/test/dotnet-run.UnitTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "dotnet": {

--- a/test/dotnet-run.UnitTests/project.json
+++ b/test/dotnet-run.UnitTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "dotnet": {

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Newtonsoft.Json": "9.0.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Newtonsoft.Json": "9.0.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Newtonsoft.Json": "9.0.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "Newtonsoft.Json": "9.0.1",
     "dotnet": {

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "Newtonsoft.Json": "9.0.1",
     "dotnet": {

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "Newtonsoft.Json": "9.0.1",
     "dotnet": {

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -42,6 +42,7 @@
     ]
   },
   "buildOptions": {
+    "keyFile": "../../tools/Key.snk",
     "copyToOutput": {
       "include": [
         "../../TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/**/*",

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001024"
+      "version": "1.1.0-preview1-001073-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001073-00"
+      "version": "1.1.0-preview1-001086-00"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.2-servicing-004528-00"
+      "version": "1.1.0-preview1-001024"
     },
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
@@ -42,7 +42,6 @@
     ]
   },
   "buildOptions": {
-    "keyFile": "../../tools/Key.snk",
     "copyToOutput": {
       "include": [
         "../../TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/**/*",

--- a/tools/Archiver/project.json
+++ b/tools/Archiver/project.json
@@ -12,7 +12,7 @@
     "Microsoft.DotNet.Archive": {
       "target": "project"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/tools/Archiver/project.json
+++ b/tools/Archiver/project.json
@@ -12,7 +12,7 @@
     "Microsoft.DotNet.Archive": {
       "target": "project"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/tools/Archiver/project.json
+++ b/tools/Archiver/project.json
@@ -12,7 +12,7 @@
     "Microsoft.DotNet.Archive": {
       "target": "project"
     },
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024"
   },
   "frameworks": {
     "netcoreapp1.0": {}

--- a/tools/MultiProjectValidator/project.json
+++ b/tools/MultiProjectValidator/project.json
@@ -5,7 +5,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001086-00",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/tools/MultiProjectValidator/project.json
+++ b/tools/MultiProjectValidator/project.json
@@ -5,7 +5,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001073-00",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/tools/MultiProjectValidator/project.json
+++ b/tools/MultiProjectValidator/project.json
@@ -5,7 +5,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.0.2-servicing-004528-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001024",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },


### PR DESCRIPTION
Putting this up here now to see if some test failures I've observed locally will repro in CI.

Still need to:

* Squash commits
* Update versions to final release versions (or do that separately)
* Add new RIDs to all places that need them (and add Dockerfiles, etc.)

The changes here are enough to get the 1.1 shared framework into the produced SDK package, and update the templates, etc.

@livarcocc , @piotrpMSFT 