### PR TITLE
Fix dotnet run3 --project to pass the project to msbuild.

### DIFF
--- a/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworks/MSBuildAppWithMultipleFrameworks.csproj
+++ b/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworks/MSBuildAppWithMultipleFrameworks.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161019-1</Version>
+      <Version>1.0.0-alpha-20161026-2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
+++ b/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161019-1</Version>
+      <Version>1.0.0-alpha-20161026-2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="dotnet-desktop-and-portable">

--- a/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
+++ b/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
@@ -15,7 +15,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161019-1</Version>
+      <Version>1.0.0-alpha-20161026-2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/TestAssets/TestProjects/MSBuildTestAppWithToolInDependencies/MSBuildTestAppWithToolInDependencies.csproj
+++ b/TestAssets/TestProjects/MSBuildTestAppWithToolInDependencies/MSBuildTestAppWithToolInDependencies.csproj
@@ -15,7 +15,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161019-1</Version>
+      <Version>1.0.0-alpha-20161026-2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="dotnet-portable">

--- a/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary1/project.json
+++ b/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary1/project.json
@@ -3,7 +3,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.NET.Sdk": "1.0.0-alpha-20161019-1",
+        "Microsoft.NET.Sdk": "1.0.0-alpha-20161026-2",
         "NETStandard.Library": "1.6.0"
       }
     }

--- a/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary2/project.json
+++ b/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary2/project.json
@@ -3,7 +3,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.NET.Sdk": "1.0.0-alpha-20161019-1",
+        "Microsoft.NET.Sdk": "1.0.0-alpha-20161026-2",
         "NETStandard.Library": "1.6.0"
       }
     }

--- a/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary3/project.json
+++ b/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary3/project.json
@@ -3,7 +3,7 @@
   "frameworks": {
     "netstandard1.5": {
       "dependencies": {
-        "Microsoft.NET.Sdk": "1.0.0-alpha-20161019-1",
+        "Microsoft.NET.Sdk": "1.0.0-alpha-20161026-2",
         "NETStandard.Library": "1.6.0"
       }
     }

--- a/TestAssets/TestProjects/VSTestDotNetCoreProject/VSTestDotNetCoreProject.csproj
+++ b/TestAssets/TestProjects/VSTestDotNetCoreProject/VSTestDotNetCoreProject.csproj
@@ -17,7 +17,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161019-1</Version>
+      <Version>1.0.0-alpha-20161026-2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 	<PackageReference Include="MSTest.TestFramework">

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -43,7 +43,7 @@
       <Version>1.0.1-beta-000933</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161019-1</Version>
+      <Version>1.0.0-alpha-20161026-2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/dotnet/commands/dotnet-new/CSharp_Console/$projectName$.csproj
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/$projectName$.csproj
@@ -16,7 +16,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161019-1</Version>
+      <Version>1.0.0-alpha-20161026-2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/$projectName$.csproj
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/$projectName$.csproj
@@ -15,7 +15,7 @@
       <Version>1.6</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161019-1</Version>
+      <Version>1.0.0-alpha-20161026-2</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/dotnet/commands/dotnet-run3/Run3Command.cs
+++ b/src/dotnet/commands/dotnet-run3/Run3Command.cs
@@ -46,6 +46,8 @@ namespace Microsoft.DotNet.Tools.Run
         {
             List<string> buildArgs = new List<string>();
 
+            buildArgs.Add(Project);
+
             buildArgs.Add("/nologo");
             buildArgs.Add("/verbosity:quiet");
 

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -39,10 +39,9 @@ namespace Microsoft.DotNet.Tests.EndToEnd
                     .Should()
                     .Pass();
 
-                //TODO: https://github.com/dotnet/sdk/issues/187 - remove framework from below.
                 new Run3Command()
                     .WithWorkingDirectory(projectDirectory)
-                    .ExecuteWithCapturedOutput("--framework netcoreapp1.0")
+                    .ExecuteWithCapturedOutput()
                     .Should()
                     .Pass()
                     .And

--- a/test/dotnet-run3.Tests/GivenDotnetRun3RunsCsProj.cs
+++ b/test/dotnet-run3.Tests/GivenDotnetRun3RunsCsProj.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 
@@ -29,10 +30,9 @@ namespace Microsoft.DotNet.Cli.Run3.Tests
                 .Should()
                 .Pass();
 
-            //TODO: https://github.com/dotnet/sdk/issues/187 - remove framework from below.
             new Run3Command()
                 .WithWorkingDirectory(testProjectDirectory)
-                .ExecuteWithCapturedOutput("--framework netcoreapp1.0")
+                .ExecuteWithCapturedOutput()
                 .Should()
                 .Pass()
                 .And
@@ -54,10 +54,9 @@ namespace Microsoft.DotNet.Cli.Run3.Tests
                 .Should()
                 .Pass();
 
-            //TODO: https://github.com/dotnet/sdk/issues/187 - remove framework from below.
             new Run3Command()
                 .WithWorkingDirectory(testProjectDirectory)
-                .ExecuteWithCapturedOutput("--framework netcoreapp1.0")
+                .ExecuteWithCapturedOutput()
                 .Should()
                 .Pass()
                 .And
@@ -85,7 +84,7 @@ namespace Microsoft.DotNet.Cli.Run3.Tests
                 .Should()
                 .Pass()
                 .And
-                .HaveStdOutContaining("Hello World!");            
+                .HaveStdOutContaining("Hello World!");
         }
 
         [Fact]
@@ -112,6 +111,62 @@ namespace Microsoft.DotNet.Cli.Run3.Tests
                 .Fail()
                 .And
                 .HaveStdErrContaining("--framework");
+        }
+
+        [Fact]
+        public void It_runs_portable_apps_from_a_different_path_after_building()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssetsManager
+                .CreateTestInstance(testAppName);
+
+            var testProjectDirectory = testInstance.TestRoot;
+
+            new Restore3Command()
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new Build3Command()
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute()
+                .Should()
+                .Pass();
+
+            string workingDirectory = Directory.GetParent(testProjectDirectory).FullName;
+            new Run3Command()
+                .WithWorkingDirectory(workingDirectory)
+                .ExecuteWithCapturedOutput($"--no-build --project {Path.Combine(testProjectDirectory, testAppName)}.csproj")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
+        }
+
+        [Fact]
+        public void It_runs_portable_apps_from_a_different_path_without_building()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssetsManager
+                .CreateTestInstance(testAppName);
+
+            var testProjectDirectory = testInstance.TestRoot;
+
+            new Restore3Command()
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute()
+                .Should()
+                .Pass();
+
+            string workingDirectory = Directory.GetParent(testProjectDirectory).FullName;
+            new Run3Command()
+                .WithWorkingDirectory(workingDirectory)
+                .ExecuteWithCapturedOutput($"--project {Path.Combine(testProjectDirectory, testAppName)}.csproj")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World!");
         }
     }
 }


### PR DESCRIPTION
Also update Microsoft.NET.Sdk to 1.0.0-alpha-20161026-2 since this has the corresponding fix needed for https://github.com/dotnet/sdk/issues/301.

Fix #4447

@livarcocc @piotrpMSFT @jgoshi 

@dsplaisted - I took your tests from https://github.com/dotnet/sdk/pull/317 and ported them to the CLI.  I think these tests are better suited in the CLI since they are explicitly calling into the CLI functionality (dotnet run3).