### PR TITLE
Localization for dotnet-clean command.

### DIFF
--- a/src/dotnet/commands/dotnet-clean/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-clean/LocalizableStrings.cs
@@ -1,0 +1,25 @@
+﻿namespace Microsoft.DotNet.Tools.Clean
+{
+    internal class LocalizableStrings
+    {
+        public const string AppFullName = ".NET Clean Command";
+
+        public const string AppDescription = "Command to clean previously generated build outputs.";
+
+        public const string CmdArgProject = "PROJECT";
+
+        public const string CmdArgProjDescription= "The MSBuild project file to build. If a project file is not specified, MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file.";
+
+        public const string CmdOutputDir = "OUTPUT_DIR";
+
+        public const string CmdOutputDirDescription = "Directory in which the build outputs have been placed";
+
+        public const string CmdFramework = "FRAMEWORK";
+
+        public const string CmdFrameworkDescription = "Clean a specific framework";
+
+        public const string CmdConfiguration = "CONFIGURATION";
+
+        public const string CmdConfigurationDescription = "Clean a specific configuration";
+    }
+}

--- a/src/dotnet/commands/dotnet-clean/Program.cs
+++ b/src/dotnet/commands/dotnet-clean/Program.cs
@@ -17,20 +17,19 @@ namespace Microsoft.DotNet.Tools.Clean
             CommandLineApplication app = new CommandLineApplication(throwOnUnexpectedArg: false)
             {
                 Name = "dotnet clean",
-                FullName = ".NET Clean Command",
-                Description = "Command to clean previously generated build outputs.",
+                FullName = LocalizableStrings.AppFullName,
+                Description = LocalizableStrings.AppDescription,
                 AllowArgumentSeparator = true,
                 ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText
             };
             app.HelpOption("-h|--help");
 
-            CommandArgument projectArgument = app.Argument("<PROJECT>",
-                "The MSBuild project file to build. If a project file is not specified," +
-                " MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file.");
+            CommandArgument projectArgument = app.Argument($"<{LocalizableStrings.CmdArgProject}>",
+                LocalizableStrings.CmdArgProjDescription);
 
-            CommandOption outputOption = app.Option("-o|--output <OUTPUT_DIR>", "Directory in which the build outputs have been placed", CommandOptionType.SingleValue);
-            CommandOption frameworkOption = app.Option("-f|--framework <FRAMEWORK>", "Clean a specific framework", CommandOptionType.SingleValue);
-            CommandOption configurationOption = app.Option("-c|--configuration <CONFIGURATION>", "Clean a specific configuration", CommandOptionType.SingleValue);
+            CommandOption outputOption = app.Option($"-o|--output <{LocalizableStrings.CmdOutputDir}>", LocalizableStrings.CmdOutputDirDescription, CommandOptionType.SingleValue);
+            CommandOption frameworkOption = app.Option($"-f|--framework <{LocalizableStrings.CmdFramework}>", LocalizableStrings.CmdFrameworkDescription, CommandOptionType.SingleValue);
+            CommandOption configurationOption = app.Option($"-c|--configuration <{LocalizableStrings.CmdConfiguration}>", LocalizableStrings.CmdConfigurationDescription, CommandOptionType.SingleValue);
             CommandOption verbosityOption = MSBuildForwardingApp.AddVerbosityOption(app);
 
             app.OnExecute(() =>

--- a/src/dotnet/commands/dotnet-clean/Program.cs
+++ b/src/dotnet/commands/dotnet-clean/Program.cs
@@ -27,9 +27,18 @@ namespace Microsoft.DotNet.Tools.Clean
             CommandArgument projectArgument = app.Argument($"<{LocalizableStrings.CmdArgProject}>",
                 LocalizableStrings.CmdArgProjDescription);
 
-            CommandOption outputOption = app.Option($"-o|--output <{LocalizableStrings.CmdOutputDir}>", LocalizableStrings.CmdOutputDirDescription, CommandOptionType.SingleValue);
-            CommandOption frameworkOption = app.Option($"-f|--framework <{LocalizableStrings.CmdFramework}>", LocalizableStrings.CmdFrameworkDescription, CommandOptionType.SingleValue);
-            CommandOption configurationOption = app.Option($"-c|--configuration <{LocalizableStrings.CmdConfiguration}>", LocalizableStrings.CmdConfigurationDescription, CommandOptionType.SingleValue);
+            CommandOption outputOption = app.Option(
+                $"-o|--output <{LocalizableStrings.CmdOutputDir}>", 
+                LocalizableStrings.CmdOutputDirDescription, 
+                CommandOptionType.SingleValue);
+            CommandOption frameworkOption = app.Option(
+                $"-f|--framework <{LocalizableStrings.CmdFramework}>", 
+                LocalizableStrings.CmdFrameworkDescription, 
+                CommandOptionType.SingleValue);
+            CommandOption configurationOption = app.Option(
+                $"-c|--configuration <{LocalizableStrings.CmdConfiguration}>", 
+                LocalizableStrings.CmdConfigurationDescription, 
+                CommandOptionType.SingleValue);
             CommandOption verbosityOption = MSBuildForwardingApp.AddVerbosityOption(app);
 
             app.OnExecute(() =>

--- a/src/dotnet/commands/dotnet-clean/Program.cs
+++ b/src/dotnet/commands/dotnet-clean/Program.cs
@@ -24,7 +24,8 @@ namespace Microsoft.DotNet.Tools.Clean
             };
             app.HelpOption("-h|--help");
 
-            CommandArgument projectArgument = app.Argument($"<{LocalizableStrings.CmdArgProject}>",
+            CommandArgument projectArgument = app.Argument(
+                $"<{LocalizableStrings.CmdArgProject}>",
                 LocalizableStrings.CmdArgProjDescription);
 
             CommandOption outputOption = app.Option(


### PR DESCRIPTION
Added localization for the clean command. All localizable strings from the command are now placed in a new file, LocalizableStrings.cs.

