### PR TITLE
Work around msbuild bug that blocks git tool tasks in VS2017 prompt

### DIFF
--- a/build_projects/dotnet-cli-build/GenerateBuildVersionInfo.cs
+++ b/build_projects/dotnet-cli-build/GenerateBuildVersionInfo.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.DotNet.Cli.Build
 {
@@ -92,7 +93,9 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string GenerateFullPathToTool()
         {
-            return "git";
+            // Workaround: https://github.com/Microsoft/msbuild/issues/1215
+            // There's a "git" folder on the PATH in VS 2017 Developer command prompt and it causes msbuild to fail to execute git.
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "git.exe" : "git";
         }
 
         protected override string GenerateCommandLineCommands()

--- a/build_projects/dotnet-cli-build/GetCommitHash.cs
+++ b/build_projects/dotnet-cli-build/GetCommitHash.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.DotNet.Cli.Build
 {
@@ -26,7 +27,9 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string GenerateFullPathToTool()
         {
-            return "git";
+            // Workaround: https://github.com/Microsoft/msbuild/issues/1215
+            // There's a "git" folder on the PATH in VS 2017 Developer command prompt and it causes msbuild to fail to execute git.
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "git.exe" : "git";
         }
 
         protected override string GenerateCommandLineCommands()


### PR DESCRIPTION
This keeps biting me every time I try to build the CLI on Windows: https://github.com/Microsoft/msbuild/issues/1215

I'm tired of re-hacking my machine to rename that folder (and break who know what!) every time I reinstall VS and have to make a CLI change. So here's a workaround that will unblock anyone else who's hitting this.

@piotrpMSFT @livarcocc 