### PR TITLE
Show nuget and msbuild commands in dotnet-help

### DIFF
--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -33,6 +33,11 @@ Commands:
   run           Compiles and immediately executes a .NET project
   test          Runs unit tests using the test runner specified in the project
   pack          Creates a NuGet package
+  migrate       Migrates a project.json based project to a msbuild based project
+
+Advanced Commands:
+  nuget         Provides additional NuGet commands
+  msbuild       msbuilds a project and all of its dependencies
   vstest        Runs tests from the specified files";
 
         public static int Run(string[] args)


### PR DESCRIPTION
This adds both `nuget` and `msbuild` verbs to the output of `dotnet help` as it isn't obvious that they exists (#4762).
I "borrowed" the msbuild text from https://docs.microsoft.com/en-us/dotnet/articles/core/preview3/tools/dotnet-msbuild.

fixes #4700

cc @blackdwarf @piotrpMSFT 
I heard there is a loc freeze coming up 🔜 