### PR TITLE
Emitting PackageId whenever we emit AssemblyName.

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Build.Construction;
 using Microsoft.DotNet.ProjectJsonMigration.Transforms;
@@ -103,6 +104,12 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                 compilerOptions => compilerOptions.OutputName,
                 compilerOptions => compilerOptions.OutputName != null);
 
+        private Func<string, AddPropertyTransform<CommonCompilerOptions>> PackageIdTransformExecute =>
+            (projectFolderName) =>
+                new AddPropertyTransform<CommonCompilerOptions>("PackageId",
+                    compilerOptions => projectFolderName,
+                    compilerOptions => compilerOptions.OutputName != null);
+
         private IncludeContextTransform CompileFilesTransform =>
             new IncludeContextTransform("Compile", transformMappings: false);
 
@@ -201,6 +208,9 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
             var itemGroup = _configurationItemGroup ?? migrationRuleInputs.CommonItemGroup;
 
             var compilerOptions = projectContext.ProjectFile.GetCompilerOptions(null, null);
+
+            var projectDirectoryName = new DirectoryInfo(migrationSettings.ProjectDirectory).Name;
+            _propertyTransforms.Add(PackageIdTransformExecute(projectDirectoryName));
 
             var project = migrationRuleInputs.DefaultProjectContext.ProjectFile;
             var projectType = project.GetProjectType();

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
@@ -84,6 +84,36 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             mockProj.Items.Count().Should().Be(0);
         }
 
+        public void MigratingOutputNamePopulatesAssemblyName()
+        {
+            var mockProj = RunBuildOptionsRuleOnPj(@"
+                {
+                    ""buildOptions"": {
+                        ""outputName"": ""some name""
+                    }
+                }");
+
+            mockProj.Properties.Count(p => p.Name == "AssemblyName").Should().Be(1);
+            mockProj.Properties.First(p => p.Name == "AssemblyName").Value.Should().Be("some name");
+        }
+
+        [Fact]
+        public void MigratingOutputNamePopulatesPackageIdWithTheProjectContainingFolderName()
+        {
+            var testDirectoryPath = Temp.CreateDirectory().Path;
+            var testDirectoryName = new DirectoryInfo(testDirectoryPath).Name;
+            var mockProj = RunBuildOptionsRuleOnPj(@"
+                {
+                    ""buildOptions"": {
+                        ""outputName"": ""some name""
+                    }
+                }",
+                testDirectoryPath);
+
+            mockProj.Properties.Count(p => p.Name == "PackageId").Should().Be(1);
+            mockProj.Properties.First(p => p.Name == "PackageId").Value.Should().Be(testDirectoryName);
+        }
+
         [Fact]
         public void MigratingEmitEntryPointTruePopulatesOutputTypeField()
         {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PackCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PackCommand.cs
@@ -107,6 +107,12 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return base.Execute(args);
         }
 
+        public override CommandResult ExecuteWithCapturedOutput(string args = "")
+        {
+            args = $"pack {BuildArgs()} {args}";
+            return base.ExecuteWithCapturedOutput(args);
+        }
+
         private string BuildArgs()
         {
             return $"{_projectPath} {OutputOption} {BuildBasePathOption} {TempOutputOption} {ConfigurationOption} {VersionSuffixOption} {ServiceableOption}";


### PR DESCRIPTION
Emitting PackageId whenever we emit AssemblyName. We need to do this to preserve the behavior from PJ where the package id matched the containing PJ folder name. In MSBuild, PackageId will match AssemblyName, unless it is explicitly specified.

Fixes https://github.com/dotnet/cli/issues/4727.

@piotrpMSFT @krwq @jgoshi 