### PR TITLE
Adding recursive restore and solution level restore

### DIFF
--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -20,7 +20,7 @@
     "System.Runtime.Serialization.Primitives": "4.1.1",
     "System.Xml.XmlSerializer": "4.0.11",
     "WindowsAzure.Storage": "6.2.2-preview",
-    "NuGet.CommandLine.XPlat": "3.6.0-rc-1979",
+    "NuGet.CommandLine.XPlat": "3.6.0-rc-1984",
     "Microsoft.Build.Utilities.Core": "0.1.0-preview-00043-160929",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },

--- a/resources/MSBuildImports/15.0/SolutionFile/ImportAfter/Microsoft.NuGet.ImportAfter.targets
+++ b/resources/MSBuildImports/15.0/SolutionFile/ImportAfter/Microsoft.NuGet.ImportAfter.targets
@@ -1,0 +1,18 @@
+<!--
+***********************************************************************************************
+Microsoft.NuGet.ImportAfter.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved. 
+***********************************************************************************************
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Import NuGet.targets for Restore -->
+  <PropertyGroup>
+    <NuGetRestoreTargets Condition="'$(NuGetRestoreTargets)'==''">$(MSBuildExtensionsPath)\NuGet.targets</NuGetRestoreTargets>
+  </PropertyGroup>
+  <Import Condition="Exists('$(NuGetRestoreTargets)')" Project="$(NuGetRestoreTargets)" />
+</Project>

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -9,10 +9,10 @@
       "target": "project"
     },
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
-    "NuGet.Versioning": "3.6.0-rc-1979",
-    "NuGet.Packaging": "3.6.0-rc-1979",
-    "NuGet.Frameworks": "3.6.0-rc-1979",
-    "NuGet.ProjectModel": "3.6.0-rc-1979"
+    "NuGet.Versioning": "3.6.0-rc-1984",
+    "NuGet.Packaging": "3.6.0-rc-1984",
+    "NuGet.Frameworks": "3.6.0-rc-1984",
+    "NuGet.ProjectModel": "3.6.0-rc-1984"
   },
   "frameworks": {
     "netstandard1.3": {

--- a/src/Microsoft.DotNet.Compiler.Common/project.json
+++ b/src/Microsoft.DotNet.Compiler.Common/project.json
@@ -14,7 +14,7 @@
     "Microsoft.DotNet.Files": {
       "target": "project"
     },
-    "NuGet.ProjectModel": "3.6.0-rc-1979"
+    "NuGet.ProjectModel": "3.6.0-rc-1984"
   },
   "frameworks": {
     "netstandard1.3": {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -8,10 +8,10 @@
     "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
     "Newtonsoft.Json": "9.0.1",
-    "NuGet.Configuration": "3.6.0-rc-1979",
-    "NuGet.Packaging": "3.6.0-rc-1979",
-    "NuGet.RuntimeModel": "3.6.0-rc-1979",
-    "NuGet.ProjectModel": "3.6.0-rc-1979",
+    "NuGet.Configuration": "3.6.0-rc-1984",
+    "NuGet.Packaging": "3.6.0-rc-1984",
+    "NuGet.RuntimeModel": "3.6.0-rc-1984",
+    "NuGet.ProjectModel": "3.6.0-rc-1984",
     "System.Reflection.Metadata": "1.4.1-beta-24410-02"
   },
   "frameworks": {

--- a/src/dotnet/commands/dotnet-restore3/Program.cs
+++ b/src/dotnet/commands/dotnet-restore3/Program.cs
@@ -60,6 +60,12 @@ namespace Microsoft.DotNet.Tools.Restore3
                     "Treat package source failures as warnings.",
                     CommandOptionType.NoValue);
 
+            // Use a boolean argument instead of a switch to match nuget.exe
+            var recursive = cmd.Option(
+                "--recursive",
+                "Restore all dependency projects.",
+                CommandOptionType.BoolValue);
+
             cmd.OnExecute(() =>
             {
                 var msbuildArgs = new List<string>()
@@ -69,7 +75,7 @@ namespace Microsoft.DotNet.Tools.Restore3
 
                 if (sourceOption.HasValue())
                 {
-                    msbuildArgs.Add($"/p:RestoreSources={string.Join(";", sourceOption.Values)}");
+                    msbuildArgs.Add($"/p:RestoreSources={string.Join("%3B", sourceOption.Values)}");
                 }
 
                 if (packagesOption.HasValue())
@@ -95,6 +101,13 @@ namespace Microsoft.DotNet.Tools.Restore3
                 if (ignoreFailedSourcesOption.HasValue())
                 {
                     msbuildArgs.Add($"/p:RestoreIgnoreFailedSources=true");
+                }
+
+                // By default restore is recursive, if set to false turn it off.
+                // If the argument is not present use the default behavior.
+                if (recursive.BoolValue == false)
+                {
+                    msbuildArgs.Add($"/p:RestoreRecursive=false");
                 }
 
                 // Add in arguments

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -22,7 +22,7 @@
     "Microsoft.Build.Runtime": "15.1.316-preview5",
     "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60922-08",
     "System.Runtime.Serialization.Xml": "4.1.1",
-    "NuGet.Build.Tasks": "3.6.0-rc-1979",
+    "NuGet.Build.Tasks": "3.6.0-rc-1984",
     "Microsoft.TestPlatform.CLI": "15.0.0-preview-20161005-01",
     "Microsoft.TestPlatform.Build": "15.0.0-preview-20161005-01"
   },

--- a/src/tool_nuget/project.json
+++ b/src/tool_nuget/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "NuGet.CommandLine.XPlat": "3.6.0-rc-1979"
+    "NuGet.CommandLine.XPlat": "3.6.0-rc-1984"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -30,10 +30,10 @@
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
-    "NuGet.Versioning": "3.6.0-rc-1979",
-    "NuGet.Packaging": "3.6.0-rc-1979",
-    "NuGet.Frameworks": "3.6.0-rc-1979",
-    "NuGet.ProjectModel": "3.6.0-rc-1979",
+    "NuGet.Versioning": "3.6.0-rc-1984",
+    "NuGet.Packaging": "3.6.0-rc-1984",
+    "NuGet.Frameworks": "3.6.0-rc-1984",
+    "NuGet.ProjectModel": "3.6.0-rc-1984",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -22,7 +22,7 @@
     },
     "xunit": "2.2.0-beta3-build3330",
     "dotnet-test-xunit": "1.0.0-rc2-350904-49",
-    "NuGet.ProjectModel": "3.6.0-rc-1979"
+    "NuGet.ProjectModel": "3.6.0-rc-1984"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
This change adds support for restoring solution files with msbuild /t:Restore and dotnet restore3.
Restoring a project file will now recursively restore all dependency projects to match build.

Updating NuGet to 3.6.0-rc-1984

Fixes https://github.com/dotnet/cli/issues/4252
Related to: https://github.com/NuGet/Home/issues/2993