### PR TITLE
Update preview2.1 branch to use netcoreapp1.1 TFM and support Fedora 24

### DIFF
--- a/TestAssets/DesktopTestProjects/AppWithDirectDependencyDesktopAndPortable/project.json
+++ b/TestAssets/DesktopTestProjects/AppWithDirectDependencyDesktopAndPortable/project.json
@@ -7,11 +7,11 @@
     "dotnet-desktop-and-portable": "1.0.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       },
       "imports": [

--- a/TestAssets/DesktopTestProjects/DesktopAppWithNativeDep/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopAppWithNativeDep/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "PackageWithFakeNativeDep": "1.0.0-*",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24530-04"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24626-02"
   },
   "buildOptions": {
     "emitEntryPoint": true

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktop/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24530-04"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24626-02"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopForce32/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24530-04"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24626-02"
   },
   "buildOptions": {
     "platform": "anycpu32bitpreferred",

--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/KestrelDesktopWithRuntimes/project.json
@@ -4,7 +4,7 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-rc2-20113",
     "Microsoft.AspNetCore.Hosting": "1.0.0-rc2-20113",
     "Microsoft.Extensions.Logging.Console": "1.0.0-rc2-20254",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24530-04"
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24626-02"
   },
   "buildOptions": {
     "emitEntryPoint": true,

--- a/TestAssets/DesktopTestProjects/LibraryWithDirectDependencyDesktopAndPortable/project.json
+++ b/TestAssets/DesktopTestProjects/LibraryWithDirectDependencyDesktopAndPortable/project.json
@@ -9,7 +9,7 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       },
       "imports": [
         "portable-net45+win8",

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithSelfReferencingDependency/project.json
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithSelfReferencingDependency/project.json
@@ -9,7 +9,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
   }

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedDependency/project.json
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedDependency/project.json
@@ -6,14 +6,14 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "ThisIsNotARealDependencyAndIfSomeoneGoesAndAddsAProjectWithThisNameIWillFindThemAndPunishThem": {
       "target": "project"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
   }

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/project.json
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/project.json
@@ -10,7 +10,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
   }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/BrokenProjectPathSample/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
     "EmptyLibrary": "1.0.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyConsoleApp/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       }
     },
     "dnx451": {}

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyLibrary/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyLibrary/project.json
@@ -5,7 +5,7 @@
     "netstandard1.3": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyNetCoreApp/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/EmptyNetCoreApp/project.json
@@ -1,12 +1,12 @@
 {
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50",
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         },
         "Newtonsoft.Json": "8.0.3"
       }

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/FailReleaseProject/project.json
@@ -1,9 +1,9 @@
 {
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       }
     }
   },

--- a/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
+++ b/TestAssets/ProjectModelServer/DthTestProjects/src/IncompatiblePackageSample/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
     "Microsoft.Web.Administration": "7.0.0"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
+++ b/TestAssets/ProjectModelServer/IncorrectGlobalJson/src/Project1/project.json
@@ -4,9 +4,9 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/TestAssets/TestPackages/ToolWithOutputName/project.json
+++ b/TestAssets/TestPackages/ToolWithOutputName/project.json
@@ -5,7 +5,7 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.1": {
+    "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",

--- a/TestAssets/TestPackages/ToolWithOutputName/project.json
+++ b/TestAssets/TestPackages/ToolWithOutputName/project.json
@@ -5,11 +5,11 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     }

--- a/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
@@ -6,14 +6,14 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.Extensions.DependencyModel": {
       "target": "project"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"

--- a/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/project.json
@@ -13,7 +13,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.1": {
+    "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"

--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
@@ -25,7 +25,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.1": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45+win8",
         "dnxcore50"

--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
@@ -25,7 +25,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "portable-net45+win8",
         "dnxcore50"

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/Program.cs
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/Program.cs
@@ -9,8 +9,8 @@ namespace ConsoleApplication
         {
 #if NET451
             Console.WriteLine($"Hello {string.Join(" ", args)} From .NETFramework,Version=v4.5.1");
-#elif NETCOREAPP1_0
-            Console.WriteLine($"Hello {string.Join(" ", args)} From .NETCoreApp,Version=v1.0");
+#elif NETCOREAPP1_1
+            Console.WriteLine($"Hello {string.Join(" ", args)} From .NETCoreApp,Version=v1.1");
 #endif
             var currentAssemblyPath = typeof(ConsoleApplication.Program).GetTypeInfo().Assembly.Location;
             Console.WriteLine($"Current Assembly Directory - {currentAssemblyPath}");

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/Program.cs
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/Program.cs
@@ -9,8 +9,8 @@ namespace ConsoleApplication
         {
 #if NET451
             Console.WriteLine($"Hello {string.Join(" ", args)} From .NETFramework,Version=v4.5.1");
-#elif NETCOREAPP1_1
-            Console.WriteLine($"Hello {string.Join(" ", args)} From .NETCoreApp,Version=v1.1");
+#elif NETCOREAPP1_0
+            Console.WriteLine($"Hello {string.Join(" ", args)} From .NETCoreApp,Version=v1.0");
 #endif
             var currentAssemblyPath = typeof(ConsoleApplication.Program).GetTypeInfo().Assembly.Location;
             Console.WriteLine($"Current Assembly Directory - {currentAssemblyPath}");

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.1": {
+    "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/project.json
@@ -4,11 +4,11 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },

--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestPackages/dotnet-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-portable/project.json
@@ -4,7 +4,7 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.1": {
+    "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",

--- a/TestAssets/TestPackages/dotnet-portable/project.json
+++ b/TestAssets/TestPackages/dotnet-portable/project.json
@@ -4,11 +4,11 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithAppDependency/TestApp1/project.json
+++ b/TestAssets/TestProjects/AppWithAppDependency/TestApp1/project.json
@@ -8,11 +8,11 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithAppDependency/TestApp2/project.json
+++ b/TestAssets/TestProjects/AppWithAppDependency/TestApp2/project.json
@@ -4,11 +4,11 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     }

--- a/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
+++ b/TestAssets/TestProjects/AppWithBomGlobalJson/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   },

--- a/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDependencyOnToolWithOutputName/project.json
@@ -5,12 +5,12 @@
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001100-00",
+      "version": "1.1.0-preview1-001153-00",
       "type": "platform"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "tools": {
     "ToolWithOutputName": {

--- a/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectAndToolDependency/project.json
@@ -4,14 +4,14 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
     "dotnet-hello": {
       "version": "1.0.0",
       "target": "package"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -25,6 +25,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   },

--- a/TestAssets/TestProjects/AppWithDirectDependency/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependency/project.json
@@ -4,14 +4,14 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
     "dotnet-hello": {
       "version": "1.0.0",
       "target": "package"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -25,6 +25,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/AppWithDirectDependencyAndTypeBuild/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependencyAndTypeBuild/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001100-00",
+      "version": "1.1.0-preview1-001153-00",
       "type": "platform"
     },
     "xunit.core": "2.1.0",
@@ -15,7 +15,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "portable-net451+win8"
       ]

--- a/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
+++ b/TestAssets/TestProjects/AppWithDirectDependencyWithOutputName/project.json
@@ -8,12 +8,12 @@
       "target": "package"
     },
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001100-00",
+      "version": "1.1.0-preview1-001153-00",
       "type": "platform"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "tools": {
     "dotnet-dependency-tool-invoker": {

--- a/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
+++ b/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/AppWithToolDependency/project.json
+++ b/TestAssets/TestProjects/AppWithToolDependency/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "tools": {
     "dotnet-portable": {
@@ -27,6 +27,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/CompileFail/project.json
+++ b/TestAssets/TestProjects/CompileFail/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json
+++ b/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json
@@ -4,11 +4,11 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     }

--- a/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json.modified
+++ b/TestAssets/TestProjects/DependencyChangeTest/PortableApp_Standalone/project.json.modified
@@ -4,7 +4,7 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "version": "1.0.0-rc3-*"
@@ -25,6 +25,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/DependencyContextFromTool/project.json
+++ b/TestAssets/TestProjects/DependencyContextFromTool/project.json
@@ -4,7 +4,7 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
@@ -12,7 +12,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     }

--- a/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/DependencyContextValidator/project.json
@@ -9,7 +9,7 @@
     "netstandard1.6": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     },
     "net451": {}

--- a/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestApp/project.json
@@ -5,11 +5,11 @@
     "preserveCompilationContext": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
@@ -28,6 +28,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppDeps/project.json
@@ -4,11 +4,11 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
@@ -27,6 +27,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppFullClr/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppFullClr/project.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "DependencyContextValidator": "1.0.0-*",
     "System.Diagnostics.Process": {
-      "version": "4.3.0-preview1-24530-04",
+      "version": "4.3.0-preview1-24626-02",
       "type": "build"
     }
   },

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppPortable/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppPortable/project.json
@@ -7,12 +7,12 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"

--- a/TestAssets/TestProjects/DependencyContextValidator/TestAppPortableDeps/project.json
+++ b/TestAssets/TestProjects/DependencyContextValidator/TestAppPortableDeps/project.json
@@ -6,12 +6,12 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "DependencyContextValidator": "1.0.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"

--- a/TestAssets/TestProjects/DuplicatedReferenceAssembly/TestApp/project.json
+++ b/TestAssets/TestProjects/DuplicatedReferenceAssembly/TestApp/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "dependencies": {
     "TestLibrary": "1.0.0",
-    "System.IO.Compression": "4.3.0-preview1-24530-04"
+    "System.IO.Compression": "4.3.0-preview1-24626-02"
   },
   "frameworks": {
     "net461": {}

--- a/TestAssets/TestProjects/EndToEndTestApp/project.json
+++ b/TestAssets/TestProjects/EndToEndTestApp/project.json
@@ -14,7 +14,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "packOptions": {
     "files": {
@@ -26,7 +26,7 @@
   },
   "publishOptions": "testpublishfile.txt",
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -40,6 +40,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/CompileFailApp/project.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "tools": {
     "dotnet-compile-fsc": {
@@ -24,7 +24,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "netstandard1.3"
@@ -43,6 +43,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
@@ -14,7 +14,7 @@
       "version": "1.0.0-*",
       "target": "project"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509"
   },
   "tools": {
@@ -28,7 +28,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
   },
@@ -44,6 +44,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestAppWithArgs/project.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "tools": {
     "dotnet-compile-fsc": {
@@ -24,7 +24,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
   },
@@ -40,6 +40,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/FSharpTestProjects/TestLibrary/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestLibrary/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160509",
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "tools": {
     "dotnet-compile-fsc": {
@@ -15,7 +15,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
   },

--- a/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelPortable/project.json
@@ -14,11 +14,11 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       },
       "imports": [

--- a/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
+++ b/TestAssets/TestProjects/KestrelSample/KestrelStandalone/project.json
@@ -14,9 +14,9 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       },
       "imports": [
         "dnxcore50",
@@ -36,6 +36,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/LibraryWithOutputAssemblyName/project.json
+++ b/TestAssets/TestProjects/LibraryWithOutputAssemblyName/project.json
@@ -3,7 +3,7 @@
     "outputName": "MyLibrary"
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
+++ b/TestAssets/TestProjects/OutputStandardOutputAndError/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetApp/project.json
@@ -6,10 +6,10 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP0/project.json
@@ -9,10 +9,10 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP1/project.json
@@ -6,10 +6,10 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/SingleTargetGraph/SingleTargetP2/project.json
@@ -3,10 +3,10 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetApp/project.json
@@ -5,17 +5,17 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04",
+        "NETStandard.Library": "1.6.1-preview1-24626-02",
         "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24608-01"
       }
     }
@@ -32,6 +32,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP0/project.json
@@ -9,17 +9,17 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04",
+        "NETStandard.Library": "1.6.1-preview1-24626-02",
         "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24608-01"
       }
     }
@@ -36,6 +36,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP1/project.json
@@ -6,17 +6,17 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraph/TwoTargetP2/project.json
@@ -2,17 +2,17 @@
   "version": "1.0.0-*",
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP0/project.json
@@ -9,17 +9,17 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04",
+        "NETStandard.Library": "1.6.1-preview1-24626-02",
         "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24608-01"
       }
     }
@@ -36,6 +36,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP1/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP1/project.json
@@ -9,17 +9,17 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP2/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP2/project.json
@@ -9,17 +9,17 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP3/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP3/project.json
@@ -6,17 +6,17 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP4/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP4/project.json
@@ -9,17 +9,17 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP5/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP5/project.json
@@ -2,17 +2,17 @@
   "version": "1.0.0-*",
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP6/project.json
+++ b/TestAssets/TestProjects/PerformanceTestProjects/TwoTargetGraphLarge/TwoTargetLargeP6/project.json
@@ -2,17 +2,17 @@
   "version": "1.0.0-*",
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     },
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/TestProjects/PortableTests/PortableApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableApp/project.json
@@ -4,11 +4,11 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     }

--- a/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppCompilationContext/project.json
@@ -7,11 +7,11 @@
     "Microsoft.CodeAnalysis.CSharp": "1.3.0"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       }
     }

--- a/TestAssets/TestProjects/PortableTests/PortableAppWithIntentionalManagedDowngrade/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppWithIntentionalManagedDowngrade/project.json
@@ -4,7 +4,7 @@
   },
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",

--- a/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
+++ b/TestAssets/TestProjects/PortableTests/PortableAppWithNative/project.json
@@ -3,11 +3,11 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         },
         "Microsoft.AspNetCore.Server.Kestrel": "1.0.0-*",
         "Libuv": "1.9.0-rc2-20896"

--- a/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
+++ b/TestAssets/TestProjects/PortableTests/StandaloneApp/project.json
@@ -3,9 +3,9 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       }
     }
   },
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   },

--- a/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/GivenThatIWantSomeFakeTests.cs
+++ b/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/GivenThatIWantSomeFakeTests.cs
@@ -27,7 +27,7 @@ namespace FakeTests
             Assert.True(true);
         }
 
-        [Fact(Skip="Skipped for NETCOREAPP1.0")]
+        [Fact(Skip="Skipped for NETCOREAPP1.1")]
         public void SkippedTest()
         {
 
@@ -48,7 +48,7 @@ namespace FakeTests
 #if NET451
             Assert.True(shouldFail, "Failing in NET451");
 #else
-            Assert.True(shouldFail, "Failing in NETCOREAPP1.0");
+            Assert.True(shouldFail, "Failing in NETCOREAPP1.1");
 #endif
         }
     }

--- a/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/MultipleFrameworkProject/project.json
@@ -2,11 +2,11 @@
   "version": "1.0.0-*",
   "dependencies": {
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24530-04",
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24626-02",
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet",
         "portable-dnxcore50+net45+win8+wp8+wpa81",
@@ -15,10 +15,10 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         },
-        "System.Linq.Expressions": "4.3.0-preview1-24530-04",
-        "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04"
+        "System.Linq.Expressions": "4.3.0-preview1-24626-02",
+        "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02"
       }
     },
     "net451": {}

--- a/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
+++ b/TestAssets/TestProjects/ProjectsWithTests/NetCoreAppOnlyProject/project.json
@@ -3,15 +3,15 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Linq.Expressions": "4.3.0-preview1-24530-04",
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Linq.Expressions": "4.3.0-preview1-24626-02",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "netstandardapp1.5",
         "dnxcore50",

--- a/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
+++ b/TestAssets/TestProjects/ResourcesTests/TestApp/project.json
@@ -7,14 +7,14 @@
     "Microsoft.Data.OData": "5.6.4",
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "TestLibraryWithResources": {
       "target": "project"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "portable-net45+win8"
       ]

--- a/TestAssets/TestProjects/ResourcesTests/TestLibraryWithResources/project.json
+++ b/TestAssets/TestProjects/ResourcesTests/TestLibraryWithResources/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
+++ b/TestAssets/TestProjects/RunTestsApps/TestAppMultiTarget/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.1.0-preview1-001100-00",
+          "version": "1.1.0-preview1-001153-00",
           "type": "platform"
         }
       }

--- a/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppCompilationContext/TestApp/project.json
@@ -6,10 +6,10 @@
   },
   "dependencies": {
     "TestLibrary": "1.0.0-*",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -23,6 +23,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppCompilationContext/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppCompilationContext/TestLibrary/project.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/TestAppSimple/project.json
+++ b/TestAssets/TestProjects/TestAppSimple/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppWithArgs/project.json
+++ b/TestAssets/TestProjects/TestAppWithArgs/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppWithBuildDependency/App/project.json
+++ b/TestAssets/TestProjects/TestAppWithBuildDependency/App/project.json
@@ -6,14 +6,14 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "LibraryWithBuildDependency": {
       "target": "project"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
   }

--- a/TestAssets/TestProjects/TestAppWithBuildDependency/LibraryWithBuildDependency/project.json
+++ b/TestAssets/TestProjects/TestAppWithBuildDependency/LibraryWithBuildDependency/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.Net.Compilers": {
       "type": "build",
@@ -11,7 +11,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50"
     }
   }

--- a/TestAssets/TestProjects/TestAppWithContentPackage/project.json
+++ b/TestAssets/TestProjects/TestAppWithContentPackage/project.json
@@ -5,11 +5,11 @@
     "outputName": "AppWithContentPackage"
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
     "SharedContentA": "1.0.0-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "netstandardapp1.5",
         "dnxcore50"
@@ -28,6 +28,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppWithContents/project.json
+++ b/TestAssets/TestProjects/TestAppWithContents/project.json
@@ -7,10 +7,10 @@
     }
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "publishOptions": {
     "include": "testcontentfile.txt"
@@ -27,6 +27,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
@@ -9,10 +9,10 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -26,6 +26,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestLibrary/project.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
+++ b/TestAssets/TestProjects/TestAppWithResourceDeps/project.json
@@ -4,16 +4,16 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
-    "Microsoft.CSharp": "4.3.0-preview1-24530-04",
-    "System.Dynamic.Runtime": "4.3.0-preview1-24530-04",
-    "System.Reflection.Metadata": "1.4.1-preview1-24530-04",
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
-    "System.Xml.XmlSerializer": "4.3.0-preview1-24530-04",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
+    "Microsoft.CSharp": "4.3.0-preview1-24626-02",
+    "System.Dynamic.Runtime": "4.3.0-preview1-24626-02",
+    "System.Reflection.Metadata": "1.4.1-preview1-24626-02",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
+    "System.Xml.XmlSerializer": "4.3.0-preview1-24626-02",
     "WindowsAzure.Storage": "6.2.2-preview"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
@@ -32,6 +32,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppWithScripts/project.json
+++ b/TestAssets/TestProjects/TestAppWithScripts/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   },

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestApp/project.json
@@ -9,10 +9,10 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -26,6 +26,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   },

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary/project.json
@@ -10,9 +10,9 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibrary2/project.json
@@ -8,10 +8,10 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -25,6 +25,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibraryWithAppDependency/project.json
+++ b/TestAssets/TestProjects/TestAppWithTransitiveAppDependency/TestLibraryWithAppDependency/project.json
@@ -5,9 +5,9 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
+++ b/TestAssets/TestProjects/TestAppWithUnicodéPath/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestApp/project.json
@@ -9,10 +9,10 @@
       "target": "project",
       "version": "1.0.0-*"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -26,6 +26,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestLibrary/project.json
+++ b/TestAssets/TestProjects/TestAppWithWrapperProjectDependency/TestLibrary/project.json
@@ -1,6 +1,6 @@
 {
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "bin": {
         "assembly": "bin.keep\\{configuration}\\dnxcore50\\TestLibrary.dll",
         "pdb": "bin.keep\\{configuration}\\dnxcore50\\TestLibrary.pdb"

--- a/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryGreater/project.json
+++ b/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryGreater/project.json
@@ -7,7 +7,7 @@
     "net451": {},
     "netstandard1.5": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       },
       "imports": "portable-net45+win8"
     }

--- a/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
+++ b/TestAssets/TestProjects/TestBindingRedirectGeneration/TestLibraryLesser/project.json
@@ -11,9 +11,9 @@
   },
   "frameworks": {
     "net451": {},
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       },
       "imports": "portable-net45+win8"
     }

--- a/TestAssets/TestProjects/TestLibraryWithAnalyzer/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithAnalyzer/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04",
+    "NETStandard.Library": "1.6.1-preview1-24626-02",
     "System.Runtime.Analyzers": {
       "version": "1.1.0",
       "type": "build"

--- a/TestAssets/TestProjects/TestLibraryWithConfiguration/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithConfiguration/project.json
@@ -10,7 +10,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "configurations": {
     "Test": {}

--- a/TestAssets/TestProjects/TestLibraryWithDeprecatedProjectFile/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithDeprecatedProjectFile/project.json
@@ -5,7 +5,7 @@
   },
   "packInclude": {},
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithMultipleFrameworks/project.json
@@ -28,7 +28,7 @@
     "netstandard1.5": {
       "imports": "dnxcore50",
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/TestAssets/TestProjects/TestLibraryWithXmlDoc/project.json
+++ b/TestAssets/TestProjects/TestLibraryWithXmlDoc/project.json
@@ -4,7 +4,7 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReference/project.json
@@ -2,15 +2,15 @@
   "version": "1.0.0",
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       }
     },
     "net451": {
       "dependencies": {
-        "Microsoft.CSharp": "4.3.0-preview1-24530-04"
+        "Microsoft.CSharp": "4.3.0-preview1-24626-02"
       }
     }
   },
@@ -26,6 +26,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
+++ b/TestAssets/TestProjects/TestMicrosoftCSharpReferenceMissingFramework/project.json
@@ -2,20 +2,20 @@
   "version": "1.0.0",
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": "dnxcore50",
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       }
     },
     "netcore50": {
       "dependencies": {
-        "System.Private.Uri": "4.3.0-preview1-24530-04"
+        "System.Private.Uri": "4.3.0-preview1-24626-02"
       }
     },
     "net99": {
       "dependencies": {
-        "Microsoft.CSharp": "4.3.0-preview1-24530-04"
+        "Microsoft.CSharp": "4.3.0-preview1-24626-02"
       }
     }
   },
@@ -31,6 +31,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestMscorlibReference/project.json
+++ b/TestAssets/TestProjects/TestMscorlibReference/project.json
@@ -2,9 +2,9 @@
   "version": "1.0.0-*",
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       }
     },
     "net451": {
@@ -25,6 +25,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestProjectContextBuildAllDedupe/project.json
+++ b/TestAssets/TestProjects/TestProjectContextBuildAllDedupe/project.json
@@ -2,12 +2,12 @@
   "version": "1.0.0-*",
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001100-00",
+      "version": "1.1.0-preview1-001153-00",
       "type": "platform"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "portable-net451+win8"
       ]

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L0/project.json
@@ -6,10 +6,10 @@
   "dependencies": {
     "L11": "1.0.0-*",
     "L12": "1.0.0-*",
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -23,6 +23,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L11/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L11/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "L12": "1.0.0-*",
     "L21": "1.0.0-*",
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L12/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L12/project.json
@@ -2,7 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "L22": "1.0.0-*",
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L21/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L21/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L22/project.json
+++ b/TestAssets/TestProjects/TestProjectToProjectDependencies/src/L22/project.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithCultureSpecificResource/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestProjectWithResource/project.json
+++ b/TestAssets/TestProjects/TestProjectWithResource/project.json
@@ -4,10 +4,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -21,6 +21,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestRuleSet/TestLibraryWithRuleSet/project.json
+++ b/TestAssets/TestProjects/TestRuleSet/TestLibraryWithRuleSet/project.json
@@ -6,7 +6,7 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04",
+    "NETStandard.Library": "1.6.1-preview1-24626-02",
     "System.Runtime.Analyzers": {
       "version": "1.1.0",
       "type": "build"

--- a/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
+++ b/TestAssets/TestProjects/TestSimpleIncrementalApp/project.json
@@ -5,10 +5,10 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "runtimes": {
     "win7-x64": {},
@@ -22,6 +22,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestSystemCoreReference/project.json
+++ b/TestAssets/TestProjects/TestSystemCoreReference/project.json
@@ -2,9 +2,9 @@
   "version": "1.0.0-*",
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       }
     },
     "net451": {
@@ -25,6 +25,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/TestAssets/TestProjects/TestSystemReference/project.json
+++ b/TestAssets/TestProjects/TestSystemReference/project.json
@@ -2,9 +2,9 @@
   "version": "1.0.0-*",
   "dependencies": {},
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
-        "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+        "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
       }
     },
     "net451": {
@@ -25,6 +25,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/project.json
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/project.json
@@ -10,9 +10,9 @@
     ]
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04",
-    "System.Diagnostics.Process": "4.3.0-preview1-24530-04",
-    "System.Reflection.TypeExtensions": "4.3.0-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02",
+    "System.Diagnostics.Process": "4.3.0-preview1-24626-02",
+    "System.Reflection.TypeExtensions": "4.3.0-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/build_projects/dotnet-cli-build/CliDependencyVersions.cs
+++ b/build_projects/dotnet-cli-build/CliDependencyVersions.cs
@@ -7,9 +7,9 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class CliDependencyVersions
     {
-        public static readonly string SharedFrameworkVersion = "1.1.0-preview1-001100-00";
-        public static readonly string SharedHostVersion = "1.1.0-preview1-001100-00";
-        public static readonly string HostFxrVersion = "1.1.0-preview1-001100-00";
+        public static readonly string SharedFrameworkVersion = "1.1.0-preview1-001153-00";
+        public static readonly string SharedHostVersion = "1.1.0-preview1-001153-00";
+        public static readonly string HostFxrVersion = "1.1.0-preview1-001153-00";
 
         public static readonly string SharedFrameworkChannel = "release/1.1.0";
         public static readonly string SharedHostChannel = "release/1.1.0";

--- a/build_projects/dotnet-cli-build/CompileTargets.cs
+++ b/build_projects/dotnet-cli-build/CompileTargets.cs
@@ -52,6 +52,7 @@ namespace Microsoft.DotNet.Cli.Build
             { "rhel.7.2-x64", "rhel.7-x64" },
             { "debian.8-x64", "debian.8-x64" },
             { "fedora.23-x64", "fedora.23-x64" },
+            { "fedora.24-x64", "fedora.24-x64" },
             { "opensuse.13.2-x64", "opensuse.13.2-x64" },
             { "opensuse.42.1-x64", "opensuse.42.1-x64" }
         };

--- a/build_projects/dotnet-cli-build/CompileTargets.cs
+++ b/build_projects/dotnet-cli-build/CompileTargets.cs
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Cli.Build
                     "--output",
                     sdkOutputDirectory,
                     "--framework",
-                    "netcoreapp1.0")
+                    "netcoreapp1.1")
                     .Execute()
                     .EnsureSuccessful();
 

--- a/build_projects/dotnet-cli-build/PublishTargets.cs
+++ b/build_projects/dotnet-cli-build/PublishTargets.cs
@@ -97,6 +97,7 @@ namespace Microsoft.DotNet.Cli.Build
                         "debian.x64.version",
                         "centos.x64.version",
                         "fedora.23.x64.version",
+                        "fedora.24.x64.version",
                         "opensuse.13.2.x64.version",
                         "opensuse.42.1.x64.version"
                     };
@@ -145,6 +146,7 @@ namespace Microsoft.DotNet.Cli.Build
                  { "Debian_x64", false },
                  { "CentOS_x64", false },
                  { "Fedora_23_x64", false },
+                 { "Fedora_24_x64", false },
                  { "openSUSE_13_2_x64", false },
                  { "openSUSE_42_1_x64", false }
              };

--- a/build_projects/dotnet-cli-build/TestPackageProjects.cs
+++ b/build_projects/dotnet-cli-build/TestPackageProjects.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = s_testPackageBuildVersionSuffix,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.0" }
+                Frameworks = new [] { "netcoreapp1.1" }
             },
             new TestPackageProject()
             {
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = s_testPackageBuildVersionSuffix,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.0" }
+                Frameworks = new [] { "netcoreapp1.1" }
             },
             new TestPackageProject()
             {
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = CurrentPlatform.IsWindows,
                 VersionSuffix = s_testPackageBuildVersionSuffix,
                 Clean = true,
-                Frameworks = new [] { "net451", "netcoreapp1.0" }
+                Frameworks = new [] { "net451", "netcoreapp1.1" }
             },
             new TestPackageProject()
             {
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable =true,
                 VersionSuffix = string.Empty,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.0" }
+                Frameworks = new [] { "netcoreapp1.1" }
             },
             new TestPackageProject()
             {
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = string.Empty,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.0" }
+                Frameworks = new [] { "netcoreapp1.1" }
             },
             new TestPackageProject()
             {
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = string.Empty,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.0" }
+                Frameworks = new [] { "netcoreapp1.1" }
             },
             new TestPackageProject()
             {
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = string.Empty,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.0" }
+                Frameworks = new [] { "netcoreapp1.1" }
             },
             new TestPackageProject()
             {
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = s_testPackageBuildVersionSuffix,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.0" }
+                Frameworks = new [] { "netcoreapp1.1" }
             }
         };
     }

--- a/build_projects/dotnet-cli-build/TestPackageProjects.cs
+++ b/build_projects/dotnet-cli-build/TestPackageProjects.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = s_testPackageBuildVersionSuffix,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.1" }
+                Frameworks = new [] { "netcoreapp1.0" }
             },
             new TestPackageProject()
             {
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = s_testPackageBuildVersionSuffix,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.1" }
+                Frameworks = new [] { "netcoreapp1.0" }
             },
             new TestPackageProject()
             {
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = CurrentPlatform.IsWindows,
                 VersionSuffix = s_testPackageBuildVersionSuffix,
                 Clean = true,
-                Frameworks = new [] { "net451", "netcoreapp1.1" }
+                Frameworks = new [] { "net451", "netcoreapp1.0" }
             },
             new TestPackageProject()
             {
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = string.Empty,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.1" }
+                Frameworks = new [] { "netcoreapp1.0" }
             },
             new TestPackageProject()
             {
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = string.Empty,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.1" }
+                Frameworks = new [] { "netcoreapp1.0" }
             },
             new TestPackageProject()
             {
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.Cli.Build
                 IsApplicable = true,
                 VersionSuffix = s_testPackageBuildVersionSuffix,
                 Clean = true,
-                Frameworks = new [] { "netcoreapp1.1" }
+                Frameworks = new [] { "netcoreapp1.0" }
             }
         };
     }

--- a/build_projects/dotnet-cli-build/TestTargets.cs
+++ b/build_projects/dotnet-cli-build/TestTargets.cs
@@ -238,7 +238,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var testAssetsRoot = Path.Combine(c.BuildContext.BuildDirectory, "TestAssets", "TestProjects");
             var dotnet = DotNetCli.Stage2;
-            var framework = "netcoreapp1.0";
+            var framework = "netcoreapp1.1";
 
             return BuildTestAssets(c, testAssetsRoot, dotnet, framework);
         }

--- a/build_projects/dotnet-cli-build/build.ps1
+++ b/build_projects/dotnet-cli-build/build.ps1
@@ -93,7 +93,7 @@ popd
 
 # Publish the builder
 Write-Host "Compiling Build Scripts..."
-dotnet publish "$PSScriptRoot" -o "$PSScriptRoot\bin" --framework netcoreapp1.0
+dotnet publish "$PSScriptRoot" -o "$PSScriptRoot\bin" --framework netcoreapp1.1
 if($LASTEXITCODE -ne 0) { throw "Failed to compile build scripts" }
 
 # Run the builder

--- a/build_projects/dotnet-cli-build/build.sh
+++ b/build_projects/dotnet-cli-build/build.sh
@@ -118,7 +118,7 @@ echo "Restoring Build Script projects..."
 
 # Build the builder
 echo "Compiling Build Scripts..."
-dotnet publish "$DIR" -o "$DIR/bin" --framework netcoreapp1.0
+dotnet publish "$DIR" -o "$DIR/bin" --framework netcoreapp1.1
 
 export PATH="$OLDPATH"
 # Run the builder

--- a/build_projects/dotnet-cli-build/project.json
+++ b/build_projects/dotnet-cli-build/project.json
@@ -5,13 +5,13 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04",
-    "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24608-01",
-    "Microsoft.CSharp": "4.3.0-preview1-24530-04",
-    "System.Dynamic.Runtime": "4.3.0-preview1-24530-04",
-    "System.Reflection.Metadata": "1.4.1-preview1-24530-04",
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
-    "System.Xml.XmlSerializer": "4.3.0-preview1-24530-04",
+    "NETStandard.Library": "1.6.1-preview1-24626-02",
+    "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24626-02",
+    "Microsoft.CSharp": "4.3.0-preview1-24626-02",
+    "System.Dynamic.Runtime": "4.3.0-preview1-24626-02",
+    "System.Reflection.Metadata": "1.4.1-preview1-24626-02",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
+    "System.Xml.XmlSerializer": "4.3.0-preview1-24626-02",
     "WindowsAzure.Storage": "6.2.2-preview",
     "NuGet.CommandLine.XPlat": "3.5.0-beta2-1484",
     "Microsoft.DotNet.Cli.Build.Framework": {
@@ -22,7 +22,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"
@@ -40,6 +40,8 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/build_projects/shared-build-targets-utils/DependencyVersions.cs
+++ b/build_projects/shared-build-targets-utils/DependencyVersions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class DependencyVersions
     {
-        public static readonly string CoreCLRVersion = "1.1.0-preview1-24608-01";
-        public static readonly string JitVersion = "1.1.0-preview1-24608-01";
+        public static readonly string CoreCLRVersion = "1.1.0-preview1-24626-02";
+        public static readonly string JitVersion = "1.1.0-preview1-24626-02";
     }
 }

--- a/build_projects/shared-build-targets-utils/Utils/Monikers.cs
+++ b/build_projects/shared-build-targets-utils/Utils/Monikers.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             string rid = RuntimeEnvironment.GetRuntimeIdentifier();
 
-            if (rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64")
+            if (rid == "ubuntu.16.04-x64" || rid == "ubuntu.16.10-x64" || rid == "fedora.23-x64" || rid == "fedora.24-x64" || rid == "opensuse.13.2-x64" || rid == "opensuse.42.1-x64")
             {
                 return $"{artifactPrefix}-{rid}.{version}";
             }
@@ -48,6 +48,8 @@ namespace Microsoft.DotNet.Cli.Build
                     return "Ubuntu_16_10_x64";
                 case "fedora.23-x64":
                     return "Fedora_23_x64";
+                case "fedora.24-x64":
+                    return "Fedora_24_x64";
                 case "opensuse.13.2-x64":
                     return "openSUSE_13_2_x64";
                 case "opensuse.42.1-x64":

--- a/build_projects/shared-build-targets-utils/project.json
+++ b/build_projects/shared-build-targets-utils/project.json
@@ -2,12 +2,12 @@
   "version": "1.0.0-*",
   "description": "Build scripts for dotnet-cli",
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04",
-    "Microsoft.CSharp": "4.3.0-preview1-24530-04",
-    "System.Dynamic.Runtime": "4.3.0-preview1-24530-04",
-    "System.Reflection.Metadata": "1.4.1-preview1-24530-04",
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
-    "System.Xml.XmlSerializer": "4.3.0-preview1-24530-04",
+    "NETStandard.Library": "1.6.1-preview1-24626-02",
+    "Microsoft.CSharp": "4.3.0-preview1-24626-02",
+    "System.Dynamic.Runtime": "4.3.0-preview1-24626-02",
+    "System.Reflection.Metadata": "1.4.1-preview1-24626-02",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
+    "System.Xml.XmlSerializer": "4.3.0-preview1-24626-02",
     "WindowsAzure.Storage": "6.2.2-preview",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"

--- a/build_projects/update-dependencies/project.json
+++ b/build_projects/update-dependencies/project.json
@@ -5,10 +5,10 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04",
-    "Microsoft.CSharp": "4.3.0-preview1-24530-04",
+    "NETStandard.Library": "1.6.1-preview1-24626-02",
+    "Microsoft.CSharp": "4.3.0-preview1-24626-02",
     "Microsoft.NETCore.Runtime.CoreCLR": "1.1.0-preview1-24608-01",
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Cli.Build.Framework": {
       "target": "project"
     },
@@ -18,7 +18,7 @@
     "Microsoft.Net.Http": "2.2.29"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win"
@@ -37,6 +37,7 @@
     "rhel.7.2-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
+    "fedora.24-x64": {},
     "opensuse.13.2-x64": {},
     "opensuse.42.1-x64": {}
   }

--- a/build_projects/update-dependencies/update-dependencies.ps1
+++ b/build_projects/update-dependencies/update-dependencies.ps1
@@ -45,7 +45,7 @@ popd
 
 # Publish the app
 Write-Host "Compiling App..."
-dotnet publish "$AppPath" -o "$AppPath\bin" --framework netcoreapp1.0
+dotnet publish "$AppPath" -o "$AppPath\bin" --framework netcoreapp1.1
 if($LASTEXITCODE -ne 0) { throw "Failed to compile build scripts" }
 
 # Run the app

--- a/scripts/docker/fedora.24/Dockerfile
+++ b/scripts/docker/fedora.24/Dockerfile
@@ -1,0 +1,27 @@
+FROM fedora:24
+
+RUN dnf install -y bash git cmake wget which python clang-3.8.0-2.fc24.x86_64 llvm-devel-3.8.0-1.fc24.x86_64 make libicu-devel lldb-devel.x86_64 \
+                   libunwind-devel.x86_64 lttng-ust-devel.x86_64 uuid-devel libuuid-devel tar glibc-locale-source zlib-devel libcurl-devel \
+                   krb5-devel openssl-devel autoconf libtool hostname
+
+RUN dnf upgrade -y nss
+
+RUN dnf clean all
+
+# Setup User to match Host User, and give superuser permissions 
+ARG USER_ID=0 
+RUN useradd -m code_executor -u ${USER_ID} -g wheel
+RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers 
+ 
+# With the User Change, we need to change permissions on these directories 
+RUN chmod -R a+rwx /usr/local 
+RUN chmod -R a+rwx /home
+
+# Force buildtools to publish for Fedora 23
+ENV __PUBLISH_RID=fedora.23-x64
+ 
+# Set user to the one we just created 
+USER ${USER_ID} 
+ 
+# Set working directory 
+WORKDIR /opt/code

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -80,6 +80,10 @@ get_current_os_name() {
                     echo "fedora.23"
                     return 0
                     ;;
+                "fedora.24")
+                    echo "fedora.24"
+                    return 0
+                    ;;
                 "opensuse.13.2")
                     echo "opensuse.13.2"
                     return 0

--- a/src/Microsoft.DotNet.Archive/project.json
+++ b/src/Microsoft.DotNet.Archive/project.json
@@ -5,8 +5,8 @@
   },
   "description": "Archive and compression types.",
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04",
-    "System.Linq.Parallel": "4.3.0-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02",
+    "System.Linq.Parallel": "4.3.0-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.3": {}

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class ProjectToolsCommandResolver : ICommandResolver
     {
-        private static readonly NuGetFramework s_toolPackageFramework = FrameworkConstants.CommonFrameworks.NetCoreApp11;
+        private static readonly NuGetFramework s_toolPackageFramework = FrameworkConstants.CommonFrameworks.NetCoreApp10;
 
         private static readonly CommandResolutionStrategy s_commandResolutionStrategy =
             CommandResolutionStrategy.ProjectToolsPackage;

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class ProjectToolsCommandResolver : ICommandResolver
     {
-        private static readonly NuGetFramework s_toolPackageFramework = FrameworkConstants.CommonFrameworks.NetCoreApp10;
+        private static readonly NuGetFramework s_toolPackageFramework = FrameworkConstants.CommonFrameworks.NetCoreApp11;
 
         private static readonly CommandResolutionStrategy s_commandResolutionStrategy =
             CommandResolutionStrategy.ProjectToolsPackage;

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -26,7 +26,7 @@
         "portable-net45+wp80+win8+wpa81+dnxcore50"
       ],
       "dependencies": {
-        "System.Diagnostics.Process": "4.3.0-preview1-24530-04"
+        "System.Diagnostics.Process": "4.3.0-preview1-24626-02"
       }
     }
   }

--- a/src/Microsoft.DotNet.Files/project.json
+++ b/src/Microsoft.DotNet.Files/project.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
-    "System.Linq.Expressions": "4.3.0-preview1-24530-04"
+    "System.Linq.Expressions": "4.3.0-preview1-24626-02"
   },
   "frameworks": {
     "net451": {

--- a/src/Microsoft.DotNet.InternalAbstractions/project.json
+++ b/src/Microsoft.DotNet.InternalAbstractions/project.json
@@ -10,14 +10,14 @@
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "System.AppContext": "4.3.0-preview1-24530-04",
-        "System.Collections": "4.3.0-preview1-24530-04",
-        "System.IO": "4.3.0-preview1-24530-04",
-        "System.IO.FileSystem": "4.3.0-preview1-24530-04",
-        "System.Reflection.TypeExtensions": "4.3.0-preview1-24530-04",
-        "System.Runtime.Extensions": "4.3.0-preview1-24530-04",
-        "System.Runtime.InteropServices": "4.3.0-preview1-24530-04",
-        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0-preview1-24530-04"
+        "System.AppContext": "4.3.0-preview1-24626-02",
+        "System.Collections": "4.3.0-preview1-24626-02",
+        "System.IO": "4.3.0-preview1-24626-02",
+        "System.IO.FileSystem": "4.3.0-preview1-24626-02",
+        "System.Reflection.TypeExtensions": "4.3.0-preview1-24626-02",
+        "System.Runtime.Extensions": "4.3.0-preview1-24626-02",
+        "System.Runtime.InteropServices": "4.3.0-preview1-24626-02",
+        "System.Runtime.InteropServices.RuntimeInformation": "4.3.0-preview1-24626-02"
       }
     }
   },

--- a/src/Microsoft.DotNet.ProjectModel.Loader/project.json
+++ b/src/Microsoft.DotNet.ProjectModel.Loader/project.json
@@ -7,7 +7,7 @@
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
-    "System.Runtime.Loader": "4.3.0-preview1-24530-04"
+    "System.Runtime.Loader": "4.3.0-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.6": {

--- a/src/Microsoft.DotNet.ProjectModel/project.json
+++ b/src/Microsoft.DotNet.ProjectModel/project.json
@@ -11,7 +11,7 @@
     "Newtonsoft.Json": "9.0.1",
     "NuGet.Packaging": "3.5.0-beta2-1484",
     "NuGet.RuntimeModel": "3.5.0-beta2-1484",
-    "System.Reflection.Metadata": "1.4.1-preview1-24530-04"
+    "System.Reflection.Metadata": "1.4.1-preview1-24626-02"
   },
   "frameworks": {
     "net451": {
@@ -33,13 +33,13 @@
         "dotnet5.4"
       ],
       "dependencies": {
-        "Microsoft.CSharp": "4.3.0-preview1-24530-04",
-        "System.Dynamic.Runtime": "4.3.0-preview1-24530-04",
-        "System.Runtime.Loader": "4.3.0-preview1-24530-04",
-        "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
-        "System.Security.Cryptography.Algorithms": "4.3.0-preview1-24530-04",
-        "System.Threading.Thread": "4.3.0-preview1-24530-04",
-        "System.Xml.XDocument": "4.3.0-preview1-24530-04"
+        "Microsoft.CSharp": "4.3.0-preview1-24626-02",
+        "System.Dynamic.Runtime": "4.3.0-preview1-24626-02",
+        "System.Runtime.Loader": "4.3.0-preview1-24626-02",
+        "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
+        "System.Security.Cryptography.Algorithms": "4.3.0-preview1-24626-02",
+        "System.Threading.Thread": "4.3.0-preview1-24626-02",
+        "System.Xml.XDocument": "4.3.0-preview1-24626-02"
       }
     }
   }

--- a/src/Microsoft.Extensions.DependencyModel/project.json
+++ b/src/Microsoft.Extensions.DependencyModel/project.json
@@ -16,9 +16,9 @@
     "netstandard1.6": {
       "imports": "portable-net45+wp80+win8+wpa81+dnxcore50",
       "dependencies": {
-        "System.Diagnostics.Debug": "4.3.0-preview1-24530-04",
-        "System.Dynamic.Runtime": "4.3.0-preview1-24530-04",
-        "System.Linq": "4.3.0-preview1-24530-04"
+        "System.Diagnostics.Debug": "4.3.0-preview1-24626-02",
+        "System.Dynamic.Runtime": "4.3.0-preview1-24626-02",
+        "System.Linq": "4.3.0-preview1-24626-02"
       }
     }
   },

--- a/src/Microsoft.Extensions.Testing.Abstractions/project.json
+++ b/src/Microsoft.Extensions.Testing.Abstractions/project.json
@@ -22,8 +22,8 @@
         "portable-net45+win8"
       ],
       "dependencies": {
-        "System.Resources.ResourceManager": "4.3.0-preview1-24530-04",
-        "System.Reflection.TypeExtensions": "4.3.0-preview1-24530-04"
+        "System.Resources.ResourceManager": "4.3.0-preview1-24626-02",
+        "System.Reflection.TypeExtensions": "4.3.0-preview1-24626-02"
       }
     }
   },

--- a/src/compilers/project.json
+++ b/src/compilers/project.json
@@ -6,14 +6,14 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.Net.Compilers.netcore": "1.3.0",
     "Microsoft.DiaSymReader.Native": "1.4.0-rc2"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"

--- a/src/dotnet-archive/project.json
+++ b/src/dotnet-archive/project.json
@@ -14,10 +14,10 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/src/dotnet-compile-fsc/project.json
+++ b/src/dotnet-compile-fsc/project.json
@@ -24,11 +24,11 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win81",

--- a/src/dotnet-compile-fsc/project.json
+++ b/src/dotnet-compile-fsc/project.json
@@ -28,7 +28,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.1": {
+    "netcoreapp1.0": {
       "imports": [
         "dnxcore50",
         "portable-net45+win81",

--- a/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/project.json.template
@@ -10,7 +10,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       },
       "imports": "dnxcore50"

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/project.json.template
@@ -7,7 +7,7 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04"
+        "NETStandard.Library": "1.6.1-preview1-24626-02"
       }
     }
   }

--- a/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
@@ -3,7 +3,7 @@
 
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.1.0-preview1-001100-00",
+      "version": "1.1.0-preview1-001153-00",
       "type": "platform"
     },
     "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
@@ -71,7 +71,7 @@
   },
 
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.6",
         "dnxcore50",

--- a/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_xunittest/project.json.template
@@ -4,7 +4,7 @@
     "debugType": "portable"
   },
   "dependencies": {
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
@@ -14,7 +14,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         }
       },
       "imports": [

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/project.json.template
@@ -14,11 +14,11 @@
     "dotnet-compile-fsc": "1.0.0-preview2.1-*"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.1.0-preview1-001100-00"
+          "version": "1.1.0-preview1-001153-00"
         },
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160629"
       }

--- a/src/dotnet/commands/dotnet-new/FSharp_Lib/project.json.template
+++ b/src/dotnet/commands/dotnet-new/FSharp_Lib/project.json.template
@@ -15,7 +15,7 @@
   "frameworks": {
     "netstandard1.6": {
       "dependencies": {
-        "NETStandard.Library": "1.6.1-preview1-24530-04",
+        "NETStandard.Library": "1.6.1-preview1-24626-02",
         "Microsoft.FSharp.Core.netcore": "1.0.0-alpha-160629"
       }
     }

--- a/src/dotnet/commands/dotnet-test/readme.md
+++ b/src/dotnet/commands/dotnet-test/readme.md
@@ -41,7 +41,7 @@ The following sample project.json shows the properties needed:
     "testRunner": "xunit",
 
     "frameworks": {
-        "netcoreapp1.0": {
+        "netcoreapp1.1": {
                 "imports": [
                     "dnxcore50",
                     "portable-net45+win8"

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -32,7 +32,7 @@
     "NuGet.CommandLine.XPlat": "3.5.0-beta2-1484",
     "Newtonsoft.Json": "9.0.1",
     "System.Text.Encoding.CodePages": "4.0.1",
-    "System.Diagnostics.FileVersionInfo": "4.3.0-preview1-24530-04",
+    "System.Diagnostics.FileVersionInfo": "4.3.0-preview1-24626-02",
     "Microsoft.ApplicationInsights": "2.0.0",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
@@ -51,21 +51,21 @@
     },
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Diagnostics.TraceSource": "4.3.0-preview1-24530-04",
-    "System.Diagnostics.TextWriterTraceListener": "4.3.0-preview1-24530-04",
-    "System.Resources.Writer": "4.3.0-preview1-24530-04",
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
-    "System.Private.DataContractSerialization": "4.3.0-preview1-24530-04",
-    "System.Text.RegularExpressions": "4.3.0-preview1-24530-04",
+    "System.Diagnostics.TraceSource": "4.3.0-preview1-24626-02",
+    "System.Diagnostics.TextWriterTraceListener": "4.3.0-preview1-24626-02",
+    "System.Resources.Writer": "4.3.0-preview1-24626-02",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
+    "System.Private.DataContractSerialization": "4.3.0-preview1-24626-02",
+    "System.Text.RegularExpressions": "4.3.0-preview1-24626-02",
     "Microsoft.Win32.Registry": {
-      "version": "4.3.0-preview1-24530-04",
+      "version": "4.3.0-preview1-24626-02",
       "exclude": "compile"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "netstandardapp1.5",

--- a/test/ArgumentForwardingTests/project.json
+++ b/test/ArgumentForwardingTests/project.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
@@ -22,7 +22,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"
@@ -31,6 +31,6 @@
   },
   "testRunner": "xunit",
   "scripts": {
-    "precompile": "dotnet publish ../ArgumentsReflector/project.json --framework netcoreapp1.0 --runtime %compile:RuntimeIdentifier% --output %compile:RuntimeOutputDir%"
+    "precompile": "dotnet publish ../ArgumentsReflector/project.json --framework netcoreapp1.1 --runtime %compile:RuntimeIdentifier% --output %compile:RuntimeOutputDir%"
   }
 }

--- a/test/ArgumentsReflector/project.json
+++ b/test/ArgumentsReflector/project.json
@@ -11,11 +11,11 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   },
   "publishOptions": {
     "include": [

--- a/test/EndToEnd/project.json
+++ b/test/EndToEnd/project.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
@@ -23,7 +23,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/Kestrel.Tests/DotnetBuildTest.cs
+++ b/test/Kestrel.Tests/DotnetBuildTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Kestrel.Tests
 
             var outputBase = new DirectoryInfo(Path.Combine(testRoot, "bin", "Debug"));
 
-            var netcoreAppOutput = outputBase.Sub("netcoreapp1.0");
+            var netcoreAppOutput = outputBase.Sub("netcoreapp1.1");
 
             netcoreAppOutput.Should()
                 .Exist().And

--- a/test/Kestrel.Tests/project.json
+++ b/test/Kestrel.Tests/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -16,7 +16,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
@@ -155,10 +155,10 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                     .Should()
                     .Pass();
 
-            var context = ProjectContext.Create(testInstance.TestRoot, FrameworkConstants.CommonFrameworks.NetCoreApp10);
+            var context = ProjectContext.Create(testInstance.TestRoot, FrameworkConstants.CommonFrameworks.NetCoreApp11);
 
             var factory = new ProjectDependenciesCommandFactory(
-                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                FrameworkConstants.CommonFrameworks.NetCoreApp11,
                 configuration,
                 null,
                 null,
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             var command = factory.Create("dotnet-tool-with-output-name", null);
 
             command.CommandArgs.Should().Contain(
-                Path.Combine("ToolWithOutputName", "1.0.0", "lib", "netcoreapp1.0", "dotnet-tool-with-output-name.dll"));
+                Path.Combine("ToolWithOutputName", "1.0.0", "lib", "netcoreapp1.1", "dotnet-tool-with-output-name.dll"));
         }
     }
 }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
@@ -155,10 +155,10 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                     .Should()
                     .Pass();
 
-            var context = ProjectContext.Create(testInstance.TestRoot, FrameworkConstants.CommonFrameworks.NetCoreApp11);
+            var context = ProjectContext.Create(testInstance.TestRoot, new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0)));
 
             var factory = new ProjectDependenciesCommandFactory(
-                FrameworkConstants.CommonFrameworks.NetCoreApp11,
+                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0)),
                 configuration,
                 null,
                 null,
@@ -167,7 +167,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             var command = factory.Create("dotnet-tool-with-output-name", null);
 
             command.CommandArgs.Should().Contain(
-                Path.Combine("ToolWithOutputName", "1.0.0", "lib", "netcoreapp1.1", "dotnet-tool-with-output-name.dll"));
+                Path.Combine("ToolWithOutputName", "1.0.0", "lib", "netcoreapp1.0", "dotnet-tool-with-output-name.dll"));
         }
     }
 }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependencyCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependencyCommandResolver.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = new string[] { "" },
                 ProjectDirectory = "/some/directory",
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0))
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = new string[] { "" },
                 ProjectDirectory = null,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0))
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = new string[] { "" },
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = null,
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0))
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0))
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0))
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -149,7 +149,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = new[] { "arg with space" },
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0))
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0))
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -190,19 +190,19 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11,
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0)),
                 OutputPath = outputDir
             };
 
             var buildCommand = new BuildCommand(
                 Path.Combine(s_liveProjectDirectory, "project.json"),
                 output: outputDir,
-                framework: FrameworkConstants.CommonFrameworks.NetCoreApp11.ToString())
+                framework: new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0)).ToString())
                 .Execute().Should().Pass();
 
             var projectContext = ProjectContext.Create(
                 s_liveProjectDirectory,
-                FrameworkConstants.CommonFrameworks.NetCoreApp11,
+                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0)),
                 RuntimeEnvironmentRidExtensions.GetAllCandidateRuntimeIdentifiers());
 
             var depsFilePath =
@@ -226,19 +226,19 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11,
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0)),
                 BuildBasePath = buildBasePath
             };
 
             var buildCommand = new BuildCommand(
                 Path.Combine(s_liveProjectDirectory, "project.json"),
                 buildBasePath: buildBasePath,
-                framework: FrameworkConstants.CommonFrameworks.NetCoreApp11.ToString())
+                framework: new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0)).ToString())
                 .Execute().Should().Pass();
 
             var projectContext = ProjectContext.Create(
                 s_liveProjectDirectory,
-                FrameworkConstants.CommonFrameworks.NetCoreApp11,
+                new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0)),
                 RuntimeEnvironmentRidExtensions.GetAllCandidateRuntimeIdentifiers());
 
             var depsFilePath =
@@ -261,7 +261,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
+                Framework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0))
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependencyCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependencyCommandResolver.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = new string[] { "" },
                 ProjectDirectory = "/some/directory",
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = new string[] { "" },
                 ProjectDirectory = null,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = new string[] { "" },
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = null,
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -149,7 +149,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = new[] { "arg with space" },
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -190,19 +190,19 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11,
                 OutputPath = outputDir
             };
 
             var buildCommand = new BuildCommand(
                 Path.Combine(s_liveProjectDirectory, "project.json"),
                 output: outputDir,
-                framework: FrameworkConstants.CommonFrameworks.NetCoreApp10.ToString())
+                framework: FrameworkConstants.CommonFrameworks.NetCoreApp11.ToString())
                 .Execute().Should().Pass();
 
             var projectContext = ProjectContext.Create(
                 s_liveProjectDirectory,
-                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                FrameworkConstants.CommonFrameworks.NetCoreApp11,
                 RuntimeEnvironmentRidExtensions.GetAllCandidateRuntimeIdentifiers());
 
             var depsFilePath =
@@ -226,19 +226,19 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11,
                 BuildBasePath = buildBasePath
             };
 
             var buildCommand = new BuildCommand(
                 Path.Combine(s_liveProjectDirectory, "project.json"),
                 buildBasePath: buildBasePath,
-                framework: FrameworkConstants.CommonFrameworks.NetCoreApp10.ToString())
+                framework: FrameworkConstants.CommonFrameworks.NetCoreApp11.ToString())
                 .Execute().Should().Pass();
 
             var projectContext = ProjectContext.Create(
                 s_liveProjectDirectory,
-                FrameworkConstants.CommonFrameworks.NetCoreApp10,
+                FrameworkConstants.CommonFrameworks.NetCoreApp11,
                 RuntimeEnvironmentRidExtensions.GetAllCandidateRuntimeIdentifiers());
 
             var depsFilePath =
@@ -261,7 +261,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandArguments = null,
                 ProjectDirectory = s_liveProjectDirectory,
                 Configuration = "Debug",
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp10
+                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp11
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 {
     public class GivenAProjectToolsCommandResolver
     {
-        private static readonly NuGetFramework s_toolPackageFramework = FrameworkConstants.CommonFrameworks.NetCoreApp10;
+        private static readonly NuGetFramework s_toolPackageFramework = FrameworkConstants.CommonFrameworks.NetCoreApp11;
 
         private static readonly string s_liveProjectDirectory =
             Path.Combine(AppContext.BaseDirectory, "TestAssets/TestProjects/AppWithToolDependency");

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 {
     public class GivenAProjectToolsCommandResolver
     {
-        private static readonly NuGetFramework s_toolPackageFramework = FrameworkConstants.CommonFrameworks.NetCoreApp11;
+        private static readonly NuGetFramework s_toolPackageFramework = FrameworkConstants.CommonFrameworks.NetCoreApp10;
 
         private static readonly string s_liveProjectDirectory =
             Path.Combine(AppContext.BaseDirectory, "TestAssets/TestProjects/AppWithToolDependency");

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/StreamForwarderTests.cs
@@ -135,7 +135,7 @@ namespace StreamForwarderTests
             buildCommand.Execute();
 
             var buildOutputExe = "OutputStandardOutputAndError" + Constants.ExeSuffix;
-            var buildOutputPath = Path.Combine(binTestProjectPath, "bin/Debug/netcoreapp1.0", buildOutputExe);
+            var buildOutputPath = Path.Combine(binTestProjectPath, "bin/Debug/netcoreapp1.1", buildOutputExe);
 
             return buildOutputPath;
         }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -16,10 +16,10 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Diagnostics.TraceSource": "4.3.0-preview1-24530-04",
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Diagnostics.TraceSource": "4.3.0-preview1-24626-02",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "NuGet.Versioning": "3.5.0-beta2-1484",
     "NuGet.Packaging": "3.5.0-beta2-1484",
     "NuGet.Frameworks": "3.5.0-beta2-1484",
@@ -38,7 +38,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "netstandardapp1.5",
         "dotnet5.4",

--- a/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
+++ b/test/Microsoft.DotNet.Compiler.Common.Tests/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -19,7 +19,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/Microsoft.DotNet.Configurer.UnitTests/project.json
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/project.json
@@ -6,9 +6,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Diagnostics.TraceSource": "4.3.0-preview1-24530-04",
+    "System.Diagnostics.TraceSource": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Configurer": {
       "target": "project"
     },
@@ -24,7 +24,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/Microsoft.DotNet.ProjectModel.Loader.Tests/ProjectLoadContextTest.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Loader.Tests/ProjectLoadContextTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.ProjectModel.Loader.Tests
 
             var runtimeIdentifier = DependencyContext.Default.Target.Runtime;
 
-            var context = ProjectContext.Create(testInstance.TestRoot, NuGetFramework.Parse("netcoreapp1.0"), new[] { runtimeIdentifier });
+            var context = ProjectContext.Create(testInstance.TestRoot, NuGetFramework.Parse("netcoreapp1.1"), new[] { runtimeIdentifier });
             var loadContext = context.CreateLoadContext(runtimeIdentifier, Constants.DefaultConfiguration);
 
             // Load the project assembly

--- a/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Loader.Tests/project.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.DotNet.ProjectModel.Loader": {
       "target": "project"
@@ -18,7 +18,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/Microsoft.DotNet.ProjectModel.Tests/PackageDependencyProviderTests.cs
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/PackageDependencyProviderTests.cs
@@ -30,8 +30,8 @@ namespace Microsoft.DotNet.ProjectModel.Tests
             target.CompileTimeAssemblies.Add("lib/dotnet/_._");
             target.NativeLibraries.Add("runtimes/any/native/Microsoft.CSharp.CurrentVersion.targets");
 
-            var p1 = provider.GetDescription(NuGetFramework.Parse("netcoreapp1.0"), package, target);
-            var p2 = provider.GetDescription(NuGetFramework.Parse("netcoreapp1.0"), package, target);
+            var p1 = provider.GetDescription(NuGetFramework.Parse("netcoreapp1.1"), package, target);
+            var p2 = provider.GetDescription(NuGetFramework.Parse("netcoreapp1.1"), package, target);
 
             Assert.True(p1.Compatible);
             Assert.True(p2.Compatible);

--- a/test/Microsoft.DotNet.ProjectModel.Tests/project.json
+++ b/test/Microsoft.DotNet.ProjectModel.Tests/project.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
@@ -24,7 +24,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/TestBase.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/TestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
     /// </summary>
     public abstract class TestBase : IDisposable
     {
-        protected const string DefaultFramework = "netcoreapp1.0";
+        protected const string DefaultFramework = "netcoreapp1.1";
         protected const string DefaultLibraryFramework = "netstandard1.5";
         private TempRoot _temp;
         private static TestAssetsManager s_testsAssetsMgr;

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/project.json
@@ -16,7 +16,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/DependencyContextJsonReaderTest.cs
@@ -26,14 +26,14 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var context = Read(
 @"{
     ""runtimeTarget"": {
-        ""name"":"".NETCoreApp,Version=v1.0/osx.10.10-x64""
+        ""name"":"".NETCoreApp,Version=v1.1/osx.10.10-x64""
     },
     ""targets"": {
-        "".NETCoreApp,Version=v1.0/osx.10.10-x64"": {},
+        "".NETCoreApp,Version=v1.1/osx.10.10-x64"": {},
     }
 }");
             context.Target.IsPortable.Should().BeFalse();
-            context.Target.Framework.Should().Be(".NETCoreApp,Version=v1.0");
+            context.Target.Framework.Should().Be(".NETCoreApp,Version=v1.1");
             context.Target.Runtime.Should().Be("osx.10.10-x64");
         }
 
@@ -78,7 +78,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var context = Read(
 @"{
     ""targets"": {
-        "".NETCoreApp,Version=v1.0"": {}
+        "".NETCoreApp,Version=v1.1"": {}
     }
 }");
             context.Target.IsPortable.Should().BeTrue();
@@ -90,10 +90,10 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var context = Read(
 @"{
     ""runtimeTarget"": {
-        ""name"": "".NETCoreApp,Version=v1.0/osx.10.10-x64""
+        ""name"": "".NETCoreApp,Version=v1.1/osx.10.10-x64""
     },
     ""targets"": {
-        "".NETCoreApp,Version=v1.0/osx.10.10-x64"": {}
+        "".NETCoreApp,Version=v1.1/osx.10.10-x64"": {}
     }
 }");
             context.Target.IsPortable.Should().BeFalse();
@@ -105,10 +105,10 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var context = Read(
 @"{
     ""targets"": {
-        "".NETCoreApp,Version=v1.0"": {}
+        "".NETCoreApp,Version=v1.1"": {}
     }
 }");
-            context.Target.Framework.Should().Be(".NETCoreApp,Version=v1.0");
+            context.Target.Framework.Should().Be(".NETCoreApp,Version=v1.1");
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var context = Read(
 @"{
     ""targets"": {
-        "".NETCoreApp,Version=v1.0/osx.10.10-x64"": {},
+        "".NETCoreApp,Version=v1.1/osx.10.10-x64"": {},
     },
     ""runtimes"": {
         ""osx.10.10-x64"": [ ],
@@ -141,7 +141,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var context = Read(
 @"{
     ""targets"": {
-        "".NETCoreApp,Version=v1.0"": {
+        "".NETCoreApp,Version=v1.1"": {
             ""MyApp/1.0.1"": {
                 ""dependencies"": {
                     ""AspNet.Mvc"": ""1.0.0""
@@ -191,7 +191,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var context = Read(
 @"{
     ""targets"": {
-        "".NETCoreApp,Version=v1.0"": {
+        "".NETCoreApp,Version=v1.1"": {
             ""MyApp/1.0.1"": {
                 ""dependencies"": {
                     ""AspNet.Mvc"": ""1.0.0""
@@ -234,10 +234,10 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             var context = Read(
 @"{
     ""runtimeTarget"": {
-        ""name"": "".NETCoreApp,Version=v1.0""
+        ""name"": "".NETCoreApp,Version=v1.1""
     },
     ""targets"": {
-        "".NETCoreApp,Version=v1.0"": {
+        "".NETCoreApp,Version=v1.1"": {
             ""MyApp/1.0.1"": {
                 ""dependencies"": {
                     ""AspNet.Mvc"": ""1.0.0""
@@ -299,9 +299,9 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         {
             var context = Read(
 @"{
-    ""runtimeTarget"": "".NETCoreApp,Version=v1.0"",
+    ""runtimeTarget"": "".NETCoreApp,Version=v1.1"",
     ""targets"": {
-        "".NETCoreApp,Version=v1.0"": {
+        "".NETCoreApp,Version=v1.1"": {
             ""System.Banana/1.0.0"": {
                 ""runtimeTargets"": {
                     ""runtime/win7-x64/lib/_._"": { ""assetType"": ""runtime"", ""rid"": ""win7-x64""},
@@ -347,7 +347,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         ""optimize"": true
     },
     ""targets"": {
-        "".NETCoreApp,Version=v1.0/osx.10.10-x64"": {},
+        "".NETCoreApp,Version=v1.1/osx.10.10-x64"": {},
     }
 }");
             context.CompilationOptions.AllowUnsafe.Should().Be(true);

--- a/test/Microsoft.Extensions.DependencyModel.Tests/project.json
+++ b/test/Microsoft.Extensions.DependencyModel.Tests/project.json
@@ -7,9 +7,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Diagnostics.TraceSource": "4.3.0-preview1-24530-04",
+    "System.Diagnostics.TraceSource": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -22,7 +22,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/Performance/project.json
+++ b/test/Performance/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
@@ -21,7 +21,7 @@
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0028"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/ScriptExecutorTests/ScriptExecutorTests.cs
+++ b/test/ScriptExecutorTests/ScriptExecutorTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli.Utils.ScriptExecutorTests
 
             var sourceTestProjectPath = Path.Combine(s_testProjectRoot, "TestApp");
             binTestProjectPath = _root.CopyDirectory(sourceTestProjectPath).Path;
-            project = ProjectContext.Create(binTestProjectPath, NuGetFramework.Parse("netcoreapp1.0")).ProjectFile;
+            project = ProjectContext.Create(binTestProjectPath, NuGetFramework.Parse("netcoreapp1.1")).ProjectFile;
         }
 
         [Fact]

--- a/test/ScriptExecutorTests/project.json
+++ b/test/ScriptExecutorTests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
@@ -18,7 +18,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.Tests/project.json
@@ -3,12 +3,12 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.Extensions.Testing.Abstractions": {
       "target": "project"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -23,7 +23,7 @@
     "FluentAssertions": "4.2.2"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
+++ b/test/TestingAbstractions/Microsoft.Extensions.Testing.Abstractions.UnitTests/project.json
@@ -3,13 +3,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.Extensions.Testing.Abstractions": {
       "target": "project"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
-    "System.Diagnostics.Process": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
+    "System.Diagnostics.Process": "4.3.0-preview1-24626-02",
     "TestAppWithPortablePdbs": {
       "target": "project"
     },
@@ -19,7 +19,7 @@
     "moq.netcore": "4.4.0-beta8"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/TestingAbstractions/TestAppWithFullPdbs/project.json
+++ b/test/TestingAbstractions/TestAppWithFullPdbs/project.json
@@ -4,7 +4,7 @@
     "debugType": "full"
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/test/TestingAbstractions/TestAppWithPortablePdbs/project.json
+++ b/test/TestingAbstractions/TestAppWithPortablePdbs/project.json
@@ -4,7 +4,7 @@
     "debugType": "portable"
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.1-preview1-24530-04"
+    "NETStandard.Library": "1.6.1-preview1-24626-02"
   },
   "frameworks": {
     "netstandard1.5": {}

--- a/test/binding-redirects.Tests/project.json
+++ b/test/binding-redirects.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24530-04",
+    "Microsoft.NETCore.Platforms": "1.1.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     }

--- a/test/crossgen.Tests/project.json
+++ b/test/crossgen.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
@@ -15,7 +15,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-build.Tests/BuildOutputTests.cs
+++ b/test/dotnet-build.Tests/BuildOutputTests.cs
@@ -250,7 +250,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
             buildResult.StdErr.Should().Contain("The dependency ThisIsNotARealDependencyAndIfSomeoneGoesAndAddsAProjectWithThisNameIWillFindThemAndPunishThem could not be resolved.");
 
-            var outputDir = new DirectoryInfo(Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.0"));
+            var outputDir = new DirectoryInfo(Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.1"));
             outputDir.GetFiles().Length.Should().Be(0);
         }
 
@@ -266,7 +266,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             var result = cmd.Execute();
             result.Should().Pass();
 
-            var outputDir = new DirectoryInfo(Path.Combine(projectRoot, "bin", "Debug", "netcoreapp1.0"));
+            var outputDir = new DirectoryInfo(Path.Combine(projectRoot, "bin", "Debug", "netcoreapp1.1"));
 
             outputDir.Should().HaveFile("TestLibraryWithResources.dll");
             outputDir.Sub("fr").Should().HaveFile("TestLibraryWithResources.resources.dll");
@@ -275,7 +275,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
             foreach (var library in new[] { Tuple.Create("Microsoft.Data.OData", "5.6.4"), Tuple.Create("TestLibraryWithResources", "1.0.0") })
             {
-                var resources = depsJson["targets"][".NETCoreApp,Version=v1.0"][library.Item1 + "/" + library.Item2]["resources"];
+                var resources = depsJson["targets"][".NETCoreApp,Version=v1.1"][library.Item1 + "/" + library.Item2]["resources"];
 
                 resources.Should().NotBeNull();
 
@@ -347,7 +347,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
             buildResult.Should().Fail();
 
-            buildResult.StdErr.Should().Contain("Can not find runtime target for framework '.NETCoreApp,Version=v1.0' compatible with one of the target runtimes");
+            buildResult.StdErr.Should().Contain("Can not find runtime target for framework '.NETCoreApp,Version=v1.1' compatible with one of the target runtimes");
             buildResult.StdErr.Should().Contain("The project has not been restored or restore failed - run `dotnet restore`");
         }
 

--- a/test/dotnet-build.Tests/BuildPortableTests.cs
+++ b/test/dotnet-build.Tests/BuildPortableTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
             var outputBase = new DirectoryInfo(Path.Combine(testInstance.TestRoot, "PortableApp", "bin", "Debug"));
 
-            return outputBase.Sub("netcoreapp1.0");
+            return outputBase.Sub("netcoreapp1.1");
         }
     }
 }

--- a/test/dotnet-build.Tests/BuildStandAloneTests.cs
+++ b/test/dotnet-build.Tests/BuildStandAloneTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             result.Should().Pass();
 
             var outputBase = new DirectoryInfo(
-                Path.Combine(testInstance.TestRoot, "StandaloneApp", "bin", "Debug", "netcoreapp1.0"));
+                Path.Combine(testInstance.TestRoot, "StandaloneApp", "bin", "Debug", "netcoreapp1.1"));
 
             return outputBase.Sub(runtime);
         }

--- a/test/dotnet-build.Tests/IncrementalTestBase.cs
+++ b/test/dotnet-build.Tests/IncrementalTestBase.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
     public class IncrementalTestBase : TestBase
     {
         protected readonly string _libraryFrameworkFullName = ".NETStandard,Version=v1.5";
-        protected readonly string _appFrameworkFullName = ".NETCoreApp,Version=v1.0";
+        protected readonly string _appFrameworkFullName = ".NETCoreApp,Version=v1.1";
 
         protected virtual string MainProject
         {
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
         protected CommandResult BuildProject(string projectFile, bool noDependencies = false, bool noIncremental = false, bool expectBuildFailure = false)
         {
-            var buildCommand = new BuildCommand(projectFile, output: GetOutputDir(), framework: "netcoreapp1.0", noIncremental: noIncremental, noDependencies : noDependencies);
+            var buildCommand = new BuildCommand(projectFile, output: GetOutputDir(), framework: "netcoreapp1.1", noIncremental: noIncremental, noDependencies : noDependencies);
             var result = buildCommand.ExecuteWithCapturedOutput();
 
             if (!expectBuildFailure)
@@ -123,14 +123,14 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
 
         protected string GetCompilationOutputPath()
         {
-            var executablePath = Path.Combine(GetBinRoot(), "Debug", "netcoreapp1.0");
+            var executablePath = Path.Combine(GetBinRoot(), "Debug", "netcoreapp1.1");
 
             return executablePath;
         }
 
         protected string GetIntermediaryOutputPath()
         {
-            var executablePath = Path.Combine(TestProjectRoot, "obj", "Debug", "netcoreapp1.0");
+            var executablePath = Path.Combine(TestProjectRoot, "obj", "Debug", "netcoreapp1.1");
 
             return executablePath;
         }

--- a/test/dotnet-build.Tests/IncrementalTestsVersionSuffix.cs
+++ b/test/dotnet-build.Tests/IncrementalTestsVersionSuffix.cs
@@ -16,14 +16,14 @@ namespace Microsoft.DotNet.Tools.Builder.Tests
             var result = command.ExecuteWithCapturedOutput();
 
             // Verify the result
-            result.Should().HaveCompiledProject("TestSimpleIncrementalApp", ".NETCoreApp,Version=v1.0");
+            result.Should().HaveCompiledProject("TestSimpleIncrementalApp", ".NETCoreApp,Version=v1.1");
 
             // Build with Version Suffix 2
             command = new BuildCommand(testInstance.TestRoot, versionSuffix: "2");
             result = command.ExecuteWithCapturedOutput();
 
             // Verify the result
-            result.Should().HaveCompiledProject("TestSimpleIncrementalApp", ".NETCoreApp,Version=v1.0");
+            result.Should().HaveCompiledProject("TestSimpleIncrementalApp", ".NETCoreApp,Version=v1.1");
         }
     }
 }

--- a/test/dotnet-build.Tests/project.json
+++ b/test/dotnet-build.Tests/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -17,7 +17,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-compile-fsc.Tests/project.json
+++ b/test/dotnet-compile-fsc.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
@@ -15,7 +15,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-compile.Tests/project.json
+++ b/test/dotnet-compile.Tests/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -16,7 +16,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-compile.UnitTests/GivenACompilationDriver.cs
+++ b/test/dotnet-compile.UnitTests/GivenACompilationDriver.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
             _workspace = new BuildWorkspace(ProjectReaderSettings.ReadFromEnvironment());
             _contexts = new List<ProjectContext>
             {
-                _workspace.GetProjectContext(_projectJson, NuGetFramework.Parse("netcoreapp1.0"))
+                _workspace.GetProjectContext(_projectJson, NuGetFramework.Parse("netcoreapp1.1"))
             };
 
             _args = new BuildCommandApp("dotnet compile", ".NET Compiler", "Compiler for the .NET Platform", _workspace);

--- a/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
+++ b/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
@@ -27,14 +27,14 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
         public void It_passes_a_FullTargetFramework_variable_to_the_pre_compile_scripts()
         {
             _fixture.PreCompileScriptVariables.Should().ContainKey("compile:FullTargetFramework");
-            _fixture.PreCompileScriptVariables["compile:FullTargetFramework"].Should().Be(".NETCoreApp,Version=v1.0");
+            _fixture.PreCompileScriptVariables["compile:FullTargetFramework"].Should().Be(".NETCoreApp,Version=v1.1");
         }
 
         [Fact]
         public void It_passes_a_TargetFramework_variable_to_the_pre_compile_scripts()
         {
             _fixture.PreCompileScriptVariables.Should().ContainKey("compile:TargetFramework");
-            _fixture.PreCompileScriptVariables["compile:TargetFramework"].Should().Be("netcoreapp1.0");
+            _fixture.PreCompileScriptVariables["compile:TargetFramework"].Should().Be("netcoreapp1.1");
         }
 
         [Fact]
@@ -79,14 +79,14 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
         public void It_passes_a_FullTargetFramework_variable_to_the_post_compile_scripts()
         {
             _fixture.PostCompileScriptVariables.Should().ContainKey("compile:FullTargetFramework");
-            _fixture.PostCompileScriptVariables["compile:FullTargetFramework"].Should().Be(".NETCoreApp,Version=v1.0");
+            _fixture.PostCompileScriptVariables["compile:FullTargetFramework"].Should().Be(".NETCoreApp,Version=v1.1");
         }
 
         [Fact]
         public void It_passes_a_TargetFramework_variable_to_the_post_compile_scripts()
         {
             _fixture.PostCompileScriptVariables.Should().ContainKey("compile:TargetFramework");
-            _fixture.PostCompileScriptVariables["compile:TargetFramework"].Should().Be("netcoreapp1.0");
+            _fixture.PostCompileScriptVariables["compile:TargetFramework"].Should().Be("netcoreapp1.1");
         }
 
         [Fact]
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
 
     public class ScriptVariablesFixture
     {
-        public readonly NuGetFramework TestAssetFramework = FrameworkConstants.CommonFrameworks.NetCoreApp10;
+        public readonly NuGetFramework TestAssetFramework = FrameworkConstants.CommonFrameworks.NetCoreApp11;
         public const string ConfigValue = "Debug";
 
         public static string TestAssetPath = Path.Combine(
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
             TestAssetPath,
             "bin",
             ConfigValue,
-            "netcoreapp1.0");
+            "netcoreapp1.1");
 
         public string RuntimeOutputDir { get; private set; }
 
@@ -161,7 +161,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
             TestAssetPath,
             "obj",
             ConfigValue,
-            "netcoreapp1.0",
+            "netcoreapp1.1",
             "dotnet-compile.rsp");
 
         public Dictionary<string, string> PreCompileScriptVariables { get; private set; }

--- a/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
+++ b/test/dotnet-compile.UnitTests/GivenThatICareAboutScriptVariablesFromAManagedCompiler.cs
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.Tools.Compiler.Tests
 
     public class ScriptVariablesFixture
     {
-        public readonly NuGetFramework TestAssetFramework = FrameworkConstants.CommonFrameworks.NetCoreApp11;
+        public readonly NuGetFramework TestAssetFramework = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new System.Version(1, 1, 0, 0));
         public const string ConfigValue = "Debug";
 
         public static string TestAssetPath = Path.Combine(

--- a/test/dotnet-compile.UnitTests/project.json
+++ b/test/dotnet-compile.UnitTests/project.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
@@ -23,7 +23,7 @@
       "target": "project"
     },
     "Microsoft.Win32.Registry": {
-      "version": "4.3.0-preview1-24530-04",
+      "version": "4.3.0-preview1-24626-02",
       "exclude": "Compile"
     },
     "Microsoft.DotNet.ProjectModel": {
@@ -35,7 +35,7 @@
     "FluentAssertions": "4.2.2"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "netstandardapp1.5",
         "dotnet5.4",

--- a/test/dotnet-new.Tests/project.json
+++ b/test/dotnet-new.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
@@ -16,7 +16,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50",
         "portable-net45+win8"

--- a/test/dotnet-pack.Tests/project.json
+++ b/test/dotnet-pack.Tests/project.json
@@ -3,10 +3,10 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
-    "System.IO.Compression.ZipFile": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
+    "System.IO.Compression.ZipFile": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -17,7 +17,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-projectmodel-server.Tests/DthTests.cs
+++ b/test/dotnet-projectmodel-server.Tests/DthTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
                                                             .AssertJArrayCount(2)
                                                             .Select(f => f["ShortName"].Value<string>());
 
-                Assert.Contains("netcoreapp1.0", frameworkShortNames);
+                Assert.Contains("netcoreapp1.1", frameworkShortNames);
                 Assert.Contains("dnx451", frameworkShortNames);
             }
         }
@@ -540,7 +540,7 @@ namespace Microsoft.DotNet.ProjectModel.Server.Tests
                 var projectJson = JsonConvert.DeserializeObject<JObject>(File.ReadAllText(projectFilePath));
 
                 // Remove newtonsoft.json dependency
-                var dependencies = projectJson["frameworks"]["netcoreapp1.0"]["dependencies"] as JObject;
+                var dependencies = projectJson["frameworks"]["netcoreapp1.1"]["dependencies"] as JObject;
                 dependencies.Remove("Newtonsoft.Json");
 
                 File.WriteAllText(projectFilePath, JsonConvert.SerializeObject(projectJson));

--- a/test/dotnet-projectmodel-server.Tests/project.json
+++ b/test/dotnet-projectmodel-server.Tests/project.json
@@ -2,13 +2,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "dotnet": {
       "target": "project"
     },
     "Microsoft.Win32.Registry": {
-      "version": "4.3.0-preview1-24530-04",
+      "version": "4.3.0-preview1-24626-02",
       "exclude": "Compile"
     },
     "Microsoft.DotNet.Tools.Tests.Utilities": {
@@ -19,10 +19,10 @@
     },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "System.Net.NameResolution": "4.3.0-preview1-24530-04"
+    "System.Net.NameResolution": "4.3.0-preview1-24626-02"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "netstandardapp1.5",
         "dotnet5.4",

--- a/test/dotnet-publish.Tests/PublishTests.cs
+++ b/test/dotnet-publish.Tests/PublishTests.cs
@@ -63,12 +63,12 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
                 return new[]
                 {
                     new object[] { "1", "", "", "", "" },
-                    new object[] { "2", "netcoreapp1.0", "", "", "" },
+                    new object[] { "2", "netcoreapp1.1", "", "", "" },
                     new object[] { "3", "", RuntimeEnvironmentRidExtensions.GetLegacyRestoreRuntimeIdentifier(), "", "" },
                     new object[] { "4", "", "", "Release", "" },
                     new object[] { "5", "", "", "", "some/dir"},
                     new object[] { "6", "", "", "", "some/dir/with spaces" },
-                    new object[] { "7", "netcoreapp1.0", RuntimeEnvironmentRidExtensions.GetLegacyRestoreRuntimeIdentifier(), "Debug", "some/dir" },
+                    new object[] { "7", "netcoreapp1.1", RuntimeEnvironmentRidExtensions.GetLegacyRestoreRuntimeIdentifier(), "Debug", "some/dir" },
                 };
             }
         }
@@ -226,7 +226,7 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             publishCommand.GetOutputDirectory().Should().HaveFile("Newtonsoft.Json.dll");
             publishCommand.GetOutputDirectory().Delete(true);
 
-            publishCommand = new PublishCommand(lesserTestProject, "netcoreapp1.0", RuntimeEnvironmentRidExtensions.GetLegacyRestoreRuntimeIdentifier());
+            publishCommand = new PublishCommand(lesserTestProject, "netcoreapp1.1", RuntimeEnvironmentRidExtensions.GetLegacyRestoreRuntimeIdentifier());
             publishCommand.Execute().Should().Pass();
 
             publishCommand.GetOutputDirectory().Should().HaveFile("TestLibraryLesser.dll");

--- a/test/dotnet-publish.Tests/project.json
+++ b/test/dotnet-publish.Tests/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.TestFramework": {
       "target": "project"
     },
@@ -15,10 +15,10 @@
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00206",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0-preview1-24530-04"
+    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0-preview1-24626-02"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-resgen.Tests/project.json
+++ b/test/dotnet-resgen.Tests/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -17,7 +17,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-run.Tests/project.json
+++ b/test/dotnet-run.Tests/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -16,7 +16,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-run.UnitTests/project.json
+++ b/test/dotnet-run.UnitTests/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "dotnet": {
       "target": "project"
     },
@@ -17,7 +17,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-test.Tests/GivenThatWeWantToRunTestsForMultipleTFMsInTheConsole.cs
+++ b/test/dotnet-test.Tests/GivenThatWeWantToRunTestsForMultipleTFMsInTheConsole.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
             // unless we re-restore
             new RestoreCommand() { WorkingDirectory = testInstance.TestRoot }.Execute().Should().Pass();
 
-            _defaultNetCoreAppOutputPath = Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.0");
+            _defaultNetCoreAppOutputPath = Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.1");
             _defaultNet451OutputPath = Path.Combine(testInstance.TestRoot, "bin", "Debug", "net451", RuntimeEnvironmentRidExtensions.GetAllCandidateRuntimeIdentifiers().First());
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                 .ExecuteWithCapturedOutput($"{_projectFilePath}");
             result.Should().Pass();
             result.StdOut.Should().Contain("Skipped for NET451");
-            result.StdOut.Should().Contain("Skipped for NETCOREAPP1.0");
+            result.StdOut.Should().Contain("Skipped for NETCOREAPP1.1");
         }
 
         [WindowsOnlyFact]
@@ -58,17 +58,17 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                 .ExecuteWithCapturedOutput($"{_projectFilePath} -f net451");
             result.Should().Pass();
             result.StdOut.Should().Contain($"Skipped for NET451");
-            result.StdOut.Should().NotContain($"Skipped for NETCOREAPP1.0");
+            result.StdOut.Should().NotContain($"Skipped for NETCOREAPP1.1");
         }
 
         [Fact]
-        public void It_builds_and_runs_tests_for_netcoreapp10()
+        public void It_builds_and_runs_tests_for_netcoreapp11()
         {
             var testCommand = new DotnetTestCommand();
             var result = testCommand
-                .ExecuteWithCapturedOutput($"{_projectFilePath} -f netcoreapp1.0");
+                .ExecuteWithCapturedOutput($"{_projectFilePath} -f netcoreapp1.1");
             result.Should().Pass();
-            result.StdOut.Should().Contain($"Skipped for NETCOREAPP1.0");
+            result.StdOut.Should().Contain($"Skipped for netcoreapp1.1");
             result.StdOut.Should().NotContain($"Skipped for NET451");
         }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         {
             var testCommand = new DotnetTestCommand();
             var result = testCommand.Execute(
-                $"{_projectFilePath} -o {Path.Combine(AppContext.BaseDirectory, "output")} -f netcoreapp1.0");
+                $"{_projectFilePath} -o {Path.Combine(AppContext.BaseDirectory, "output")} -f netcoreapp1.1");
             result.Should().Pass();
         }
 
@@ -94,7 +94,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         public void It_skips_build_when_the_no_build_flag_is_passed_for_netcoreapp10()
         {
             var buildCommand = new BuildCommand(_projectFilePath);
-            var result = buildCommand.Execute($"-f netcoreapp1.0 -o {_defaultNetCoreAppOutputPath}");
+            var result = buildCommand.Execute($"-f netcoreapp1.1 -o {_defaultNetCoreAppOutputPath}");
             result.Should().Pass();
 
             var testCommand = new DotnetTestCommand();
@@ -143,7 +143,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
 
             result.Should().Fail();
             result.StdOut.Should().Contain("Failing in NET451");
-            result.StdOut.Should().Contain("Failing in NETCOREAPP1.0");
+            result.StdOut.Should().Contain("Failing in NETCOREAPP1.1");
         }
 
         private string GetNotSoLongBuildBasePath()

--- a/test/dotnet-test.Tests/GivenThatWeWantToRunTestsForMultipleTFMsInTheConsole.cs
+++ b/test/dotnet-test.Tests/GivenThatWeWantToRunTestsForMultipleTFMsInTheConsole.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
             var result = testCommand
                 .ExecuteWithCapturedOutput($"{_projectFilePath} -f netcoreapp1.1");
             result.Should().Pass();
-            result.StdOut.Should().Contain($"Skipped for netcoreapp1.1");
+            result.StdOut.Should().Contain($"Skipped for NETCOREAPP1.1");
             result.StdOut.Should().NotContain($"Skipped for NET451");
         }
 
@@ -91,14 +91,14 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         }
 
         [Fact]
-        public void It_skips_build_when_the_no_build_flag_is_passed_for_netcoreapp10()
+        public void It_skips_build_when_the_no_build_flag_is_passed_for_netcoreapp11()
         {
             var buildCommand = new BuildCommand(_projectFilePath);
             var result = buildCommand.Execute($"-f netcoreapp1.1 -o {_defaultNetCoreAppOutputPath}");
             result.Should().Pass();
 
             var testCommand = new DotnetTestCommand();
-            result = testCommand.Execute($"{_projectFilePath} -f netcoreapp10 -o {_defaultNetCoreAppOutputPath} --no-build");
+            result = testCommand.Execute($"{_projectFilePath} -f netcoreapp1.1 -o {_defaultNetCoreAppOutputPath} --no-build");
             result.Should().Pass();
         }
 

--- a/test/dotnet-test.Tests/GivenThatWeWantToRunTestsInTheConsole.cs
+++ b/test/dotnet-test.Tests/GivenThatWeWantToRunTestsInTheConsole.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
             // unless we re-restore
             new RestoreCommand() { WorkingDirectory = testInstance.TestRoot }.Execute().Should().Pass();
 
-            _defaultOutputPath = Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.0");
+            _defaultOutputPath = Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.1");
         }
 
         //ISSUE https://github.com/dotnet/cli/issues/1935
@@ -72,7 +72,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         {
             var testCommand = new DotnetTestCommand();
             var result = testCommand.Execute(
-                $"{_projectFilePath} -o {Path.Combine(AppContext.BaseDirectory, "output")} -f netcoreapp1.0");
+                $"{_projectFilePath} -o {Path.Combine(AppContext.BaseDirectory, "output")} -f netcoreapp1.1");
             result.Should().Pass();
         }
 

--- a/test/dotnet-test.Tests/GivenThatWeWantToUseDotnetTestE2EInDesignTime.cs
+++ b/test/dotnet-test.Tests/GivenThatWeWantToUseDotnetTestE2EInDesignTime.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
             // unless we re-restore
             new RestoreCommand() { WorkingDirectory = testInstance.TestRoot }.Execute().Should().Pass();
 
-            _outputPath = Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.0");
+            _outputPath = Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.1");
             var buildCommand = new BuildCommand(_projectFilePath);
             var result = buildCommand.Execute();
 

--- a/test/dotnet-test.Tests/GivenThatWeWantToUseDotnetTestE2EInDesignTimeForMultipleTFms.cs
+++ b/test/dotnet-test.Tests/GivenThatWeWantToUseDotnetTestE2EInDesignTimeForMultipleTFms.cs
@@ -34,9 +34,9 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
             // unless we re-restore
             new RestoreCommand() { WorkingDirectory = testInstance.TestRoot }.Execute().Should().Pass();
 
-            _netCoreAppOutputPath = Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.0");
+            _netCoreAppOutputPath = Path.Combine(testInstance.TestRoot, "bin", "Debug", "netcoreapp1.1");
             var buildCommand = new BuildCommand(_projectFilePath);
-            var result = buildCommand.Execute($"-f netcoreapp1.0 -o {_netCoreAppOutputPath}");
+            var result = buildCommand.Execute($"-f netcoreapp1.1 -o {_netCoreAppOutputPath}");
 
             result.Should().Pass();
 
@@ -59,7 +59,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                 adapter.Listen();
 
                 var testCommand = new DotnetTestCommand();
-                var result = testCommand.Execute($"{_projectFilePath} -f netcoreapp1.0 -o {_netCoreAppOutputPath} --port {adapter.Port} --no-build");
+                var result = testCommand.Execute($"{_projectFilePath} -f netcoreapp1.1 -o {_netCoreAppOutputPath} --port {adapter.Port} --no-build");
                 result.Should().Pass();
 
                 adapter.Messages["TestSession.Connected"].Count.Should().Be(1);
@@ -98,7 +98,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
                 adapter.Listen();
 
                 var testCommand = new DotnetTestCommand();
-                var result = testCommand.Execute($"{_projectFilePath} -f netcoreapp1.0 -o {_netCoreAppOutputPath} --port {adapter.Port} --no-build");
+                var result = testCommand.Execute($"{_projectFilePath} -f netcoreapp1.1 -o {_netCoreAppOutputPath} --port {adapter.Port} --no-build");
                 result.Should().Pass();
 
                 adapter.Messages["TestSession.Connected"].Count.Should().Be(1);

--- a/test/dotnet-test.Tests/project.json
+++ b/test/dotnet-test.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Newtonsoft.Json": "9.0.1",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
@@ -15,14 +15,14 @@
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
-    "System.Net.NameResolution": "4.3.0-preview1-24530-04",
-    "System.Net.Sockets": "4.3.0-preview1-24530-04",
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Net.NameResolution": "4.3.0-preview1-24626-02",
+    "System.Net.Sockets": "4.3.0-preview1-24626-02",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dotnet5.4",
         "portable-net451+win8"

--- a/test/dotnet-test.UnitTests/GivenATestCommand.cs
+++ b/test/dotnet-test.UnitTests/GivenATestCommand.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         [Fact]
         public void It_creates_a_runner_if_the_args_do_no_include_help()
         {
-            var result = _testCommand.DoRun(new[] { ProjectJsonPath, "-f", "netcoreapp1.0" });
+            var result = _testCommand.DoRun(new[] { ProjectJsonPath, "-f", "netcoreapp1.1" });
 
             result.Should().Be(0);
             _dotnetTestRunnerFactoryMock.Verify(d => d.Create(It.IsAny<int?>()), Times.Once);
@@ -59,7 +59,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         [Fact]
         public void It_runs_the_tests_through_the_DotnetTestRunner()
         {
-            var result = _testCommand.DoRun(new[] { ProjectJsonPath, "-f", "netcoreapp1.0" });
+            var result = _testCommand.DoRun(new[] { ProjectJsonPath, "-f", "netcoreapp1.1" });
 
             _dotnetTestRunnerMock.Verify(
                 d => d.RunTests(It.IsAny<ProjectContext>(), It.IsAny<DotnetTestParams>(), It.IsAny<BuildWorkspace>()),

--- a/test/dotnet-test.UnitTests/GivenThatWeWantToParseArgumentsForDotnetTest.cs
+++ b/test/dotnet-test.UnitTests/GivenThatWeWantToParseArgumentsForDotnetTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
     public class GivenThatWeWantToParseArgumentsForDotnetTest
     {
         private const string ProjectJson = "project.json";
-        private const string Framework = "netcoreapp1.0";
+        private const string Framework = "netcoreapp1.1";
         private const string Output = "some output";
         private const string BuildBasePath = "some build base path";
         private const string Config = "some config";
@@ -108,7 +108,7 @@ namespace Microsoft.Dotnet.Tools.Test.Tests
         [Fact]
         public void It_converts_the_framework_to_NugetFramework()
         {
-            _dotnetTestFullParams.Framework.DotNetFrameworkName.Should().Be(".NETCoreApp,Version=v1.0");
+            _dotnetTestFullParams.Framework.DotNetFrameworkName.Should().Be(".NETCoreApp,Version=v1.1");
         }
 
         [Fact]

--- a/test/dotnet-test.UnitTests/project.json
+++ b/test/dotnet-test.UnitTests/project.json
@@ -3,14 +3,14 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
     "Newtonsoft.Json": "9.0.1",
     "dotnet": {
       "target": "project"
     },
     "Microsoft.Win32.Registry": {
-      "version": "4.3.0-preview1-24530-04",
+      "version": "4.3.0-preview1-24626-02",
       "exclude": "Compile"
     },
     "xunit": "2.1.0",
@@ -19,7 +19,7 @@
     "FluentAssertions": "4.2.2"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "netstandardapp1.5",
         "dotnet5.4",

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Tests
                 var projectOutputPath = $"AppWithDirectDependencyDesktopAndPortable\\bin\\Debug\\net451\\{rid}\\dotnet-desktop-and-portable.exe";
                 return new[]
                 {
-                    new object[] { ".NETCoreApp,Version=v1.0", "CoreFX", "lib\\netcoreapp1.0\\dotnet-desktop-and-portable.dll", true },
+                    new object[] { ".NETCoreApp,Version=v1.1", "CoreFX", "lib\\netcoreapp1.1\\dotnet-desktop-and-portable.dll", true },
                     new object[] { ".NETFramework,Version=v4.5.1", "NetFX", projectOutputPath, true }
                 };
             }
@@ -94,7 +94,7 @@ namespace Microsoft.DotNet.Tests
         public void CanInvokeToolFromDirectDependenciesIfPackageNameDifferentFromToolName()
         {
             var appDirectory = Path.Combine(_testProjectsRoot, "AppWithDirectDependencyWithOutputName");
-            const string framework = ".NETCoreApp,Version=v1.0";
+            const string framework = ".NETCoreApp,Version=v1.1";
 
             new BuildCommand(Path.Combine(appDirectory, "project.json"))
                 .Execute()

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Tests
                 var projectOutputPath = $"AppWithDirectDependencyDesktopAndPortable\\bin\\Debug\\net451\\{rid}\\dotnet-desktop-and-portable.exe";
                 return new[]
                 {
-                    new object[] { ".NETCoreApp,Version=v1.1", "CoreFX", "lib\\netcoreapp1.1\\dotnet-desktop-and-portable.dll", true },
+                    new object[] { ".NETCoreApp,Version=v1.1", "CoreFX", "lib\\netcoreapp1.0\\dotnet-desktop-and-portable.dll", true },
                     new object[] { ".NETFramework,Version=v4.5.1", "NetFX", projectOutputPath, true }
                 };
             }

--- a/test/dotnet.Tests/project.json
+++ b/test/dotnet.Tests/project.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.1.0-preview1-001100-00"
+      "version": "1.1.0-preview1-001153-00"
     },
-    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24530-04",
+    "System.Runtime.Serialization.Primitives": "4.3.0-preview1-24626-02",
     "Microsoft.DotNet.Tools.Tests.Utilities": {
       "target": "project"
     },
@@ -20,7 +20,7 @@
     "dotnet-test-xunit": "1.0.0-rc2-192208-24"
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "netstandardapp1.5",
         "dotnet5.4",

--- a/tools/Archiver/project.json
+++ b/tools/Archiver/project.json
@@ -12,9 +12,9 @@
     "Microsoft.DotNet.Archive": {
       "target": "project"
     },
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00"
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00"
   },
   "frameworks": {
-    "netcoreapp1.0": {}
+    "netcoreapp1.1": {}
   }
 }

--- a/tools/MultiProjectValidator/project.json
+++ b/tools/MultiProjectValidator/project.json
@@ -5,7 +5,7 @@
     "emitEntryPoint": true
   },
   "dependencies": {
-    "Microsoft.NETCore.App": "1.1.0-preview1-001100-00",
+    "Microsoft.NETCore.App": "1.1.0-preview1-001153-00",
     "Microsoft.DotNet.ProjectModel": {
       "target": "project"
     },
@@ -14,7 +14,7 @@
     }
   },
   "frameworks": {
-    "netcoreapp1.0": {
+    "netcoreapp1.1": {
       "imports": [
         "dnxcore50"
       ]


### PR DESCRIPTION
I'm not yet able to get a fully clean test build on my machine yet, but I'm close. Some of the failures are the same incremental build test failures I saw last time (the tests are fundamentally broken), so I am going to submit here to see what test cases are legitimately failing on CI. On my box, all of the tests except for a handful in `dotnet-build.Tests` are passing.

@livarcocc @piotrpMSFT 