### PR TITLE
Finishing touches on help messages

### DIFF
--- a/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
@@ -6,7 +6,7 @@
 
         public const string AppFullName = ".NET Builder";
 
-        public const string ConfigurationOptionDescription = "Configuration to use for buulding the project. Default is  \"Debug\".";
+        public const string ConfigurationOptionDescription = "Configuration to use for building the project. Default is  \"Debug\".";
 
         public const string ConfigurationOptionName = "CONFIGURATION";
 

--- a/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
@@ -6,19 +6,19 @@
 
         public const string AppFullName = ".NET Builder";
 
-        public const string ConfigurationOptionDescription = "Configuration under which to build";
+        public const string ConfigurationOptionDescription = "Configuration to use for buulding the project. Default is  \"Debug\".";
 
         public const string ConfigurationOptionName = "CONFIGURATION";
 
-        public const string FrameworkOptionDescription = "Compile a specific framework";
+        public const string FrameworkOptionDescription = "Target framework to build for. The target framework has to be specified in the project file.";
 
         public const string FrameworkOptionName = "FRAMEWORK";
 
         public const string NoDependenciesOptionDescription = "Set this flag to ignore project to project references and only build the root project";
 
-        public const string NoIncrementialOptionDescription = "Set this flag to turn off incremental build";
+        public const string NoIncrementialOptionDescription = "Disables incremental build.";
 
-        public const string OutputOptionDescription = "Directory in which to place outputs";
+        public const string OutputOptionDescription = "Output directory in which to place built artifacts.";
 
         public const string OutputOptionName = "OUTPUT_DIR";
 

--- a/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
@@ -14,7 +14,7 @@
 
         public const string FrameworkOptionName = "FRAMEWORK";
 
-        public const string NoDependenciesOptionDescription = "Set this flag to ignore project to project references and only build the root project";
+        public const string NoDependenciesOptionDescription = "Set this flag to ignore project-to-project references and only build the root project";
 
         public const string NoIncrementialOptionDescription = "Disables incremental build.";
 

--- a/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-build/LocalizableStrings.cs
@@ -6,7 +6,7 @@
 
         public const string AppFullName = ".NET Builder";
 
-        public const string ConfigurationOptionDescription = "Configuration to use for building the project. Default is  \"Debug\".";
+        public const string ConfigurationOptionDescription = "Configuration to use for building the project. Default for most projects is  \"Debug\".";
 
         public const string ConfigurationOptionName = "CONFIGURATION";
 

--- a/src/dotnet/commands/dotnet-clean/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-clean/LocalizableStrings.cs
@@ -12,14 +12,14 @@
 
         public const string CmdOutputDir = "OUTPUT_DIR";
 
-        public const string CmdOutputDirDescription = "Directory in which the build outputs have been placed";
+        public const string CmdOutputDirDescription = "Directory in which the build outputs have been placed.";
 
         public const string CmdFramework = "FRAMEWORK";
 
-        public const string CmdFrameworkDescription = "Clean a specific framework";
+        public const string CmdFrameworkDescription = "Clean a specific framework.";
 
         public const string CmdConfiguration = "CONFIGURATION";
 
-        public const string CmdConfigurationDescription = "Clean a specific configuration";
+        public const string CmdConfigurationDescription = "Clean a specific configuration.";
     }
 }

--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -34,6 +34,7 @@ namespace Microsoft.DotNet.Tools.Help
   test          {LocalizableStrings.TestDefinition}
   pack          {LocalizableStrings.PackDefinition}
   migrate       {LocalizableStrings.MigrateDefinition}
+  clean         {LocalizableStrings.CleanDefinition}
 
 Project modification commands:
   add           Add items to the project

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -59,5 +59,7 @@
         public const string MsBuildDefinition = "msbuilds a project and all of its dependencies";
 
         public const string VsTestDefinition = "Runs tests from the specified files";
+
+        public const string CleanDefinition = "Clean build output(s)";
     }
 }

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -56,9 +56,9 @@
 
         public const string NugetDefinition = "Provides additional NuGet commands.";
 
-        public const string MsBuildDefinition = "Builds a project using MSBuild and all of its dependencies.";
+        public const string MsBuildDefinition = "Runs Microsoft Build Engine (MSBuild).";
 
-        public const string VsTestDefinition = "Runs tests from the specified files.";
+        public const string VsTestDefinition = "Runs Microsoft Test Execution Command Line Tool.";
 
         public const string CleanDefinition = "Clean build output(s).";
     }

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -30,36 +30,36 @@
 
         public const string Commands = "Commands";
 
-        public const string NewDefinition = "Initialize a basic .NET project";
+        public const string NewDefinition = "Initialize .NET projects.";
 
-        public const string RestoreDefinition = "Restore dependencies specified in the .NET project";
+        public const string RestoreDefinition = "Restore dependencies specified in the .NET project.";
 
-        public const string BuildDefinition = "Builds a .NET project";
+        public const string BuildDefinition = "Builds a .NET project.";
 
-        public const string PublishDefinition = "Publishes a .NET project for deployment (including the runtime)";
+        public const string PublishDefinition = "Publishes a .NET project for deployment (including the runtime).";
 
-        public const string RunDefinition = "Compiles and immediately executes a .NET project";
+        public const string RunDefinition = "Compiles and immediately executes a .NET project.";
 
-        public const string TestDefinition = "Runs unit tests using the test runner specified in the project";
+        public const string TestDefinition = "Runs unit tests using the test runner specified in the project.";
 
-        public const string PackDefinition = "Creates a NuGet package";
+        public const string PackDefinition = "Creates a NuGet package.";
 
-        public const string MigrateDefinition = "Migrates a project.json based project to a msbuild based project";
+        public const string MigrateDefinition = "Migrates a project.json based project to a msbuild based project.";
 
         public const string ProjectModificationCommands = "Project modification commands";
 
-        public const string AddDefinition = "Add items to the project";
-        
-        public const string RemoveDefinition = "Remove items from the project";
+        public const string AddDefinition = "Add items to the project.";
+
+        public const string RemoveDefinition = "Remove items from the project.";
 
         public const string AdvancedCommands = "Advanced Commands";
 
-        public const string NugetDefinition = "Provides additional NuGet commands";
+        public const string NugetDefinition = "Provides additional NuGet commands.";
 
-        public const string MsBuildDefinition = "msbuilds a project and all of its dependencies";
+        public const string MsBuildDefinition = "Builds a project using MSBuild and all of its dependencies.";
 
-        public const string VsTestDefinition = "Runs tests from the specified files";
+        public const string VsTestDefinition = "Runs tests from the specified files.";
 
-        public const string CleanDefinition = "Clean build output(s)";
+        public const string CleanDefinition = "Clean build output(s).";
     }
 }

--- a/src/dotnet/commands/dotnet-migrate/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-migrate/LocalizableStrings.cs
@@ -8,13 +8,10 @@ namespace Microsoft.DotNet.Tools.Migrate
 
         public const string CmdProjectArgument = "PROJECT_JSON/GLOBAL_JSON/SOLUTION_FILE/PROJECT_DIR";
         public const string CmdProjectArgumentDescription = 
-@"The path to 
+@"The path to one of the following:
     - a project.json file to migrate.
-or
     - a global.json file, it will migrate the folders specified in global.json.
-or
     - a solution.sln file, it will migrate the projects referenced in the solution.
-or
     - a directory to migrate, it will recursively search for project.json files to migrate.
 Defaults to current directory if nothing is specified.";
 

--- a/src/dotnet/commands/dotnet-pack/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-pack/LocalizableStrings.cs
@@ -2,29 +2,29 @@
 {
     internal class LocalizableStrings
     {
-        public const string AppFullName = "pack";
+        public const string AppFullName = ".NET Core NuGet Package Packer";
 
         public const string AppDescription = "pack for msbuild";
 
         public const string CmdOutputDir  = "OUTPUT_DIR";
 
-        public const string CmdOutputDirDescription = "Directory in which to place outputs";
+        public const string CmdOutputDirDescription = "Directory in which to place built packages.";
 
-        public const string CmdNoBuildOptionDescription = "Do not build project before packing";
+        public const string CmdNoBuildOptionDescription = "Skip building the project prior to packing. By default, the project will be built.";
 
-        public const string CmdIncludeSymbolsDescription = "Include PDBs along with the DLLs in the output folder";
+        public const string CmdIncludeSymbolsDescription = "Include packages with symbols in addition to assembly (DLL) packages in output directory.";
 
         public const string CmdIncludeSourceDescription  = "Include PDBs and source files. Source files go into the src folder in the resulting nuget package";
 
         public const string CmdConfig = "CONFIGURATION";
 
-        public const string CmdConfigDescription = "Configuration under which to build";
+        public const string CmdConfigDescription = "Configuration to use for building the project.  Default is  \"Debug\".";
 
         public const string CmdVersionSuffix = "VERSION_SUFFIX";
 
-        public const string CmdVersionSuffixDescription = "Defines what `*` should be replaced with in version field in project.json";
+        public const string CmdVersionSuffixDescription = "Defines the value for the $(VersionSuffix) property in the project.";
 
-        public const string CmdServiceableDescription = "Set the serviceable flag in the package";
+        public const string CmdServiceableDescription = "Set the serviceable flag in the package. For more information, please see https://aka.ms/nupkgservicing.";
 
         public const string CmdArgumentProject = "PROJECT";
 

--- a/src/dotnet/commands/dotnet-pack/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-pack/LocalizableStrings.cs
@@ -12,13 +12,13 @@
 
         public const string CmdNoBuildOptionDescription = "Skip building the project prior to packing. By default, the project will be built.";
 
-        public const string CmdIncludeSymbolsDescription = "Include packages with symbols in addition to assembly (DLL) packages in output directory.";
+        public const string CmdIncludeSymbolsDescription = "Include packages with symbols in addition to regular packages in output directory.";
 
         public const string CmdIncludeSourceDescription  = "Include PDBs and source files. Source files go into the src folder in the resulting nuget package";
 
         public const string CmdConfig = "CONFIGURATION";
 
-        public const string CmdConfigDescription = "Configuration to use for building the project.  Default is  \"Debug\".";
+        public const string CmdConfigDescription = "Configuration to use for building the project.  Default for most projects is  \"Debug\".";
 
         public const string CmdVersionSuffix = "VERSION_SUFFIX";
 

--- a/src/dotnet/commands/dotnet-publish/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-publish/LocalizableStrings.cs
@@ -12,7 +12,7 @@
 
         public const string FrameworkOption = "FRAMEWORK";
 
-        public const string FrameworkOptionDescription = " Target framework to publish for. The target framework has to be specified in the project file.";
+        public const string FrameworkOptionDescription = "Target framework to publish for. The target framework has to be specified in the project file.";
 
         public const string RuntimeOption = "RUNTIME_IDENTIFIER";
 

--- a/src/dotnet/commands/dotnet-publish/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-publish/LocalizableStrings.cs
@@ -12,22 +12,22 @@
 
         public const string FrameworkOption = "FRAMEWORK";
 
-        public const string FrameworkOptionDescription = "Target framework to publish for";
+        public const string FrameworkOptionDescription = " Target framework to publish for. The target framework has to be specified in the project file.";
 
         public const string RuntimeOption = "RUNTIME_IDENTIFIER";
 
-        public const string RuntimeOptionDescription = "Target runtime to publish for. The default is to publish a portable application.";
+        public const string RuntimeOptionDescription = "Publish the project for a given runtime. This is used when creating self-contained deployment. Default is to publish a framework-dependented app.";
 
         public const string OutputOption = "OUTPUT_DIR";
 
-        public const string OutputOptionDescription = "Path in which to publish the app";
+        public const string OutputOptionDescription = "Output directory in which to place the published artifacts.";
 
         public const string ConfigurationOption = "CONFIGURATION";
 
-        public const string ConfigurationOptionDescription = "Configuration under which to build";
+        public const string ConfigurationOptionDescription = "Configuration to use for building the project.  Default is  \"Debug\".";
 
         public const string VersionSuffixOption = "VERSION_SUFFIX";
 
-        public const string VersionSuffixOptionDescription = "Defines the value for the $(VersionSuffix) property in the project";
+        public const string VersionSuffixOptionDescription = "Defines the value for the $(VersionSuffix) property in the project.";
     }
 }

--- a/src/dotnet/commands/dotnet-publish/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-publish/LocalizableStrings.cs
@@ -24,7 +24,7 @@
 
         public const string ConfigurationOption = "CONFIGURATION";
 
-        public const string ConfigurationOptionDescription = "Configuration to use for building the project.  Default is  \"Debug\".";
+        public const string ConfigurationOptionDescription = "Configuration to use for building the project.  Default for most projects is  \"Debug\".";
 
         public const string VersionSuffixOption = "VERSION_SUFFIX";
 

--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
@@ -2,11 +2,11 @@
 {
     internal class LocalizableStrings
     {
-        public const string AppFullName = "restore";
+        public const string AppFullName = ".NET dependency restorer";
 
         public const string AppDescription = "restore for msbuild";
 
-        public const string CmdArgument = "root";
+        public const string CmdArgument = "project";
 
         public const string CmdArgumentDescription = "Optional path to a project file or MSBuild arguments.";
 

--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
@@ -6,21 +6,21 @@
 
         public const string AppDescription = "restore for msbuild";
 
-        public const string CmdArgument = "project";
+        public const string CmdArgument = "PROJECT";
 
         public const string CmdArgumentDescription = "Optional path to a project file or MSBuild arguments.";
 
-        public const string CmdSourceOption = "source";
+        public const string CmdSourceOption = "SOURCE";
 
         public const string CmdSourceOptionDescription = "Specifies a NuGet package source to use during the restore.";
 
-        public const string CmdPackagesOption = "packagesDirectory";
+        public const string CmdPackagesOption = "PACKAGES_DIRECTORY";
 
         public const string CmdPackagesOptionDescription = "Directory to install packages in.";
 
         public const string CmdDisableParallelOptionDescription = "Disables restoring multiple projects in parallel.";
 
-        public const string CmdConfigFileOption = "file";
+        public const string CmdConfigFileOption = "FILE";
 
         public const string CmdConfigFileOptionDescription = "The NuGet configuration file to use.";
 

--- a/src/dotnet/commands/dotnet-run/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-run/LocalizableStrings.cs
@@ -6,11 +6,11 @@
 
         public const string AppDescription = "Command used to run .NET apps";
 
-        public const string CommandOptionConfigurationDescription = "Configuration to use for building the project. Default is \"Debug\".";
+        public const string CommandOptionConfigurationDescription = "Configuration to use for building the project. Default for most projects is \"Debug\".";
 
         public const string CommandOptionFramework = "FRAMEWORK";
 
-        public const string CommandOptionFrameworkDescription = "Build and run the specified framework. The framework has to be specified in the project file. ";
+        public const string CommandOptionFrameworkDescription = "Build and run the app using the specified framework. The framework has to be specified in the project file. ";
 
         public const string CommandOptionProjectDescription = "The path to the project file to run (defaults to the current directory if there is only one project).";
 

--- a/src/dotnet/commands/dotnet-run/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-run/LocalizableStrings.cs
@@ -6,11 +6,11 @@
 
         public const string AppDescription = "Command used to run .NET apps";
 
-        public const string CommandOptionConfigurationDescription = "Configuration under which to build";
+        public const string CommandOptionConfigurationDescription = "Configuration to use for building the project. Default is \"Debug\".";
 
         public const string CommandOptionFramework = "FRAMEWORK";
 
-        public const string CommandOptionFrameworkDescription = "Compile a specific framework";
+        public const string CommandOptionFrameworkDescription = "Build and run the specified framework. The framework has to be specified in the project file. ";
 
         public const string CommandOptionProjectDescription = "The path to the project file to run (defaults to the current directory if there is only one project).";
 
@@ -43,5 +43,7 @@
         public const string RunCommandInvalidOperationException3 = "Specify which project file to use because this ";
 
         public const string RunCommandInvalidOperationException4 = "contains more than one project file.";
+
+        public const string RunCommandAdditionalArgsHelpText = "Arguments passed to the application that is being run.";
     }
 }

--- a/src/dotnet/commands/dotnet-run/Program.cs
+++ b/src/dotnet/commands/dotnet-run/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tools.Run
             app.Description = LocalizableStrings.AppDescription;
             app.HandleResponseFiles = true;
             app.AllowArgumentSeparator = true;
-            app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;
+            app.ArgumentSeparatorHelpText = $"{HelpMessageStrings.MSBuildAdditionalArgsHelpText}\n{LocalizableStrings.RunCommandAdditionalArgsHelpText}";
             app.HelpOption("-h|--help");
 
             CommandOption configuration = app.Option(

--- a/src/dotnet/commands/dotnet-run/Program.cs
+++ b/src/dotnet/commands/dotnet-run/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tools.Run
             app.Description = LocalizableStrings.AppDescription;
             app.HandleResponseFiles = true;
             app.AllowArgumentSeparator = true;
-            app.ArgumentSeparatorHelpText = $"{HelpMessageStrings.MSBuildAdditionalArgsHelpText}\n{LocalizableStrings.RunCommandAdditionalArgsHelpText}";
+            app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;
             app.HelpOption("-h|--help");
 
             CommandOption configuration = app.Option(

--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
@@ -10,13 +10,13 @@
 
         public const string CmdArgDescription = "The project to test, defaults to the current directory.";
 
-        public const string CmdSettingsFile = "SettingsFile";
+        public const string CmdSettingsFile = "SETTINGS_FILE";
 
         public const string CmdSettingsDescription = "Settings to use when running tests.";
 
         public const string CmdListTestsDescription = @"Lists discovered tests";
 
-        public const string CmdTestCaseFilterExpression = "Expression";
+        public const string CmdTestCaseFilterExpression = "EXPRESSION";
 
         public const string CmdTestCaseFilterDescription = @"Run tests that match the given expression.
                                         Examples:
@@ -27,26 +27,26 @@
                                         ";
 
         public const string CmdTestAdapterPathDescription = @"Use custom adapters from the given path in the test run.
-                                        Example: --test-adapter-path:<pathToCustomAdapters>";
+                                        Example: --test-adapter-path <PATH_TO_ADAPTER>";
 
         public const string CmdLoggerOption = "LoggerUri/FriendlyName";
 
         public const string CmdLoggerDescription = @"Specify a logger for test results. 
                                         Example: --logger:trx";
 
-        public const string CmdConfiguration = "configuration";
+        public const string CmdConfiguration = "CONFIGURATION";
 
-        public const string CmdConfigDescription = @"Configuration under which to build, i.e. Debug/Release";
+        public const string CmdConfigDescription = "Configuration to use for building the project.  Default is  \"Debug\".";
 
-        public const string CmdFramework = "FrameworkVersion";
+        public const string CmdFramework = "FRAMEWORK";
 
         public const string CmdFrameworkDescription = @"Looks for test binaries for a specific framework";
 
-        public const string CmdOutputDir = "OutputDir";
+        public const string CmdOutputDir = "OUTPUT_DIR";
 
         public const string CmdOutputDescription = @"Directory in which to find the binaries to be run";
 
-        public const string CmdPathToLogFile = "PathToLogFile";
+        public const string CmdPathToLogFile = "PATH_TO_FILE";
 
         public const string CmdPathTologFileDescription = @"Enable verbose logs for test platform.
                                         Logs are written to the provided file.";

--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
@@ -36,7 +36,7 @@
 
         public const string CmdConfiguration = "CONFIGURATION";
 
-        public const string CmdConfigDescription = "Configuration to use for building the project.  Default is  \"Debug\".";
+        public const string CmdConfigDescription = "Configuration to use for building the project.  Default for most projects is  \"Debug\".";
 
         public const string CmdFramework = "FRAMEWORK";
 

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -40,6 +40,7 @@ Commands:
   test          Runs unit tests using the test runner specified in the project.
   pack          Creates a NuGet package.
   migrate       Migrates a project.json based project to a msbuild based project.
+  clean         Clean build output(s).
 
 Project modification commands:
   add           Add items to the project

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -32,14 +32,14 @@ Host options (passed before the command):
   --info                Display .NET CLI Info
 
 Commands:
-  new           Initialize a basic .NET project
-  restore       Restore dependencies specified in the .NET project
-  build         Builds a .NET project
-  publish       Publishes a .NET project for deployment (including the runtime)
-  run           Compiles and immediately executes a .NET project
-  test          Runs unit tests using the test runner specified in the project
-  pack          Creates a NuGet package
-  migrate       Migrates a project.json based project to a msbuild based project
+  new           Initialize .NET projects.
+  restore       Restore dependencies specified in the .NET project.
+  build         Builds a .NET project.
+  publish       Publishes a .NET project for deployment (including the runtime).
+  run           Compiles and immediately executes a .NET project.
+  test          Runs unit tests using the test runner specified in the project.
+  pack          Creates a NuGet package.
+  migrate       Migrates a project.json based project to a msbuild based project.
 
 Project modification commands:
   add           Add items to the project
@@ -47,9 +47,9 @@ Project modification commands:
   list          List items in the project
 
 Advanced Commands:
-  nuget         Provides additional NuGet commands
-  msbuild       msbuilds a project and all of its dependencies
-  vstest        Runs tests from the specified files";
+  nuget         Provides additional NuGet commands.
+  msbuild       Runs Microsoft Build Engine (MSBuild).
+  vstest        Runs Microsoft Test Execution Command Line Tool.";
 
         [Theory]
         [InlineData("--help")]


### PR DESCRIPTION
Making finishing touches on all the CLI commands' help messages. Also adding dotnet clean to the help output list.

Fixes #5048, #5017