### PR TITLE
Forcing a new commit and a new build to pick up the latest sharedfx

### DIFF
--- a/Documentation/cli-prerequisites.md
+++ b/Documentation/cli-prerequisites.md
@@ -1,5 +1,5 @@
 CLI native prerequisites
-=========================
+========================
 
 This document outlines the dependencies needed to run .NET Core CLI tools. Most of these dependencies are also .NET Core's general dependencies, so installing them will make sure that you can run applications written for .NET Core in general.
 


### PR DESCRIPTION
Forcing a new commit and a new build to pick up the latest sharedfx packages.

The sharedfx packages have reved in place, all we need is to spin a new build to pick the new packages up. However, because of our commit count versioning, we need to add a "fake" commit to bump our own version.

cc @gkhanna79 @leecow @piotrpMSFT @jgoshi @krwq 