### PR TITLE
Removing an extra 'the' a the welcome message of the pkg installer.

### DIFF
--- a/packaging/osx/clisdk/resources/en.lproj/welcome.html
+++ b/packaging/osx/clisdk/resources/en.lproj/welcome.html
@@ -13,7 +13,7 @@
             .NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform and is supported by Microsoft. We hope you enjoy using it! If you do, please consider joining the active community of developers that are contributing to the project on GitHub (https://github.com/dotnet/core). We happily accept issues and PRs.
         </p>
         <p>
-            This package contains all the tools you will need to start writing applications with .NET Core. It includes the several tools, including the C# compiler and the NuGet package manager, and a copy of .NET Core for both you and the tools to use. 
+            This package contains all the tools you will need to start writing applications with .NET Core. It includes several tools, including the C# compiler and the NuGet package manager, and a copy of .NET Core for both you and the tools to use. 
         </p>
     </font>
 </body>


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/3704

@piotrpMSFT @jgoshi @krwq @blackdwarf 