### PR TITLE
MSBuild to 15.1.458

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_MSBuild_Version>15.1.0-preview-000454-01</CLI_MSBuild_Version>
+    <CLI_MSBuild_Version>15.1.0-preview-000458-02</CLI_MSBuild_Version>
     <CLI_NETSDK_Version>1.0.0-alpha-20161104-2</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20161203-1-150</CLI_WEBSDK_Version>
   </PropertyGroup>


### PR DESCRIPTION
This version of MSBuild has an additional fix for Microsoft/msbuild#1445. I spoke to @andygerlicher about this and we believe that the current migration code in CLI will not hit the bug, so it's not imperative that this be taken for RC2. However, if you're going to need to take a new CLI to VS, it is probably worth taking the fix just in case (and for consistency).

The change was shiproom approved for VS insertion.