### PR TITLE
Setting the template Microsoft.NetCore.App version to 1.0.1

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
@@ -10,7 +10,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2"
+          "version": "1.0.1"
         }
       },
       "imports": "dnxcore50"

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -14,7 +14,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2"
+          "version": "1.0.1"
         }
       },
       "imports": [

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
@@ -18,7 +18,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.2"
+          "version": "1.0.1"
         },
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160629"
       }


### PR DESCRIPTION
Setting the template Microsoft.NetCore.App version to 1.0.1 so that even if we only update OSX packages, everything will continue to work.

@eerhardt @brthor @piotrpMSFT @jgoshi 