### PR TITLE
Removing duplicate space in "The Current OutputType is" usage

### DIFF
--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Tools.Run
                 throw new GracefulException(string.Join(Environment.NewLine,
                     LocalizableStrings.RunCommandExceptionUnableToRun1,
                     LocalizableStrings.RunCommandExceptionUnableToRun2,
-                    $"{LocalizableStrings.RunCommandExceptionUnableToRun3} '{outputType}'."));
+                    $"{LocalizableStrings.RunCommandExceptionUnableToRun3}'{outputType}'."));
             }
 
             string runArguments = projectInstance.GetPropertyValue(LocalizableStrings.RunCommandRunArguments);


### PR DESCRIPTION
Removing duplicate space in "The Current OutputType is" usage

The LocalizableStrings.RunCommandExceptionUnableToRun3 always has as trailing space. Every instances does. Here we are adding a SECOND space so the result is:

`The current OutputType is  'Library'.`