### PR TITLE
Changing the host verbosity flag to -d|--diagnostics

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -116,7 +116,7 @@ namespace Microsoft.DotNet.Cli
             {
                 for (; lastArg < args.Length; lastArg++)
                 {
-                    if (IsArg(args[lastArg], "v", "verbose"))
+                    if (IsArg(args[lastArg], "d", "diagnostics"))
                     {
                         verbose = true;
                     }

--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Help
   -h|--help             {LocalizableStrings.HelpDefinition} 
 
 {LocalizableStrings.HostOptions}:
-  -v|--verbose          {LocalizableStrings.VerboseDefinition}
+  -d|--diagnostics      {LocalizableStrings.DiagnosticsDefinition}
   --version             {LocalizableStrings.VersionDescription}
   --info                {LocalizableStrings.InfoDescription}
 

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -18,7 +18,7 @@
 
         public const string VerboseDefinition = "Enable verbose output";
 
-        public const string DiagnosticsDefinition = "Enable diagnostics output";
+        public const string DiagnosticsDefinition = "Enable diagnostic output";
 
         public const string HelpDefinition = "Show help";
 

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -18,6 +18,8 @@
 
         public const string VerboseDefinition = "Enable verbose output";
 
+        public const string DiagnosticsDefinition = "Enable diagnostics output";
+
         public const string HelpDefinition = "Show help";
 
         public const string HostOptions = "Host options (passed before the command)";

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             new DotnetCommand()
                 .WithWorkingDirectory(testProjectDirectory)
                 .ExecuteWithCapturedOutput(
-                    $"-v dependency-tool-invoker -c {configuration} -f netcoreapp1.0 portable")
+                    $"-d dependency-tool-invoker -c {configuration} -f netcoreapp1.0 portable")
                 .Should().Pass()
                      .And.HaveStdOutContaining("Hello Portable World!");;
         }

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -24,10 +24,10 @@ Arguments:
 
 Common options:
   -v|--verbose          Enable verbose output
-  -h|--help             Show help
+  -h|--help             Show help 
 
 Host options (passed before the command):
-  -d|--diagnostic       Enable diagnostics output
+  -d|--diagnostics      Enable diagnostic output
   --version             Display .NET CLI Version Number
   --info                Display .NET CLI Info
 

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Construction;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+using FluentAssertions;
+
+namespace Microsoft.DotNet.Help.Tests
+{
+    public class GivenThatIWantToShowHelpForDotnetCommand : TestBase
+    {
+        private const string HelpText =
+@"Usage: dotnet [host-options] [command] [arguments] [common-options]
+
+Arguments:
+  [command]             The command to execute
+  [arguments]           Arguments to pass to the command
+  [host-options]        Options specific to dotnet (host)
+  [common-options]      Options common to all commands
+
+Common options:
+  -v|--verbose          Enable verbose output
+  -h|--help             Show help
+
+Host options (passed before the command):
+  -d|--diagnostic       Enable diagnostics output
+  --version             Display .NET CLI Version Number
+  --info                Display .NET CLI Info
+
+Commands:
+  new           Initialize a basic .NET project
+  restore       Restore dependencies specified in the .NET project
+  build         Builds a .NET project
+  publish       Publishes a .NET project for deployment (including the runtime)
+  run           Compiles and immediately executes a .NET project
+  test          Runs unit tests using the test runner specified in the project
+  pack          Creates a NuGet package
+  migrate       Migrates a project.json based project to a msbuild based project
+
+Project modification commands:
+  add           Add items to the project
+  remove        Remove items from the project
+  list          List items in the project
+
+Advanced Commands:
+  nuget         Provides additional NuGet commands
+  msbuild       msbuilds a project and all of its dependencies
+  vstest        Runs tests from the specified files";
+
+        [Theory]
+        [InlineData("--help")]
+        [InlineData("-h")]
+        public void WhenHelpOptionIsPassedToDotnetItPrintsUsage(string helpArg)
+        {
+            var cmd = new DotnetCommand()
+                .ExecuteWithCapturedOutput($"{helpArg}");
+            cmd.Should().Pass().And.HaveStdOutContaining(HelpText);
+        }
+    }
+}

--- a/test/dotnet-help.Tests/dotnet-help.Tests.csproj
+++ b/test/dotnet-help.Tests/dotnet-help.Tests.csproj
@@ -1,0 +1,63 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>dotnet-help.Tests</AssemblyName>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj" />
+    <ProjectReference Include="..\..\src\dotnet\dotnet.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Sln.Internal\Microsoft.DotNet.Cli.Sln.Internal.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.TestFramework\Microsoft.DotNet.TestFramework.csproj">
+      <FromP2P>true</FromP2P>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj">
+      <FromP2P>true</FromP2P>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj">
+      <FromP2P>true</FromP2P>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Configurer\Microsoft.DotNet.Configurer.csproj">
+      <FromP2P>true</FromP2P>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\Microsoft.DotNet.ProjectJsonMigration.csproj">
+      <FromP2P>true</FromP2P>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Archive\Microsoft.DotNet.Archive.csproj">
+      <FromP2P>true</FromP2P>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Sdk">
+      <Version>$(CLI_NETSDK_Version)</Version>
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>15.0.0-preview-20161024-02</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.2.0-beta4-build1194</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build">
+      <Version>$(CLI_MSBuild_Version)</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.2.0-beta4-build3444</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
Changing the host verbosity flag to -d|--diagnostics from -v|--verbosity so that it is not confused with the verbs verbosity flag.

Fixes https://github.com/dotnet/cli/issues/5013.

@piotrpMSFT @jgoshi @krwq @jonsequitur @blackdwarf 