### PR TITLE
Prevent rebuild of CLI SDK installer after signing

### DIFF
--- a/build/package/Microsoft.DotNet.Cli.Installer.MSI.targets
+++ b/build/package/Microsoft.DotNet.Cli.Installer.MSI.targets
@@ -28,7 +28,7 @@
 
       <!-- Generate SDK MSI Inputs -->
       <ItemGroup>
-        <GenerateSdkMsiInputs Include="$(SdkLayoutOutputDirectory);
+        <GenerateSdkMsiInputs Include="$(SdkLayoutOutputDirectory)/**/*;
                                        $(SdkGenerateMsiPowershellScript)" />
       </ItemGroup>
 
@@ -81,7 +81,7 @@
     <Target Name="GenerateSdkMsi"
             DependsOnTargets="Init;Layout;AcquireWix;MsiTargetsSetupInputOutputs"
             Condition=" '$(OS)' == 'Windows_NT'"
-            Inputs="$(GenerateSdkMsiInputs)"
+            Inputs="@(GenerateSdkMsiInputs)"
             Outputs="$(SdkInstallerFile)">
 
       <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateMsiPowershellScript)

--- a/build/package/Microsoft.DotNet.Cli.Installer.MSI.targets
+++ b/build/package/Microsoft.DotNet.Cli.Installer.MSI.targets
@@ -26,6 +26,12 @@
         <SdkInstallerNupkgFile>$(InstallerOutputDirectory)/VS.Redist.Common.Net.Core.SDK.$(Architecture).$(NugetVersion).nupkg</SdkInstallerNupkgFile>
       </PropertyGroup>
 
+      <!-- Generate SDK MSI Inputs -->
+      <ItemGroup>
+        <GenerateSdkMsiInputs Include="$(SdkLayoutOutputDirectory);
+                                       $(SdkGenerateMsiPowershellScript)" />
+      </ItemGroup>
+
       <!-- Consumed By Publish -->
       <ItemGroup>
         <GeneratedInstallers Include="$(SdkInstallerFile);$(CombinedFrameworkSdkHostInstallerFile)" />
@@ -75,8 +81,7 @@
     <Target Name="GenerateSdkMsi"
             DependsOnTargets="Init;Layout;AcquireWix;MsiTargetsSetupInputOutputs"
             Condition=" '$(OS)' == 'Windows_NT'"
-            Inputs="$(SdkLayoutOutputDirectory);
-                    $(SdkGenerateMsiPowershellScript)"
+            Inputs="$(GenerateSdkMsiInputs)"
             Outputs="$(SdkInstallerFile)">
 
       <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateMsiPowershellScript)


### PR DESCRIPTION
@eerhardt @brthor @livarcocc

A bug in the MSI generation inputs prevents incrementality from avoiding rebuilds of the MSI. Since this target is involved with the build-sign-msi-sign-bundle-sign pipeline, and is a pre-req to subsequent steps, the bug causes a destructive recreation of all publishable artifacts after each signing step. This is why recent builds are completely unsigned: after the final signing occurs, the MSI is rebuilt --> the bundle is rebuilt --> signatures are lost.