### PR TITLE
Removing dotnet-test-xunit when migration from project.json to csproj

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/PackageConstants.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/PackageConstants.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
         public const string MstestTestFrameworkName = "MSTest.TestFramework";
         public const string NetStandardPackageName = "NETStandard.Library";
         public const string NetStandardPackageVersion = "1.6.0";
+        public const string DotnetTestXunit = "dotnet-test-xunit";
 
         public static readonly IDictionary<string, PackageDependencyInfo> ProjectDependencyPackages = 
             new Dictionary<string, PackageDependencyInfo> {
@@ -50,6 +51,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
                 { MstestTestFrameworkName, new PackageDependencyInfo {
                     Name = MstestTestFrameworkName,
                     Version = ConstantPackageVersions.MstestTestFrameworkVersion } },
+                { DotnetTestXunit, null },
         };
 
         public static readonly IDictionary<string, PackageDependencyInfo> ProjectToolPackages = 

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTools.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTools.cs
@@ -9,7 +9,7 @@ using System;
 
 namespace Microsoft.DotNet.ProjectJsonMigration.Tests
 {
-    public class GivenThatIWantToMigrateAspNetTools : PackageDependenciesTestBase
+    public class GivenThatIWantToMigrateTools : PackageDependenciesTestBase
     {
         [Theory]
         [InlineData("Microsoft.EntityFrameworkCore.Tools", "Microsoft.EntityFrameworkCore.Tools", ConstantPackageVersions.AspNetToolsVersion)]
@@ -33,7 +33,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         [InlineData("Microsoft.AspNetCore.Razor.Tools")]
         [InlineData("Microsoft.AspNetCore.Razor.Design")]
         [InlineData("Microsoft.VisualStudio.Web.CodeGeneration.Tools")]
-        public void It_does_not_migrate_asp_project_tool_dependency(string dependencyName)
+        [InlineData("dotnet-test-xunit")]
+        public void It_does_not_migrate_project_tool_dependency_that_is_no_longer_needed(string dependencyName)
         {
             var mockProj = RunPackageDependenciesRuleOnPj(@"
                 {


### PR DESCRIPTION
Removing dotnet-test-xunit when migration from project.json to csproj, as that package is no longer needed.

Fixes https://github.com/dotnet/cli/issues/4640

@jgoshi @piotrpMSFT @krwq 