### PR TITLE
Remove the dependency to System.Runtime.Serialization.Xml

### DIFF
--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -28,9 +28,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks">
       <Version>2.0.0-beta6-60922-08</Version>
     </PackageReference>
-    <PackageReference Include="System.Runtime.Serialization.Xml">
-      <Version>4.1.1</Version>
-    </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks">
       <Version>4.0.0-rc2</Version>
     </PackageReference>


### PR DESCRIPTION
Remove the dependency to System.Runtime.Serialization.Xml now that MSBuild dependencies are correct.

Fixes https://github.com/dotnet/cli/issues/4084.

@piotrpMSFT @krwq @jgoshi @nguerrera 