### PR TITLE
update NuGet in CLI to 4.0.0.2048

### DIFF
--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
@@ -17,7 +17,7 @@
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-    "NuGet.Frameworks": "4.0.0-rc-2047"
+    "NuGet.Frameworks": "4.0.0-rc-2048"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/project.json
@@ -17,7 +17,7 @@
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },
-    "NuGet.Frameworks": "4.0.0-rc-2037"
+    "NuGet.Frameworks": "4.0.0-rc-2047"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -34,7 +34,7 @@
       <Version>6.2.2-preview</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine.XPlat">
-      <Version>4.0.0-rc-2047</Version>
+      <Version>4.0.0-rc-2048</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core">
       <Version>15.1.0-preview-000370-00</Version>

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -34,7 +34,7 @@
       <Version>6.2.2-preview</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine.XPlat">
-      <Version>4.0.0-rc-2037</Version>
+      <Version>4.0.0-rc-2047</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core">
       <Version>15.1.0-preview-000370-00</Version>

--- a/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -24,16 +24,16 @@
       <Version>1.0.1-beta-000933</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
-      <Version>4.0.0-rc-2037</Version>
+      <Version>4.0.0-rc-2047</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.0.0-rc-2037</Version>
+      <Version>4.0.0-rc-2047</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>4.0.0-rc-2037</Version>
+      <Version>4.0.0-rc-2047</Version>
     </PackageReference>
     <PackageReference Include="NuGet.ProjectModel">
-      <Version>4.0.0-rc-2037</Version>
+      <Version>4.0.0-rc-2047</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
       <Version>15.1.0-preview-000370-00</Version>

--- a/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -24,16 +24,16 @@
       <Version>1.0.1-beta-000933</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
-      <Version>4.0.0-rc-2047</Version>
+      <Version>4.0.0-rc-2048</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.0.0-rc-2047</Version>
+      <Version>4.0.0-rc-2048</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>4.0.0-rc-2047</Version>
+      <Version>4.0.0-rc-2048</Version>
     </PackageReference>
     <PackageReference Include="NuGet.ProjectModel">
-      <Version>4.0.0-rc-2047</Version>
+      <Version>4.0.0-rc-2048</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
       <Version>15.1.0-preview-000370-00</Version>

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -8,10 +8,10 @@
     "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
 
-    "NuGet.Versioning": "4.0.0-rc-2047",
-    "NuGet.Packaging": "4.0.0-rc-2047",
-    "NuGet.Frameworks": "4.0.0-rc-2047",
-    "NuGet.ProjectModel": "4.0.0-rc-2047",
+    "NuGet.Versioning": "4.0.0-rc-2048",
+    "NuGet.Packaging": "4.0.0-rc-2048",
+    "NuGet.Frameworks": "4.0.0-rc-2048",
+    "NuGet.ProjectModel": "4.0.0-rc-2048",
 
     "Microsoft.Build": "15.1.0-preview-000370-00",
     "Microsoft.Build.Utilities.Core": "15.1.0-preview-000370-00"

--- a/src/Microsoft.DotNet.Cli.Utils/project.json
+++ b/src/Microsoft.DotNet.Cli.Utils/project.json
@@ -8,10 +8,10 @@
     "Microsoft.Extensions.DependencyModel": "1.0.1-beta-000933",
     "Microsoft.DotNet.PlatformAbstractions": "1.0.1-beta-000933",
 
-    "NuGet.Versioning": "4.0.0-rc-2037",
-    "NuGet.Packaging": "4.0.0-rc-2037",
-    "NuGet.Frameworks": "4.0.0-rc-2037",
-    "NuGet.ProjectModel": "4.0.0-rc-2037",
+    "NuGet.Versioning": "4.0.0-rc-2047",
+    "NuGet.Packaging": "4.0.0-rc-2047",
+    "NuGet.Frameworks": "4.0.0-rc-2047",
+    "NuGet.ProjectModel": "4.0.0-rc-2047",
 
     "Microsoft.Build": "15.1.0-preview-000370-00",
     "Microsoft.Build.Utilities.Core": "15.1.0-preview-000370-00"

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -22,7 +22,7 @@
     "Microsoft.Build.Runtime": "15.1.0-preview-000370-00",
     "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60922-08",
     "System.Runtime.Serialization.Xml": "4.1.1",
-    "NuGet.Build.Tasks": "4.0.0-rc-2047",
+    "NuGet.Build.Tasks": "4.0.0-rc-2048",
     "Microsoft.TestPlatform.CLI": "15.0.0-preview-20161028-03",
     "Microsoft.TestPlatform.Build": "15.0.0-preview-20161028-03"
   },

--- a/src/redist/project.json
+++ b/src/redist/project.json
@@ -22,7 +22,7 @@
     "Microsoft.Build.Runtime": "15.1.0-preview-000370-00",
     "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-beta6-60922-08",
     "System.Runtime.Serialization.Xml": "4.1.1",
-    "NuGet.Build.Tasks": "4.0.0-rc-2037",
+    "NuGet.Build.Tasks": "4.0.0-rc-2047",
     "Microsoft.TestPlatform.CLI": "15.0.0-preview-20161028-03",
     "Microsoft.TestPlatform.Build": "15.0.0-preview-20161028-03"
   },

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -30,7 +30,7 @@
       <Version>4.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks">
-      <Version>4.0.0-rc-2047</Version>
+      <Version>4.0.0-rc-2048</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.CLI">
       <Version>15.0.0-preview-20161102-02</Version>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -30,7 +30,7 @@
       <Version>4.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks">
-      <Version>4.0.0-rc-2037</Version>
+      <Version>4.0.0-rc-2047</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.CLI">
       <Version>15.0.0-preview-20161102-02</Version>

--- a/src/tool_nuget/project.json
+++ b/src/tool_nuget/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "NuGet.CommandLine.XPlat": "4.0.0-rc-2037"
+    "NuGet.CommandLine.XPlat": "4.0.0-rc-2047"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/tool_nuget/project.json
+++ b/src/tool_nuget/project.json
@@ -8,7 +8,7 @@
       "type": "platform",
       "version": "1.0.1"
     },
-    "NuGet.CommandLine.XPlat": "4.0.0-rc-2047"
+    "NuGet.CommandLine.XPlat": "4.0.0-rc-2048"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/src/tool_nuget/tool_nuget.csproj
+++ b/src/tool_nuget/tool_nuget.csproj
@@ -13,7 +13,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine.XPlat">
-      <Version>4.0.0-rc-2047</Version>
+      <Version>4.0.0-rc-2048</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">

--- a/src/tool_nuget/tool_nuget.csproj
+++ b/src/tool_nuget/tool_nuget.csproj
@@ -13,7 +13,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine.XPlat">
-      <Version>4.0.0-rc-2037</Version>
+      <Version>4.0.0-rc-2047</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -30,10 +30,10 @@
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
-    "NuGet.Versioning": "4.0.0-rc-2047",
-    "NuGet.Packaging": "4.0.0-rc-2047",
-    "NuGet.Frameworks": "4.0.0-rc-2047",
-    "NuGet.ProjectModel": "4.0.0-rc-2047",
+    "NuGet.Versioning": "4.0.0-rc-2048",
+    "NuGet.Packaging": "4.0.0-rc-2048",
+    "NuGet.Frameworks": "4.0.0-rc-2048",
+    "NuGet.ProjectModel": "4.0.0-rc-2048",
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/project.json
@@ -30,10 +30,10 @@
     },
     "System.Diagnostics.TraceSource": "4.0.0",
     "System.Runtime.Serialization.Primitives": "4.1.1",
-    "NuGet.Versioning": "4.0.0-rc-2037",
-    "NuGet.Packaging": "4.0.0-rc-2037",
-    "NuGet.Frameworks": "4.0.0-rc-2037",
-    "NuGet.ProjectModel": "4.0.0-rc-2037",
+    "NuGet.Versioning": "4.0.0-rc-2047",
+    "NuGet.Packaging": "4.0.0-rc-2047",
+    "NuGet.Frameworks": "4.0.0-rc-2047",
+    "NuGet.ProjectModel": "4.0.0-rc-2047",
     "Microsoft.DotNet.Cli.Utils": {
       "target": "project"
     },


### PR DESCRIPTION
Inserting NuGet 4.0.0.2048 into CLI  (was originally 2047)

Tests will fail initially, our packages will be ready around 8pm, at that point, tests can be rerun and the PR merged.

Tracked by issue: http://github.com/nuget/home/issues/3869 


