### PR TITLE
Add the path to the dotnet being used to --info

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -244,6 +244,7 @@ namespace Microsoft.DotNet.Cli
             Reporter.Output.WriteLine($" OS Version:  {RuntimeEnvironment.OperatingSystemVersion}");
             Reporter.Output.WriteLine($" OS Platform: {RuntimeEnvironment.OperatingSystemPlatform}");
             Reporter.Output.WriteLine($" RID:         {GetDisplayRid(versionFile)}");
+            Reporter.Output.WriteLine($" Base Path:   {ApplicationEnvironment.ApplicationBasePath}");
         }
 
         private static bool IsArg(string candidate, string longName)


### PR DESCRIPTION
- Please add description for changes you are making.
Utilize ApplicationEnvironment.ApplicationBasePath of DotNet.PlatformAbstractions

Output from Windows
```bat
C:\Users>dotnet --info
.NET Command Line Tools (1.0.0-preview4-004109)

Product Information:
 Version:            1.0.0-preview4-004109
 Commit SHA-1 hash:  98a3974557

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.14393
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   C:\Program Files\dotnet\sdk\1.0.0-preview4-004109
```

Output from Ubuntu
```bash
xingmu@xingmu-UX31A:~/Documents/cli/artifacts/ubuntu.16.04-x64/stage2$ ./dotnet --info
.NET Command Line Tools (1.0.0-preview4-004109)

Product Information:
 Version: 1.0.0-preview4-004109
 Commit SHA-1 hash: 98a3974557

Runtime Environment:
 OS Name: ubuntu
 OS Version: 16.04
 OS Platform: Linux
 RID: ubuntu.16.04-x64
 Base Path: /home/xingmu/Documents/cli/artifacts/ubuntu.16.04-x64/stage2/sdk/1.0.0-preview4-004109
```

- If there is an issue related to this PR, please add the reference.
#3900