### PR TITLE
Use --disable-parallel during xplat restores

### DIFF
--- a/.toolversions
+++ b/.toolversions
@@ -1,2 +1,2 @@
-microsoft.dotnet.buildtools=1.0.26-prerelease-00802-01
+microsoft.dotnet.buildtools=1.0.26-prerelease-00926-02
 microsoft.dotnet.buildtools.run=1.0.0-prerelease-00807-04

--- a/build.proj
+++ b/build.proj
@@ -68,7 +68,11 @@
           Inputs="$(DotnetCliBuildDirectory)/dotnet-cli-build.csproj"
           Outputs="@(RestoreDotnetCliBuildFrameworkOutputs)">
 
-    <Exec Command="$(DotnetStage0) restore3" WorkingDirectory="$(DotnetCliBuildDirectory)"/>
+    <PropertyGroup>
+      <ExtraRestoreArgs Condition="'$(OS)' != 'Windows_NT'">$(ExtraRestoreArgs) --disable-parallel</ExtraRestoreArgs>
+    </PropertyGroup>
+
+    <Exec Command="$(DotnetStage0) restore3 $(ExtraRestoreArgs)" WorkingDirectory="$(DotnetCliBuildDirectory)"/>
   </Target>
 
   <Target DependsOnTargets="$(CLITargets)" Name="BuildTheWholeCli"></Target>

--- a/build_projects/dotnet-cli-build/DotNetRestore.cs
+++ b/build_projects/dotnet-cli-build/DotNetRestore.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{GetSource()} {GetPackages()} {GetSkipInvalidConfigurations()}"; }
+            get { return $"{GetSource()} {GetPackages()} {GetSkipInvalidConfigurations()} {GetDisableParallel()}"; }
         }
 
         public string Source { get; set; }
@@ -49,6 +49,11 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             return null;
+        }
+
+        private string GetDisableParallel()
+        {
+            return "--disable-parallel";
         }
     }
 }

--- a/build_projects/dotnet-cli-build/DotNetRestoreProjectJson.cs
+++ b/build_projects/dotnet-cli-build/DotNetRestoreProjectJson.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{GetVerbosity()} {GetFallbackSource()} {GetPackages()}"; }
+            get { return $"{GetVerbosity()} {GetFallbackSource()} {GetPackages()} {GetDisableParallel()}"; }
         }
 
         public string FallbackSource { get; set; }
@@ -49,6 +49,11 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             return null;
+        }
+
+        private string GetDisableParallel()
+        {
+            return "--disable-parallel";
         }
     }
 }

--- a/run-build.sh
+++ b/run-build.sh
@@ -132,6 +132,9 @@ done < "$REPOROOT/branchinfo.txt"
 [ -z "$DOTNET_INSTALL_DIR" ] && export DOTNET_INSTALL_DIR=$REPOROOT/.dotnet_stage0/$ARCHITECTURE
 [ -d "$DOTNET_INSTALL_DIR" ] || mkdir -p $DOTNET_INSTALL_DIR
 
+# During xplat bootstrapping, disable HTTP parallelism to avoid fatal restore timeouts.
+export __INIT_TOOLS_RESTORE_ARGS="$__INIT_TOOLS_RESTORE_ARGS --disable-parallel"
+
 DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 toolsLocalPath="$REPOROOT/build_tools"
 bootStrapperPath="$toolsLocalPath/bootstrap.sh"

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
@@ -14,13 +14,13 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         public override CommandResult Execute(string args = "")
         {
-            args = $"restore {args}";
+            args = $"restore {args} --disable-parallel";
             return base.Execute(args);
         }
 
         public override CommandResult ExecuteWithCapturedOutput(string args = "")
         {
-            args = $"restore {args}";
+            args = $"restore {args} --disable-parallel";
             return base.ExecuteWithCapturedOutput(args);
         }
     }


### PR DESCRIPTION
Works around NuGet parallel restore timeouts becoming build failures when the machine has a slow connection, for example in our Docker Fedora containers.

See https://github.com/dotnet/core-setup/issues/327

Upgrades buildtools to take https://github.com/dotnet/buildtools/pull/1114

Restore takes a very long time (> 7 minutes) in my Fedora 23 Docker container, but I haven't compared before/after yet. Having 4 NuGet sources seems like it would hurt even more with `--disable-parallel`. Some followup work to this would be to add a switch to let devs enable parallel restores if their connection can handle it.

I noticed a manually-queued (I think) Fedora build succeeded recently: https://mseng.visualstudio.com/dotnetcore/_build/index?buildId=3380864&_a=summary. Getting a lucky connection speed is a factor in this bug, so it's possible that instead of taking this PR, CLI could start spinning builds repeatedly to get successful ones.

@livarcocc @piotrpMSFT 
/cc @dleeapho @mellinoe 