### PR TITLE
Removing dotnet-test-mstest when migrating because that package is no…

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/PackageConstants.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/PackageConstants.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
         public const string NetStandardPackageName = "NETStandard.Library";
         public const string NetStandardPackageVersion = "1.6.0";
         public const string DotnetTestXunit = "dotnet-test-xunit";
+        public const string DotnetTestMSTest = "dotnet-test-mstest";
 
         public static readonly IDictionary<string, PackageDependencyInfo> ProjectDependencyPackages = 
             new Dictionary<string, PackageDependencyInfo> {
@@ -52,6 +53,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
                     Name = MstestTestFrameworkName,
                     Version = ConstantPackageVersions.MstestTestFrameworkVersion } },
                 { DotnetTestXunit, null },
+                { DotnetTestMSTest, null },
         };
 
         public static readonly IDictionary<string, PackageDependencyInfo> ProjectToolPackages = 

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTools.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTools.cs
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         [InlineData("Microsoft.AspNetCore.Razor.Design")]
         [InlineData("Microsoft.VisualStudio.Web.CodeGeneration.Tools")]
         [InlineData("dotnet-test-xunit")]
+        [InlineData("dotnet-test-mstest")]
         public void It_does_not_migrate_project_tool_dependency_that_is_no_longer_needed(string dependencyName)
         {
             var mockProj = RunPackageDependenciesRuleOnPj(@"


### PR DESCRIPTION
Removing dotnet-test-mstest when migrating longer needed.

@piotrpMSFT @jgoshi @krwq 

Fixes https://github.com/dotnet/cli/issues/4686