### PR TITLE
Adding a SdkNugetVersion property when invoking dotnet pack on test packages

### DIFF
--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
@@ -10,6 +10,10 @@
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);portable-net45+win8;dnxcore50</PackageTargetFallback>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <SdkNugetVersion Condition=" '$(SdkNugetVersion)' == ''">1.0.0-preview4-*</SdkNugetVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <Compile Include="..\..\..\src\dotnet\CommandLine\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
@@ -34,7 +38,7 @@
       <Version>4.0.0-rc2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
-      <Version>1.0.0-preview4-*</Version>
+      <Version>$(SdkNugetVersion)</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/build/Microsoft.DotNet.Cli.Test.targets
+++ b/build/Microsoft.DotNet.Cli.Test.targets
@@ -208,12 +208,13 @@
       <DotNetPackMsbuildArgs Condition=" '$(IsDesktopAvailable)' == 'True' And '%(TestPackageProject.PackRuntime)' != '' ">/p:RuntimeIdentifier=%(TestPackageProject.PackRuntime)</DotNetPackMsbuildArgs>
     </PropertyGroup>
     
+    <!-- https://github.com/NuGet/Home/issues/4063 -->
     <DotNetPack NoBuild="True"
                 Output="$(TestPackagesDir)"
                 ProjectPath="%(TestPackageProject.ProjectPath)"
                 ToolPath="$(Stage0Directory)"
                 VersionSuffix="%(TestPackageProject.VersionSuffix)"
-                MsbuildArgs="$(DotNetPackMsbuildArgs)" />
+                MsbuildArgs="$(DotNetPackMsbuildArgs) /p:SdkNuGetVersion=$(SdkNugetVersion)" />
   </Target>
 
   <Target Name="BuildTestAssetPackageProjects"


### PR DESCRIPTION
Adding a SdkNugetVersion property when invoking dotnet pack on test packages so that test packages can reference exact packages. We need that because of https://github.com/NuGet/Home/issues/4063. Without it, pack creates the nuspec with a version like 1.0.0-version-, instead of 1.0.0-version-<version_used_in_build>, which leads to problems when restoring the tool. Like, it ends up restoring to the closest version of the package (oldest), instead of the latest.

@piotrpMSFT @krwq @jgoshi @enricosada 

@MattGertz for approval.