### PR TITLE
Fix f# web template publish (preview4)

### DIFF
--- a/src/dotnet/commands/dotnet-new/FSharp_Web/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Web/$projectName$.fsproj
@@ -10,20 +10,10 @@
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81;</PackageTargetFallback>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <GlobalExclude>$(GlobalExclude);bin\**;obj\**;node_modules\**;jspm_packages\**;bower_components\**;**\*.user;**\*.*proj</GlobalExclude>
-  </PropertyGroup>
-
   <ItemGroup>
-    <None Include="**\*" />
     <Compile Include="Controllers\*.fs" />
     <Compile Include="Startup.fs" />
     <Compile Include="Program.fs" />
-    <EmbeddedResource Include="**\*.resx" />
-    <Content Include="wwwroot\**" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="**\*.cshtml" Exclude="wwwroot\**\*.cshtml" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="**\*.config" Exclude="wwwroot\**\*.config" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="**\*.json" Exclude="wwwroot\**\*.json" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fix #4982 

Align f# web template to fix publish after 9533e07ab7896a4bc5cdfbebf59829cf065b8f82 ( same diff as c#  https://github.com/dotnet/cli/pull/4948/files#diff-bb0946228d6e0cac29bbbedbe8071b85 )

@piotrpMSFT @MattGertz @livarcocc for approval for next preview4 🙏 😄 

The failure wasnt found by test suites, because the dotnet-new tests just check for build, not publish.
