### PR TITLE
Allow CLI CI servers to opt out of test

### DIFF
--- a/build/Microsoft.DotNet.Cli.Test.targets
+++ b/build/Microsoft.DotNet.Cli.Test.targets
@@ -11,6 +11,7 @@
   <Import Project="test/TestProjects.targets" />
 
   <Target Name="Test"
+          Condition=" '$(CLIBUILD_SKIP_TESTS)' != 'true' "
           DependsOnTargets="PrepareTests;
                             BuildTestAssets;
                             BuildTests;">


### PR DESCRIPTION
Enables signing builds to opt out of running CLI tests. These tests run in PR validation builds and we've not caught any issues in the second layer of testing. This will allow speeding up end-to-end CLI builds.

/cc @eerhardt @livarcocc @krwq @jgoshi 

/approvers: @srivatsn @MattGertz 

Fixes #3527 