### PR TITLE
Upgrade NSS in Fedora 23 Dockerfile to avoid NuGet restore timeout

### DIFF
--- a/scripts/docker/fedora.23/Dockerfile
+++ b/scripts/docker/fedora.23/Dockerfile
@@ -36,6 +36,10 @@ RUN dnf install -y libicu-devel \
         lttng-ust-devel && \
     dnf clean all
 
+# Upgrade NSS, used for SSL, to avoid NuGet restore timeouts.
+RUN dnf upgrade -y nss
+RUN dnf clean all
+
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0
 RUN useradd -m code_executor -u ${USER_ID} -g wheel


### PR DESCRIPTION
I tried this out in a Fedora 23 Docker container and the restore timeout issue no longer repro'd. It also is working so far in core-setup: https://github.com/dotnet/core-setup/pull/541. Thanks @mellinoe for the fix.

The idea is that in Fedora 24, NSS is used for SSL, and the older version might have been too slow, causing parallel requests to take too long, pile up, and fail the restore. The same might be true for 23.

An alternative to https://github.com/dotnet/cli/pull/4516 that won't impact other platforms' builds. When I first encountered the NuGet restore timeouts in core-setup they did affect more platforms than Fedora23, though, so this might come up again. Fedora did seem the worst affected, though.

@livarcocc @piotrpMSFT
/cc @dleeapho @mellinoe 