### PR TITLE
Adding a Exclude @(EmbeddedResource) during migration to EmbeddedResources

### DIFF
--- a/TestAssets/TestProjects/TestAppWithEmbeddedResources/Program.cs
+++ b/TestAssets/TestProjects/TestAppWithEmbeddedResources/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var thisAssembly = typeof(Program).GetTypeInfo().Assembly;
+            var resources = from resourceName in thisAssembly.GetManifestResourceNames()
+                            select resourceName;
+
+            if (resources.Count() > 1)
+            {
+                throw new Exception($"{resources.Count()} found in the assembly. Was expecting only 1.");    
+            }
+
+            var resourceNames = string.Join(",", resources);
+            Console.WriteLine($"{resources.Count()} Resources Found: {resourceNames}");
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestAppWithEmbeddedResources/Resources/Strings.resx
+++ b/TestAssets/TestProjects/TestAppWithEmbeddedResources/Resources/Strings.resx
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="hello" xml:space="preserve">
+    <value>Hello World!</value>
+  </data>
+</root>

--- a/TestAssets/TestProjects/TestAppWithEmbeddedResources/project.json
+++ b/TestAssets/TestProjects/TestAppWithEmbeddedResources/project.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "debugType": "portable",
+    "emitEntryPoint": true,
+    "embed": [ "Resources/*.resx" ]
+  },
+  "dependencies": {},
+  "frameworks": {
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "imports": "dnxcore50"
+    }
+  }
+}

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
@@ -150,7 +150,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
             };
 
         private readonly string[] DefaultEmptyExcludeOption = new string[0];
-        
+
         private readonly ProjectPropertyGroupElement _configurationPropertyGroup;
         private readonly ProjectItemGroupElement _configurationItemGroup;
         private readonly CommonCompilerOptions _configurationBuildOptions;
@@ -419,13 +419,17 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
         private IncludeContext GetEmbedIncludeContext(CommonCompilerOptions compilerOptions, string projectDirectory)
         {
             // Defaults from src/Microsoft.DotNet.ProjectModel/ProjectReader.cs #L602
-            return compilerOptions.EmbedInclude ??
+            var embedIncludeContext = compilerOptions.EmbedInclude ??
                 new IncludeContext(
                     projectDirectory,
                     "embed",
                     new JObject(),
                     ProjectFilesCollection.DefaultResourcesBuiltInPatterns,
                     DefaultEmptyExcludeOption);
+
+            embedIncludeContext.BuiltInsExclude.Add("@(EmbeddedResource)");
+
+            return embedIncludeContext;
         }
 
         private IncludeContext GetCopyToOutputIncludeContext(CommonCompilerOptions compilerOptions, string projectDirectory)

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             mockProj.Items.First(i => i.ItemType == "Compile").Include.Should().Be(@"**\*.cs");
             mockProj.Items.First(i => i.ItemType == "Compile").Exclude.Should().BeEmpty();
             mockProj.Items.First(i => i.ItemType == "EmbeddedResource").Include.Should().Be(@"compiler\resources\**\*;**\*.resx");
-            mockProj.Items.First(i => i.ItemType == "EmbeddedResource").Exclude.Should().BeEmpty();
+            mockProj.Items.First(i => i.ItemType == "EmbeddedResource").Exclude.Should().Be("@(EmbeddedResource)");
         }
 
         [Fact]
@@ -555,8 +555,16 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
 
         private static IEnumerable<string> GetDefaultExcludePatterns(string group)
         {
-            return group == "copyToOutput" ? ProjectFilesCollection.DefaultPublishExcludePatterns
-                                       : ProjectFilesCollection.DefaultBuiltInExcludePatterns;
+            var defaultExcludePatterns = new List<string>(group == "copyToOutput" ?
+                                    ProjectFilesCollection.DefaultPublishExcludePatterns :
+                                    ProjectFilesCollection.DefaultBuiltInExcludePatterns);
+
+            if (group == "embed")
+            {
+                defaultExcludePatterns.Add("@(EmbeddedResource)");
+            }
+
+            return defaultExcludePatterns;
         }
 
         private static IEnumerable<string> GetDefaultIncludePatterns(string group)

--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.Migration.Tests
         [InlineData("TestAppWithRuntimeOptions")]
         [InlineData("TestAppWithContents")]
         [InlineData("AppWithAssemblyInfo")]
+        [InlineData("TestAppWithEmbeddedResources")]
         public void ItMigratesApps(string projectName)
         {
             var projectDirectory = TestAssetsManager.CreateTestInstance(projectName, identifier: projectName)


### PR DESCRIPTION
Adding a Exclude @(EmbeddedResource) during migration to EmbeddedResources so that we don't get duplicate resources when building migrated apps.

Fixes https://github.com/dotnet/cli/issues/4667