### PR TITLE
Emitting runtime identifiers if the source project has any full framework TFMs

### DIFF
--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTFMs.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTFMs.cs
@@ -69,6 +69,31 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Fact]
+        public void Migrating_desktop_TFMs_adds_RuntimeIdentifiers()
+        {
+            var testDirectory = Temp.CreateDirectory().Path;
+            var testPJ = new ProjectJsonBuilder(TestAssetsManager)
+                .FromTestAssetBase("TestLibraryWithMultipleFrameworks")
+                .SaveToDisk(testDirectory);
+
+            var projectContexts = ProjectContext.CreateContextForEachFramework(testDirectory);
+            var mockProj = ProjectRootElement.Create();
+
+            var migrationSettings = new MigrationSettings(testDirectory, testDirectory, "1.0.0", mockProj);
+            var migrationInputs = new MigrationRuleInputs(
+                projectContexts, 
+                mockProj, 
+                mockProj.AddItemGroup(), 
+                mockProj.AddPropertyGroup());
+
+            new MigrateTFMRule().Apply(migrationSettings, migrationInputs);
+
+            mockProj.Properties.Count(p => p.Name == "RuntimeIdentifiers").Should().Be(1);
+            mockProj.Properties.First(p => p.Name == "RuntimeIdentifiers")
+                .Value.Should().Be("win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64");
+        }
+
+        [Fact]
         public void Migrating_Single_TFM_project_Populates_TargetFramework()
         {
             var testDirectory = Temp.CreateDirectory().Path;


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/4689

@piotrpMSFT @jgoshi @krwq 