### PR TITLE
Allow dotnet-install.ps1 to work behind an outbound proxy

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -47,7 +47,7 @@
 .PARAMETER AzureFeed
     Default: https://dotnetcli.azureedge.net/dotnet
     This parameter should not be usually changed by user. It allows to change URL for the Azure feed used by this installer.
-.PARAMETER Proxy
+.PARAMETER ProxyAddress
     If set, the installer will use the proxy when making web requests
 #>
 [cmdletbinding()]

--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -136,12 +136,15 @@ function GetHTTPResponse([Uri] $Uri)
     try {
         # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
         Load-Assembly -Assembly System.Net.Http
-        $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
         if($ProxyAddress){
+            $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
             $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{Address=$ProxyAddress}
+            $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
+        } 
+        else {
+            $HttpClient = New-Object System.Net.Http.HttpClient
         }
 
-        $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
         $Response = $HttpClient.GetAsync($Uri).Result
         if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode)))
         {


### PR DESCRIPTION
- Please add description for changes you are making.

The `dotnet-install.ps1` script for obtaining dotnet currently does not work behind a proxy (example, corporates with outbound proxies).  This PR adds an optional parameter, `-ProxyAddress`, which takes the address of a proxy server, such as `http://servername:3128/` and uses it when initializing the `System.Net.Http.HttpClient`.   

- If there is an issue related to this PR, please add the reference.

Issue #4273 
