### PR TITLE
When Library add reference to NETStandardLib if not present

### DIFF
--- a/TestAssets/TestProjects/LibraryWithNetStandardLibRef/.noautobuild
+++ b/TestAssets/TestProjects/LibraryWithNetStandardLibRef/.noautobuild
@@ -1,0 +1,1 @@
+noautobuild

--- a/TestAssets/TestProjects/LibraryWithNetStandardLibRef/Program.cs
+++ b/TestAssets/TestProjects/LibraryWithNetStandardLibRef/Program.cs
@@ -1,0 +1,5 @@
+using System;
+
+class Program
+{
+}

--- a/TestAssets/TestProjects/LibraryWithNetStandardLibRef/project.json
+++ b/TestAssets/TestProjects/LibraryWithNetStandardLibRef/project.json
@@ -1,0 +1,10 @@
+{
+  "frameworks": {
+    "netstandard1.3": {
+        "dependencies": {
+            "System.AppContext": "4.1.0",
+            "NETStandard.Library": "1.5.0"
+        }
+    }
+  }
+}

--- a/TestAssets/TestProjects/LibraryWithoutNetStandardLibRef/.noautobuild
+++ b/TestAssets/TestProjects/LibraryWithoutNetStandardLibRef/.noautobuild
@@ -1,0 +1,1 @@
+noautobuild

--- a/TestAssets/TestProjects/LibraryWithoutNetStandardLibRef/Program.cs
+++ b/TestAssets/TestProjects/LibraryWithoutNetStandardLibRef/Program.cs
@@ -1,0 +1,5 @@
+using System;
+
+class Program
+{
+}

--- a/TestAssets/TestProjects/LibraryWithoutNetStandardLibRef/project.json
+++ b/TestAssets/TestProjects/LibraryWithoutNetStandardLibRef/project.json
@@ -1,0 +1,9 @@
+{
+  "frameworks": {
+    "netstandard1.3": {
+        "dependencies": {
+            "System.AppContext": "4.1.0"
+        }
+    }
+  }
+}

--- a/src/Microsoft.DotNet.ProjectJsonMigration/PackageConstants.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/PackageConstants.cs
@@ -19,6 +19,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration
         public const string TestSdkPackageName = "Microsoft.NET.Test.Sdk";
         public const string XUnitPackageName = "xunit";
         public const string XUnitRunnerPackageName = "xunit.runner.visualstudio";
+        public const string NetStandardPackageName = "NETStandard.Library";
+        public const string NetStandardPackageVersion = "1.6.0";
 
         public static readonly IDictionary<string, PackageDependencyInfo> ProjectDependencyPackages = 
             new Dictionary<string, PackageDependencyInfo> {

--- a/src/Microsoft.DotNet.ProjectJsonMigration/ProjectType.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/ProjectType.cs
@@ -3,7 +3,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration
     internal enum ProjectType
     {
         Console,
-        Web,
-        Test
+        Library,
+        Test,
+        Web
     }
 }

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
@@ -136,6 +136,21 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                             mergeExisting: false);
                     }
                     break;
+                case ProjectType.Library:
+                    if (!project.HasDependency(
+                        (dep) => dep.Name.Trim().ToLower() == PackageConstants.NetStandardPackageName.ToLower()))
+                    {
+                        _transformApplicator.Execute(
+                            PackageDependencyInfoTransform().Transform(
+                                new PackageDependencyInfo
+                                {
+                                    Name = PackageConstants.NetStandardPackageName,
+                                    Version = PackageConstants.NetStandardPackageVersion
+                                }),
+                            noFrameworkPackageReferenceItemGroup,
+                            mergeExisting: true);
+                    }
+                    break;
                 default:
                     break;
             }

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateAspNetTools.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateAspNetTools.cs
@@ -44,7 +44,10 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
                     }
                 }");
 
-            var packageRef = mockProj.Items.Where(i => i.Include != "Microsoft.NET.Sdk" && i.ItemType == "PackageReference").Should().BeEmpty();
+            var packageRef = mockProj.Items.Where(i =>
+                i.Include != "Microsoft.NET.Sdk" &&
+                i.Include != "NETStandard.Library" &&
+                i.ItemType == "PackageReference").Should().BeEmpty();
         }
 
         [Theory]

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackageDependencies.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackageDependencies.cs
@@ -347,6 +347,36 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
                       i.GetMetadataWithName("Version").Value == "2.2.0-beta4-build1188"));
         }
 
+        [Theory]
+        [InlineData(@"
+            {
+              ""frameworks"": {
+                ""netstandard1.3"": {
+                    ""dependencies"": {
+                        ""System.AppContext"": ""4.1.0"",
+                        ""NETStandard.Library"": ""1.5.0""
+                    }
+                }
+              }
+            }")]
+        [InlineData(@"
+            {
+              ""frameworks"": {
+                ""netstandard1.3"": {
+                    ""dependencies"": {
+                        ""System.AppContext"": ""4.1.0""
+                    }
+                }
+              }
+            }")]
+        public void It_migrates_library_and_does_not_double_netstandard_ref(string pjContent)
+        {
+            var mockProj = RunPackageDependenciesRuleOnPj(pjContent);
+
+            mockProj.Items.Should().ContainSingle(
+                i => (i.Include == "NETStandard.Library" && i.ItemType == "PackageReference"));
+        }
+
         private void EmitsPackageReferences(ProjectRootElement mockProj, params Tuple<string, string, string>[] packageSpecs)
         {
             foreach (var packageSpec in packageSpecs)

--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
@@ -423,6 +423,19 @@ namespace Microsoft.DotNet.Migration.Tests
                 .Count().Should().Be(1);
         }
 
+        [Theory]
+        [InlineData("LibraryWithoutNetStandardLibRef")]
+        [InlineData("LibraryWithNetStandardLibRef")]
+        public void It_migrates_and_builds_library(string projectName)
+        {
+            var projectDirectory = TestAssetsManager.CreateTestInstance(projectName,
+                callingMethod: $"{nameof(It_migrates_and_builds_library)}-projectName").Path;
+
+            MigrateProject(projectDirectory);
+            Restore(projectDirectory, projectName);
+            BuildMSBuild(projectDirectory, projectName);
+        }
+
         private void VerifyAutoInjectedDesktopReferences(string projectDirectory, string projectName, bool shouldBePresent)
         {
             if (projectName != null)


### PR DESCRIPTION
Fix https://github.com/dotnet/cli/issues/4547

When NetStandardLibrary ref not present explicitly in project.json (i.e. present through transient dep) the generated msbuild was causing build errors

cc: @livarcocc