### PR TITLE
Making OutputPathCommandResolver work with MSBuild.

### DIFF
--- a/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
+++ b/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk">
+      <Version>1.0.0-alpha-20161019-1</Version>
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="dotnet-desktop-and-portable">
+      <Version>1.0.0-*</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-dependency-tool-invoker">
+      <Version>1.0.0-*</Version>
+    </DotNetCliToolReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/Program.cs
+++ b/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/IProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/IProject.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         string RuntimeConfigJsonPath { get; }
 
-        string OutputPath { get; }
+        string FullOutputPath { get; }
 
         Dictionary<string, string> EnvironmentVariables { get; }
     }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/IProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/IProject.cs
@@ -16,6 +16,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
         string RuntimeConfigJsonPath { get; }
 
+        string OutputPath { get; }
+
         Dictionary<string, string> EnvironmentVariables { get; }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Cli.Utils
             }
         }
 
-        public string OutputPath
+        public string FullOutputPath
         {
             get
             {

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
@@ -39,6 +39,17 @@ namespace Microsoft.DotNet.Cli.Utils
             }
         }
 
+        public string OutputPath
+        {
+            get
+            {
+                return _project
+                    .AllEvaluatedProperties
+                    .FirstOrDefault(p => p.Name.Equals("TargetDir"))
+                    .EvaluatedValue;
+            }
+        }
+
         public Dictionary<string, string> EnvironmentVariables
         {
             get

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/OutputPathCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/OutputPathCommandResolver.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 return null;
             }
 
-            var buildOutputPath = project.OutputPath;
+            var buildOutputPath = project.FullOutputPath;
 
             if (!Directory.Exists(buildOutputPath))
             {

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectJsonProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectJsonProject.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Cli.Utils
             }
         }
 
-        public string OutputPath
+        public string FullOutputPath
         {
             get
             {

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectJsonProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectJsonProject.cs
@@ -67,6 +67,15 @@ namespace Microsoft.DotNet.Cli.Utils
             }
         }
 
+        public string OutputPath
+        {
+            get
+            {
+                return
+                    ProjectContext.GetOutputPaths(_configuration, _buildBasePath, _outputPath).RuntimeFiles.BasePath;
+            }
+        }
+
         public Dictionary<string, string> EnvironmentVariables
         {
             get


### PR DESCRIPTION
@eerhardt @piotrpMSFT @jgoshi 

Fixes https://github.com/dotnet/cli/issues/4471

