### PR TITLE
[WIP] use Sdk attribute in F# templates too

### DIFF
--- a/build/Microsoft.DotNet.Cli.BundledSdks.props
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.props
@@ -8,5 +8,6 @@
     <BundledSdk Include="Microsoft.NET.Sdk.Web" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Publish" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Web.ProjectSystem" Version="$(CLI_WEBSDK_Version)" />
+    <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.0-beta-040011" />
   </ItemGroup>
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/$projectName$.fsproj
@@ -1,5 +1,4 @@
-﻿<Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,10 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-alpha-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -28,7 +24,5 @@
       <Version>1.0.0-preview2-020000</Version>
     </DotNetCliToolReference>
   </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Lib/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Lib/$projectName$.fsproj
@@ -1,5 +1,4 @@
-﻿<Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -14,10 +13,7 @@
   <ItemGroup>
     <PackageReference Include="NETStandard.Library" Version="1.6" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-alpha-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -27,7 +23,5 @@
       <Version>1.0.0-preview2-020000</Version>
     </DotNetCliToolReference>
   </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Mstest/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Mstest/$projectName$.fsproj
@@ -1,5 +1,4 @@
-<Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,13 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161109-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.5-preview" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.6-preview" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-alpha-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -31,5 +27,4 @@
     </DotNetCliToolReference>
   </ItemGroup>
 
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Xunittest/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Xunittest/$projectName$.fsproj
@@ -1,5 +1,4 @@
-<Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,14 +12,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
-    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
     <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-alpha-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -30,7 +26,5 @@
       <Version>1.0.0-preview2-020000</Version>
     </DotNetCliToolReference>
   </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
 </Project>


### PR DESCRIPTION
The idea is to bundle **only** the `Sdk` directory of package `FSharp.NET.Sdk`. The other target file are not needed because these inside restored package are used, not these embeeded (so less code for sdk, and easier for me to update f# afterwards, if needed).
 
The rest of targets files required for F# will be used after restore from `PackageReference` `Fsharp.NET.Sdk`, but at least i can hook inside normal `LanguageTarget` ( ref dotnet/sdk#448 ) for f#, so the flow for c# and f# is the same. The trick is to import FSharp.NET.Sdk **before** microsoft.net.sdk, to populate `LanguageTargets` property.

pratically the embedded sdk include is:

```xml
<PropertyGroup Condition=" '$(LanguageTargets)' == '' and '$(MSBuildProjectExtension)' == '.fsproj' ">

  <!-- On restore -->
  <LanguageTargets Condition=" '$(FSharpLanguageTargets)' == '' ">$(MSBuildThisFileDirectory)Sdk.OnRestore.targets</LanguageTargets>

  <!-- Normal commands -->
  <LanguageTargets Condition=" '$(FSharpLanguageTargets)' != '' ">$(FSharpLanguageTargets)</LanguageTargets>
</PropertyGroup>
```

At `dotnet restore` is imported the $(MSBuildToolsPath)\Microsoft.Common.targets, so restore target exists.
After the `dotnet restore`, the `FSharpLanguageTargets` property is auto-added by the props file inside `FSharp.NET.Sdk` package so can be used to hook usual f# target file for `CoreCompile`.

Like that, c# and f# templates are aligned, the cli contains just the minimal files required (2 sdk files, 1 empty props file) to use a *symbolic* sdk package (ref #1436 )

Checking the bundle locally (take a bit of time the build on my machine), but the sdk import mechanism works ok.

- [ ] bundle only `Sdk` directory of `FSharp.NET.Sdk` package
- [x] template console
- [x] template lib
- [x] template mstest
- [x] template xunit
- [ ] template web

/cc @piotrpMSFT @livarcocc for cli
/cc @dsplaisted @rainersigwald @nguerrera for sdk
/cc  @cartermp @KevinRansom @cloudRoutine for F#
