### PR TITLE
Web project template now includes content in "views" and "wwwroot" fo…

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Web/$projectName$.csproj
+++ b/src/dotnet/commands/dotnet-new/CSharp_Web/$projectName$.csproj
@@ -13,6 +13,8 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="$(GlobalExclude)" />
+    <Content Include="Views\**\*" Exclude="$(GlobalExclude)" />
+    <Content Include="wwwroot\**\*" Exclude="$(GlobalExclude)" />
     <EmbeddedResource Include="**\*.resx" Exclude="$(GlobalExclude)" />
   </ItemGroup>
 


### PR DESCRIPTION
skipciplease

In the generated "Web" project file, the directories "Views" and "wwwroot" are not shown when edited in an IDE (VS for Mac etc.), so I added them as Content.

Probably a project system issue. Is there a planned approach? Or is this there another preferred way to add them?