### PR TITLE
Fix output race

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -248,14 +248,12 @@ namespace Microsoft.DotNet.Cli.Utils
 
             try
             {
-                File.Copy(tempDepsFile, depsPath);
+                File.Move(tempDepsFile, depsPath);
             }
             catch (Exception e)
             {
                 Reporter.Verbose.WriteLine($"unable to generate deps.json, it may have been already generated: {e.Message}");
-            }
-            finally
-            {
+                
                 try
                 {
                     File.Delete(tempDepsFile);

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -131,11 +131,16 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         private CommandResult RunProcess(string executable, string args, StreamForwarder stdOut, StreamForwarder stdErr)
         {
-            CurrentProcess = StartProcess(executable, args);
+            CurrentProcess = CreateProcess(executable, args);
+
             var taskOut = stdOut.BeginRead(CurrentProcess.StandardOutput);
+
             var taskErr = stdErr.BeginRead(CurrentProcess.StandardError);
 
+            CurrentProcess.Start();
+
             CurrentProcess.WaitForExit();
+
             Task.WaitAll(taskOut, taskErr);
 
             var result = new CommandResult(
@@ -149,9 +154,13 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         private Task<CommandResult> RunProcessAsync(string executable, string args, StreamForwarder stdOut, StreamForwarder stdErr)
         {
-            CurrentProcess = StartProcess(executable, args);
+            CurrentProcess = CreateProcess(executable, args);
+
             var taskOut = stdOut.BeginRead(CurrentProcess.StandardOutput);
+
             var taskErr = stdErr.BeginRead(CurrentProcess.StandardError);
+
+            CurrentProcess.Start();
 
             var tcs = new TaskCompletionSource<CommandResult>();
             CurrentProcess.Exited += (sender, arg) =>
@@ -168,7 +177,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return tcs.Task;
         }
 
-        private Process StartProcess(string executable, string args)
+        private Process CreateProcess(string executable, string args)
         {
             var psi = new ProcessStartInfo
             {
@@ -202,7 +211,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             };
 
             process.EnableRaisingEvents = true;
-            process.Start();
+
             return process;
         }
 


### PR DESCRIPTION
TestCommand starts the test process before wiring up stderr & stdout. This change delays process start until after the wireup is finished so that the test process cannot shut down before we have wired up output redirection.

Note, we haven't seen this failure on OS's I use regularly, so pushing to CI without local run.