### PR TITLE
Show meaningful error when failing to migrate invalid scripts

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/MigrationErrorCodes.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/MigrationErrorCodes.cs
@@ -31,6 +31,9 @@ namespace Microsoft.DotNet.ProjectJsonMigration
         public static Func<string, MigrationError> MIGRATE1018
             => (message) => new MigrationError(nameof(MIGRATE1018), "Dependency Project not found", message);
 
+        public static Func<string, MigrationError> MIGRATE1019
+            => (message) => new MigrationError(nameof(MIGRATE1019), "Unsupported Script Event Hook", message);
+
         // Potentially Temporary (Point in Time) Errors
         public static Func<string, MigrationError> MIGRATE20011
             => (message) => new MigrationError(nameof(MIGRATE20011), "Multi-TFM", message);

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateScriptsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateScriptsRule.cs
@@ -87,7 +87,14 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
         private ProjectTargetElement CreateTarget(ProjectRootElement csproj, string scriptSetName)
         {
             var targetName = $"{scriptSetName[0].ToString().ToUpper()}{string.Concat(scriptSetName.Skip(1))}Script";
-            var targetHookInfo = ScriptSetToMSBuildHookTargetMap[scriptSetName];
+
+            TargetHookInfo targetHookInfo;
+            if(!ScriptSetToMSBuildHookTargetMap.TryGetValue(scriptSetName, out targetHookInfo))
+            {
+                MigrationErrorCodes.MIGRATE1019(
+                        $"{scriptSetName} is an unsupported script event hook for project migration")
+                    .Throw();
+            }
 
             var target = csproj.CreateTargetElement(targetName);
             csproj.InsertBeforeChild(target, csproj.LastChild);

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateScripts.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateScripts.cs
@@ -154,5 +154,19 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             var target = scriptMigrationRule.MigrateScriptSet(mockProj, mockProj.AddPropertyGroup(), commands, "prepublish");
             target.Condition.Should().Be(" '$(IsCrossTargetingBuild)' != 'true' ");
         }
+
+        [Fact]
+        public void Migrating_scripts_throws_on_invalid_ScriptSet()
+        {
+            var scriptMigrationRule = new MigrateScriptsRule();
+            ProjectRootElement mockProj = ProjectRootElement.Create();
+
+            var commands = new string[] { "fakecommand" };
+
+            Action action = () => scriptMigrationRule.MigrateScriptSet(mockProj, mockProj.AddPropertyGroup(),  commands, "invalidScriptSet");
+
+            action.ShouldThrow<MigrationException>()
+                .WithMessage("MIGRATE1019::Unsupported Script Event Hook: invalidScriptSet is an unsupported script event hook for project migration");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/4835#issuecomment-262792492 (repro in comment, not sure about the original issue yet).

When a `project.json` contains an invalid / unknown script entry, migration fails with:
```
System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
   at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
   at Microsoft.DotNet.ProjectJsonMigration.Rules.MigrateScriptsRule.CreateTarget(ProjectRootElement csproj, String scriptSetName)
```

This may happen with users having a `prebuild` / `postbuild` section from DNX times. I did not add a migration for these scripts as the resulting csproj would then behave differently as the project.json.

It now fails with a **new error**:
`MIGRATE1019::Unsupported Script Event Hook: postbuild is currently an unsupported script event hook for project migration`

cc @livarcocc @piotrpMSFT 