### PR TITLE
Fix for current ci fails

### DIFF
--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -130,6 +130,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             String[] trxFiles = Directory.GetFiles(trxLoggerDirectory, "*.trx");
             Assert.Equal(1, trxFiles.Length);
             result.StdOut.Should().Contain(trxFiles[0]);
+
+            // Cleanup trxLoggerDirectory if it exist
+            if(Directory.Exists(trxLoggerDirectory))
+            {
+                Directory.Delete(trxLoggerDirectory, true);
+            }
         }
     }
 }


### PR DESCRIPTION
The current `HEAD` eb8e0cfa409d2ef89091f2058487be0e48e8a32e has a test failure  [.VSTestFailTest (from MSTestSuite)](https://ci.dot.net/job/dotnet_cli/job/rel_1.0.0/job/release_windows_nt_x64_prtest/119/testReport/(root)/(empty)/VSTestFailTest/).

But i think is just beacuase jenkins consider the trx log used in a `dotnet test` to assert failure is reported

