### PR TITLE
Update package versions for 1.0.3

### DIFF
--- a/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
+++ b/src/dotnet/commands/dotnet-new/CSharp_Web/project.json.template
@@ -3,66 +3,66 @@
 
   "dependencies": {
     "Microsoft.NETCore.App": {
-      "version": "1.0.1",
+      "version": "1.0.3",
       "type": "platform"
     },
-    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
-    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-    "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0",
-    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
-    "Microsoft.AspNetCore.Mvc": "1.0.1",
+    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.1",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.1",
+    "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.1",
+    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.1",
+    "Microsoft.AspNetCore.Mvc": "1.0.2",
     "Microsoft.AspNetCore.Razor.Tools": {
-      "version": "1.0.0-preview2-final",
+      "version": "1.0.0-preview4-final",
       "type": "build"
     },
-    "Microsoft.AspNetCore.Routing": "1.0.1",
-    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
-    "Microsoft.EntityFrameworkCore.Sqlite": "1.0.1",
+    "Microsoft.AspNetCore.Routing": "1.0.2",
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.1",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.2",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.1",
+    "Microsoft.EntityFrameworkCore.Sqlite": "1.0.2",
     "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "1.0.0-preview2-final",
+      "version": "1.0.0-preview4-final",
       "type": "build"
     },
-    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0",
-    "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0",
-    "Microsoft.Extensions.Logging": "1.0.0",
-    "Microsoft.Extensions.Logging.Console": "1.0.0",
-    "Microsoft.Extensions.Logging.Debug": "1.0.0",
-    "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.1",
+    "Microsoft.Extensions.Configuration.Json": "1.0.1",
+    "Microsoft.Extensions.Configuration.UserSecrets": "1.0.1",
+    "Microsoft.Extensions.Logging": "1.0.1",
+    "Microsoft.Extensions.Logging.Console": "1.0.1",
+    "Microsoft.Extensions.Logging.Debug": "1.0.1",
+    "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.1",
     "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-      "version": "1.0.0-preview2-update1",
+      "version": "1.0.0-preview4-final",
       "type": "build"
     },
     "Microsoft.VisualStudio.Web.CodeGenerators.Mvc": {
-      "version": "1.0.0-preview2-update1",
+      "version": "1.0.0-preview4-final",
       "type": "build"
     }
   },
 
   "tools": {
     "Microsoft.AspNetCore.Razor.Tools": {
-      "version": "1.0.0-preview2-final",
+      "version": "1.0.0-preview4-final",
       "imports": "portable-net45+win8+dnxcore50"
     },
     "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-preview2-final",
+      "version": "1.0.0-preview4-final",
       "imports": "portable-net45+win8+dnxcore50"
     },
     "Microsoft.EntityFrameworkCore.Tools": {
-      "version": "1.0.0-preview2-final",
+      "version": "1.0.0-preview4-final",
       "imports": [
         "portable-net45+win8+dnxcore50",
         "portable-net45+win8"
       ]
     },
     "Microsoft.Extensions.SecretManager.Tools": {
-      "version": "1.0.0-preview2-final",
+      "version": "1.0.0-preview4-final",
       "imports": "portable-net45+win8+dnxcore50"
     },
     "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-      "version": "1.0.0-preview2-final",
+      "version": "1.0.0-preview4-final",
       "imports": [
         "portable-net45+win8+dnxcore50",
         "portable-net45+win8"


### PR DESCRIPTION
Updated the package versions, currently getting this on restore though

```
    Version conflict detected for Microsoft.DotNet.Cli.Utils.
     web (>= 1.0.0) -> Microsoft.VisualStudio.Web.CodeGenerators.Mvc (>= 1.0.0-preview4-final) -> Microsoft.VisualStudio.Web.CodeGeneration (>= 1.0.0-preview4-final) -> Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore (>= 1.0.0-preview4-final) -> Microsoft.VisualStudio.Web.CodeGeneration.Core (>= 1.0.0-preview4-final) -> Microsoft.DotNet.Cli.Utils (>= 1.0.0-preview2-003121)
     web (>= 1.0.0) -> Microsoft.AspNetCore.Razor.Tools (>= 1.0.0-preview4-final) -> Microsoft.DotNet.Cli.Utils (>= 1.0.0-preview2-003121).
```

Tested `dotnet restore`, `dotnet build`, `dotnet run` and `dotnet publish` on the generated project, all seem good

@prafullbhosale @NTaylorMullen @MattGertz @piotrpMSFT @phenning 