### PR TITLE
Fix build scripts to pass architecture into the bootstrapper.

### DIFF
--- a/run-build.ps1
+++ b/run-build.ps1
@@ -78,7 +78,7 @@ if ((Test-Path $bootStrapperPath) -eq 0)
 }
 
 # now execute it
-& $bootStrapperPath -RepositoryRoot (Get-Location) -ToolsLocalPath $toolsLocalPath -CliLocalPath $env:DOTNET_INSTALL_DIR | Out-File (Join-Path (Get-Location) "bootstrap.log")
+& $bootStrapperPath -RepositoryRoot (Get-Location) -ToolsLocalPath $toolsLocalPath -CliLocalPath $env:DOTNET_INSTALL_DIR -Architecture $Architecture | Out-File (Join-Path (Get-Location) "bootstrap.log")
 if ($LastExitCode -ne 0)
 {
     Write-Output "Boot-strapping failed with exit code $LastExitCode, see bootstrap.log for more information."

--- a/run-build.sh
+++ b/run-build.sh
@@ -143,7 +143,7 @@ if [ ! -f $bootStrapperPath ]; then
     chmod u+x $bootStrapperPath
 fi
 
-$bootStrapperPath --repositoryRoot "$REPOROOT" --toolsLocalPath "$toolsLocalPath" --cliInstallPath $DOTNET_INSTALL_DIR > bootstrap.log
+$bootStrapperPath --repositoryRoot "$REPOROOT" --toolsLocalPath "$toolsLocalPath" --cliInstallPath $DOTNET_INSTALL_DIR --architecture $ARCHITECTURE > bootstrap.log
 
 if [ $? != 0 ]; then
     echo "run-build: Error: Boot-strapping failed with exit code $?, see bootstrap.log for more information." >&2


### PR DESCRIPTION
This fixes always building 64-bit even on 32-bit builds (from https://github.com/dotnet/buildtools/issues/1165).