### PR TITLE
Making Project Tools use the CLI shared runtime

### DIFF
--- a/TestAssets/TestPackages/dotnet-prefercliruntime/Program.cs
+++ b/TestAssets/TestPackages/dotnet-prefercliruntime/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello I prefer the cli runtime World!");
+        }
+    }
+}

--- a/TestAssets/TestPackages/dotnet-prefercliruntime/dotnet-prefercliruntime.csproj
+++ b/TestAssets/TestPackages/dotnet-prefercliruntime/dotnet-prefercliruntime.csproj
@@ -1,0 +1,42 @@
+﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="$(OutputPath)\$(AssemblyName).runtimeconfig.json">
+      <Pack>true</Pack>
+      <PackagePath>lib\$(TargetFramework)</PackagePath>
+    </Content>
+    <Content Include="prefercliruntime">
+      <Pack>true</Pack>
+      <PackagePath>\prefercliruntime</PackagePath>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk">
+      <Version>1.0.0-alpha-20161104-2</Version>
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.1.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
+++ b/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
@@ -25,6 +25,9 @@
     <DotNetCliToolReference Include="dotnet-portable">
       <Version>1.0.0</Version>
     </DotNetCliToolReference>
+    <DotNetCliToolReference Include="dotnet-prefercliruntime">
+      <Version>1.0.0</Version>
+    </DotNetCliToolReference>
   </ItemGroup>
 
   <Import Project="$(MSBuildExtensionsPath)\Microsoft.CSharp.targets" />

--- a/build/test/TestPackageProjects.targets
+++ b/build/test/TestPackageProjects.targets
@@ -155,6 +155,16 @@
         <Clean>True</Clean>
         <Frameworks>netcoreapp1.0</Frameworks>
       </BaseTestPackageProject>
+      <BaseTestPackageProject Include="TestAssets/TestPackages/dotnet-prefercliruntime">
+        <Name>dotnet-prefercliruntime</Name>
+        <ProjectName>dotnet-prefercliruntime.csproj</ProjectName>
+        <IsTool>True</IsTool>
+        <IsApplicable>True</IsApplicable>
+        <VersionPrefix>1.0.0</VersionPrefix>
+        <VersionSuffix></VersionSuffix>
+        <Clean>True</Clean>
+        <Frameworks>netcoreapp1.0</Frameworks>
+      </BaseTestPackageProject>
       <BaseTestPackageProject Include="TestAssets/TestPackages/ToolWithOutputName">
         <Name>dotnet-tool-with-output-name</Name>
         <ProjectName>ToolWithOutputName.csproj</ProjectName>

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/DefaultCommandResolverPolicy.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/DefaultCommandResolverPolicy.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Utils
         public static CompositeCommandResolver Create()
         {
             var environment = new EnvironmentProvider();
-            var packagedCommandSpecFactory = new PackagedCommandSpecFactory();
+            var packagedCommandSpecFactory = new PackagedCommandSpecFactoryWithCliRuntime();
             var publishedPathCommandSpecFactory = new PublishPathCommandSpecFactory();
 
             var platformCommandSpecFactory = default(IPlatformCommandSpecFactory);

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/PackagedCommandSpecFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/PackagedCommandSpecFactory.cs
@@ -10,6 +10,13 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class PackagedCommandSpecFactory : IPackagedCommandSpecFactory
     {
+        private Action<string, IList<string>> _addAdditionalArguments;
+
+        internal PackagedCommandSpecFactory(Action<string, IList<string>> addAdditionalArguments = null)
+        {
+            _addAdditionalArguments = addAdditionalArguments;
+        }
+
         public CommandSpec CreateCommandSpecFromLibrary(
             LockFileTargetLibrary toolLibrary,
             string commandName,
@@ -119,6 +126,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
             arguments.Add("--additionalprobingpath");
             arguments.Add(nugetPackagesRoot);
+
+            if(_addAdditionalArguments != null)
+            {
+                _addAdditionalArguments(commandPath, arguments);
+            }
 
             arguments.Add(commandPath);
             arguments.AddRange(commandArguments);

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/PackagedCommandSpecFactoryWithCliRuntime.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/PackagedCommandSpecFactoryWithCliRuntime.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Tools.Common;
+using NuGet.Packaging;
+using NuGet.ProjectModel;
+
+namespace Microsoft.DotNet.Cli.Utils
+{
+    public class PackagedCommandSpecFactoryWithCliRuntime : PackagedCommandSpecFactory
+    {
+        public PackagedCommandSpecFactoryWithCliRuntime() : base(AddAditionalParameters)
+        {
+        }
+
+        private static void AddAditionalParameters(string commandPath, IList<string> arguments)
+        {
+            if(PrefersCliRuntime(commandPath))
+            {
+                arguments.Add("--fx-version");
+                arguments.Add(new Muxer().SharedFxVersion);
+            }
+        }
+
+        private static bool PrefersCliRuntime(string commandPath)
+        {
+            var libTFMPackageDirectory = Path.GetDirectoryName(commandPath);
+            var packageDirectory = Path.Combine(libTFMPackageDirectory, "..", "..");
+            var preferCliRuntimePath = Path.Combine(packageDirectory, "prefercliruntime");
+
+            Reporter.Verbose.WriteLine(
+                $"packagedcommandspecfactory: Looking for prefercliruntime file at `{preferCliRuntimePath}`");
+
+            return File.Exists(preferCliRuntimePath);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -15,7 +15,8 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             get
             {
-                return new DirectoryInfo(Path.GetDirectoryName(GetDataFromAppDomain("FX_DEPS_FILE"))).Name;
+                var depsFile = new FileInfo(Path.GetDirectoryName(GetDataFromAppDomain("FX_DEPS_FILE")));
+                return depsFile.Directory.Name;
             }
         }
 

--- a/src/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -11,6 +11,14 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private string _muxerPath;
 
+        internal string SharedFxVersion
+        {
+            get
+            {
+                return new DirectoryInfo(Path.GetDirectoryName(GetDataFromAppDomain("FX_DEPS_FILE"))).Name;
+            }
+        }
+
         public string MuxerPath
         {
             get

--- a/src/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             get
             {
-                var depsFile = new FileInfo(Path.GetDirectoryName(GetDataFromAppDomain("FX_DEPS_FILE")));
+                var depsFile = new FileInfo(GetDataFromAppDomain("FX_DEPS_FILE"));
                 return depsFile.Directory.Name;
             }
         }

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -70,6 +70,25 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         }
 
         [Fact]
+        public void ItCanRunToolsThatPrefersTheCliRuntime()
+        {
+            var testInstance = TestAssets.Get("MSBuildTestApp")
+                                         .CreateInstance()
+                                         .WithSourceFiles()
+                                         .WithRestoreFiles();
+
+            var testProjectDirectory = testInstance.Root;
+
+            new DotnetCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .ExecuteWithCapturedOutput("prefercliruntime")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello I prefer the cli runtime World!");;
+        }
+
+        [Fact]
         public void ItCanRunAToolThatInvokesADependencyToolInACSProj()
         {
             var repoDirectoriesProvider = new RepoDirectoriesProvider();

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
         }
 
         [Fact]
-        public void ItCanRunToolsThatPrefersTheCliRuntime()
+        public void ItCanRunToolsThatPrefersTheCliRuntimeEvenWhenTheToolItselfDeclaresADifferentRuntime()
         {
             var testInstance = TestAssets.Get("MSBuildTestApp")
                                          .CreateInstance()
@@ -82,10 +82,8 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             new DotnetCommand()
                 .WithWorkingDirectory(testInstance.Root)
                 .ExecuteWithCapturedOutput("prefercliruntime")
-                .Should()
-                .Pass()
-                .And
-                .HaveStdOutContaining("Hello I prefer the cli runtime World!");;
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello I prefer the cli runtime World!");;
         }
 
         [Fact]

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -306,7 +306,7 @@ namespace Microsoft.DotNet.Tests
 
             result.Should().NotBeNull();
 
-            result.Args.Should().NotContain("-fx-version");
+            result.Args.Should().NotContain("--fx-version");
         }
 
         private ProjectToolsCommandResolver SetupProjectToolsCommandResolver()

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -80,16 +80,16 @@ namespace Microsoft.DotNet.Tests
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
-            var testInstance = TestAssetsManager
-                .CreateTestInstance(TestProjectName)
-                .WithNuGetMSBuildFiles()
-                .WithLockFiles();
+            var testInstance = TestAssets.Get(TestProjectName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
 
             var commandResolverArguments = new CommandResolverArguments()
             {
                 CommandName = "nonexistent-command",
                 CommandArguments = null,
-                ProjectDirectory = testInstance.Path
+                ProjectDirectory = testInstance.Root.FullName
             };
 
             var result = projectToolsCommandResolver.Resolve(commandResolverArguments);
@@ -102,16 +102,16 @@ namespace Microsoft.DotNet.Tests
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
-            var testInstance = TestAssetsManager
-                .CreateTestInstance(TestProjectName)
-                .WithNuGetMSBuildFiles()
-                .WithLockFiles();
+            var testInstance = TestAssets.Get(TestProjectName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
 
             var commandResolverArguments = new CommandResolverArguments()
             {
                 CommandName = "dotnet-portable",
                 CommandArguments = null,
-                ProjectDirectory = testInstance.Path
+                ProjectDirectory = testInstance.Root.FullName
             };
 
             var result = projectToolsCommandResolver.Resolve(commandResolverArguments);
@@ -266,23 +266,23 @@ namespace Microsoft.DotNet.Tests
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
-            var testInstance = TestAssetsManager
-                .CreateTestInstance("MSBuildTestApp")
-                .WithNuGetMSBuildFiles()
-                .WithLockFiles();
+            var testInstance = TestAssets.Get("MSBuildTestApp")
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
 
             var commandResolverArguments = new CommandResolverArguments()
             {
                 CommandName = "dotnet-prefercliruntime",
                 CommandArguments = null,
-                ProjectDirectory = testInstance.Path
+                ProjectDirectory = testInstance.Root.FullName
             };
 
             var result = projectToolsCommandResolver.Resolve(commandResolverArguments);
 
             result.Should().NotBeNull();
 
-            result.Args.Should().Contain("-fx-version 1.0.1");
+            result.Args.Should().Contain("--fx-version 1.0.1");
         }
 
         [Fact]
@@ -290,16 +290,16 @@ namespace Microsoft.DotNet.Tests
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
-            var testInstance = TestAssetsManager
-                .CreateTestInstance(TestProjectName)
-                .WithNuGetMSBuildFiles()
-                .WithLockFiles();
+            var testInstance = TestAssets.Get(TestProjectName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
 
             var commandResolverArguments = new CommandResolverArguments()
             {
                 CommandName = "dotnet-portable",
                 CommandArguments = null,
-                ProjectDirectory = testInstance.Path
+                ProjectDirectory = testInstance.Root.FullName
             };
 
             var result = projectToolsCommandResolver.Resolve(commandResolverArguments);

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -17,7 +17,8 @@ namespace Microsoft.DotNet.Tests
 {
     public class GivenAProjectToolsCommandResolver : TestBase
     {
-        private static readonly NuGetFramework s_toolPackageFramework = FrameworkConstants.CommonFrameworks.NetCoreApp10;
+        private static readonly NuGetFramework s_toolPackageFramework =
+            FrameworkConstants.CommonFrameworks.NetCoreApp10;
 
         private const string TestProjectName = "AppWithToolDependency";
 
@@ -260,16 +261,64 @@ namespace Microsoft.DotNet.Tests
             File.Delete(depsJsonFile);
         }
 
-        private ProjectToolsCommandResolver SetupProjectToolsCommandResolver(
-            IPackagedCommandSpecFactory packagedCommandSpecFactory = null)
+        [Fact]
+        public void It_adds_fx_version_as_a_param_when_the_tool_has_the_prefercliruntime_file()
+        {
+            var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
+
+            var testInstance = TestAssetsManager
+                .CreateTestInstance("MSBuildTestApp")
+                .WithNuGetMSBuildFiles()
+                .WithLockFiles();
+
+            var commandResolverArguments = new CommandResolverArguments()
+            {
+                CommandName = "dotnet-prefercliruntime",
+                CommandArguments = null,
+                ProjectDirectory = testInstance.Path
+            };
+
+            var result = projectToolsCommandResolver.Resolve(commandResolverArguments);
+
+            result.Should().NotBeNull();
+
+            result.Args.Should().Contain("-fx-version 1.0.1");
+        }
+
+        [Fact]
+        public void It_does_not_add_fx_version_as_a_param_when_the_tool_does_not_have_the_prefercliruntime_file()
+        {
+            var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
+
+            var testInstance = TestAssetsManager
+                .CreateTestInstance(TestProjectName)
+                .WithNuGetMSBuildFiles()
+                .WithLockFiles();
+
+            var commandResolverArguments = new CommandResolverArguments()
+            {
+                CommandName = "dotnet-portable",
+                CommandArguments = null,
+                ProjectDirectory = testInstance.Path
+            };
+
+            var result = projectToolsCommandResolver.Resolve(commandResolverArguments);
+
+            result.Should().NotBeNull();
+
+            result.Args.Should().NotContain("-fx-version");
+        }
+
+        private ProjectToolsCommandResolver SetupProjectToolsCommandResolver()
         {
             Environment.SetEnvironmentVariable(
                 Constants.MSBUILD_EXE_PATH,
                 Path.Combine(new RepoDirectoriesProvider().Stage2Sdk, "MSBuild.dll"));
 
-            packagedCommandSpecFactory = packagedCommandSpecFactory ?? new PackagedCommandSpecFactory();
+            var packagedCommandSpecFactory = new PackagedCommandSpecFactoryWithCliRuntime();
 
-            var projectToolsCommandResolver = new ProjectToolsCommandResolver(packagedCommandSpecFactory, new EnvironmentProvider());
+            var projectToolsCommandResolver =
+                new ProjectToolsCommandResolver(packagedCommandSpecFactory, new EnvironmentProvider());
 
             return projectToolsCommandResolver;
         }


### PR DESCRIPTION
Making Project Tools use the CLI shared runtime if they have the prefercliruntime in the root of their package. This allows for project tools to not have to change when a new runtime comes up as long as they are compatible with the runtime that the CLI is using.

@piotrpMSFT @krwq @jgoshi 