### PR TITLE
Changing dotnet-test options

### DIFF
--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
@@ -20,11 +20,11 @@
 
         public const string CmdTestCaseFilterDescription = @"Run tests that match the given expression.
                                         Examples:
-                                        --testCaseFilter:""Priority = 1""
-                                        --testCaseFilter: ""(FullyQualifiedName~Nightly | Name = MyTestMethod)""";
+                                        --test-case-filter:""Priority = 1""
+                                        --test-case-filter: ""(FullyQualifiedName~Nightly | Name = MyTestMethod)""";
 
         public const string CmdTestAdapterPathDescription = @"Use custom adapters from the given path in the test run.
-                                        Example: --testAdapterPath:<pathToCustomAdapters>";
+                                        Example: --test-adapter-path:<pathToCustomAdapters>";
 
         public const string CmdLoggerOption = "LoggerUri/FriendlyName";
 

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -39,17 +39,17 @@ namespace Microsoft.DotNet.Tools.Test
                 CommandOptionType.SingleValue);
 
             var listTestsOption = cmd.Option(
-                "-lt|--listTests",
+                "-t|--list-tests",
                 LocalizableStrings.CmdListTestsDescription,
                 CommandOptionType.NoValue);
 
             var testCaseFilterOption = cmd.Option(
-                $"-tcf|--testCaseFilter <{LocalizableStrings.CmdTestCaseFilterExpression}>",
+                $"--test-case-filter <{LocalizableStrings.CmdTestCaseFilterExpression}>",
                 LocalizableStrings.CmdTestCaseFilterDescription,
                 CommandOptionType.SingleValue);
 
             var testAdapterPathOption = cmd.Option(
-                "-tap|--testAdapterPath",
+                "-a|--test-adapter-path",
                 LocalizableStrings.CmdTestAdapterPathDescription,
                 CommandOptionType.SingleValue);
 
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Tools.Test
                 CommandOptionType.SingleValue);
 
             var noBuildtOption = cmd.Option(
-               "--noBuild",
+               "--no-build",
                LocalizableStrings.CmdNoBuildDescription,
                CommandOptionType.NoValue);
 

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Call test
             CommandResult result = new DotnetTestCommand()
                                        .WithWorkingDirectory(testProjectDirectory)
-                                       .ExecuteWithCapturedOutput("--noBuild");
+                                       .ExecuteWithCapturedOutput("--no-build");
 
             // Verify
             result.StdOut.Should().Contain(expectedError); 


### PR DESCRIPTION
In Preview 3, the `dotnet test` options were not aligned with the CLI's
adopted format. This PR changes the options to be aligned. Where
possible/applicable, I have shortened the long options to a meaningful
mnemonic short version.

Fixes #4960

/cc @livarcocc @piotrpMSFT @Faizan2304 