### PR TITLE
Localized strings for the dotnet-pack command.

### DIFF
--- a/src/dotnet/commands/dotnet-pack/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-pack/LocalizableStrings.cs
@@ -1,0 +1,33 @@
+﻿namespace Microsoft.DotNet.Tools.Pack
+{
+    internal class LocalizableStrings
+    {
+        public const string AppFullName = "pack";
+
+        public const string AppDescription = "pack for msbuild";
+
+        public const string CmdOutputDir  = "OUTPUT_DIR";
+
+        public const string CmdOutputDirDescription = "Directory in which to place outputs";
+
+        public const string CmdNoBuildOptionDescription = "Do not build project before packing";
+
+        public const string CmdIncludeSymbolsDescription = "Include PDBs along with the DLLs in the output folder";
+
+        public const string CmdIncludeSourceDescription  = "Include PDBs and source files. Source files go into the src folder in the resulting nuget package";
+
+        public const string CmdConfig = "CONFIGURATION";
+
+        public const string CmdConfigDescription = "Configuration under which to build";
+
+        public const string CmdVersionSuffix = "VERSION_SUFFIX";
+
+        public const string CmdVersionSuffixDescription = "Defines what `*` should be replaced with in version field in project.json";
+
+        public const string CmdServiceableDescription = "Set the serviceable flag in the package";
+
+        public const string CmdArgumentProject = "PROJECT";
+
+        public const string CmdArgumentDescription = "The project to pack, defaults to the project file in the current directory. Can be a path to any project file";
+    }
+}

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -25,7 +25,8 @@ namespace Microsoft.DotNet.Tools.Pack
 
             cmd.HelpOption("-h|--help");
 
-            var output = cmd.Option($"-o|--output <{LocalizableStrings.CmdOutputDir}>",
+            var output = cmd.Option(
+                $"-o|--output <{LocalizableStrings.CmdOutputDir}>",
                 LocalizableStrings.CmdOutputDirDescription,
                 CommandOptionType.SingleValue);
             var noBuild = cmd.Option("--no-build",
@@ -37,16 +38,19 @@ namespace Microsoft.DotNet.Tools.Pack
             var includeSource = cmd.Option("--include-source",
                 LocalizableStrings.CmdIncludeSourceDescription,
                 CommandOptionType.NoValue);
-            var configuration = cmd.Option($"-c|--configuration <{LocalizableStrings.CmdConfig}>",
+            var configuration = cmd.Option(
+                $"-c|--configuration <{LocalizableStrings.CmdConfig}>",
                 LocalizableStrings.CmdConfigDescription, 
                 CommandOptionType.SingleValue);
-            var versionSuffix = cmd.Option($"--version-suffix <{LocalizableStrings.CmdVersionSuffix}>",
+            var versionSuffix = cmd.Option(
+                $"--version-suffix <{LocalizableStrings.CmdVersionSuffix}>",
                 LocalizableStrings.CmdVersionSuffixDescription,
                 CommandOptionType.SingleValue);
             var serviceable = cmd.Option("-s|--serviceable",
                 LocalizableStrings.CmdServiceableDescription, 
                 CommandOptionType.NoValue);
-            var argRoot = cmd.Argument($"<{LocalizableStrings.CmdArgumentProject}>",
+            var argRoot = cmd.Argument(
+                $"<{LocalizableStrings.CmdArgumentProject}>",
                 LocalizableStrings.CmdArgumentDescription,
                 multipleValues:true);
             CommandOption verbosityOption = MSBuildForwardingApp.AddVerbosityOption(cmd);

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -29,13 +29,16 @@ namespace Microsoft.DotNet.Tools.Pack
                 $"-o|--output <{LocalizableStrings.CmdOutputDir}>",
                 LocalizableStrings.CmdOutputDirDescription,
                 CommandOptionType.SingleValue);
-            var noBuild = cmd.Option("--no-build",
+            var noBuild = cmd.Option(
+                "--no-build",
                 LocalizableStrings.CmdNoBuildOptionDescription, 
                 CommandOptionType.NoValue);
-            var includeSymbols = cmd.Option("--include-symbols",
+            var includeSymbols = cmd.Option(
+                "--include-symbols",
                 LocalizableStrings.CmdIncludeSymbolsDescription,
                 CommandOptionType.NoValue);
-            var includeSource = cmd.Option("--include-source",
+            var includeSource = cmd.Option(
+                "--include-source",
                 LocalizableStrings.CmdIncludeSourceDescription,
                 CommandOptionType.NoValue);
             var configuration = cmd.Option(
@@ -46,7 +49,8 @@ namespace Microsoft.DotNet.Tools.Pack
                 $"--version-suffix <{LocalizableStrings.CmdVersionSuffix}>",
                 LocalizableStrings.CmdVersionSuffixDescription,
                 CommandOptionType.SingleValue);
-            var serviceable = cmd.Option("-s|--serviceable",
+            var serviceable = cmd.Option(
+                "-s|--serviceable",
                 LocalizableStrings.CmdServiceableDescription, 
                 CommandOptionType.NoValue);
             var argRoot = cmd.Argument(

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -17,37 +17,37 @@ namespace Microsoft.DotNet.Tools.Pack
             CommandLineApplication cmd = new CommandLineApplication(throwOnUnexpectedArg: false)
             {
                 Name = "pack",
-                FullName = "pack",
-                Description = "pack for msbuild",
+                FullName = LocalizableStrings.AppFullName,
+                Description = LocalizableStrings.AppDescription,
                 AllowArgumentSeparator = true,
                 ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText
             };
 
             cmd.HelpOption("-h|--help");
 
-            var output = cmd.Option("-o|--output <OUTPUT_DIR>",
-                "Directory in which to place outputs",
+            var output = cmd.Option($"-o|--output <{LocalizableStrings.CmdOutputDir}>",
+                LocalizableStrings.CmdOutputDirDescription,
                 CommandOptionType.SingleValue);
             var noBuild = cmd.Option("--no-build",
-                "Do not build project before packing", 
+                LocalizableStrings.CmdNoBuildOptionDescription, 
                 CommandOptionType.NoValue);
             var includeSymbols = cmd.Option("--include-symbols",
-                "Include PDBs along with the DLLs in the output folder",
+                LocalizableStrings.CmdIncludeSymbolsDescription,
                 CommandOptionType.NoValue);
             var includeSource = cmd.Option("--include-source",
-                "Include PDBs and source files. Source files go into the src folder in the resulting nuget package",
+                LocalizableStrings.CmdIncludeSourceDescription,
                 CommandOptionType.NoValue);
-            var configuration = cmd.Option("-c|--configuration <CONFIGURATION>",
-                "Configuration under which to build", 
+            var configuration = cmd.Option($"-c|--configuration <{LocalizableStrings.CmdConfig}>",
+                LocalizableStrings.CmdConfigDescription, 
                 CommandOptionType.SingleValue);
-            var versionSuffix = cmd.Option("--version-suffix <VERSION_SUFFIX>",
-                "Defines what `*` should be replaced with in version field in project.json",
+            var versionSuffix = cmd.Option($"--version-suffix <{LocalizableStrings.CmdVersionSuffix}>",
+                LocalizableStrings.CmdVersionSuffixDescription,
                 CommandOptionType.SingleValue);
-            var serviceable = cmd.Option("-s|--serviceable", 
-                "Set the serviceable flag in the package", 
+            var serviceable = cmd.Option("-s|--serviceable",
+                LocalizableStrings.CmdServiceableDescription, 
                 CommandOptionType.NoValue);
-            var argRoot = cmd.Argument("<PROJECT>",
-                "The project to pack, defaults to the project file in the current directory. Can be a path to any project file",
+            var argRoot = cmd.Argument($"<{LocalizableStrings.CmdArgumentProject}>",
+                LocalizableStrings.CmdArgumentDescription,
                 multipleValues:true);
             CommandOption verbosityOption = MSBuildForwardingApp.AddVerbosityOption(cmd);
 


### PR DESCRIPTION
Added localization for the pack command. All localizable strings from the command are now placed in a new file, LocalizableStrings.cs.