### PR TITLE
Checking that the lock file exists before trying to acquire the lock for it.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Extensions/LockFileFormatExtensions.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Extensions/LockFileFormatExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,6 +20,14 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public static async Task<LockFile> ReadWithLock(this LockFileFormat subject, string path)
         {
+            if(!File.Exists(path))
+            {
+                throw new GracefulException(string.Join(
+                    Environment.NewLine,
+                    $"File not found `{path}`.",
+                    "The project may not have been restored or restore failed - run `dotnet restore`"));
+            }
+
             return await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
                 path, 
                 lockedToken =>

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenThatWeWantToReadLockFilesQuickly.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenThatWeWantToReadLockFilesQuickly.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using FluentAssertions;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.InternalAbstractions;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using NuGet.Frameworks;
+using NuGet.ProjectModel;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    public class GivenThatWeWantToReadLockFilesQuickly : TestBase
+    {
+        [Fact]
+        public void ItFailsInLessThanOneSecondWhenTheProjectAssetsJsonDoesNotExist()
+        {
+            var testInstance = TestAssets.Get("TestAppWithProjDepTool")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            var assetsFile = testInstance.Root.GetDirectory("obj").GetFile("project.assets.json").FullName;
+            var expectedMessage = string.Join(
+                Environment.NewLine,
+                $"File not found `{assetsFile}`.",
+                "The project may not have been restored or restore failed - run `dotnet restore`");
+
+            Action action = () =>
+            {
+                var lockFile = new LockFileFormat()
+                    .ReadWithLock(assetsFile)
+                    .Result;
+            };
+
+            var stopWatch = Stopwatch.StartNew();
+
+            action.ShouldThrow<GracefulException>().WithMessage(expectedMessage);
+
+            stopWatch.Stop();
+            stopWatch.ElapsedMilliseconds.Should().BeLessThan(1000);
+        }
+    }
+}


### PR DESCRIPTION
Checking that the lock file exists before trying to acquire the lock for it, which takes up to 30 seconds.

Fixex https://github.com/dotnet/cli/issues/4034.

@piotrpMSFT @krwq @jgoshi 