### PR TITLE
Reduce MSBuild verbosity for restore

### DIFF
--- a/src/dotnet/commands/dotnet-restore3/Program.cs
+++ b/src/dotnet/commands/dotnet-restore3/Program.cs
@@ -69,7 +69,9 @@ namespace Microsoft.DotNet.Tools.Restore3
             {
                 var msbuildArgs = new List<string>()
                 {
-                     "/t:Restore"
+                     "/NoLogo",
+                     "/t:Restore",
+                     "/ConsoleLoggerParameters:Verbosity=Minimal"
                 };
 
                 if (sourceOption.HasValue())


### PR DESCRIPTION
Wanted to run this by everyone.  This is the alternative to a custom logger but might address the concern in #4433.

* Remove the MSBuild logo
* Set verbosity to minimal

Sample output now with only high importance messages:

![image](https://cloud.githubusercontent.com/assets/17556515/19486385/0983ef02-9513-11e6-93d1-ccd9c09d5105.png)

The user could still see the normal output with the file logger:

`dotnet restore3 /fl /flp:Verbosity:Normal`