### PR TITLE
Removed workaround for https://github.com/docker/docker/issues/20818

### DIFF
--- a/scripts/docker/debian/Dockerfile
+++ b/scripts/docker/debian/Dockerfile
@@ -60,9 +60,3 @@ USER ${USER_ID}
 
 # Set working directory
 WORKDIR /opt/code
-
-# Work around https://github.com/dotnet/cli/issues/1582 until Docker releases a
-# fix (https://github.com/docker/docker/issues/20818). This workaround allows
-# the container to be run with the default seccomp Docker settings by avoiding
-# the restart_syscall made by LTTng which causes a failed assertion.
-ENV LTTNG_UST_REGISTER_TIMEOUT 0


### PR DESCRIPTION
This workaround is not needed since the release of Docker 1.11.0 which addresses the underlying issue.

See relevant changes in dotnet-docker:
dotnet/dotnet-docker-nightly@f8cb0d5
dotnet/dotnet-docker#42