### PR TITLE
Create a nuget package with the windows installers.

### DIFF
--- a/build/package/Microsoft.DotNet.Cli.Installer.MSI.targets
+++ b/build/package/Microsoft.DotNet.Cli.Installer.MSI.targets
@@ -18,9 +18,12 @@
 
         <SdkGenerateMsiPowershellScript>$(RepoRoot)/packaging/windows/clisdk/generatemsi.ps1</SdkGenerateMsiPowershellScript>
         <SdkGenerateBundlePowershellScript>$(RepoRoot)/packaging/windows/clisdk/generatebundle.ps1</SdkGenerateBundlePowershellScript>
+        <SdkGenerateNupkgPowershellScript>$(RepoRoot)/packaging/windows/clisdk/generatenupkg.ps1</SdkGenerateNupkgPowershellScript>
 
         <SdkInstallerFile>$(InstallerOutputDirectory)/$(ArtifactNameWithVersionSdk)$(InstallerExtension)</SdkInstallerFile>
         <CombinedFrameworkSdkHostInstallerFile>$(InstallerOutputDirectory)/$(ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(BundleExtension)</CombinedFrameworkSdkHostInstallerFile>
+        <SdkInstallerNuspecFile>$(RepoRoot)/packaging/windows/clisdk/VS.Redist.Common.Net.Core.SDK.$(Architecture).nuspec</SdkInstallerNuspecFile>
+        <SdkInstallerNupkgFile>$(InstallerOutputDirectory)/VS.Redist.Common.Net.Core.SDK.$(Architecture).$(NugetVersion).nupkg</SdkInstallerNupkgFile>
       </PropertyGroup>
 
       <!-- Consumed By Publish -->
@@ -113,6 +116,21 @@
                       '$(Architecture)'" />
     </Target>
 
+    <Target Name="GenerateSdkNupkg"
+            DependsOnTargets="Init;Layout;MsiTargetsSetupInputOutputs;GenerateSdkBundle"
+            Condition=" '$(OS)' == 'Windows_NT'"
+            Inputs="$(CombinedFrameworkSdkHostInstallerFile);
+                    $(SdkInstallerNuspecFile);
+                    $(SdkGenerateNupkgPowershellScript)"
+            Outputs="$(SdkInstallerNupkgFile)">
+
+      <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateNupkgPowershellScript)
+                      '$(CombinedFrameworkSdkHostInstallerFile)'
+                      '$(NugetVersion)'
+                      '$(SdkInstallerNuspecFile)'
+                      '$(SdkInstallerNupkgFile)'" />
+    </Target>
+
     <Target Name="TestSdkMsi"
             Inputs="$(SdkInstallerFile)"
             Outputs="$(SdkMsiTestedSentinel)"
@@ -137,6 +155,7 @@
                             AcquireWix;
                             GenerateSdkMsi;
                             GenerateSdkBundle;
+                            GenerateSdkNupkg;
                             TestSdkMsi"
           Condition=" '$(OS)' == 'Windows_NT'" />
 

--- a/packaging/windows/clisdk/VS.Redist.Common.Net.Core.SDK.x64.nuspec
+++ b/packaging/windows/clisdk/VS.Redist.Common.Net.Core.SDK.x64.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>VS.Redist.Common.Net.Core.SDK.x64</id>
+        <version>1.0.0</version>
+        <title>VS.Redist.Common.Net.Core.SDK.x64</title>
+        <authors>Microsoft</authors>
+        <owners>Microsoft</owners>
+        <licenseUrl>https://www.microsoft.com/net/dotnet_library_license.htm</licenseUrl>
+        <projectUrl>https://github.com/dotnet/cli</projectUrl>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <description>Windows Installers (x64) for .Net Core SDK</description>
+        <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    </metadata>
+    <files>
+        <file src="[DOTNET_BUNDLE]" target="[DOTNET_BUNDLE]" />
+    </files>
+</package>

--- a/packaging/windows/clisdk/VS.Redist.Common.Net.Core.SDK.x86.nuspec
+++ b/packaging/windows/clisdk/VS.Redist.Common.Net.Core.SDK.x86.nuspec
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>VS.Redist.Common.Net.Core.SDK.x86</id>
+        <version>1.0.0</version>
+        <title>VS.Redist.Common.Net.Core.SDK.x86</title>
+        <authors>Microsoft</authors>
+        <owners>Microsoft</owners>
+        <licenseUrl>https://www.microsoft.com/net/dotnet_library_license.htm</licenseUrl>
+        <projectUrl>https://github.com/dotnet/cli</projectUrl>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <description>Windows Installer (x86) for .Net Core SDK</description>
+        <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    </metadata>
+    <files>
+        <file src="[DOTNET_BUNDLE]" target="[DOTNET_BUNDLE]" />
+    </files>
+</package>

--- a/packaging/windows/clisdk/generatenupkg.ps1
+++ b/packaging/windows/clisdk/generatenupkg.ps1
@@ -1,0 +1,74 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# This script is used to generate a nuget package with the windows installer bundle.
+# The generated nupkg file is used to deliver the CLI payload to Visual Studio.
+
+param(
+    [Parameter(Mandatory=$true)][string]$SdkBundlePath,
+    [Parameter(Mandatory=$true)][string]$NugetVersion,
+    [Parameter(Mandatory=$true)][string]$NuspecFile,
+    [Parameter(Mandatory=$true)][string]$NupkgFile
+)
+
+. "$PSScriptRoot\..\..\..\scripts\common\_common.ps1"
+$RepoRoot = Convert-Path "$PSScriptRoot\..\..\.."
+$NuGetDir = Join-Path $RepoRoot ".nuget"
+$NuGetExe = Join-Path $NuGetDir "nuget.exe"
+$OutputDirectory = [System.IO.Path]::GetDirectoryName($SdkBundlePath)
+
+function DownloadNugetExe
+{
+    if (-not (Test-Path $NuGetDir))
+    {
+        New-Item -ItemType Directory -Force -Path $NuGetDir | Out-Null
+    }
+
+    if (-not (Test-Path $NuGetExe)) {
+        Write-Host 'Downloading nuget.exe to ' + $NuGetExe
+        wget https://dist.nuget.org/win-x86-commandline/v3.5.0-rc1/NuGet.exe -OutFile $NuGetExe
+    }
+}
+
+function GenerateNupkg
+{
+    if (-not (Test-Path $NuspecFile))
+    {
+        Write-Host 'Error nuspec not found - $NuspecFile'
+    }
+
+    $SdkBundleName = [System.IO.Path]::GetFileName($SdkBundlePath)
+    $NuspecFileName = [System.IO.Path]::GetFileName($NuspecFile)
+    $TempNuspecFile = [System.IO.Path]::Combine($OutputDirectory, $NuspecFileName)
+    (Get-Content $NuspecFile) -replace '\[DOTNET_BUNDLE\]', $SdkBundleName | Set-Content $TempNuspecFile
+    & $NuGetExe pack $TempNuspecFile -Version $NugetVersion -OutputDirectory $OutputDirectory
+}
+
+
+if(!(Test-Path $SdkBundlePath))
+{
+    throw "$SdkBundlePath not found"
+}
+
+Write-Host "Creating nupkg for Sdk installer"
+
+DownloadNugetExe
+
+if(Test-Path $NupkgFile)
+{
+    Remove-Item -Force $NupkgFile
+}
+
+if(-Not (GenerateNupkg))
+{
+    Exit -1
+}
+
+if(!(Test-Path $NupkgFile))
+{
+    throw "$NupkgFile not generated"
+}
+
+Write-Host -ForegroundColor Green "Successfully created installer nupkg - $NupkgFile"
+
+exit $LastExitCode


### PR DESCRIPTION
These nuget packages are used to deliver the CLI payload to Visual Studio setup authoring. They are pushed (by VSO build definitions) into an internal feed consumed by Visual Studio.

@piotrpMSFT @livarcocc 