### PR TITLE
Adding MigrateWebSdkRule to the DefaultMigrationRuleSet

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/DefaultMigrationRuleSet.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/DefaultMigrationRuleSet.cs
@@ -25,7 +25,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration
             new MigrateAssemblyInfoRule(),
             new RemoveDefaultsFromProjectRule(),
             new CleanOutputProjectRule(),
-            new SaveOutputProjectRule()
+            new SaveOutputProjectRule(),
+            new MigrateWebSdkRule()
         };
 
         public void Apply(MigrationSettings migrationSettings, MigrationRuleInputs migrationRuleInputs)

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
@@ -331,11 +331,13 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
             if(projectType == ProjectType.Web)
             {
                 var itemsToRemove = transform.Where(p => 
-                    p != null && p.Include.Contains("**\\*")).Select(p => p.ItemType);
+                        p != null && 
+                        p.Include.Contains("**\\*") &&
+                        (p.ItemType == "Compile" || p.ItemType == "EmbeddedResource"));
 
-                CleanExistingItems(csproj, itemsToRemove);
+                CleanExistingItems(csproj, new [] {"Compile", "EmbeddedResource"});
 
-                transform = transform.Where(p => p != null && !p.Include.Contains("**\\*"));
+                transform = transform.Where(p => !itemsToRemove.Contains(p));
             }
 
             return transform;

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
@@ -64,6 +64,27 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Fact]
+        public void Migrating_web_project_without_custom_sources_or_resources_does_not_emit_compile_and_embeddedResource()
+        {
+            var mockProj = RunBuildOptionsRuleOnPj(@"
+                {
+                    ""buildOptions"": {
+                        ""emitEntryPoint"": true
+                    },
+                    ""dependencies"": {
+                        ""Microsoft.AspNetCore.Mvc"" : {
+                            ""version"": ""1.0.0""
+                        }
+                    },
+                    ""frameworks"": {
+                        ""netcoreapp1.0"": {}
+                    }
+                }");
+
+            mockProj.Items.Count().Should().Be(0);
+        }
+
+        [Fact]
         public void Migrating_EmitEntryPoint_true_populates_OutputType_field()
         {
             var mockProj = RunBuildOptionsRuleOnPj(@"

--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
@@ -96,6 +96,7 @@ namespace Microsoft.DotNet.Migration.Tests
             VerifyAllMSBuildOutputsRunnable(projectDirectory);
         }
 
+        [Fact]
         public void ItMigratesOldDotnetNewWebWithoutToolsWithOutputsContainingProjectJsonOutputs()
         {
             var testInstance = TestAssetsManager

--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Migration.Tests
         [InlineData("TestAppWithRuntimeOptions")]
         [InlineData("TestAppWithContents")]
         [InlineData("AppWithAssemblyInfo")]
-        public void It_migrates_apps(string projectName)
+        public void ItMigratesApps(string projectName)
         {
             var projectDirectory = TestAssetsManager.CreateTestInstance(projectName, identifier: projectName)
                                                     .WithLockFiles()
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Migration.Tests
         }
 
         [Fact]
-        public void It_migrates_signed_apps()
+        public void ItMigratesSignedApps()
         {
             var projectDirectory = TestAssetsManager.CreateTestInstance("TestAppWithSigning").WithLockFiles().Path;
 
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Migration.Tests
         }
 
         [Fact]
-        public void It_migrates_dotnet_new_console_with_identical_outputs()
+        public void ItMigratesDotnetNewConsoleWithIdenticalOutputs()
         {
             var testInstance = TestAssetsManager
                 .CreateTestInstance("ProjectJsonConsoleTemplate");
@@ -96,8 +96,7 @@ namespace Microsoft.DotNet.Migration.Tests
             VerifyAllMSBuildOutputsRunnable(projectDirectory);
         }
 
-        [Fact(Skip="Final tools version missing.")]
-        public void It_migrates_old_dotnet_new_web_without_tools_with_outputs_containing_project_json_outputs()
+        public void ItMigratesOldDotnetNewWebWithoutToolsWithOutputsContainingProjectJsonOutputs()
         {
             var testInstance = TestAssetsManager
                 .CreateTestInstance("ProjectJsonWebTemplate")
@@ -108,10 +107,7 @@ namespace Microsoft.DotNet.Migration.Tests
             var globalDirectory = Path.Combine(projectDirectory, "..");  
             var projectJsonFile = Path.Combine(projectDirectory, "project.json");  
               
-            WriteGlobalJson(globalDirectory);  
-            var projectJson = JObject.Parse(File.ReadAllText(projectJsonFile));  
-            projectJson.Remove("tools");  
-            File.WriteAllText(projectJsonFile, projectJson.ToString());  
+            WriteGlobalJson(globalDirectory);
 
             var outputComparisonData = GetComparisonData(projectDirectory);
 
@@ -126,9 +122,27 @@ namespace Microsoft.DotNet.Migration.Tests
             outputsIdentical.Should().BeTrue();
         }
 
+        public void ItAddsMicrosoftNetWebSdkToTheSdkAttributeOfAWebApp()
+        {
+            var testInstance = TestAssetsManager
+                .CreateTestInstance("ProjectJsonWebTemplate")
+                .WithLockFiles();
+
+            var projectDirectory = testInstance.Path;
+
+            var globalDirectory = Path.Combine(projectDirectory, "..");  
+            var projectJsonFile = Path.Combine(projectDirectory, "project.json");  
+              
+            MigrateProject(new [] { projectDirectory });
+
+            var csProj = Path.Combine(projectDirectory, $"{new DirectoryInfo(projectDirectory).Name}.csproj");
+
+            File.ReadAllText(csProj).Should().Contain(@"Sdk=""Microsoft.NET.Sdk.Web""");
+        }
+
         [Theory]
         [InlineData("TestLibraryWithTwoFrameworks")]
-        public void It_migrates_projects_with_multiple_TFMs(string projectName)
+        public void ItMigratesProjectsWithMultipleTFMs(string projectName)
         {
             var projectDirectory =
                 TestAssetsManager.CreateTestInstance(projectName, identifier: projectName).WithLockFiles().Path;
@@ -150,7 +164,7 @@ namespace Microsoft.DotNet.Migration.Tests
         [InlineData("TestAppWithLibrary/TestLibrary")]
         [InlineData("TestLibraryWithAnalyzer")]
         [InlineData("PJTestLibraryWithConfiguration")]
-        public void It_migrates_a_library(string projectName)
+        public void ItMigratesALibrary(string projectName)
         {
             var projectDirectory =
                 TestAssetsManager.CreateTestInstance(projectName, identifier: projectName).WithLockFiles().Path;
@@ -174,7 +188,7 @@ namespace Microsoft.DotNet.Migration.Tests
         [InlineData("ProjectC", "ProjectC,ProjectD,ProjectE")]
         [InlineData("ProjectD", "ProjectD")]
         [InlineData("ProjectE", "ProjectE")]
-        public void It_migrates_root_project_and_references(string projectName, string expectedProjects)
+        public void ItMigratesRootProjectAndReferences(string projectName, string expectedProjects)
         {
             var projectDirectory =
                 TestAssetsManager.CreateTestInstance("TestAppDependencyGraph", callingMethod: $"{projectName}.RefsTest").Path;
@@ -192,7 +206,7 @@ namespace Microsoft.DotNet.Migration.Tests
         [InlineData("ProjectC")]
         [InlineData("ProjectD")]
         [InlineData("ProjectE")]
-        public void It_migrates_root_project_and_skips_references(string projectName)
+        public void ItMigratesRootProjectAndSkipsReferences(string projectName)
         {
             var projectDirectory =
                 TestAssetsManager.CreateTestInstance("TestAppDependencyGraph", callingMethod: $"{projectName}.SkipRefsTest").Path;
@@ -205,7 +219,7 @@ namespace Microsoft.DotNet.Migration.Tests
          [Theory]
          [InlineData(true)]
          [InlineData(false)]
-         public void It_migrates_all_projects_in_given_directory(bool skipRefs)
+         public void ItMigratesAllProjectsInGivenDirectory(bool skipRefs)
          {
             var projectDirectory = TestAssetsManager.CreateTestInstance("TestAppDependencyGraph", callingMethod: $"MigrateDirectory.SkipRefs.{skipRefs}").Path;
 
@@ -224,7 +238,7 @@ namespace Microsoft.DotNet.Migration.Tests
          }
 
          [Fact]
-         public void It_migrates_given_project_json()
+         public void ItMigratesGivenProjectJson()
          {
             var projectDirectory = TestAssetsManager.CreateTestInstance("TestAppDependencyGraph").Path;
 
@@ -239,7 +253,7 @@ namespace Microsoft.DotNet.Migration.Tests
 
          [Fact]
          // regression test for https://github.com/dotnet/cli/issues/4269
-         public void It_migrates_and_builds_P2P_references()
+         public void ItMigratesAndBuildsP2PReferences()
          {
             var assetsDir = TestAssetsManager.CreateTestInstance("TestAppDependencyGraph").WithLockFiles().Path;
 
@@ -269,7 +283,7 @@ namespace Microsoft.DotNet.Migration.Tests
          [Theory]
          [InlineData("src", "ProjectH")]
          [InlineData("src with spaces", "ProjectJ")]
-         public void It_migrates_and_builds_projects_in_global_json(string path, string projectName)
+         public void ItMigratesAndBuildsProjectsInGlobalJson(string path, string projectName)
          {
             var assetsDir = TestAssetsManager.CreateTestInstance(Path.Combine("TestAppDependencyGraph", "ProjectsWithGlobalJson"), 
                                                                  callingMethod: $"ProjectsWithGlobalJson.{projectName}")
@@ -306,7 +320,7 @@ namespace Microsoft.DotNet.Migration.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void Migration_outputs_error_when_no_projects_found(bool useGlobalJson)
+        public void MigrationOutputsErrorWhenNoProjectsFound(bool useGlobalJson)
         {
             var projectDirectory = TestAssetsManager.CreateTestDirectory("Migration_outputs_error_when_no_projects_found");
 
@@ -353,7 +367,7 @@ namespace Microsoft.DotNet.Migration.Tests
         }
 
         [Fact]
-        public void It_migrates_and_publishes_projects_with_runtimes()
+        public void ItMigratesAndPublishesProjectsWithRuntimes()
         {
             var projectName = "PJTestAppSimple";
             var projectDirectory = TestAssetsManager
@@ -369,7 +383,7 @@ namespace Microsoft.DotNet.Migration.Tests
         [WindowsOnlyTheory]
         [InlineData("DesktopTestProjects", "AutoAddDesktopReferencesDuringMigrate", true)]
         [InlineData("TestProjects", "PJTestAppSimple", false)]
-        public void It_auto_add_desktop_references_during_migrate(string testGroup, string projectName, bool isDesktopApp)
+        public void ItAutoAddDesktopReferencesDuringMigrate(string testGroup, string projectName, bool isDesktopApp)
         {
             var runtime = DotnetLegacyRuntimeIdentifiers.InferLegacyRestoreRuntimeIdentifier();
             var testAssetManager = GetTestGroupTestAssetsManager(testGroup);
@@ -384,7 +398,7 @@ namespace Microsoft.DotNet.Migration.Tests
         }
 
         [Fact]
-        public void It_builds_a_migrated_app_with_a_indirect_dependency()
+        public void ItBuildsAMigratedAppWithAnIndirectDependency()
         {
             const string projectName = "ProjectA";
             var solutionDirectory =
@@ -399,7 +413,7 @@ namespace Microsoft.DotNet.Migration.Tests
         }
 
         [Fact]
-        public void It_migrates_project_with_output_name()
+        public void ItMigratesProjectWithOutputName()
         {
             string projectName = "AppWithOutputAssemblyName";
             string expectedOutputName = "MyApp";
@@ -426,10 +440,10 @@ namespace Microsoft.DotNet.Migration.Tests
         [Theory]
         [InlineData("LibraryWithoutNetStandardLibRef")]
         [InlineData("LibraryWithNetStandardLibRef")]
-        public void It_migrates_and_builds_library(string projectName)
+        public void ItMigratesAndBuildsLibrary(string projectName)
         {
             var projectDirectory = TestAssetsManager.CreateTestInstance(projectName,
-                callingMethod: $"{nameof(It_migrates_and_builds_library)}-projectName").Path;
+                callingMethod: $"{nameof(ItMigratesAndBuildsLibrary)}-projectName").Path;
 
             MigrateProject(projectDirectory);
             Restore(projectDirectory, projectName);
@@ -437,7 +451,7 @@ namespace Microsoft.DotNet.Migration.Tests
         }
 
         [Fact]
-        public void It_fails_gracefully_when_migrating_app_with_missing_dependency()
+        public void ItFailsGracefullyWhenMigratingAppWithMissingDependency()
         {
             string projectName = "MigrateAppWithMissingDep";
             var projectDirectory = Path.Combine(GetTestGroupTestAssetsManager("NonRestoredTestProjects").CreateTestInstance(projectName).Path, "MyApp");


### PR DESCRIPTION
Adding MigrateWebSdkRule to the DefaultMigrationRuleSet and adding a E2E test to cover it.

Fixes https://github.com/dotnet/cli/issues/4962.

@piotrpMSFT @jgoshi @krwq 

@MattGertz for approval.