### PR TITLE
Making version an attribute for packagereference and dotnetclitoolreference

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/MSBuildExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/MSBuildExtensions.cs
@@ -212,6 +212,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
 #endif
                 var metametadata = item.AddMetadata(metadata.Name, metadata.Value);
                 metametadata.Condition = metadata.Condition;
+                metametadata.ExpressedAsAttribute = metadata.ExpressedAsAttribute;
             }
         }
 

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Models/ItemMetadataValue.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Models/ItemMetadataValue.cs
@@ -9,6 +9,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Models
     {
         public string MetadataName { get; }
         public string Condition { get; }
+        public bool ExpressedAsAttribute { get; }
 
         private readonly Func<T, string> _metadataValueFunc;
         private readonly Func<T, bool> _writeMetadataConditionFunc;
@@ -16,10 +17,12 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Models
         public ItemMetadataValue(
             string metadataName,
             string metadataValue,
-            string condition = null) :
+            string condition = null,
+            bool expressedAsAttribute = false) :
                 this(metadataName,
                      _ => metadataValue,
-                     condition: condition)
+                     condition: condition,
+                     expressedAsAttribute: expressedAsAttribute)
         {
         }
 
@@ -27,7 +30,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Models
             string metadataName,
             Func<T, string> metadataValueFunc,
             Func<T, bool> writeMetadataConditionFunc = null,
-            string condition = null)
+            string condition = null,
+            bool expressedAsAttribute = false)
         {
             if (metadataName == null)
             {
@@ -43,6 +47,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Models
             _metadataValueFunc = metadataValueFunc;
             _writeMetadataConditionFunc = writeMetadataConditionFunc;
             Condition = condition;
+            ExpressedAsAttribute = expressedAsAttribute;
         }
 
         public bool ShouldWriteMetadata(T source)

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
@@ -394,7 +394,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                 dep => dep.Name,
                 dep => "",
                 dep => dep != null)
-                .WithMetadata("Version", r => r.Version);
+                .WithMetadata("Version", r => r.Version, expressedAsAttribute: true);
 
         private AddItemTransform<PackageDependencyInfo> SdkPackageDependencyTransform => 
             PackageDependencyInfoTransform()
@@ -406,7 +406,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                 dep => dep.Name,
                 dep => "",
                 dep => dep != null)
-                .WithMetadata("Version", r => r.Version);
+                .WithMetadata("Version", r => r.Version, expressedAsAttribute: true);
 
         private AddPropertyTransform<TargetFrameworkInformation> ImportsTransformation => 
             new AddPropertyTransform<TargetFrameworkInformation>(

--- a/src/Microsoft.DotNet.ProjectJsonMigration/transforms/AddItemTransform.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/transforms/AddItemTransform.cs
@@ -95,18 +95,29 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Transforms
             _excludeValue = excludeValue;
         }
 
-        public AddItemTransform<T> WithMetadata(string metadataName, string metadataValue)
+        public AddItemTransform<T> WithMetadata(
+            string metadataName,
+            string metadataValue,
+            bool expressedAsAttribute = false)
         {
-            _metadata.Add(new ItemMetadataValue<T>(metadataName, metadataValue));
+            _metadata.Add(new ItemMetadataValue<T>(
+                metadataName,
+                metadataValue,
+                expressedAsAttribute: expressedAsAttribute));
             return this;
         }
 
         public AddItemTransform<T> WithMetadata(
             string metadataName, 
             Func<T, string> metadataValueFunc, 
-            Func<T, bool> writeMetadataConditionFunc = null)
+            Func<T, bool> writeMetadataConditionFunc = null,
+            bool expressedAsAttribute = false)
         {
-            _metadata.Add(new ItemMetadataValue<T>(metadataName, metadataValueFunc, writeMetadataConditionFunc));
+            _metadata.Add(new ItemMetadataValue<T>(
+                metadataName,
+                metadataValueFunc,
+                writeMetadataConditionFunc,
+                expressedAsAttribute: expressedAsAttribute));
             return this;
         }
 
@@ -133,6 +144,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Transforms
                 {
                     var metametadata = item.AddMetadata(metadata.MetadataName, metadata.GetMetadataValue(source));
                     metametadata.Condition = metadata.Condition;
+                    metametadata.ExpressedAsAttribute = metadata.ExpressedAsAttribute;
                 }
             }
 

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackageDependencies.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackageDependencies.cs
@@ -250,7 +250,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "Microsoft.NET.Test.Sdk" &&
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "15.0.0-preview-20161024-02"));
+                      i.GetMetadataWithName("Version").Value == "15.0.0-preview-20161024-02" &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute));
 
             mockProj.Items.Should().NotContain(
                 i => (i.Include == "xunit" && i.ItemType == "PackageReference"));
@@ -282,17 +283,20 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "Microsoft.NET.Test.Sdk" && 
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "15.0.0-preview-20161024-02"));
+                      i.GetMetadataWithName("Version").Value == "15.0.0-preview-20161024-02") &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute);
 
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "xunit" && 
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "2.2.0-beta4-build3444"));
+                      i.GetMetadataWithName("Version").Value == "2.2.0-beta4-build3444" &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute));
 
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "xunit.runner.visualstudio" && 
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "2.2.0-beta4-build1194"));
+                      i.GetMetadataWithName("Version").Value == "2.2.0-beta4-build1194" &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute));
 
             mockProj.Items.Should().NotContain(
                 i => (i.Include == "MSTest.TestAdapter" && i.ItemType == "PackageReference"));
@@ -321,17 +325,20 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "Microsoft.NET.Test.Sdk" &&
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "15.0.0-preview-20161024-02"));
+                      i.GetMetadataWithName("Version").Value == "15.0.0-preview-20161024-02" &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute));
 
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "xunit" &&
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "2.2.0-beta4-build3444"));
+                      i.GetMetadataWithName("Version").Value == "2.2.0-beta4-build3444" &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute));
 
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "xunit.runner.visualstudio" &&
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "2.2.0-beta4-build1194"));
+                      i.GetMetadataWithName("Version").Value == "2.2.0-beta4-build1194" &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute));
 
             mockProj.Items.Should().NotContain(
                 i => (i.Include == "MSTest.TestAdapter" && i.ItemType == "PackageReference"));
@@ -357,17 +364,20 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "Microsoft.NET.Test.Sdk" &&
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "15.0.0-preview-20161024-02"));
+                      i.GetMetadataWithName("Version").Value == "15.0.0-preview-20161024-02" &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute));
 
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "MSTest.TestAdapter" &&
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "1.1.3-preview"));
+                      i.GetMetadataWithName("Version").Value == "1.1.3-preview" &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute));
 
             mockProj.Items.Should().ContainSingle(
                 i => (i.Include == "MSTest.TestFramework" &&
                       i.ItemType == "PackageReference" &&
-                      i.GetMetadataWithName("Version").Value == "1.0.4-preview"));
+                      i.GetMetadataWithName("Version").Value == "1.0.4-preview" &&
+                      i.GetMetadataWithName("Version").ExpressedAsAttribute));
 
             mockProj.Items.Should().NotContain(
                 i => (i.Include == "xunit" && i.ItemType == "PackageReference"));
@@ -418,7 +428,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
                     .Where(i => i.ItemType == "PackageReference")
                     .Where(i => string.IsNullOrEmpty(packageTFM) || i.ConditionChain().Any(c => c.Contains(packageTFM)))
                     .Where(i => i.Include == packageName)
-                    .Where(i => i.GetMetadataWithName("Version").Value == packageVersion);
+                    .Where(i => i.GetMetadataWithName("Version").Value == packageVersion &&
+                                i.GetMetadataWithName("Version").ExpressedAsAttribute);
 
                 items.Should().HaveCount(1);
             }
@@ -434,7 +445,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
                 var items = mockProj.Items
                     .Where(i => i.ItemType == "DotNetCliToolReference")
                     .Where(i => i.Include == packageName)
-                    .Where(i => i.GetMetadataWithName("Version").Value == packageVersion);
+                    .Where(i => i.GetMetadataWithName("Version").Value == packageVersion &&
+                                i.GetMetadataWithName("Version").ExpressedAsAttribute);
 
                 items.Should().HaveCount(1);
             }


### PR DESCRIPTION
Making version an attribute for packagereference and dotnetclitoolreference

Fixes https://github.com/dotnet/cli/issues/5023

@piotrpMSFT @jonsequitur @krwq @jgoshi 