### PR TITLE
Adding a tool migration for BundleMinifier.Core to move all version o…

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/ConstantPackageVersions.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/ConstantPackageVersions.cs
@@ -11,5 +11,6 @@ namespace Microsoft.DotNet.ProjectJsonMigration
         public const string XUnitRunnerPackageVersion = "2.2.0-beta4-build1188";
         public const string MstestTestAdapterVersion = "1.1.3-preview";
         public const string MstestTestFrameworkVersion = "1.0.4-preview";
+        public const string BundleMinifierToolVersion = "2.2.301";
     }
 }

--- a/src/Microsoft.DotNet.ProjectJsonMigration/PackageConstants.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/PackageConstants.cs
@@ -67,7 +67,10 @@ namespace Microsoft.DotNet.ProjectJsonMigration
                 { "Microsoft.Extensions.SecretManager.Tools", new PackageDependencyInfo {
                     Name = "Microsoft.Extensions.SecretManager.Tools",
                     Version = ConstantPackageVersions.AspNetToolsVersion } },
-                { "Microsoft.AspNetCore.Server.IISIntegration.Tools", null}
+                { "Microsoft.AspNetCore.Server.IISIntegration.Tools", null},
+                { "BundlerMinifier.Core", new PackageDependencyInfo {
+                    Name = "BundlerMinifier.Core",
+                    Version = ConstantPackageVersions.BundleMinifierToolVersion } }
         };
     }
 }

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateAspNetTools.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateAspNetTools.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         [InlineData("Microsoft.VisualStudio.Web.CodeGeneration.Tools", "Microsoft.VisualStudio.Web.CodeGeneration.Tools", ConstantPackageVersions.AspNetToolsVersion)]
         [InlineData("Microsoft.DotNet.Watcher.Tools", "Microsoft.DotNet.Watcher.Tools", ConstantPackageVersions.AspNetToolsVersion)]
         [InlineData("Microsoft.Extensions.SecretManager.Tools", "Microsoft.Extensions.SecretManager.Tools", ConstantPackageVersions.AspNetToolsVersion)]
+        [InlineData("BundlerMinifier.Core", "BundlerMinifier.Core", ConstantPackageVersions.BundleMinifierToolVersion)]
         public void It_migrates_asp_project_tools_to_a_new_name_and_version(
             string sourceToolName,
             string targetToolName,


### PR DESCRIPTION
Adding a tool migration for BundleMinifier.Core to move all version of the tool to 2.2.301 during migration.

Fixes https://github.com/dotnet/cli/issues/4605

@piotrpMSFT @jgoshi @krwq @barrytang @madskristensen 