### PR TITLE
Custom logger for MSBuild to receive telemetry events

### DIFF
--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -97,7 +97,7 @@
 
     <!-- Workaround for https://github.com/dotnet/sdk/issues/115 -->
     <ItemGroup>
-      <HackFilesToCopy Include="$(NuGetPackagesDir)\microsoft.build.runtime\15.1.319-preview5\contentFiles\any\netcoreapp1.0\**;$(NuGetPackagesDir)\microsoft.codeanalysis.build.tasks\2.0.0-beta6-60922-08\contentFiles\any\any\**;" />
+      <HackFilesToCopy Include="$(NuGetPackagesDir)\microsoft.build.runtime\15.1.0-preview-000370-00\contentFiles\any\netcoreapp1.0\**;$(NuGetPackagesDir)\microsoft.codeanalysis.build.tasks\2.0.0-beta6-60922-08\contentFiles\any\any\**;" />
     </ItemGroup>
     <Copy SourceFiles="@(HackFilesToCopy)"
           DestinationFiles="@(HackFilesToCopy->'$(SdkOutputDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" />

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -37,7 +37,7 @@
       <Version>4.0.0-rc-2037</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core">
-      <Version>0.1.0-preview-00043-160929</Version>
+      <Version>15.1.0-preview-000370-00</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions">
       <Version>1.0.1-beta-000933</Version>

--- a/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -36,10 +36,10 @@
       <Version>4.0.0-rc-2037</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
-      <Version>15.1.319-preview5</Version>
+      <Version>15.1.0-preview-000370-00</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core">
-      <Version>15.1.319-preview5</Version>
+      <Version>15.1.0-preview-000370-00</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -13,8 +13,8 @@
     "NuGet.Frameworks": "4.0.0-rc-2037",
     "NuGet.ProjectModel": "4.0.0-rc-2037",
 
-    "Microsoft.Build": "15.1.0-preview-000366-00",
-    "Microsoft.Build.Utilities.Core": "15.1.0-preview-000366-00"
+    "Microsoft.Build": "15.1.0-preview-000370-00",
+    "Microsoft.Build.Utilities.Core": "15.1.0-preview-000370-00"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
-      <Version>15.1.319-preview5</Version>
+      <Version>15.1.0-preview-000370-00</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
       <Version>2.0.0-beta6-60922-08</Version>

--- a/src/Microsoft.DotNet.ProjectJsonMigration/project.json
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/project.json
@@ -11,7 +11,7 @@
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-    "Microsoft.Build": "15.1.0-preview-000366-00",
+    "Microsoft.Build": "15.1.0-preview-000370-00",
     "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60922-08"
   },
   "frameworks": {

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Configurer;
+
+namespace Microsoft.DotNet.Tools.MSBuild
+{
+    public sealed class MSBuildLogger : Logger
+    {
+        private readonly INuGetCacheSentinel _sentinel = new NuGetCacheSentinel();
+        private readonly ITelemetry _telemetry;
+
+        public MSBuildLogger()
+        {
+            string sessionId = Environment.GetEnvironmentVariable(MSBuildForwardingApp.TelemetrySessionIdEnvironmentVariableName);
+
+            if (sessionId != null)
+            {
+                _telemetry = new Telemetry(_sentinel, sessionId);
+            }
+        }
+
+        public override void Initialize(IEventSource eventSource)
+        {
+            if (_telemetry != null)
+            {
+                IEventSource2 eventSource2 = eventSource as IEventSource2;
+
+                if (eventSource2 != null)
+                {
+                    eventSource2.TelemetryLogged += (sender, telemetryEventArgs) =>
+                    {
+                        Console.WriteLine($"Received telemetry event '{telemetryEventArgs.EventName}'");
+                        _telemetry.TrackEvent(telemetryEventArgs.EventName, telemetryEventArgs.Properties, measurements: null);
+                    };
+                }
+            }
+        }
+
+        public override void Shutdown()
+        {
+            _sentinel?.Dispose();
+
+            base.Shutdown();
+        }
+    }
+}

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -62,7 +62,7 @@
       <IncludeAssets>Analyzers;Build;ContentFiles;Native;Runtime</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
-      <Version>15.1.319-preview5</Version>
+      <Version>15.1.0-preview-000370-00</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
       <Version>2.0.0-beta6-60922-08</Version>

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -57,7 +57,7 @@
       "exclude": "compile"
     },
 
-    "Microsoft.Build": "15.1.0-preview-000366-00",
+    "Microsoft.Build": "15.1.0-preview-000370-00",
     "Microsoft.CodeAnalysis.CSharp": "2.0.0-beta6-60922-08",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933"
   },

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -19,7 +19,7 @@
     "tool_nuget": "1.0.0-preview3-*",
     "tool_msbuild": "1.0.0-preview3-*",
 
-    "Microsoft.Build.Runtime": "15.1.0-preview-000366-00",
+    "Microsoft.Build.Runtime": "15.1.0-preview-000370-00",
     "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60922-08",
     "System.Runtime.Serialization.Xml": "4.1.1",
     "NuGet.Build.Tasks": "4.0.0-rc-2037",

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -21,7 +21,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Runtime">
-      <Version>15.1.319-preview5</Version>
+      <Version>15.1.0-preview-000370-00</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks">
       <Version>2.0.0-beta6-60922-08</Version>

--- a/src/tool_msbuild/project.json
+++ b/src/tool_msbuild/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "Microsoft.Build.Runtime": "15.1.0-preview-000366-00",
+    "Microsoft.Build.Runtime": "15.1.0-preview-000370-00",
     "Microsoft.Net.Compilers.netcore": "2.0.0-beta6-60922-08",
     "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60922-08",
     "Microsoft.Cci": "4.0.0-rc3-24128-00",

--- a/src/tool_msbuild/tool_msbuild.csproj
+++ b/src/tool_msbuild/tool_msbuild.csproj
@@ -14,7 +14,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Runtime">
-      <Version>15.1.319-preview5</Version>
+      <Version>15.1.0-preview-000370-00</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Net.Compilers.netcore">
       <Version>2.0.0-beta6-60922-08</Version>

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -44,7 +44,7 @@
     "xunit": "2.2.0-beta3-build3330",
     "dotnet-test-xunit": "1.0.0-rc2-350904-49",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
-    "Microsoft.Build.Runtime": "15.1.0-preview-000366-00"
+    "Microsoft.Build.Runtime": "15.1.0-preview-000370-00"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/dotnet-new.Tests/project.json
+++ b/test/dotnet-new.Tests/project.json
@@ -11,7 +11,7 @@
     "dotnet": {
       "target": "project"
     },
-    "Microsoft.Build": "15.1.0-preview-000366-00",
+    "Microsoft.Build": "15.1.0-preview-000370-00",
     "xunit": "2.2.0-beta3-build3330",
     "dotnet-test-xunit": "1.0.0-rc2-350904-49"
   },

--- a/tools/MigrationDefaultsConstructor/MigrationDefaultsConstructor.csproj
+++ b/tools/MigrationDefaultsConstructor/MigrationDefaultsConstructor.csproj
@@ -15,7 +15,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Runtime">
-      <Version>15.1.319-preview5</Version>
+      <Version>15.1.0-preview-000370-00</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/tools/MigrationDefaultsConstructor/project.json
+++ b/tools/MigrationDefaultsConstructor/project.json
@@ -15,7 +15,7 @@
         "dotnet": {
           "target": "project"
         },
-        "Microsoft.Build.Runtime": "15.1.0-preview-000366-00"
+        "Microsoft.Build.Runtime": "15.1.0-preview-000370-00"
       },
       "imports": ["dnxcore50", "portable-net45+win8"]
     }


### PR DESCRIPTION
1. Upgraded MSBuild version to latest
2. Had to make the telemetry session ID a static variable so that the forwarding app could use it.
3. Simple Logger implementation that forwards telemetry events to the `Telemetry` pipeline

Best to look at 27458107daec6c1158fe5481b7927528f8395db5 since it doesn't have the MSBuild version upgrade.  I've tested this all manually and will be writing tests after everyone signs off on the implementation here.  How can I find the events in the back-end?  Any place where an exception could occur, I'm just ignoring it so that telemetry related stuff never fails an operation.  Should I trace something instead?

@piotrpMSFT @livarcocc @rainersigwald @cdmihai 