### PR TITLE
[rel/1.0.0-preview2.1] Add support for building and testing on new RIDs

### DIFF
--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
+++ b/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
@@ -16,11 +16,13 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   },
   "tools": {
     "dotnet-portable": {

--- a/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
@@ -20,11 +20,13 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   },
   "tools": {
     "dotnet-portable": {

--- a/TestAssets/TestProjects/AppWithDirectDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependency/project.json
@@ -20,10 +20,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
+++ b/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/AppWithToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithToolDependency/project.json
@@ -22,10 +22,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/CompileFail/project.json
+++ b/TestAssets/TestProjects/CompileFail/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json.modified
+++ b/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json.modified
@@ -20,10 +20,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
@@ -23,10 +23,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
@@ -22,10 +22,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/EndToEndTestApp/project.json
+++ b/TestAssets/TestProjects/EndToEndTestApp/project.json
@@ -35,10 +35,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
@@ -38,10 +38,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
@@ -39,10 +39,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
@@ -35,10 +35,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
@@ -31,10 +31,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
+++ b/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
@@ -27,10 +27,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
@@ -31,10 +31,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
@@ -31,10 +31,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
@@ -16,11 +16,13 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   },
   "runtimeOptions": {
     "somethingString": "anything",

--- a/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
@@ -18,10 +18,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppSimple/project.json
+++ b/TestAssets/TestProjects/TestAppSimple/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/TestAppWithArgs/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithContentPackage/project.json
+++ b/TestAssets/TestProjects/TestAppWithContentPackage/project.json
@@ -23,10 +23,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithContents/project.json
+++ b/TestAssets/TestProjects/TestAppWithContents/project.json
@@ -22,10 +22,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
@@ -21,10 +21,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
+++ b/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
@@ -27,10 +27,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithScripts/project.json
+++ b/TestAssets/TestProjects/TestAppWithScripts/project.json
@@ -16,11 +16,13 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   },
   "scripts": {
     "prepublish": [

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
@@ -21,11 +21,13 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   },
   "scripts": {
     "prepublish": [

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
@@ -20,10 +20,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
+++ b/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
@@ -21,10 +21,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
@@ -21,10 +21,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
@@ -26,10 +26,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestMscorlibReference/project.json
+++ b/TestAssets/TestProjects/TestMscorlibReference/project.json
@@ -20,10 +20,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
@@ -18,10 +18,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestProjectWithResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithResource/project.json
@@ -16,10 +16,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
+++ b/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
@@ -17,10 +17,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestSystemCoreReference/project.json
+++ b/TestAssets/TestProjects/TestSystemCoreReference/project.json
@@ -20,10 +20,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/TestAssets/TestProjects/TestSystemReference/project.json
+++ b/TestAssets/TestProjects/TestSystemReference/project.json
@@ -20,10 +20,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/build_projects/dotnet-cli-build/CompileTargets.cs
+++ b/build_projects/dotnet-cli-build/CompileTargets.cs
@@ -46,12 +46,14 @@ namespace Microsoft.DotNet.Cli.Build
             { "osx.10.11-x64", "osx.10.10-x64" },
             { "ubuntu.14.04-x64", "ubuntu.14.04-x64" },
             { "ubuntu.16.04-x64", "ubuntu.16.04-x64" },
+            { "ubuntu.16.10-x64", "ubuntu.16.10-x64" },
             { "centos.7-x64", "rhel.7-x64" },
             { "rhel.7-x64", "rhel.7-x64" },
             { "rhel.7.2-x64", "rhel.7-x64" },
             { "debian.8-x64", "debian.8-x64" },
             { "fedora.23-x64", "fedora.23-x64" },
-            { "opensuse.13.2-x64", "opensuse.13.2-x64" }
+            { "opensuse.13.2-x64", "opensuse.13.2-x64" },
+            { "opensuse.42.1-x64", "opensuse.42.1-x64" }
         };
 
         public const string SharedFrameworkName = "Microsoft.NETCore.App";

--- a/build_projects/dotnet-cli-build/PublishTargets.cs
+++ b/build_projects/dotnet-cli-build/PublishTargets.cs
@@ -91,12 +91,14 @@ namespace Microsoft.DotNet.Cli.Build
                         "win.x64.version",
                         "ubuntu.x64.version",
                         "ubuntu.16.04.x64.version",
+                        "ubuntu.16.10.x64.version",
                         "rhel.x64.version",
                         "osx.x64.version",
                         "debian.x64.version",
                         "centos.x64.version",
                         "fedora.23.x64.version",
-                        "opensuse.13.2.x64.version"
+                        "opensuse.13.2.x64.version",
+                        "opensuse.42.1.x64.version"
                     };
 
                     string cliVersion = Utils.GetCliVersionFileContent(c);
@@ -137,12 +139,14 @@ namespace Microsoft.DotNet.Cli.Build
                  { "Windows_x64", false },
                  { "Ubuntu_x64", false },
                  { "Ubuntu_16_04_x64", false },
+                 { "Ubuntu_16_10_x64", false },
                  { "RHEL_x64", false },
                  { "OSX_x64", false },
                  { "Debian_x64", false },
                  { "CentOS_x64", false },
                  { "Fedora_23_x64", false },
-                 { "openSUSE_13_2_x64", false }
+                 { "openSUSE_13_2_x64", false },
+                 { "openSUSE_42_1_x64", false }
              };
 
             List<string> blobs = new List<string>(AzurePublisherTool.ListBlobs($"{Channel}/Binaries/{CliNuGetVersion}/"));

--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -35,10 +35,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             string rid = RuntimeEnvironment.GetRuntimeIdentifier();
 
-            if (rid == "ubuntu.16.04-x64" || rid == "fedora.23-x64" || rid == "opensuse.13.2-x64")
+            if (rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64")
             {
                 return $"{artifactPrefix}-{rid}.{version}";
             }
@@ -44,10 +44,14 @@ namespace Microsoft.DotNet.Cli.Build
             {
                 case "ubuntu.16.04-x64":
                     return "Ubuntu_16_04_x64";
+                case "ubuntu.16.10-x64":
+                    return "Ubuntu_16_10_x64";
                 case "fedora.23-x64":
                     return "Fedora_23_x64";
                 case "opensuse.13.2-x64":
                     return "openSUSE_13_2_x64";
+                case "opensuse.42.1-x64":
+                    return "openSUSE_42_1_x64";
             }
 
             return $"{CurrentPlatform.Current}_{CurrentArchitecture.Current}";

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -32,10 +32,12 @@
     "osx.10.11-x64": {},
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
+    "ubuntu.16.10-x64": {},
     "centos.7-x64": {},
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
-    "opensuse.13.2-x64": {}
+    "opensuse.13.2-x64": {},
+    "opensuse.42.1-x64": {}
   }
 }

--- a/scripts/docker/opensuse.42.1/Dockerfile
+++ b/scripts/docker/opensuse.42.1/Dockerfile
@@ -1,0 +1,50 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+FROM opensuse:42.1
+
+# Install the base toolchain we need to build anything (clang, cmake, make and the like)
+# this does not include libraries that we need to compile different projects, we'd like
+# them in a different layer.
+RUN zypper -n install binutils \
+              cmake \
+              which \
+              gcc \
+              llvm-clang \
+              tar \
+              ncurses-utils \
+              curl \
+              git \
+              sudo && \
+    ln -s /usr/bin/clang++ /usr/bin/clang++-3.5 && \
+    zypper clean -a
+
+# Dependencies of CoreCLR and CoreFX.
+
+RUN zypper -n install --force-resolution \
+                      libunwind \
+                      libicu \
+                      lttng-ust \
+                      libuuid1 \
+                      libopenssl1_0_0 \
+                      libcurl4 \
+                      krb5 && \
+    zypper clean -a
+
+# Setup User to match Host User, and give superuser permissions
+ARG USER_ID=0
+RUN useradd -m code_executor -u ${USER_ID} -g wheel
+RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# With the User Change, we need to change permissions on these directories
+RUN chmod -R a+rwx /usr/local
+RUN chmod -R a+rwx /home
+RUN chmod -R 755 /usr/lib/sudo
+
+# Set user to the one we just created
+USER ${USER_ID}
+
+# Set working directory
+WORKDIR /opt/code

--- a/scripts/docker/ubuntu.16.10/Dockerfile
+++ b/scripts/docker/ubuntu.16.10/Dockerfile
@@ -1,0 +1,63 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# Dockerfile that creates a container suitable to build dotnet-cli
+FROM ubuntu:16.10
+
+# Misc Dependencies for build
+RUN apt-get update && \
+    apt-get -qqy install \
+        curl \
+        unzip \
+        gettext \
+        sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# This could become a "microsoft/coreclr" image, since it just installs the dependencies for CoreCLR (and stdlib)
+RUN apt-get update && \
+    apt-get -qqy install \
+        libunwind8 \
+        libkrb5-3 \
+        libicu57 \
+        liblttng-ust0 \
+        libssl1.0.0 \
+        zlib1g \
+        libuuid1 \
+        liblldb-3.5 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Build Prereqs
+RUN apt-get update && \
+    apt-get -qqy install \
+        debhelper \
+        build-essential \
+        devscripts \
+        git \
+        cmake \
+        clang-3.5 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Use clang as c++ compiler
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.5 100
+RUN update-alternatives --set c++ /usr/bin/clang++-3.5
+
+# Setup User to match Host User, and give superuser permissions
+ARG USER_ID=0
+RUN useradd -m code_executor -u ${USER_ID} -g sudo
+RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# With the User Change, we need to change permissions on these directories
+RUN chmod -R a+rwx /usr/local
+RUN chmod -R a+rwx /home
+RUN chmod -R 755 /usr/lib/sudo
+
+# Set user to the one we just created
+USER ${USER_ID}
+
+# Set working directory
+WORKDIR /opt/code

--- a/scripts/docker/ubuntu.16.10/Dockerfile
+++ b/scripts/docker/ubuntu.16.10/Dockerfile
@@ -26,8 +26,9 @@ RUN apt-get update && \
         libssl1.0.0 \
         zlib1g \
         libuuid1 \
-        liblldb-3.5 && \
-    apt-get clean && \
+        liblldb-3.5 \
+        libcurl4-openssl-dev \
+    && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Build Prereqs

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -64,34 +64,47 @@ get_current_os_name() {
         echo "osx"
         return 0
     else
-        # Detect Distro
-        if [ "$(cat /etc/*-release | grep -cim1 ubuntu)" -eq 1 ]; then
-            if [ "$(cat /etc/*-release | grep -cim1 16.04)" -eq 1 ]; then
-                echo "ubuntu.16.04"
-                return 0
-            fi
+        if [ -e /etc/os-release ]; then
+            . /etc/os-release
 
-            echo "ubuntu"
-            return 0
-        elif [ "$(cat /etc/*-release | grep -cim1 centos)" -eq 1 ]; then
-            echo "centos"
-            return 0
-        elif [ "$(cat /etc/*-release | grep -cim1 rhel)" -eq 1 ]; then
-            echo "rhel"
-            return 0
-        elif [ "$(cat /etc/*-release | grep -cim1 debian)" -eq 1 ]; then
-            echo "debian"
-            return 0
-        elif [ "$(cat /etc/*-release | grep -cim1 fedora)" -eq 1 ]; then
-            if [ "$(cat /etc/*-release | grep -cim1 23)" -eq 1 ]; then
-                echo "fedora.23"
-                return 0
-            fi
-        elif [ "$(cat /etc/*-release | grep -cim1 opensuse)" -eq 1 ]; then
-            if [ "$(cat /etc/*-release | grep -cim1 13.2)" -eq 1 ]; then
-                echo "opensuse.13.2"
-                return 0
-            fi
+            case "$ID.$VERSION_ID" in
+                "centos.7")
+                    echo "centos"
+                    return 0
+                    ;;
+                "debian.8")
+                    echo "debian"
+                    return 0
+                    ;;
+                "fedora.23")
+                    echo "fedora.23"
+                    return 0
+                    ;;
+                "opensuse.13.2")
+                    echo "opensuse.13.2"
+                    return 0
+                    ;;
+                "opensuse.42.1")
+                    echo "opensuse.42.1"
+                    return 0
+                    ;;
+                "rhel.7.0" | "rhel.7.1" | "rhel.7.2")
+                    echo "rhel"
+                    return 0
+                    ;;
+                "ubuntu.14.04")
+                    echo "ubuntu"
+                    return 0
+                    ;;
+                "ubuntu.16.04")
+                    echo "ubuntu.16.04"
+                    return 0
+                    ;;
+                "ubuntu.16.10")
+                    echo "ubuntu.16.10"
+                    return 0
+                    ;;
+            esac
         fi
     fi
     
@@ -284,12 +297,7 @@ get_latest_version_info() {
     
     local osname=$(get_current_os_name)
     
-    local version_file_url=null
-    if [ "$shared_runtime" = true ]; then
-        version_file_url="$azure_feed/$azure_channel/dnvm/latest.sharedfx.$osname.$normalized_architecture.version"
-    else
-        version_file_url="$azure_feed/$azure_channel/dnvm/latest.$osname.$normalized_architecture.version"
-    fi
+    local version_file_url="$azure_feed/$azure_channel/dnvm/latest.$osname.$normalized_architecture.version"
     say_verbose "get_latest_version_info: latest url: $version_file_url"
     
     download $version_file_url
@@ -370,13 +378,7 @@ construct_download_link() {
     
     local osname=$(get_current_os_name)
     
-    local download_link=null
-    if [ "$shared_runtime" = true ]; then
-        download_link="$azure_feed/$azure_channel/Binaries/$specific_version/dotnet-$osname-$normalized_architecture.$specific_version.tar.gz"
-    else
-        download_link="$azure_feed/$azure_channel/Binaries/$specific_version/dotnet-dev-$osname-$normalized_architecture.$specific_version.tar.gz"
-    fi
-    
+    local download_link="$azure_feed/$azure_channel/Binaries/$specific_version/dotnet-dev-$osname-$normalized_architecture.$specific_version.tar.gz"
     echo "$download_link"
     return 0
 }
@@ -566,7 +568,6 @@ dry_run=false
 no_path=false
 azure_feed="https://dotnetcli.blob.core.windows.net/dotnet"
 verbose=false
-shared_runtime=false
 
 while [ $# -ne 0 ]
 do
@@ -587,9 +588,6 @@ do
         --arch|--architecture|-[Aa]rch|-[Aa]rchitecture)
             shift
             architecture="$1"
-            ;;
-        --shared-runtime|-[Ss]hared[Rr]untime)
-            shared_runtime=true
             ;;
         --debug-symbols|-[Dd]ebug[Ss]ymbols)
             debug_symbols=true
@@ -624,8 +622,6 @@ do
             echo "      -InstallDir"
             echo "  --architecture <ARCHITECTURE>  Architecture of .NET Tools. Currently only x64 is supported."
             echo "      --arch,-Architecture,-Arch"
-            echo "  --shared-runtime               Installs just the shared runtime bits, not the entire SDK."
-            echo "      -SharedRuntime"
             echo "  --debug-symbols,-DebugSymbols  Specifies if symbols should be included in the installation."
             echo "  --dry-run,-DryRun              Do not perform installation. Display download link."
             echo "  --no-path, -NoPath             Do not set PATH for the current process."
@@ -668,4 +664,4 @@ else
     say "Binaries of dotnet can be found in $bin_path"
 fi
 
-say "Installation finished successfully."
+say "Installation finished successfuly."


### PR DESCRIPTION
* Add new RIDs throughout the build process and into all of the standalone test projects and other projects which explicitly list RIDs.
* Add new Dockerfiles for the two new RIDs. Mostly copy-pasted from the ones in core-setup.
* Update the `scripts/obtain/dotnet-install.sh` file to correctly handle installation on the new distros. This file has just been copied over from core-setup, which was recently updated for the exact same scenario.

@livarcocc