### PR TITLE
Migrate Args update comment

### DIFF
--- a/src/dotnet/commands/dotnet-migrate/Program.cs
+++ b/src/dotnet/commands/dotnet-migrate/Program.cs
@@ -11,6 +11,12 @@ namespace Microsoft.DotNet.Tools.Migrate
     {
         public static int Run(string[] args)
         {
+
+            // IMPORTANT:
+            // When updating the command line args for dotnet-migrate, we need to update the in-VS caller of dotnet migrate as well.
+            // It is located at dotnet/roslyn-project-system:
+            //     src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojFactory.cs
+
             DebugHelper.HandleDebugSwitch(ref args);
 
             CommandLineApplication app = new CommandLineApplication();


### PR DESCRIPTION
The new project system calls dotnet migrate on the command line. When we update the cli, we also need to update the VS side. I'm skipping CI since this is purely a comment change. Tagging @brthor for review.

skip ci please