### PR TITLE
use Sdk attribute in F# templates too (branch preview4)

### DIFF
--- a/build/Microsoft.DotNet.Cli.BundledSdks.proj
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.proj
@@ -17,6 +17,9 @@
     <Copy SourceFiles="@(SdkContent)"
           DestinationFiles="@(SdkContent->'$(SdkLayoutDirectory)/%(RecursiveDir)%(FileName)%(Extension)')" />
     
+    <!-- Remove unused directories for FSharp.NET.Sdk, just Sdk directory is needed -->
+    <RemoveDir Condition=" '$([System.IO.Path]::GetFileName($(SdkLayoutDirectory)))' == 'FSharp.NET.Sdk' " Directories="$(SdkLayoutDirectory)/build;$(SdkLayoutDirectory)/buildCrossTargeting" />
+
     <Message Text="Copied Sdk $(SdkPackageName) from $(SdkNuPkgPath) to $(SdkLayoutDirectory)."
              Importance="High" />
   </Target>

--- a/build/Microsoft.DotNet.Cli.BundledSdks.props
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.props
@@ -8,5 +8,6 @@
     <BundledSdk Include="Microsoft.NET.Sdk.Web" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Publish" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Web.ProjectSystem" Version="$(CLI_WEBSDK_Version)" />
+    <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.0-beta-040011" />
   </ItemGroup>
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Console/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Console/$projectName$.fsproj
@@ -1,5 +1,4 @@
-﻿<Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,10 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-alpha-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -28,7 +24,5 @@
       <Version>1.0.0-preview2-020000</Version>
     </DotNetCliToolReference>
   </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Lib/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Lib/$projectName$.fsproj
@@ -1,5 +1,4 @@
-﻿<Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
@@ -14,10 +13,7 @@
   <ItemGroup>
     <PackageReference Include="NETStandard.Library" Version="1.6" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-alpha-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -27,7 +23,5 @@
       <Version>1.0.0-preview2-020000</Version>
     </DotNetCliToolReference>
   </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Mstest/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Mstest/$projectName$.fsproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161109-01" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.5-preview" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.6-preview" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">

--- a/src/dotnet/commands/dotnet-new/FSharp_Mstest/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Mstest/$projectName$.fsproj
@@ -1,5 +1,4 @@
-<Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,13 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161109-01" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.1.5-preview" />
     <PackageReference Include="MSTest.TestFramework" Version="1.0.6-preview" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-alpha-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -31,5 +27,4 @@
     </DotNetCliToolReference>
   </ItemGroup>
 
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Web/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Web/$projectName$.fsproj
@@ -1,5 +1,4 @@
-<Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project ToolsVersion="15.0" Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -11,20 +10,26 @@
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <GlobalExclude>$(GlobalExclude);bin\**;obj\**;node_modules\**;jspm_packages\**;bower_components\**;**\*.user;**\*.*proj</GlobalExclude>
+  </PropertyGroup>
+
   <ItemGroup>
+    <None Include="**\*" />
     <Compile Include="Controllers\*.fs" />
     <Compile Include="Startup.fs" />
     <Compile Include="Program.fs" />
     <EmbeddedResource Include="**\*.resx" />
+    <Content Include="wwwroot\**" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="**\*.cshtml" Exclude="wwwroot\**\*.cshtml" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="**\*.config" Exclude="wwwroot\**\*.config" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="**\*.json" Exclude="wwwroot\**\*.json" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
-    <PackageReference Include="Microsoft.NET.Sdk.Web" Version="1.0.0-alpha-20161117-1-119">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-alpha-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="1.0.0" />
@@ -49,5 +54,4 @@
     </DotNetCliToolReference>
   </ItemGroup>
 
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Xunittest/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Xunittest/$projectName$.fsproj
@@ -1,5 +1,4 @@
-<Project ToolsVersion="15.0">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk" ToolsVersion="15.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,14 +12,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
-    <PackageReference Include="Microsoft.NET.Sdk" Version="1.0.0-alpha-20161104-2">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
     <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-alpha-*">
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -30,7 +26,5 @@
       <Version>1.0.0-preview2-020000</Version>
     </DotNetCliToolReference>
   </ItemGroup>
-
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
 
 </Project>


### PR DESCRIPTION
this pr target `rel/1.0.0-preview4`

All f# templates are aligned with c#, using `Sdk`.

same as #4922 but for `preview4` branch, rebased on latest HEAD

Only the `Sdk` directory of `FSharp.NET.Sdk` packages is added as symbols packages inside `Sdks` subdirectory of cli, not the whole package. **It's just a switch for the restored package becase remote sdk isnt implemented yet, and just simulated atm**. 
That's used to set `LanguageTargets` property before is used inside `Microsoft.NET.Sdk`.
The f# targets used for `CoreCompile` are the one after `dotnet restore`

- [x] bundle only `Sdk` directory of `FSharp.NET.Sdk` package
- [x] template console
- [x] template lib
- [x] template mstest
- [x] template xunit
- [x] template web
