### PR TITLE
Return non-zero exit code for test failure in multitargeted test project

### DIFF
--- a/resources/MSBuildImports/15.0/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
+++ b/resources/MSBuildImports/15.0/Microsoft.Common.CrossTargeting.targets/ImportAfter/Microsoft.TestPlatform.CrossTargeting.targets
@@ -41,7 +41,7 @@ Copyright (c) .NET Foundation. All rights reserved.
              Condition="'$(TargetFrameworks)' != '' "
              Targets="$(InnerVSTestTargets)"
              Properties="TargetFramework=%(_TargetFramework.Identity);VSTestNoBuild=true"
-             ContinueOnError="true">
+             ContinueOnError="ErrorAndContinue">
       <Output ItemName="InnerOutput" TaskParameter="TargetOutputs" />
     </MSBuild>
   </Target>

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -39,6 +39,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                      .And.Contain("Passed   TestNamespace.VSTestTests.VSTestPassTestDesktop", "because .NET 4.6 tests will pass")
                      .And.Contain("Total tests: 3. Passed: 1. Failed: 2. Skipped: 0.", "because netcoreapp1.0 tests will fail")
                      .And.Contain("Failed   TestNamespace.VSTestTests.VSTestFailTestNetCoreApp", "because netcoreapp1.0 tests will fail");
+            result.ExitCode.Should().Be(1);
         }
 
         [WindowsOnlyFact]
@@ -70,6 +71,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // for target framework netcoreapp1.0
             result.StdOut.Should().Contain("Total tests: 3. Passed: 1. Failed: 2. Skipped: 0.");
             result.StdOut.Should().Contain("Failed   TestNamespace.VSTestXunitTests.VSTestXunitFailTestNetCoreApp");
+            result.ExitCode.Should().Be(1);
         }
     }
 }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -38,6 +38,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.StdOut.Should().Contain("Total tests: 2. Passed: 1. Failed: 1. Skipped: 0.");
             result.StdOut.Should().Contain("Passed   TestNamespace.VSTestTests.VSTestPassTest");
             result.StdOut.Should().Contain("Failed   TestNamespace.VSTestTests.VSTestFailTest");
+            result.ExitCode.Should().Be(1);
         }
 
         [Fact]
@@ -65,6 +66,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.StdOut.Should().Contain("Total tests: 2. Passed: 1. Failed: 1. Skipped: 0.");
             result.StdOut.Should().Contain("Passed   TestNamespace.VSTestXunitTests.VSTestXunitPassTest");
             result.StdOut.Should().Contain("Failed   TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
+            result.ExitCode.Should().Be(1);
         }
 
         [Fact]

--- a/test/dotnet-vstest.Tests/VSTestTests.cs
+++ b/test/dotnet-vstest.Tests/VSTestTests.cs
@@ -32,12 +32,12 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
             var argsForVstest = $"\"{outputDll.FullName}\"";
 
             // Call vstest
-            new VSTestCommand()
-                .ExecuteWithCapturedOutput(argsForVstest)
-                .StdOut
+            var result = new VSTestCommand().ExecuteWithCapturedOutput(argsForVstest);
+            result.StdOut
                 .Should().Contain("Total tests: 2. Passed: 1. Failed: 1. Skipped: 0.")
-                     .And.Contain("Passed   TestNamespace.VSTestTests.VSTestPassTest")
-                     .And.Contain("Failed   TestNamespace.VSTestTests.VSTestFailTest");
+                .And.Contain("Passed   TestNamespace.VSTestTests.VSTestPassTest")
+                .And.Contain("Failed   TestNamespace.VSTestTests.VSTestFailTest");
+            result.ExitCode.Should().Be(1);
         }
     }
 }


### PR DESCRIPTION
Issue: `dotnet test` returns zero exit code for a failure in one of the TFMs for a multi tfm test project

Treat the errors from vstest task as errors (instead of warnings) before continuing further.
Add asserts for exit code in tests for dotnet-test and dotnet-vstest.