### PR TITLE
Enable overriding MSBuildSDKsPath with env var

### DIFF
--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -86,6 +86,13 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         private static string GetMSBuildSDKsPath()
         {
+            var envMSBuildSDKsPath = Environment.GetEnvironmentVariable("MSBuildSDKsPath");
+
+            if (envMSBuildSDKsPath != null)
+            {
+                return envMSBuildSDKsPath;
+            }
+
             return Path.Combine(
                 AppContext.BaseDirectory,
                 ExtensionsDirectoryName);

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/FileInfoExtensions.FileInfoNuGetLock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/FileInfoExtensions.FileInfoNuGetLock.cs
@@ -15,8 +15,6 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
     {
         private class FileInfoNuGetLock : IDisposable
         {
-            private FileStream _fileStream;
-
             private CancellationTokenSource _cancellationTokenSource;
 
             private Task _task;

--- a/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
+++ b/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
@@ -103,5 +103,23 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
 
             cmd.ExitCode.Should().NotBe(0);
         }
+
+        [Fact]
+        public void When_MSBuildSDKsPath_is_set_by_env_var_then_it_is_not_overridden()
+        {
+            var testInstance = TestAssets.Get("MSBuildIntegration")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            var cmd = new DotnetCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .WithEnvironmentVariable("MSBuildSDKsPath", "AnyString")
+                .ExecuteWithCapturedOutput($"msbuild");
+
+            cmd.ExitCode.Should().NotBe(0);
+
+            cmd.StdOut.Should().Contain("Expected 'AnyString")
+                           .And.Contain("to exist, but it does not.");
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/4884

/cc @dsplaisted @livarcocc @jgoshi @krwq @MattGertz 
