### PR TITLE
Migration: Handle different variations of specifying assembly attributes.

### DIFF
--- a/TestAssets/TestProjects/AppWithAssemblyInfo/Properties/AssemblyInfo.cs
+++ b/TestAssets/TestProjects/AppWithAssemblyInfo/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -7,16 +6,15 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("ConsoleApp1")]
+[assembly: AssemblyCompanyAttribute("")]
+[assembly: System.Reflection.AssemblyProduct("ConsoleApp1")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCopyright("")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyFileVersion("")]
 [assembly: AssemblyInformationalVersion("")]
-[assembly: AssemblyTitle("")]
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: NeutralResourcesLanguage("")]
+[assembly: System.Reflection.AssemblyTitleAttribute("")]
+[assembly: AssemblyVersion("1.0.0"), System.Resources.NeutralResourcesLanguageAttribute("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
This addresses an issue i came across in https://github.com/dotnet/cli/issues/4710#issuecomment-260757371

The migration rule for parsing the assembly attribute definitions only checked for "the standard" way of defining attributes, but other variations are possible (e.g. VSCode autocompletes to the full "XYZAttribute" version, which is probably how i ended up having this issue).

cc @piotrpMSFT @livarcocc 