### PR TITLE
Some unit tests for MSBuild telemetry

### DIFF
--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -33,9 +33,16 @@ namespace Microsoft.DotNet.Tools.MSBuild
         {
             if (Telemetry.CurrentSessionId != null)
             {
-                Type loggerType = typeof(MSBuildLogger);
-                
-                argsToForward = argsToForward.Concat(new[] {$"\"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location};{Telemetry.CurrentSessionId}\""});
+                try
+                {
+                    Type loggerType = typeof(MSBuildLogger);
+
+                    argsToForward = argsToForward.Concat(new[] { $"\"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}\"" });
+                }
+                catch (Exception)
+                {
+                    // Exceptions during telemetry shouldn't cause anything else to fail
+                }
             }
 
             _forwardingApp = new ForwardingApp(

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
                     argsToForward = argsToForward.Concat(new[]
                     {
-                        $"\"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}\""
+                        $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
                     });
                 }
                 catch (Exception)

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -37,7 +37,10 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 {
                     Type loggerType = typeof(MSBuildLogger);
 
-                    argsToForward = argsToForward.Concat(new[] { $"\"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}\"" });
+                    argsToForward = argsToForward.Concat(new[]
+                    {
+                        $"\"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}\""
+                    });
                 }
                 catch (Exception)
                 {

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -18,7 +18,8 @@ namespace Microsoft.DotNet.Tools.MSBuild
         {
             try
             {
-                string sessionId = Environment.GetEnvironmentVariable(MSBuildForwardingApp.TelemetrySessionIdEnvironmentVariableName);
+                string sessionId = 
+                    Environment.GetEnvironmentVariable(MSBuildForwardingApp.TelemetrySessionIdEnvironmentVariableName);
 
                 if (sessionId != null)
                 {

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.Cli;
-using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 
 namespace Microsoft.DotNet.Tools.MSBuild
@@ -17,34 +16,56 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         public MSBuildLogger()
         {
-            string sessionId = Environment.GetEnvironmentVariable(MSBuildForwardingApp.TelemetrySessionIdEnvironmentVariableName);
-
-            if (sessionId != null)
+            try
             {
-                _telemetry = new Telemetry(_sentinel, sessionId);
+                string sessionId = Environment.GetEnvironmentVariable(MSBuildForwardingApp.TelemetrySessionIdEnvironmentVariableName);
+
+                if (sessionId != null)
+                {
+                    _telemetry = new Telemetry(_sentinel, sessionId);
+                }
+            }
+            catch (Exception)
+            {
+                // Exceptions during telemetry shouldn't cause anything else to fail
             }
         }
 
         public override void Initialize(IEventSource eventSource)
         {
-            if (_telemetry != null)
+            try
             {
-                IEventSource2 eventSource2 = eventSource as IEventSource2;
-
-                if (eventSource2 != null)
+                if (_telemetry != null && _telemetry.Enabled)
                 {
-                    eventSource2.TelemetryLogged += (sender, telemetryEventArgs) =>
+                    IEventSource2 eventSource2 = eventSource as IEventSource2;
+
+                    if (eventSource2 != null)
                     {
-                        Console.WriteLine($"Received telemetry event '{telemetryEventArgs.EventName}'");
-                        _telemetry.TrackEvent(telemetryEventArgs.EventName, telemetryEventArgs.Properties, measurements: null);
-                    };
+                        eventSource2.TelemetryLogged += OnTelemetryLogged;
+                    }
                 }
             }
+            catch(Exception)
+            {
+                // Exceptions during telemetry shouldn't cause anything else to fail
+            }
+        }
+
+        private void OnTelemetryLogged(object sender, TelemetryEventArgs args)
+        {
+            _telemetry.TrackEvent(args.EventName, args.Properties, measurements: null);
         }
 
         public override void Shutdown()
         {
-            _sentinel?.Dispose();
+            try
+            {
+                _sentinel?.Dispose();
+            }
+            catch (Exception)
+            {
+                // Exceptions during telemetry shouldn't cause anything else to fail
+            }
 
             base.Shutdown();
         }

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             allArgs.Should().NotBeNull();
 
             allArgs.Should().Contain(
-                value => value.StartsWith("\"/Logger:"),
+                value => value.IndexOf("/Logger", StringComparison.OrdinalIgnoreCase) >= 0,
                 "The MSBuild logger argument should be specified when telemetry is enabled.");
         }
 

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -84,7 +84,9 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             allArgs.Should().NotBeNull();
 
-            allArgs.Should().Contain(value => value.StartsWith("\"/Logger:"), "The MSBuild logger argument should be specified when telemetry is enabled.");
+            allArgs.Should().Contain(
+                value => value.StartsWith("\"/Logger:"),
+                "The MSBuild logger argument should be specified when telemetry is enabled.");
         }
 
         [Fact]
@@ -94,7 +96,9 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             allArgs.Should().NotBeNull();
 
-            allArgs.Should().NotContain(value => value.IndexOf("/Logger", StringComparison.OrdinalIgnoreCase) >= 0, $"The MSBuild logger argument should not be specified when telemetry is disabled.");
+            allArgs.Should().NotContain(
+                value => value.IndexOf("/Logger", StringComparison.OrdinalIgnoreCase) >= 0,
+                $"The MSBuild logger argument should not be specified when telemetry is disabled.");
         }
 
         private string[] GetArgsForMSBuild(Func<bool> sentinelExists)
@@ -103,11 +107,15 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             MSBuildForwardingApp msBuildForwardingApp = new MSBuildForwardingApp(Enumerable.Empty<string>());
 
-            FieldInfo forwardingAppFieldInfo = msBuildForwardingApp.GetType().GetField("_forwardingApp", BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo forwardingAppFieldInfo = msBuildForwardingApp
+                .GetType()
+                .GetField("_forwardingApp", BindingFlags.Instance | BindingFlags.NonPublic);
 
             ForwardingApp forwardingApp = forwardingAppFieldInfo?.GetValue(msBuildForwardingApp) as ForwardingApp;
 
-            FieldInfo allArgsFieldinfo = forwardingApp?.GetType().GetField("_allArgs", BindingFlags.Instance | BindingFlags.NonPublic);
+            FieldInfo allArgsFieldinfo = forwardingApp?
+                .GetType()
+                .GetField("_allArgs", BindingFlags.Instance | BindingFlags.NonPublic);
 
             return allArgsFieldinfo?.GetValue(forwardingApp) as string[];
         }

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -1,9 +1,17 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
 using FluentAssertions;
+using Microsoft.DotNet.Configurer;
+using Microsoft.DotNet.Tools.MSBuild;
 using Microsoft.DotNet.Tools.Test.Utilities;
+using NuGet.Protocol;
 using Xunit;
+using MSBuildCommand = Microsoft.DotNet.Tools.Test.Utilities.MSBuildCommand;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -57,7 +65,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             var result = new TestCommand("dotnet")
                 .WithWorkingDirectory(projectDirectory.Path)
                 .ExecuteWithCapturedOutput($"{commandName} --help");
-            
+
             result.ExitCode.Should().Be(0);
             if (isMSBuildCommand)
             {
@@ -69,5 +77,60 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             }
         }
 
+        [Fact]
+        public void WhenTelemetryIsEnabledTheLoggerIsAddedToTheCommandLine()
+        {
+            string[] allArgs = GetArgsForMSBuild(() => true);
+
+            allArgs.Should().NotBeNull();
+
+            allArgs.Should().Contain(value => value.StartsWith("\"/Logger:"), "The MSBuild logger argument should be specified when telemetry is enabled.");
+        }
+
+        [Fact]
+        public void WhenTelemetryIsDisabledTheLoggerIsNotAddedToTheCommandLine()
+        {
+            string[] allArgs = GetArgsForMSBuild(() => false);
+
+            allArgs.Should().NotBeNull();
+
+            allArgs.Should().NotContain(value => value.IndexOf("/Logger", StringComparison.OrdinalIgnoreCase) >= 0, $"The MSBuild logger argument should not be specified when telemetry is disabled.");
+        }
+
+        private string[] GetArgsForMSBuild(Func<bool> sentinelExists)
+        {
+            Telemetry telemetry = new Telemetry(new MockNuGetCacheSentinel(sentinelExists));
+
+            MSBuildForwardingApp msBuildForwardingApp = new MSBuildForwardingApp(Enumerable.Empty<string>());
+
+            FieldInfo forwardingAppFieldInfo = msBuildForwardingApp.GetType().GetField("_forwardingApp", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            ForwardingApp forwardingApp = forwardingAppFieldInfo?.GetValue(msBuildForwardingApp) as ForwardingApp;
+
+            FieldInfo allArgsFieldinfo = forwardingApp?.GetType().GetField("_allArgs", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            return allArgsFieldinfo?.GetValue(forwardingApp) as string[];
+        }
+    }
+
+    public sealed class MockNuGetCacheSentinel : INuGetCacheSentinel
+    {
+        private readonly Func<bool> _exists;
+
+        public MockNuGetCacheSentinel(Func<bool> exists = null)
+        {
+            _exists = exists ?? (() => true);
+        }
+        public void Dispose()
+        {
+        }
+
+        public bool InProgressSentinelAlreadyExists() => false;
+
+        public bool Exists() => _exists();
+
+        public void CreateIfNotExists()
+        {
+        }
     }
 }

--- a/test/dotnet-msbuild.Tests/project.json
+++ b/test/dotnet-msbuild.Tests/project.json
@@ -10,7 +10,10 @@
       "target": "project"
     },
     "xunit": "2.2.0-beta3-build3330",
-    "dotnet-test-xunit": "1.0.0-rc2-350904-49"
+    "dotnet-test-xunit": "1.0.0-rc2-350904-49",
+    "dotnet": {
+      "target": "project"
+    }
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
Also added a commit that I didn't push with the original PR which has some more try...catches.

The `MSBuildForwardingApp` is hard to test because it has a private `ForwardingApp` which has private arguments.  So I used reflection in order to verify the functionality.  The only other option I saw was to make stuff `internal` instead of `private` or expose some properties to just tests; both of which I wasn't sure if I was allowed to do.
