### PR TITLE
Marking hoisted P2P projects with a FromP2P attribute.

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/ProjectDependency.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/ProjectDependency.cs
@@ -7,11 +7,25 @@ namespace Microsoft.DotNet.ProjectJsonMigration
     {
         public string Name { get; }
         public string ProjectFilePath { get; }
+        public bool Hoisted { get; }
 
-        public ProjectDependency(string name, string projectFilePath)
+        public ProjectDependency(string name, string projectFilePath, bool hoisted)
         {
             Name = name;
             ProjectFilePath = System.IO.Path.GetFullPath(projectFilePath);
+            Hoisted = hoisted;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as ProjectDependency;
+
+            return other != null && other.ProjectFilePath == ProjectFilePath;
+        }
+
+        public override int GetHashCode()
+        {
+            return ProjectFilePath.GetHashCode();
         }
     }
 }

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateProjectDependencies.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateProjectDependencies.cs
@@ -250,6 +250,45 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Fact]
+        public void All_promoted_P2P_references_are_marked_with_a_FromP2P_attribute()
+        {
+            var expectedHoistedProjectReferences = new [] {
+                Path.Combine("..", "ProjectD", "ProjectD.csproj"),
+                Path.Combine("..", "ProjectE", "ProjectE.csproj"),
+                Path.Combine("..", "CsprojLibrary1", "CsprojLibrary1.csproj"),
+                Path.Combine("..", "CsprojLibrary2", "CsprojLibrary2.csproj"),
+                Path.Combine("..", "CsprojLibrary3", "CsprojLibrary3.csproj")
+            };
+
+            var mockProj = MigrateProject("TestAppDependencyGraph", "ProjectA");
+
+            var projectReferences = mockProj.Items
+                .Where(item =>
+                    item.ItemType == "ProjectReference" && item.GetMetadataWithName("FromP2P") != null)
+                .Select(i => i.Include);
+
+            projectReferences.Should().BeEquivalentTo(expectedHoistedProjectReferences);
+        }
+
+        [Fact]
+        public void All_non_promoted_P2P_references_are_not_marked_with_a_FromP2P_attribute()
+        {
+            var expectedNonHoistedProjectReferences = new [] {
+                Path.Combine("..", "ProjectB", "ProjectB.csproj"),
+                Path.Combine("..", "ProjectC", "ProjectC.csproj")
+            };
+
+            var mockProj = MigrateProject("TestAppDependencyGraph", "ProjectA");
+
+            var projectReferences = mockProj.Items
+                .Where(item =>
+                    item.ItemType == "ProjectReference" && item.GetMetadataWithName("FromP2P") == null)
+                .Select(i => i.Include);
+
+            projectReferences.Should().BeEquivalentTo(expectedNonHoistedProjectReferences);
+        }
+
+        [Fact]
         public void It_migrates_unqualified_dependencies_as_ProjectReference_when_a_matching_project_is_found()
         {
             var mockProj = MigrateProject("TestAppWithUnqualifiedDependencies", "ProjectA");


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/4596.

This is so that these hoisted projects can be easily removed once we add support for transitive P2P dependencies.

This is what the migrate csproj will look like regarding ProjectReferences:

```
<ItemGroup>
    <ProjectReference Include="../ProjectB/ProjectB.csproj" />
    <ProjectReference Include="../ProjectC/ProjectC.csproj" />
    <ProjectReference Include="../ProjectD/ProjectD.csproj">
      <FromP2P>true</FromP2P>
    </ProjectReference>
    <ProjectReference Include="../ProjectE/ProjectE.csproj">
      <FromP2P>true</FromP2P>
    </ProjectReference>
    <ProjectReference Include="../CsprojLibrary1/CsprojLibrary1.csproj">
      <FromP2P>true</FromP2P>
    </ProjectReference>
    <ProjectReference Include="../CsprojLibrary2/CsprojLibrary2.csproj">
      <FromP2P>true</FromP2P>
    </ProjectReference>
    <ProjectReference Include="../CsprojLibrary3/CsprojLibrary3.csproj">
      <FromP2P>true</FromP2P>
    </ProjectReference>
  </ItemGroup>
```

cc @piotrpMSFT @jgoshi @krwq 