### PR TITLE
Added a clean empty targets method to CleanOutputProjectRule

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/CleanOutputProjectRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/CleanOutputProjectRule.cs
@@ -22,19 +22,13 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
             CleanEmptyPropertiesAndItems(outputProject);
             CleanPropertiesThatDontChangeValue(outputProject);
             CleanEmptyPropertyAndItemGroups(outputProject);
+            CleanEmptyTargets(outputProject);
         }
 
         private void CleanEmptyPropertyAndItemGroups(ProjectRootElement msbuildProject)
         {
-            foreach (var propertyGroup in msbuildProject.PropertyGroups)
-            {
-                propertyGroup.RemoveIfEmpty();
-            }
-
-            foreach (var itemGroup in msbuildProject.ItemGroups)
-            {
-                itemGroup.RemoveIfEmpty();
-            }
+            CleanEmptyProjectElementContainers(msbuildProject.PropertyGroups);
+            CleanEmptyProjectElementContainers(msbuildProject.ItemGroups);
         }
 
         private void CleanEmptyPropertiesAndItems(ProjectRootElement msbuildProject)
@@ -67,6 +61,19 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                 {
                     property.Parent.RemoveChild(property);
                 }
+            }
+        }
+
+        private void CleanEmptyTargets(ProjectRootElement msbuildProject)
+        {
+            CleanEmptyProjectElementContainers(msbuildProject.Targets);
+        }
+
+        private void CleanEmptyProjectElementContainers(IEnumerable<ProjectElementContainer> containers)
+        {
+            foreach (var container in containers)
+            {
+                container.RemoveIfEmpty();
             }
         }
     }

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToCleanTheOutputProject.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToCleanTheOutputProject.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+using Microsoft.DotNet.ProjectJsonMigration;
+using System;
+using System.IO;
+using Microsoft.Build.Construction;
+using Microsoft.DotNet.ProjectJsonMigration.Rules;
+using Microsoft.DotNet.Internal.ProjectModel;
+
+namespace Microsoft.DotNet.ProjectJsonMigration.Tests
+{
+    public class GivenThatIWantToCleanTheOutputProject : TestBase
+    {
+        [Fact]
+        public void ItRemovesEmptyTargetsFromTheProject()
+        {
+            var mockProj = ProjectRootElement.Create();
+            var target = mockProj.CreateTargetElement("Test");
+            mockProj.AppendChild(target);
+            target.AddTask("Exec");
+
+            var targetToRemove = mockProj.CreateTargetElement("ToRemove");
+            mockProj.AppendChild(targetToRemove);
+
+            var migrationRuleInputs = new MigrationRuleInputs(Enumerable.Empty<ProjectContext>(), mockProj, null, null);
+            var cleanOutputProjectRule = new CleanOutputProjectRule();
+
+            cleanOutputProjectRule.Apply(null, migrationRuleInputs);
+
+            mockProj.Targets.Should().HaveCount(c => c == 1);
+        }
+    }
+}


### PR DESCRIPTION
Added a clean empty targets method to CleanOutputProjectRule that removes any targets without content inside of them from the csproj.
Added a unit test for cleaning empty targets.

Fixes https://github.com/dotnet/cli/issues/5024

@jonsequitur @piotrpMSFT @jgoshi @krwq 