### PR TITLE
Switching the archiver to be a portable app

### DIFF
--- a/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
+++ b/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
@@ -28,10 +28,9 @@
       <DotNetPublish ToolPath="$(Stage0Directory)"
                      WorkingDirectory="$(RepoRoot)/tools/Archiver"
                      Output="$(ToolsOutputDirectory)"
-                     Configuration="$(Configuration)"
-                     Runtime="$(CoreCLRRid)" />
+                     Configuration="$(Configuration)" />
 
-      <Exec Command="$(ArchiverExe) -a $(IntermediateArchive) $(NuGetPackagesArchiveFolder)" />
+      <Exec Command="$(DotnetStage0) $(ArchiverDll) -a $(IntermediateArchive) $(NuGetPackagesArchiveFolder)" />
 
       <Copy SourceFiles="$(IntermediateArchive)" DestinationFiles="$(FinalArchive)" />
     </Target>
@@ -41,7 +40,7 @@
       <PropertyGroup>
         <NuGetPackagesArchiveProject>$(IntermediateDirectory)/NuGetPackagesArchiveProject</NuGetPackagesArchiveProject>
         <NuGetPackagesArchiveFolder>$(IntermediateDirectory)/NuGetPackagesArchiveFolder</NuGetPackagesArchiveFolder>
-        <ArchiverExe>$(ToolsOutputDirectory)/Archiver</ArchiverExe>
+        <ArchiverDll>$(ToolsOutputDirectory)/Archiver.dll</ArchiverDll>
         <IntermediateArchive>$(IntermediateDirectory)/nuGetPackagesArchive.lzma</IntermediateArchive>
         <FinalArchive>$(Stage2Directory)/sdk/$(SdkVersion)/nuGetPackagesArchive.lzma</FinalArchive>
       </PropertyGroup>

--- a/src/dotnet/project.json
+++ b/src/dotnet/project.json
@@ -12,7 +12,8 @@
         "commands/dotnet-new/CSharp_Web.zip",
         "commands/dotnet-new/CSharp_nunittest.zip",
         "commands/dotnet-new/FSharp_Console.zip",
-        "commands/dotnet-new/FSharp_Lib.zip"
+        "commands/dotnet-new/FSharp_Lib.zip",
+        "commands/dotnet-new/CSharp_Mstest.zip"
       ]
     },
     "compile": {
@@ -24,7 +25,8 @@
         "commands/dotnet-new/CSharp_MSBuild/**",
         "commands/dotnet-new/FSharp_Lib/**",
         "commands/dotnet-new/CSharp_xunittest/**",
-        "commands/dotnet-new/CSharp_nunittest/**"
+        "commands/dotnet-new/CSharp_nunittest/**",
+        "commands/dotnet-new/CSharp_Mstest/**",
       ]
     }
   },


### PR DESCRIPTION
Switching the archiver to be a portable app to get around runtime specific issues with having two stage0.

We ran into build issues on windows because we were restoring the archiver without a runtime and then trying to publish it for a specific runtime. To fix this, I switched the archiver to be a portable app.

@piotrpMSFT @jgoshi @krwq 