### PR TITLE
Extract Localizable strings from dotnet-build

### DIFF
--- a/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
@@ -22,9 +22,7 @@
 
         public const string OutputOptionName = "OUTPUT_DIR";
 
-        public const string ProjectArgumentDescription1 = "The MSBuild project file to build. If a project file is not specified,";
-
-        public const string ProjectArgumentDescription2 = " MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file.";
+        public const string ProjectArgumentDescription = "The MSBuild project file to build. If a project file is not specified, MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file.";
 
         public const string ProjectArgumentValueName = "PROJECT";
 

--- a/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
@@ -1,4 +1,4 @@
-﻿namespace dotnet.commands.dotnet_build
+﻿namespace Microsoft.DotNet.Tools.Build
 {
     internal class LocalizableStrings
     {

--- a/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
@@ -1,0 +1,40 @@
+﻿namespace dotnet.commands.dotnet_build
+{
+    internal class LocalizableStrings
+    {
+        public const string AppDescription = "Builder for the .NET Platform. Delegates to the MSBuild 'Build' target in the project file.";
+
+        public const string AppFullName = ".NET Builder";
+
+        public const string ConfigurationOptionDescription = "Configuration under which to build";
+
+        public const string ConfigurationOptionName = "CONFIGURATION";
+
+        public const string FrameworkOptionDescription = "Compile a specific framework";
+
+        public const string FrameworkOptionName = "FRAMEWORK";
+
+        public const string NoDependenciesOptionDescription = "Set this flag to ignore project to project references and only build the root project";
+
+        public const string NoIncrementialOptionDescription = "Set this flag to turn off incremental build";
+
+        public const string OutputOptionDescription = "Directory in which to place outputs";
+
+        public const string OutputOptionName = "OUTPUT_DIR";
+
+        public const string ProjectArgumentDescription1 = "The MSBuild project file to build. If a project file is not specified,";
+
+        public const string ProjectArgumentDescription2 = " MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file.";
+
+        public const string ProjectArgumentValueName = "PROJECT";
+
+        public const string RuntimeOptionDescription = "Target runtime to build for. The default is to build a portable application.";
+
+        public const string RuntimeOptionName = "RUNTIME_IDENTIFIER";
+
+        public const string VersionSuffixOptionDescription = "Defines the value for the $(VersionSuffix) property in the project";
+
+        public const string VersionSuffixOptionName = "VERSION_SUFFIX";
+
+    }
+}

--- a/src/dotnet/commands/dotnet-build/Program.cs
+++ b/src/dotnet/commands/dotnet-build/Program.cs
@@ -22,9 +22,7 @@ namespace Microsoft.DotNet.Tools.Build
             app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;
             app.HelpOption("-h|--help");
 
-            CommandArgument projectArgument = app.Argument("<{LocalizableStrings.ProjectArgumentValueName}>",
-                LocalizableStrings.ProjectArgumentDescription1 +
-                LocalizableStrings.ProjectArgumentDescription2);
+            CommandArgument projectArgument = app.Argument("<{LocalizableStrings.ProjectArgumentValueName}>", LocalizableStrings.ProjectArgumentDescription);
 
             CommandOption outputOption = app.Option("-o|--output <{LocalizableStrings.OutputOptionName}>", LocalizableStrings.OutputOptionDescription, CommandOptionType.SingleValue);
             CommandOption frameworkOption = app.Option("-f|--framework <{LocalizableStrings.FrameworkOptionName}>", LocalizableStrings.FrameworkOptionDescription, CommandOptionType.SingleValue);

--- a/src/dotnet/commands/dotnet-build/Program.cs
+++ b/src/dotnet/commands/dotnet-build/Program.cs
@@ -16,26 +16,26 @@ namespace Microsoft.DotNet.Tools.Build
 
             CommandLineApplication app = new CommandLineApplication(throwOnUnexpectedArg: false);
             app.Name = "dotnet build";
-            app.FullName = ".NET Builder";
-            app.Description = "Builder for the .NET Platform. Delegates to the MSBuild 'Build' target in the project file.";
+            app.FullName = LocalizableStrings.AppFullName;
+            app.Description = LocalizableStrings.AppDescription;
             app.AllowArgumentSeparator = true;
             app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;
             app.HelpOption("-h|--help");
 
-            CommandArgument projectArgument = app.Argument("<PROJECT>",
-                "The MSBuild project file to build. If a project file is not specified," +
-                " MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file.");
+            CommandArgument projectArgument = app.Argument("<{LocalizableStrings.ProjectArgumentValueName}>",
+                LocalizableStrings.ProjectArgumentDescription1 +
+                LocalizableStrings.ProjectArgumentDescription2);
 
-            CommandOption outputOption = app.Option("-o|--output <OUTPUT_DIR>", "Directory in which to place outputs", CommandOptionType.SingleValue);
-            CommandOption frameworkOption = app.Option("-f|--framework <FRAMEWORK>", "Compile a specific framework", CommandOptionType.SingleValue);
+            CommandOption outputOption = app.Option("-o|--output <{LocalizableStrings.OutputOptionName}>", LocalizableStrings.OutputOptionDescription, CommandOptionType.SingleValue);
+            CommandOption frameworkOption = app.Option("-f|--framework <{LocalizableStrings.FrameworkOptionName}>", LocalizableStrings.FrameworkOptionDescription, CommandOptionType.SingleValue);
             CommandOption runtimeOption = app.Option(
-                "-r|--runtime <RUNTIME_IDENTIFIER>", "Target runtime to build for. The default is to build a portable application.",
+                "-r|--runtime <{LocalizableStrings.RuntimeOptionName}>", LocalizableStrings.RuntimeOptionDescription,
                 CommandOptionType.SingleValue);
-            CommandOption configurationOption = app.Option("-c|--configuration <CONFIGURATION>", "Configuration under which to build", CommandOptionType.SingleValue);
-            CommandOption versionSuffixOption = app.Option("--version-suffix <VERSION_SUFFIX>", "Defines the value for the $(VersionSuffix) property in the project", CommandOptionType.SingleValue);
+            CommandOption configurationOption = app.Option("-c|--configuration <{LocalizableStrings.ConfigurationOptionName}>", LocalizableStrings.FrameworkOptionDescription, CommandOptionType.SingleValue);
+            CommandOption versionSuffixOption = app.Option("--version-suffix <{LocalizableStrings.VersionSuffixOptionName}>", LocalizableStrings.VersionSuffixOptionDescription, CommandOptionType.SingleValue);
 
-            CommandOption noIncrementalOption = app.Option("--no-incremental", "Set this flag to turn off incremental build", CommandOptionType.NoValue);
-            CommandOption noDependenciesOption = app.Option("--no-dependencies", "Set this flag to ignore project to project references and only build the root project", CommandOptionType.NoValue);
+            CommandOption noIncrementalOption = app.Option("--no-incremental", LocalizableStrings.NoIncrementialOptionDescription, CommandOptionType.NoValue);
+            CommandOption noDependenciesOption = app.Option("--no-dependencies", LocalizableStrings.NoDependenciesOptionDescription, CommandOptionType.NoValue);
             CommandOption verbosityOption = MSBuildForwardingApp.AddVerbosityOption(app);
 
             app.OnExecute(() =>


### PR DESCRIPTION
This commit extracts localizable strings from dotnet-build and leaves them in a separate file. The majority of the strings from the file are extracted except for tags or MSbuild arguments. If any of those need to be extracted, please let me know.