### PR TITLE
Fixing the tools item name in csproj. Nuget used a different one then…

### DIFF
--- a/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
+++ b/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolsReference Include="dotnet-portable">
+    <DotNetCliToolReference Include="dotnet-portable">
       <Version>1.0.0</Version>
-    </DotNetCliToolsReference>
+    </DotNetCliToolReference>
   </ItemGroup>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft.CSharp.targets" />

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
@@ -233,7 +233,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
             .WithMetadata("Version", r => r.Version);
 
         private AddItemTransform<ProjectLibraryDependency> ToolTransform => new AddItemTransform<ProjectLibraryDependency>(
-            "DotNetCliToolsReference",
+            "DotNetCliToolReference",
             dep => dep.Name,
             dep => "",
             dep => true)

--- a/src/dotnet/CommandResolution/MSBuildProject.cs
+++ b/src/dotnet/CommandResolution/MSBuildProject.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Cli.CommandResolution
 
         public IEnumerable<SingleProjectInfo> GetTools()
         {
-            var toolsReferences = _project.AllEvaluatedItems.Where(i => i.ItemType.Equals("DotNetCliToolsReference"));
+            var toolsReferences = _project.AllEvaluatedItems.Where(i => i.ItemType.Equals("DotNetCliToolReference"));
             var tools = toolsReferences.Select(t => new SingleProjectInfo(
                 t.EvaluatedInclude,
                 t.GetMetadataValue("Version"),

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackageDependencies.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackageDependencies.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
                 var packageVersion = toolSpec.Item2;
 
                 var items = mockProj.Items
-                    .Where(i => i.ItemType == "DotNetCliToolsReference")
+                    .Where(i => i.ItemType == "DotNetCliToolReference")
                     .Where(i => i.Include == packageName)
                     .Where(i => i.GetMetadataWithName("Version").Value == packageVersion);
 


### PR DESCRIPTION
Nuget used a different one then was originally at the spec.

@eerhardt @Sridhar-MS @brthor @piotrpMSFT 