### PR TITLE
Changing the lzma generation

### DIFF
--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -19,7 +19,7 @@
                                            SetupStage;
                                            CompileStage;
                                            BuildProjectsForNuGetPackages;
-                                           GenerateNuGetPackagesArchive" />
+                                           GetNuGetPackagesArchive" />
 
   <Target Name="SetupStage"
           DependsOnTargets="Prepare">

--- a/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
+++ b/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
@@ -1,9 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Target Name="GetNuGetPackagesArchive"
+            DependsOnTargets="SetupNuGetPackagesArchiveInputsOutputs;
+                              DownloadNuGetPackagesArchive;
+                              GenerateNuGetPackagesArchive;
+                              UploadNuGetPackagesArchiveToAzure"
+            Inputs="$(IntermediateArchive)"
+            Outputs="$(FinalArchive)">
+      <Copy SourceFiles="$(IntermediateArchive)" DestinationFiles="$(FinalArchive)" />
+    </Target>
+
+    <Target Name="UploadNuGetPackagesArchiveToAzure"
+            DependsOnTargets="SetupNuGetPackagesArchiveInputsOutputs;
+                              SetupAzureBlobInformation;
+                              GenerateNuGetPackagesArchive"
+            Condition=" 'UploadNuGetPackagesArchiveToAzure' == 'true' And  '$(PUBLISH_TO_AZURE_BLOB)' != '' ">
+      <ItemGroup>
+        <NuGetPackagesArchiveToUpload Include="$(IntermediateArchive)" />
+      </ItemGroup>
+
+      <ItemGroup>
+        <NuGetPackagesArchiveToUpload>
+          <RelativeBlobPath>$(CoreSetupChannel)/Binaries/$(SharedFrameworkVersion)/$([System.String]::Copy('%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
+        </NuGetPackagesArchiveToUpload>
+      </ItemGroup>
+
+      <UploadToAzure
+        AccountKey="$(ArtifactCloudDropAccessToken)"
+        AccountName="$(ArtifactCloudDropAccountName)"
+        ContainerName="$(ArtifactContainerName)"
+        Items="@(NuGetPackagesArchiveToUpload)"
+        Overwrite="false"
+        ContinueOnError="WarnAndContinue" />
+    </Target>
+
+    <Target Name="DownloadNuGetPackagesArchive"
+            DependsOnTargets="SetupNuGetPackagesArchiveInputsOutputs"
+            Inputs="$(IntermediateArchive)"
+            Outputs="$(IntermediateArchive)">
+      <DownloadFile Uri="$(NugetPackagesArchiveBlobUrl)"
+                    DestinationPath="$(IntermediateArchive)"
+                    ContinueOnError="WarnAndContinue" />
+    </Target>
+
     <Target Name="GenerateNuGetPackagesArchive"
             DependsOnTargets="SetupNuGetPackagesArchiveInputsOutputs"
-            Inputs="@(GenerateNuGetPackagesArchiveInputs)"
-            Outputs="$(FinalArchive)">
+            Inputs="$(IntermediateArchive)"
+            Outputs="$(IntermediateArchive)">
+      <PropertyGroup>
+        <UploadNuGetPackagesArchiveToAzure>true</UploadNuGetPackagesArchiveToAzure>
+      </PropertyGroup>
+
       <ItemGroup>
         <FilesToClean Include="$(NuGetPackagesArchiveProject)/**/*" />
         <FilesToClean Include="$(NuGetPackagesArchiveFolder)/**/*" />
@@ -31,28 +78,18 @@
                      Configuration="$(Configuration)" />
 
       <Exec Command="$(DotnetStage0) $(ArchiverDll) -a $(IntermediateArchive) $(NuGetPackagesArchiveFolder)" />
-
-      <Copy SourceFiles="$(IntermediateArchive)" DestinationFiles="$(FinalArchive)" />
     </Target>
 
     <Target Name="SetupNuGetPackagesArchiveInputsOutputs"
             DependsOnTargets="Prepare;SetupStage">
       <PropertyGroup>
+        <NugetPackagesArchiveName>nuGetPackagesArchive.$(SharedFrameworkVersion).lzma</NugetPackagesArchiveName>
         <NuGetPackagesArchiveProject>$(IntermediateDirectory)/NuGetPackagesArchiveProject</NuGetPackagesArchiveProject>
         <NuGetPackagesArchiveFolder>$(IntermediateDirectory)/NuGetPackagesArchiveFolder</NuGetPackagesArchiveFolder>
         <ArchiverDll>$(ToolsOutputDirectory)/Archiver.dll</ArchiverDll>
-        <IntermediateArchive>$(IntermediateDirectory)/nuGetPackagesArchive.lzma</IntermediateArchive>
+        <IntermediateArchive>$(IntermediateDirectory)/$(NugetPackagesArchiveName)</IntermediateArchive>
         <FinalArchive>$(Stage2Directory)/sdk/$(SdkVersion)/nuGetPackagesArchive.lzma</FinalArchive>
+        <NugetPackagesArchiveBlobUrl>$(SharedFrameworkArchiveBlobRootUrl)/$(NugetPackagesArchiveName)</NugetPackagesArchiveBlobUrl>
       </PropertyGroup>
-
-      <ItemGroup>
-        <GenerateNuGetPackagesArchiveInputs Include="$(_DotNetNewFolder)/CSharp_Console/**/*" />
-        <GenerateNuGetPackagesArchiveInputs Include="$(SrcDirectory)/dotnet-archive/**/*"
-                                            Exclude="$(SrcDirectory)/dotnet-archive/**/bin/**/*;
-                                                     $(SrcDirectory)/dotnet-archive/**/obj/**/*" />
-        <GenerateNuGetPackagesArchiveInputs Include="$(SrcDirectory)/Microsoft.DotNet.Archive/**/*"
-                                            Exclude="$(SrcDirectory)/Microsoft.DotNet.Archive/**/bin/**/*;
-                                                     $(SrcDirectory)/Microsoft.DotNet.Archive/**/obj/**/*" />
-      </ItemGroup>
     </Target>
 </Project>

--- a/build_projects/dotnet-cli-build/DownloadFile.cs
+++ b/build_projects/dotnet-cli-build/DownloadFile.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Net.Http;
 using Microsoft.Build.Framework;
@@ -35,7 +36,15 @@ namespace Microsoft.DotNet.Cli.Build
 
                 using (var outStream = File.Create(DestinationPath))
                 {
-                    getTask.Result.CopyTo(outStream);
+                    try
+                    {
+                        getTask.Result.CopyTo(outStream);
+                    }
+                    catch (Exception)
+                    {
+                        File.Delete(DestinationPath);
+                        throw;
+                    }
                 }
             }
 

--- a/build_projects/dotnet-cli-build/DownloadFile.cs
+++ b/build_projects/dotnet-cli-build/DownloadFile.cs
@@ -34,17 +34,17 @@ namespace Microsoft.DotNet.Cli.Build
             {
                 var getTask = httpClient.GetStreamAsync(Uri);
 
-                using (var outStream = File.Create(DestinationPath))
+                try
                 {
-                    try
+                    using (var outStream = File.Create(DestinationPath))
                     {
                         getTask.Result.CopyTo(outStream);
                     }
-                    catch (Exception)
-                    {
-                        File.Delete(DestinationPath);
-                        throw;
-                    }
+                }
+                catch (Exception)
+                {
+                    File.Delete(DestinationPath);
+                    throw;
                 }
             }
 


### PR DESCRIPTION
Changing the lzma generation to first trying to download it from blob. If that fails, generate it. And if we generate it and we are uploading things to azure, upload it as well.

@piotrpMSFT @krwq @jgoshi 

Fixes https://github.com/dotnet/cli/issues/4593