### PR TITLE
Updating migrate to not add system.dll during migration.

### DIFF
--- a/TestAssets/DesktopTestProjects/AppWithProjTool2Fx/App.csproj
+++ b/TestAssets/DesktopTestProjects/AppWithProjTool2Fx/App.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="dotnet-desktop-and-portable">

--- a/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsAndConfig/AppWithRedirectsAndConfig.csproj
+++ b/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsAndConfig/AppWithRedirectsAndConfig.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">

--- a/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsNoConfig/AppWithRedirectsNoConfig.csproj
+++ b/TestAssets/DesktopTestProjects/BindingRedirectSample/AppWithRedirectsNoConfig/AppWithRedirectsNoConfig.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">

--- a/TestAssets/DesktopTestProjects/LibWithProjTool2Fx/Lib.csproj
+++ b/TestAssets/DesktopTestProjects/LibWithProjTool2Fx/Lib.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="dotnet-desktop-and-portable">

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/TestProjectWithUnresolvedPlatformDependency.csproj
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/TestProjectWithUnresolvedPlatformDependency.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="ThisIsNotARealDependencyAndIfSomeoneGoesAndAddsAProjectWithThisNameIWillFindThemAndPunishThem">

--- a/TestAssets/TestPackages/PackageWithFakeNativeDep/PackageWithFakeNativeDep.csproj
+++ b/TestAssets/TestPackages/PackageWithFakeNativeDep/PackageWithFakeNativeDep.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/TestAssets/TestPackages/ToolWithOutputName/ToolWithOutputName.csproj
+++ b/TestAssets/TestPackages/ToolWithOutputName/ToolWithOutputName.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/dotnet-desktop-and-portable.csproj
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/dotnet-desktop-and-portable.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/TestAssets/TestPackages/dotnet-desktop-binding-redirects/dotnet-desktop-binding-redirects.csproj
+++ b/TestAssets/TestPackages/dotnet-desktop-binding-redirects/dotnet-desktop-binding-redirects.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">

--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/dotnet-hello.csproj
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/dotnet-hello.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/dotnet-hello.csproj
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/dotnet-hello.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/TestAssets/TestPackages/dotnet-portable/dotnet-portable.csproj
+++ b/TestAssets/TestPackages/dotnet-portable/dotnet-portable.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/TestAssets/TestProjects/AppWithDepOnToolWithOutputName/AppWithDepOnToolWithOutputName.csproj
+++ b/TestAssets/TestProjects/AppWithDepOnToolWithOutputName/AppWithDepOnToolWithOutputName.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/TestAssets/TestProjects/AppWithDirectAndToolDep/AppWithDirectAndToolDep.csproj
+++ b/TestAssets/TestProjects/AppWithDirectAndToolDep/AppWithDirectAndToolDep.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/TestAssets/TestProjects/AppWithDirectDep/AppWithDirectDep.csproj
+++ b/TestAssets/TestProjects/AppWithDirectDep/AppWithDirectDep.csproj
@@ -21,7 +21,7 @@
     <EmbeddedResource Include="**\*.resx" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <EmbeddedResource Include="compiler\resources\**\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/TestAssets/TestProjects/AppWithDirectDepWithOutputName/AppWithDirectDepWithOutputName.csproj
+++ b/TestAssets/TestProjects/AppWithDirectDepWithOutputName/AppWithDirectDepWithOutputName.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="ToolWithOutputName">

--- a/TestAssets/TestProjects/AppWithMultipleFxAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
+++ b/TestAssets/TestProjects/AppWithMultipleFxAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="dotnet-desktop-and-portable">

--- a/TestAssets/TestProjects/AppWithToolDependency/AppWithToolDependency.csproj
+++ b/TestAssets/TestProjects/AppWithToolDependency/AppWithToolDependency.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/TestAssets/TestProjects/DependencyContextFromTool/DependencyContextFromTool.csproj
+++ b/TestAssets/TestProjects/DependencyContextFromTool/DependencyContextFromTool.csproj
@@ -14,7 +14,7 @@
     <EmbeddedResource Include="**\*.resx" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <EmbeddedResource Include="compiler\resources\**\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/TestAssets/TestProjects/LibraryWithOutputAssemblyName/MyLibrary.csproj
+++ b/TestAssets/TestProjects/LibraryWithOutputAssemblyName/MyLibrary.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworks/MSBuildAppWithMultipleFrameworks.csproj
+++ b/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworks/MSBuildAppWithMultipleFrameworks.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
+++ b/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="dotnet-desktop-and-portable">

--- a/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
+++ b/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
@@ -16,7 +16,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary1/CsprojLibrary1.csproj
+++ b/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary1/CsprojLibrary1.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary2/CsprojLibrary2.csproj
+++ b/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary2/CsprojLibrary2.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary3/CsprojLibrary3.csproj
+++ b/TestAssets/TestProjects/TestAppDependencyGraph/CsprojLibrary3/CsprojLibrary3.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/TestAssets/TestProjects/TestAppSimple/TestAppSimple.csproj
+++ b/TestAssets/TestProjects/TestAppSimple/TestAppSimple.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/TestAssets/TestProjects/TestAppWithProjDepTool/TestAppWithProjDepTool.csproj
+++ b/TestAssets/TestProjects/TestAppWithProjDepTool/TestAppWithProjDepTool.csproj
@@ -15,7 +15,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="dotnet-portable">

--- a/TestAssets/TestProjects/TestLibraryWithConfiguration/TestLibraryWithConfiguration.csproj
+++ b/TestAssets/TestProjects/TestLibraryWithConfiguration/TestLibraryWithConfiguration.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/TestAssets/TestProjects/VSTestDesktopAndNetCore/VSTestDesktopAndNetCore.csproj
+++ b/TestAssets/TestProjects/VSTestDesktopAndNetCore/VSTestDesktopAndNetCore.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">

--- a/TestAssets/TestProjects/VSTestDotNetCore/VSTestDotNetCore.csproj
+++ b/TestAssets/TestProjects/VSTestDotNetCore/VSTestDotNetCore.csproj
@@ -15,7 +15,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/Microsoft.DotNet.Cli.Build.Framework.csproj
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/Microsoft.DotNet.Cli.Build.Framework.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -43,7 +43,7 @@
       <Version>1.0.1-beta-000933</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/build_projects/shared-build-targets-utils/shared-build-targets-utils.csproj
+++ b/build_projects/shared-build-targets-utils/shared-build-targets-utils.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/build_projects/update-dependencies/update-dependencies.csproj
+++ b/build_projects/update-dependencies/update-dependencies.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/src/Microsoft.DotNet.Archive/Microsoft.DotNet.Archive.csproj
+++ b/src/Microsoft.DotNet.Archive/Microsoft.DotNet.Archive.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyModel">

--- a/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj
+++ b/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Microsoft.DotNet.InternalAbstractions/Microsoft.DotNet.InternalAbstractions.csproj
+++ b/src/Microsoft.DotNet.InternalAbstractions/Microsoft.DotNet.InternalAbstractions.csproj
@@ -20,7 +20,7 @@
       <Version>1.6.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.ProjectJsonMigration.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
@@ -317,7 +317,6 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
         {
             if (framework?.IsDesktop() ?? false)
             {
-                InjectAssemblyReferenceIfNotPresent("System", packageDependencies);
                 if (framework.Version >= new Version(4, 0))
                 {
                     InjectAssemblyReferenceIfNotPresent("Microsoft.CSharp", packageDependencies);

--- a/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.csproj
+++ b/src/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/dotnet-archive/dotnet-archive.csproj
+++ b/src/dotnet-archive/dotnet-archive.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/src/dotnet/commands/dotnet-new/CSharp_Console/$projectName$.csproj
+++ b/src/dotnet/commands/dotnet-new/CSharp_Console/$projectName$.csproj
@@ -16,7 +16,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/dotnet/commands/dotnet-new/CSharp_Lib/$projectName$.csproj
+++ b/src/dotnet/commands/dotnet-new/CSharp_Lib/$projectName$.csproj
@@ -15,7 +15,7 @@
       <Version>1.6</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/dotnet/commands/dotnet-new/CSharp_Mstest/$projectName$.csproj
+++ b/src/dotnet/commands/dotnet-new/CSharp_Mstest/$projectName$.csproj
@@ -16,7 +16,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/src/dotnet/commands/dotnet-new/CSharp_Web/$projectName$.csproj
+++ b/src/dotnet/commands/dotnet-new/CSharp_Web/$projectName$.csproj
@@ -21,7 +21,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk.Web">
-      <Version>1.0.0-alpha-20161104-2-112</Version>
+      <Version>1.0.0-alpha-20161117-1-112</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics">
       <Version>1.0.0</Version>

--- a/src/dotnet/commands/dotnet-new/CSharp_Xunittest/$projectName$.csproj
+++ b/src/dotnet/commands/dotnet-new/CSharp_Xunittest/$projectName$.csproj
@@ -16,7 +16,7 @@
       <Version>1.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/src/tool_csc/tool_csc.csproj
+++ b/src/tool_csc/tool_csc.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/src/tool_msbuild/tool_msbuild.csproj
+++ b/src/tool_msbuild/tool_msbuild.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/src/tool_nuget/tool_nuget.csproj
+++ b/src/tool_nuget/tool_nuget.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests.csproj
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/ArgumentsReflector/ArgumentsReflector.csproj
+++ b/test/ArgumentsReflector/ArgumentsReflector.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/test/EndToEnd/EndToEnd.csproj
+++ b/test/EndToEnd/EndToEnd.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/Installer/Microsoft.DotNet.Cli.Msi.Tests/Microsoft.DotNet.Cli.Msi.Tests.csproj
+++ b/test/Installer/Microsoft.DotNet.Cli.Msi.Tests/Microsoft.DotNet.Cli.Msi.Tests.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/test/Kestrel.Tests/Kestrel.Tests.csproj
+++ b/test/Kestrel.Tests/Kestrel.Tests.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/Microsoft.DotNet.Configurer.UnitTests/Microsoft.DotNet.Configurer.UnitTests.csproj
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/Microsoft.DotNet.Configurer.UnitTests.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Microsoft.DotNet.ProjectJsonMigration.Tests.csproj
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Microsoft.DotNet.ProjectJsonMigration.Tests.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackageDependencies.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackageDependencies.cs
@@ -239,23 +239,19 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
 
             var itemGroup = mockProj.ItemGroups.Where(i => i.Condition == " '$(TargetFramework)' == 'net451' ");
             itemGroup.Should().HaveCount(1);
-            itemGroup.First().Items.Should().HaveCount(2);
+            itemGroup.First().Items.Should().HaveCount(1);
             var items = itemGroup.First().Items.ToArray();
-            items[0].Include.Should().Be("System");
-            items[1].Include.Should().Be("Microsoft.CSharp");
+            items[0].Include.Should().Be("Microsoft.CSharp");
 
             itemGroup = mockProj.ItemGroups.Where(i => i.Condition == " '$(TargetFramework)' == 'net40' ");
             itemGroup.Should().HaveCount(1);
-            itemGroup.First().Items.Should().HaveCount(2);
+            itemGroup.First().Items.Should().HaveCount(1);
             items = itemGroup.First().Items.ToArray();
-            items[0].Include.Should().Be("System");
-            items[1].Include.Should().Be("Microsoft.CSharp");
+            items[0].Include.Should().Be("Microsoft.CSharp");
 
             itemGroup = mockProj.ItemGroups.Where(i => i.Condition == " '$(TargetFramework)' == 'net35' ");
             itemGroup.Should().HaveCount(1);
-            itemGroup.First().Items.Should().HaveCount(1);
-            items = itemGroup.First().Items.ToArray();
-            items[0].Include.Should().Be("System");
+            itemGroup.First().Items.Should().HaveCount(0);
         }
 
         [Fact]

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">

--- a/test/Performance/Performance.csproj
+++ b/test/Performance/Performance.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/ScriptExecutorTests/ScriptExecutorTests.csproj
+++ b/test/ScriptExecutorTests/ScriptExecutorTests.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/binding-redirects.Tests/binding-redirects.Tests.csproj
+++ b/test/binding-redirects.Tests/binding-redirects.Tests.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/crossgen.Tests/crossgen.Tests.csproj
+++ b/test/crossgen.Tests/crossgen.Tests.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-build.Tests/dotnet-build.Tests.csproj
+++ b/test/dotnet-build.Tests/dotnet-build.Tests.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-migrate.Tests/dotnet-migrate.Tests.csproj
+++ b/test/dotnet-migrate.Tests/dotnet-migrate.Tests.csproj
@@ -44,7 +44,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-msbuild.Tests/dotnet-msbuild.Tests.csproj
+++ b/test/dotnet-msbuild.Tests/dotnet-msbuild.Tests.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-new.Tests/dotnet-new.Tests.csproj
+++ b/test/dotnet-new.Tests/dotnet-new.Tests.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-nuget.UnitTests/dotnet-nuget.UnitTests.csproj
+++ b/test/dotnet-nuget.UnitTests/dotnet-nuget.UnitTests.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-pack.Tests/dotnet-pack.Tests.csproj
+++ b/test/dotnet-pack.Tests/dotnet-pack.Tests.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-publish.Tests/dotnet-publish.Tests.csproj
+++ b/test/dotnet-publish.Tests/dotnet-publish.Tests.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-run.Tests/dotnet-run.Tests.csproj
+++ b/test/dotnet-run.Tests/dotnet-run.Tests.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-test.Tests/dotnet-test.Tests.csproj
+++ b/test/dotnet-test.Tests/dotnet-test.Tests.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet-vstest.Tests/dotnet-vstest.Tests.csproj
+++ b/test/dotnet-vstest.Tests/dotnet-vstest.Tests.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -56,7 +56,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/test/msbuild.IntegrationTests/msbuild.IntegrationTests.csproj
+++ b/test/msbuild.IntegrationTests/msbuild.IntegrationTests.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk">

--- a/tools/Archiver/Archiver.csproj
+++ b/tools/Archiver/Archiver.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.App">

--- a/tools/MigrationDefaultsConstructor/MigrationDefaultsConstructor.csproj
+++ b/tools/MigrationDefaultsConstructor/MigrationDefaultsConstructor.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk">
-      <Version>1.0.0-alpha-20161104-2</Version>
+      <Version>1.0.0-alpha-20161117-1</Version>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
Updating the version of the SDK in the CLI and making migrate not add System.dll when migrating net40 and higher projects.

Fixes https://github.com/dotnet/cli/issues/4695

@piotrpMSFT @jgoshi @krwq 