### PR TITLE
Avoid putting non-reference assemblies from shared framework into refs on publish

### DIFF
--- a/test/dotnet-publish.Tests/PublishPortableTests.cs
+++ b/test/dotnet-publish.Tests/PublishPortableTests.cs
@@ -96,8 +96,10 @@ namespace Microsoft.DotNet.Tools.Publish.Tests
             publishCommand.GetOutputDirectory(true).Should().HaveFile("PortableAppCompilationContext.dll");
 
             var refsDirectory = new DirectoryInfo(Path.Combine(publishCommand.GetOutputDirectory(true).FullName, "refs"));
-            // Microsoft.CodeAnalysis.CSharp is IL only
+            // Microsoft.CodeAnalysis.CSharp is IL only direct reference
             refsDirectory.Should().NotHaveFile("Microsoft.CodeAnalysis.CSharp.dll");
+            // System.Diagnostics.DiagnosticSource is IL only shared framework dependency
+            refsDirectory.Should().NotHaveFile("System.Diagnostics.DiagnosticSource.dll");
             // System.IO has facede
             refsDirectory.Should().HaveFile("System.IO.dll");
             // Libraries in which lib==ref should be deduped


### PR DESCRIPTION
Right now we copy assemblies to `refs` folder even if they are not reference assemblies and are included into shared framework which causes unnecessary duplication.  

DependencyModel has support for falling back to shared framework directory when searching for compilation references so this fix would not require any changes to it.

@davidfowl @DamianEdwards @eerhardt 
