### PR TITLE
Migrating project with OutputName

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
@@ -104,6 +104,11 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                 @"$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml",
                 compilerOptions => compilerOptions.GenerateXmlDocumentation != null && compilerOptions.GenerateXmlDocumentation.Value);
 
+        private AddPropertyTransform<CommonCompilerOptions> AssemblyNameTransform =>
+            new AddPropertyTransform<CommonCompilerOptions>("AssemblyName",
+                compilerOptions => compilerOptions.OutputName,
+                compilerOptions => compilerOptions.OutputName != null);
+
         private IncludeContextTransform CompileFilesTransform =>
             new IncludeContextTransform("Compile", transformMappings: false);
 
@@ -171,7 +176,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                 DebugTypeTransform,
                 XmlDocTransform,
                 XmlDocTransformFilePath,
-                PreserveCompilationContextTransform
+                PreserveCompilationContextTransform,
+                AssemblyNameTransform
             };
 
             _propertyTransforms.AddRange(EmitEntryPointTransforms);

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/SaveOutputProjectRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/SaveOutputProjectRule.cs
@@ -8,11 +8,18 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
 {
     internal class SaveOutputProjectRule : IMigrationRule
     {
+        private static string GetContainingFolderName(string projectDirectory)
+        {
+            projectDirectory = projectDirectory.TrimEnd(new char[] { '/', '\\' });
+            return Path.GetFileName(projectDirectory);
+        }
+
         public void Apply(MigrationSettings migrationSettings, MigrationRuleInputs migrationRuleInputs)
         {
             var outputName = migrationRuleInputs.DefaultProjectContext.GetProjectName();
 
-            var outputProject = Path.Combine(migrationSettings.OutputDirectory, outputName + ".csproj");
+            string csprojName = $"{GetContainingFolderName(migrationSettings.ProjectDirectory)}.csproj";
+            var outputProject = Path.Combine(migrationSettings.OutputDirectory, csprojName);
 
             migrationRuleInputs.OutputMSBuildProject.Save(outputProject);
         }

--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
@@ -390,6 +390,31 @@ namespace Microsoft.DotNet.Migration.Tests
             VerifyAllMSBuildOutputsRunnable(projectDirectory);
         }
 
+        [Fact]
+        public void It_migrates_project_with_output_name()
+        {
+            string projectName = "AppWithOutputAssemblyName";
+            string expectedOutputName = "MyApp";
+
+            var projectDirectory = TestAssetsManager.CreateTestInstance(projectName, callingMethod: $"It_migrates_{projectName}")
+                .WithLockFiles()
+                .Path;
+            
+            string expectedCsprojPath = Path.Combine(projectDirectory, $"{projectName}.csproj");
+            if (File.Exists(expectedCsprojPath))
+            {
+                File.Delete(expectedCsprojPath);
+            }
+
+            CleanBinObj(projectDirectory);
+            MigrateProject(projectDirectory);
+            File.Exists(expectedCsprojPath).Should().BeTrue();
+            Restore(projectDirectory, projectName);
+            BuildMSBuild(projectDirectory, projectName);
+            Directory.EnumerateFiles(Path.Combine(projectDirectory, "bin"), $"{expectedOutputName}.pdb", SearchOption.AllDirectories)
+                .Count().Should().Be(1);
+        }
+
         private void VerifyAutoInjectedDesktopReferences(string projectDirectory, string projectName, bool shouldBePresent)
         {
             if (projectName != null)
@@ -536,7 +561,7 @@ namespace Microsoft.DotNet.Migration.Tests
             result.Should().Pass();
         }
 
-        private void MigrateProject(string[] migrateArgs)
+        private void MigrateProject(params string[] migrateArgs)
         {
             var result =
                 MigrateCommand.Run(migrateArgs);


### PR DESCRIPTION
new behavior of outputName as per https://github.com/dotnet/cli/issues/4506
- (PJ) outputName -> (CSPROJ) AssemblyName
- .../<dirname>/project.json -> <dirname>.csproj

