### PR TITLE
Skipping dotnet publish-iis when migrating scripts as it is now part of the web.sdk

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateScriptsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateScriptsRule.cs
@@ -40,6 +40,11 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
             var target = CreateTarget(csproj, scriptSetName);
             foreach (var scriptCommand in scriptCommands)
             {
+                if (CommandIsNotNeededInMSBuild(scriptCommand))
+                {
+                    continue;
+                }
+
                 AddExec(target, FormatScriptCommand(scriptCommand));
             }
 
@@ -77,6 +82,11 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
             scriptArguments = scriptArguments.Where(argument => !string.IsNullOrEmpty(argument)).ToArray();
 
             return string.Join(" ", scriptArguments);
+        }
+
+        private bool CommandIsNotNeededInMSBuild(string command)
+        {
+            return command.Contains("dotnet publish-iis");
         }
 
         private bool IsPathRootedForAnyOS(string path)


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/4612.

@piotrpMSFT @jgoshi @krwq 