### PR TITLE
Adds initial code for adding and removing a package reference

### DIFF
--- a/src/dotnet/commands/dotnet-ref/Program.cs
+++ b/src/dotnet/commands/dotnet-ref/Program.cs
@@ -1,0 +1,120 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Construction;
+using Microsoft.DotNet.ProjectJsonMigration;
+
+namespace Microsoft.DotNet.Tools.Ref
+{
+    public class RefCommand
+    {
+        public static int Run(string[] args)
+        {
+            DebugHelper.HandleDebugSwitch(ref args);
+
+            DirectoryInfo currDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            FileInfo projectFile = currDir.GetFiles("*.csproj").FirstOrDefault();
+
+            if (!projectFile.Exists)
+            {
+                throw new Exception("Unable to find any projects in the current folder");
+            }
+
+            CommandLineApplication app = new CommandLineApplication(throwOnUnexpectedArg: false)
+            {
+                Name = "dotnet ref",
+                FullName = ".NET Ref Command",
+                Description = "Command to modify project and package references",
+                AllowArgumentSeparator = true,
+                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText
+            };
+            app.HelpOption("-h|--help");
+
+            app.Command("add", c =>
+            {
+                c.Description = "Add package and project references";
+                c.HelpOption("-h|--help");
+
+                CommandArgument packageNameArg = c.Argument("<PACKAGE_NAME>", "The package name to install");
+                CommandOption packageVersionOption = c.Option("-v|--version <PACKAGE_VERSION>", "The package version to install, defaults to * if omited", CommandOptionType.SingleValue);
+
+                c.OnExecute(() =>
+                {
+
+                    string version = "*";
+                    if (packageVersionOption.HasValue())
+                    {
+                        version = packageVersionOption.Value();
+                    }
+
+                    var rootElement = ProjectRootElement.Open(projectFile.FullName);
+                    AddOrUpdatePackageRef(packageNameArg.Value, version, rootElement);         
+                    rootElement.Save();
+
+                    // List<string> msbuildArgs = new List<string>();
+                    // msbuildArgs.Add("/t:RefAdd");
+                    // msbuildArgs.Add($"/p:PackageName={packageNameArg.Value}");
+                    // msbuildArgs.Add($"/p:PackageVersion={version}");
+                    // msbuildArgs.AddRange(app.RemainingArguments);
+                    // return new MSBuildForwardingApp(msbuildArgs).Execute();
+                    return 1;
+                });
+                
+            });            
+
+            app.Command("del", c =>
+            {
+                c.Description = "Remove package and project references";
+                c.HelpOption("-h|--help");
+
+                CommandArgument packageNameArg = c.Argument("<PACKAGE_NAME>", "The package name to remove");
+
+                c.OnExecute(() =>
+                {
+                    var rootElement = ProjectRootElement.Open(projectFile.FullName);
+                    RemovePackageRef(packageNameArg.Value, rootElement);
+                    rootElement.Save();
+
+                    // List<string> msbuildArgs = new List<string>();
+                    // msbuildArgs.Add("/t:RefDel");                    
+                    // msbuildArgs.Add($"/p:PackageName={packageNameArg.Value}");
+                    // msbuildArgs.AddRange(app.RemainingArguments);
+                    // return new MSBuildForwardingApp(msbuildArgs).Execute();
+                    return 1;
+                });
+                
+            });            
+
+            return app.Execute(args);
+        }
+
+        private static void RemovePackageRef(string packageName, ProjectRootElement proj)
+        {            
+            //find existing ones
+            var packageRefs = proj.Items.Where(i => i.ItemType == "PackageReference")
+                .Where(x => x.Include == packageName)
+                .ToList();
+            //remove any existing ones
+            foreach (var packageRef in packageRefs)
+            {
+                var parent = packageRef.Parent;
+                packageRef.Parent.RemoveChild(packageRef);
+                parent.RemoveIfEmpty();
+            }
+        }
+
+        private static void AddOrUpdatePackageRef(string packageName, string packageVersion, ProjectRootElement proj)
+        {            
+            RemovePackageRef(packageName, proj);
+
+            //add this one
+            proj.AddItem("PackageReference", packageName, new Dictionary<string, string>{{"Version", packageVersion}});
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-ref/Program.cs
+++ b/src/dotnet/commands/dotnet-ref/Program.cs
@@ -56,13 +56,6 @@ namespace Microsoft.DotNet.Tools.Ref
                     var rootElement = ProjectRootElement.Open(projectFile.FullName);
                     AddOrUpdatePackageRef(packageNameArg.Value, version, rootElement);         
                     rootElement.Save();
-
-                    // List<string> msbuildArgs = new List<string>();
-                    // msbuildArgs.Add("/t:RefAdd");
-                    // msbuildArgs.Add($"/p:PackageName={packageNameArg.Value}");
-                    // msbuildArgs.Add($"/p:PackageVersion={version}");
-                    // msbuildArgs.AddRange(app.RemainingArguments);
-                    // return new MSBuildForwardingApp(msbuildArgs).Execute();
                     return 1;
                 });
                 
@@ -80,12 +73,6 @@ namespace Microsoft.DotNet.Tools.Ref
                     var rootElement = ProjectRootElement.Open(projectFile.FullName);
                     RemovePackageRef(packageNameArg.Value, rootElement);
                     rootElement.Save();
-
-                    // List<string> msbuildArgs = new List<string>();
-                    // msbuildArgs.Add("/t:RefDel");                    
-                    // msbuildArgs.Add($"/p:PackageName={packageNameArg.Value}");
-                    // msbuildArgs.AddRange(app.RemainingArguments);
-                    // return new MSBuildForwardingApp(msbuildArgs).Execute();
                     return 1;
                 });
                 


### PR DESCRIPTION
Hi,

At the MVP Summit Hackathon I created this ability via a dotnet extension however I realize that this functionality is supposed to be part of the core cli code so I'm submitting this as a PR.

Related Issue: https://github.com/dotnet/cli/issues/4521 

I know this doesn't complete the functionality required for 4521 but it's a start.

##Some notes about this:

* This only deals with package references, not project references. 
* This follows the syntax as specified in https://github.com/dotnet/cli/issues/4521 
* It will add or update a project reference with using `dotnet ref add`
* Originally I did this using an MSBuild extension which allowed me to automatically get the location of the csproj, but to do this in the CLI project meant adding a few references in places they didn't already exist so I opted to finding the csproj file manually - I tried following the same format that's currently in this codebase so hopefully that is satisfactory
* I could not get the entire project to build with the build.cmd script. It mostly builds but fails eventually with

```
\TestAssets\TestPackages\dotnet-desktop-binding-redirects\project.json(7,30): error NU1001: The dependency Newtonsoft.Json >= 5.0.0 could not be resolved. [X:\Projects\NETCLI\Source\build.proj]
```

* I wanted to create unit tests for this, however I could not get the other unit tests to run correctly. I tried to build some test projects manually such as: `/test/dotnet-new.Tests` by running `dotnet restore`, `dotnet build`, `dotnet test` but running the tests fail so I figured I must be missing something in order to get these tests to run and to use for my own.

##Usage

- this will default to using "*" as the version
`dotnet ref add NewtonSoft.Json`
- to specify specific version
`dotnet ref add NewtonSoft.Json 9.0.1`
- to remove
`dotnet ref del NewtonSoft.Json`

