### PR TITLE
Fixing dotnet test help text

### DIFF
--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
@@ -20,8 +20,11 @@
 
         public const string CmdTestCaseFilterDescription = @"Run tests that match the given expression.
                                         Examples:
-                                        --test-case-filter:""Priority = 1""
-                                        --test-case-filter: ""(FullyQualifiedName~Nightly | Name = MyTestMethod)""";
+                                        Run tests with priority set to 1: --filter ""Priority = 1""
+                                        Run a test with the specified full name: --filter ""FullyQualifiedName=Namespace.ClassName.MethodName""
+                                        Run tests that contain the specified name: --filter ""FullyQualifiedName~Namespace.Class""
+                                        More info on filtering support: https://aka.ms/vstest-filtering
+                                        ";
 
         public const string CmdTestAdapterPathDescription = @"Use custom adapters from the given path in the test run.
                                         Example: --test-adapter-path:<pathToCustomAdapters>";

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Tools.Test
                 CommandOptionType.NoValue);
 
             var testCaseFilterOption = cmd.Option(
-                $"--test-case-filter <{LocalizableStrings.CmdTestCaseFilterExpression}>",
+                $"--filter <{LocalizableStrings.CmdTestCaseFilterExpression}>",
                 LocalizableStrings.CmdTestCaseFilterDescription,
                 CommandOptionType.SingleValue);
 


### PR DESCRIPTION
Renaming --test-case-filter to just --filter to make it easier to use.
Placing more examples and more clarity for the --filter command.

Fixes #5021

/cc @livarcocc @jonsequitur @Faizan2304 @codito 