### PR TITLE
Remove unused lock file read from tool resolving logic.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -76,7 +76,6 @@ namespace Microsoft.DotNet.Cli.Utils
                 tools,
                 commandResolverArguments.CommandName,
                 commandResolverArguments.CommandArguments.OrEmptyIfNull(),
-                project.GetLockFile(),
                 project);
         }
 
@@ -84,7 +83,6 @@ namespace Microsoft.DotNet.Cli.Utils
             IEnumerable<SingleProjectInfo> toolsLibraries,
             string commandName,
             IEnumerable<string> args,
-            LockFile lockFile,
             IProject project)
         {
             Reporter.Verbose.WriteLine($"projecttoolscommandresolver: resolving commandspec from {toolsLibraries.Count()} Tool Libraries.");
@@ -95,7 +93,6 @@ namespace Microsoft.DotNet.Cli.Utils
                     toolLibrary,
                     commandName,
                     args,
-                    lockFile,
                     project);
 
                 if (commandSpec != null)
@@ -113,7 +110,6 @@ namespace Microsoft.DotNet.Cli.Utils
             SingleProjectInfo toolLibraryRange,
             string commandName,
             IEnumerable<string> args,
-            LockFile lockFile,
             IProject project)
         {
             Reporter.Verbose.WriteLine($"projecttoolscommandresolver: Attempting to resolve command spec from tool {toolLibraryRange.Name}");


### PR DESCRIPTION
During tool resolving, the project's lock / assets file is read unnecessarily.

Removing this code also fixes an exception that occurs when the file cannot be read, e.g. when the project hasn't been restored:
```
$ dotnet sfsgas
System.AggregateException: One or more errors occurred. (Could not access assets file.) ---> System.InvalidOperationException: Could not access assets file.
   at Microsoft.DotNet.Cli.Utils.FileAccessRetrier.<RetryOnFileAccessFailure>d__0`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NuGet.Common.ConcurrencyUtilities.<ExecuteWithFileLockedAsync>d__2`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.DotNet.Cli.Utils.LockFileFormatExtensions.<ReadWithLock>d__2.MoveNext()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Microsoft.DotNet.Cli.Utils.MSBuildProject.GetLockFile()
   at Microsoft.DotNet.Cli.Utils.ProjectToolsCommandResolver.ResolveFromProjectTools(CommandResolverArguments commandResolverArguments)
   at Microsoft.DotNet.Cli.Utils.ProjectToolsCommandResolver.Resolve(CommandResolverArguments commandResolverArguments)
   at Microsoft.DotNet.Cli.Utils.CompositeCommandResolver.Resolve(CommandResolverArguments commandResolverArguments)
   at Microsoft.DotNet.Cli.Utils.CommandResolver.TryResolveCommandSpec(ICommandResolverPolicy commandResolverPolicy, String commandName, IEnumerable`1 args, NuGetFramework framework, String configuration, String outputPath, String applicationName)
   at Microsoft.DotNet.Cli.Utils.Command.Create(ICommandResolverPolicy commandResolverPolicy, String commandName, IEnumerable`1 args, NuGetFramework framework, String configuration, String outputPath, String applicationName)
   at Microsoft.DotNet.Cli.Utils.Command.Create(String commandName, IEnumerable`1 args, NuGetFramework framework, String configuration, String outputPath, String applicationName)
   at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, ITelemetry telemetryClient)
   at Microsoft.DotNet.Cli.Program.Main(String[] args)
---> (Inner Exception #0) System.InvalidOperationException: Could not access assets file.
   at Microsoft.DotNet.Cli.Utils.FileAccessRetrier.<RetryOnFileAccessFailure>d__0`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at NuGet.Common.ConcurrencyUtilities.<ExecuteWithFileLockedAsync>d__2`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Microsoft.DotNet.Cli.Utils.LockFileFormatExtensions.<ReadWithLock>d__2.MoveNext()<---
```

cc @livarcocc @piotrpMSFT 