### PR TITLE
Include Microsoft.Net.Sdk in CLI layout

### DIFF
--- a/TestAssets/TestProjects/MSBuildIntegration/build.proj
+++ b/TestAssets/TestProjects/MSBuildIntegration/build.proj
@@ -35,11 +35,11 @@
     <Error Condition=" '$(MSBuildSDKsPath)' == '' " 
            Text="Expected MSBuildSDKsPath to be set, but it is not." />
 
-    <Error Condition=" !Exists('$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/build/InitialImport.props') " 
-           Text="Expected '$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/build/InitialImport.props' to exist, but it does not. " />
+    <Error Condition=" !Exists('$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/sdk/Sdk.props') " 
+           Text="Expected '$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/build/Sdk.props' to exist, but it does not. " />
 
-    <Error Condition=" !Exists('$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/build/FinalImport.targets') " 
-           Text="Expected '$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/build/FinalImport.targets' to exist, but it does not. " />
+    <Error Condition=" !Exists('$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/sdk/Sdk.targets') " 
+           Text="Expected '$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/build/Sdk.targets' to exist, but it does not. " />
 
     <Message Importance="low" Text="Message with low importance" />
     <Message Importance="normal" Text="Message with normal importance" />

--- a/TestAssets/TestProjects/MSBuildIntegration/build.proj
+++ b/TestAssets/TestProjects/MSBuildIntegration/build.proj
@@ -35,11 +35,11 @@
     <Error Condition=" '$(MSBuildSDKsPath)' == '' " 
            Text="Expected MSBuildSDKsPath to be set, but it is not." />
 
-    <Error Condition=" !Exists('$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/sdk/Sdk.props') " 
-           Text="Expected '$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/build/Sdk.props' to exist, but it does not. " />
+    <Error Condition=" !Exists('$(MSBuildSDKsPath)/%(Sdk.Identity)/Sdk/Sdk.props') " 
+           Text="Expected '$(MSBuildSDKsPath)/%(Sdk.Identity)/Sdk/Sdk.props' to exist, but it does not. " />
 
-    <Error Condition=" !Exists('$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/sdk/Sdk.targets') " 
-           Text="Expected '$(MSBuildSDKsPath)/%(Sdk.Identity)/%(Sdk.Version)/build/Sdk.targets' to exist, but it does not. " />
+    <Error Condition=" !Exists('$(MSBuildSDKsPath)/%(Sdk.Identity)/Sdk/Sdk.targets') " 
+           Text="Expected '$(MSBuildSDKsPath)/%(Sdk.Identity)/Sdk/Sdk.targets' to exist, but it does not. " />
 
     <Message Importance="low" Text="Message with low importance" />
     <Message Importance="normal" Text="Message with normal importance" />

--- a/TestAssets/TestProjects/MSBuildIntegration/build.props
+++ b/TestAssets/TestProjects/MSBuildIntegration/build.props
@@ -1,6 +1,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Validate">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
   <ItemGroup>
-    <Sdk Include="Microsoft.Core.Sdk" Version="1.0.0-RC2" />
-    <Sdk Include="Microsoft.Web.Sdk" Version="1.0.0-RC2" />
+    <Sdk Include="Microsoft.Core.Sdk" Version="$(CLI_NETSDK_Version)" />
   </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/MSBuildIntegration/build.props
+++ b/TestAssets/TestProjects/MSBuildIntegration/build.props
@@ -2,6 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
-    <Sdk Include="Microsoft.Core.Sdk" Version="$(CLI_NETSDK_Version)" />
+    <Sdk Include="Microsoft.Net.Sdk" Version="$(CLI_NETSDK_Version)" />
   </ItemGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.BundledSdks.proj
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.proj
@@ -13,7 +13,7 @@
                             EnsureSdkRestored;
                             GetSdkItemsToCopy"
           Inputs="@(SdkContent)"
-          Outputs="@(SdkContent->'$(oz)/$(SdkPackageName)/$(SdkPackageVersion)/%(RecursiveDir)%(FileName)%(Extension)')">
+          Outputs="@(SdkContent->'$(SdkLayoutDirectory)/%(RecursiveDir)%(FileName)%(Extension)')">
     <Copy SourceFiles="@(SdkContent)"
           DestinationFiles="@(SdkContent->'$(SdkLayoutDirectory)/%(RecursiveDir)%(FileName)%(Extension)')" />
   </Target>
@@ -29,10 +29,6 @@
 
   <Target Name="EnsureSdkRestored"
           Condition="!Exists('$(SdkNuPkgPath)/$(SdkPackageName.ToLower()).nuspec')">
-    
-    <Message Text="$(SdkNuPkgPath)/$(SdkPackageName.ToLower()).nuspec" 
-             Importance="High" />
-
     <DotNetRestore ToolPath="$(Stage0Directory)"
                    ProjectPath="$(MSBuildThisFileDirectory)/sdks/sdks.csproj"
                    AdditionalParameters="/p:SdkPackageName=$(SdkPackageName) /p:SdkPackageVersion=$(SdkPackageVersion)" />

--- a/build/Microsoft.DotNet.Cli.BundledSdks.proj
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.proj
@@ -1,0 +1,46 @@
+<Project ToolsVersion="15.0" DefaultTargets="CopySdkToOutput">
+  <!-- workaround for https://github.com/Microsoft/msbuild/issues/885 -->
+  <!-- renaming the property because the original property is a global property and therefore
+       cannot be redefined at runtime. -->
+  <PropertyGroup>
+    <CLIBuildDllPath>$([MSBuild]::Unescape($(CLIBuildDll)))</CLIBuildDllPath>
+  </PropertyGroup>
+
+  <UsingTask TaskName="DotNetRestore" AssemblyFile="$(CLIBuildDllPath)" />
+
+  <Target Name="CopySdkToOutput"
+          DependsOnTargets="PrepareBundledSdksProps;
+                            EnsureSdkRestored;
+                            GetSdkItemsToCopy"
+          Inputs="@(SdkContent)"
+          Outputs="@(SdkContent->'$(oz)/$(SdkPackageName)/$(SdkPackageVersion)/%(RecursiveDir)%(FileName)%(Extension)')">
+    <Copy SourceFiles="@(SdkContent)"
+          DestinationFiles="@(SdkContent->'$(SdkLayoutDirectory)/%(RecursiveDir)%(FileName)%(Extension)')" />
+  </Target>
+
+  <Target Name="GetSdkItemsToCopy">
+    <ItemGroup>
+      <SdkContent Include="$(SdkNuPkgPath)/**/*" 
+                  Exclude="$(SdkNuPkgPath)/$(SdkPackageName).nuspec;
+                           $(SdkNuPkgPath)/$(SdkPackageName).$(SdkPackageVersion).nupkg;
+                           $(SdkNuPkgPath)/$(SdkPackageName).$(SdkPackageVersion).nupkg.sha512" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="EnsureSdkRestored"
+          Condition="!Exists('$(SdkNuPkgPath)/$(SdkPackageName.ToLower()).nuspec')">
+    
+    <Message Text="$(SdkNuPkgPath)/$(SdkPackageName.ToLower()).nuspec" 
+             Importance="High" />
+
+    <DotNetRestore ToolPath="$(Stage0Directory)"
+                   ProjectPath="$(MSBuildThisFileDirectory)/sdks/sdks.csproj"
+                   AdditionalParameters="/p:SdkPackageName=$(SdkPackageName) /p:SdkPackageVersion=$(SdkPackageVersion)" />
+  </Target>
+
+  <Target Name="PrepareBundledSdksProps">
+    <PropertyGroup>
+      <SdkNuPkgPath>$(NuGetPackagesDir)/$(SdkPackageName.ToLower())/$(SdkPackageVersion.ToLower())</SdkNuPkgPath>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/build/Microsoft.DotNet.Cli.BundledSdks.props
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.props
@@ -1,6 +1,8 @@
 <Project ToolsVersion="15.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
   <ItemGroup>
-    <BundledSdk Include="Microsoft.Core.Sdk" Version="1.0.0-RC2" />
-    <BundledSdk Include="Microsoft.Web.Sdk" Version="1.0.0-RC2" />
+    <BundledSdk Include="Microsoft.Net.Sdk" Version="$(CLI_NETSDK_Version)" />
+    <BundledSdk Include="Microsoft.NET.Sdk.Web" Version="$(CLI_WEBSDK_Version)" />
   </ItemGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.BundledSdks.props
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.props
@@ -2,7 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <ItemGroup>
-    <BundledSdk Include="Microsoft.Net.Sdk" Version="$(CLI_NETSDK_Version)" />
+    <!-- CLI cannot use the latest SDK until we move away from SDK PackageRef -->
+    <BundledSdk Include="Microsoft.Net.Sdk" Version="1.0.0-alpha-20161202-1" />
     <BundledSdk Include="Microsoft.NET.Sdk.Web" Version="$(CLI_WEBSDK_Version)" />
   </ItemGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -251,7 +251,7 @@
         <Properties>
           CLIBuildDll=$(CLIBuildDll);
           NuGetPackagesDir=$(NuGetPackagesDir);
-          SdkLayoutDirectory=$(SdkOutputDirectory)/Extensions/%(BundledSdk.Identity)/%(BundledSdk.Version);
+          SdkLayoutDirectory=$(SdkOutputDirectory)/Extensions/%(BundledSdk.Identity);
           SdkPackageName=%(BundledSdk.Identity);
           SdkPackageVersion=%(BundledSdk.Version);
           Stage0Directory=$(Stage0Directory)

--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -244,17 +244,24 @@
       <Delete Files="@(PdbsToClean)" />
   </Target>
 
-  <Target Name="PublishSdks">
-    <MakeDir Directories="$(SdkOutputDirectory)/Extensions/%(BundledSdk.Identity)/%(BundledSdk.Version)/build/" />
-    
-    <!-- Generate sdk placeholder files -->
-    <WriteLinesToFile File="$(SdkOutputDirectory)/Extensions/%(BundledSdk.Identity)/%(BundledSdk.Version)/build/InitialImport.props"
-                      Lines="placeholder"
-                      Overwrite="true" />
-    
-    <WriteLinesToFile File="$(SdkOutputDirectory)/Extensions/%(BundledSdk.Identity)/%(BundledSdk.Version)/build/FinalImport.targets"
-                      Lines="placeholder"
-                      Overwrite="true" />
+  <Target Name="PublishSdks"
+          DependsOnTargets="Prepare">
+    <ItemGroup>
+      <SdksToBundle Include="build/Microsoft.DotNet.Cli.BundledSdks.proj">
+        <Properties>
+          CLIBuildDll=$(CLIBuildDll);
+          NuGetPackagesDir=$(NuGetPackagesDir);
+          SdkLayoutDirectory=$(SdkOutputDirectory)/Extensions/%(BundledSdk.Identity)/%(BundledSdk.Version);
+          SdkPackageName=%(BundledSdk.Identity);
+          SdkPackageVersion=%(BundledSdk.Version);
+          Stage0Directory=$(Stage0Directory)
+        </Properties>
+      </SdksToBundle>
+    </ItemGroup>
 
+    <MSBuild
+      BuildInParallel="True"
+      Projects="@(SdksToBundle)">
+    </MSBuild>
   </Target>
 </Project>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -3,6 +3,6 @@
   <PropertyGroup>
     <CLI_MSBuild_Version>15.1.0-preview-000451-02</CLI_MSBuild_Version>
     <CLI_NETSDK_Version>1.0.0-alpha-20161104-2</CLI_NETSDK_Version>
-    <CLI_WEBSDK_Version>1.0.0-alpha-20161117-1-119</CLI_WEBSDK_Version>
+    <CLI_WEBSDK_Version>1.0.0-alpha-20161104-2-112</CLI_WEBSDK_Version>
   </PropertyGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <CLI_MSBuild_Version>15.1.0-preview-000451-02</CLI_MSBuild_Version>
     <CLI_NETSDK_Version>1.0.0-alpha-20161104-2</CLI_NETSDK_Version>
+    <CLI_WEBSDK_Version>1.0.0-alpha-20161117-1-119</CLI_WEBSDK_Version>
   </PropertyGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_MSBuild_Version>15.1.0-preview-000451-02</CLI_MSBuild_Version>
-    <CLI_NETSDK_Version>1.0.0-alpha-20161104-2</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.0.0-alpha-20161202-1</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20161104-2-112</CLI_WEBSDK_Version>
   </PropertyGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_MSBuild_Version>15.1.0-preview-000451-02</CLI_MSBuild_Version>
-    <CLI_NETSDK_Version>1.0.0-alpha-20161202-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.0.0-alpha-20161104-2</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20161104-2-112</CLI_WEBSDK_Version>
   </PropertyGroup>
 </Project>

--- a/build/sdks/sdks.csproj
+++ b/build/sdks/sdks.csproj
@@ -1,0 +1,17 @@
+﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+  
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="$(SdkPackageName)">
+      <Version>$(SdkPackageVersion)</Version>
+    </PackageReference>
+  </ItemGroup>
+  
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/build_projects/dotnet-cli-build/DotNetRestore.cs
+++ b/build_projects/dotnet-cli-build/DotNetRestore.cs
@@ -12,8 +12,10 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{GetProjectPath()} {GetSource()} {GetPackages()} {GetSkipInvalidConfigurations()} {GetRuntime()}"; }
+            get { return $"{GetProjectPath()} {GetSource()} {GetPackages()} {GetSkipInvalidConfigurations()} {GetRuntime()} {GetAdditionalParameters()}"; }
         }
+
+        public string AdditionalParameters { get; set; }
 
         public string ProjectPath { get; set; }
 
@@ -73,6 +75,11 @@ namespace Microsoft.DotNet.Cli.Build
             }
 
             return null;
+        }
+
+        private string GetAdditionalParameters()
+        {
+            return AdditionalParameters;
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -25,6 +25,8 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         private List<Action<string>> _writeLines = new List<Action<string>>();
 
+        private List<string> _cliGeneratedEnvironmentVariables = new List<string> { "MSBuildSDKsPath" };
+
         public TestCommand(string command)
         {
             _command = command;
@@ -178,6 +180,8 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 UseShellExecute = false
             };
 
+            RemoveCliGeneratedEnvironmentVariables(psi);
+
             foreach (var item in Environment)
             {
 #if NET451
@@ -218,6 +222,18 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             }
 
             return $" in pwd {WorkingDirectory}";
+        }
+
+        private void RemoveCliGeneratedEnvironmentVariables(ProcessStartInfo psi)
+        {
+            foreach (var name in _cliGeneratedEnvironmentVariables)
+            {
+#if NET451
+                psi.EnvironmentVariables.Remove(name);
+#else
+                psi.Environment.Remove(name);
+#endif
+            }
         }
     }
 }


### PR DESCRIPTION
Helps towards #4887 

Adds publishing of Microsoft.Net.Sdk to the CLI layout. Adds one-line addition of new SDKs through BundledSdks.props.

/cc @MattGertz @srivatsn @dsplaisted @livarcocc @mlorbetske 