### PR TITLE
Only adding rids for full framework TFMs if the project.json does not have runtimes

### DIFF
--- a/TestAssets/TestProjects/TestAppWithMultipleFrameworksAndRuntimes/Program.cs
+++ b/TestAssets/TestProjects/TestAppWithMultipleFrameworksAndRuntimes/Program.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Xml;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            Console.WriteLine("Hello World!");
+#if NET20 || NET35 || NET45 || NET461
+            // Force XmlDocument to be used
+            var doc = new XmlDocument();
+#endif
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestAppWithMultipleFrameworksAndRuntimes/project.json
+++ b/TestAssets/TestProjects/TestAppWithMultipleFrameworksAndRuntimes/project.json
@@ -1,0 +1,38 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+  "dependencies": {},
+  "frameworks": {
+    "net20": {
+      "frameworkAssemblies": {
+        "System.Xml": {}
+      }
+    },
+    "net35": {
+      "frameworkAssemblies": {
+        "System.Xml": {}
+      }
+    },
+    "net40": {
+      "frameworkAssemblies": {
+        "System.Xml": {}
+      }
+    },
+    "net461": {
+      "frameworkAssemblies": {
+        "System.Xml": {}
+      }
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NetCore.App": "1.0.1"
+      }
+    }
+  },
+  "runtimes": {
+    "win7-x64": {},
+    "win7-x86": {}
+  }
+}

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTFMs.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTFMs.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
     public class GivenThatIWantToMigrateTFMs : TestBase
     {
         [Fact(Skip="Emitting this until x-targetting full support is in")]
-        public void Migrating_netcoreapp_project_Does_not_populate_TargetFrameworkIdentifier_and_TargetFrameworkVersion()
+        public void MigratingNetcoreappProjectDoesNotPopulateTargetFrameworkIdentifierAndTargetFrameworkVersion()
         {
             var testDirectory = Temp.CreateDirectory().Path;
             var testPJ = new ProjectJsonBuilder(TestAssetsManager)
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Fact]
-        public void Migrating_MultiTFM_project_Populates_TargetFrameworks_with_short_tfms()
+        public void MigratingMultiTFMProjectPopulatesTargetFrameworksWithShortTfms()
         {
             var testDirectory = Temp.CreateDirectory().Path;
             var testPJ = new ProjectJsonBuilder(TestAssetsManager)
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Fact]
-        public void Migrating_desktop_TFMs_adds_RuntimeIdentifiers()
+        public void MigratingDesktopTFMsAddsAllRuntimeIdentifiersIfTheProjectDoesNothaveAnyAlready()
         {
             var testDirectory = Temp.CreateDirectory().Path;
             var testPJ = new ProjectJsonBuilder(TestAssetsManager)
@@ -94,7 +94,31 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Fact]
-        public void Migrating_Single_TFM_project_Populates_TargetFramework()
+        public void MigrateTFMRuleDoesNotAddRuntimesWhenMigratingDesktopTFMsWithRuntimesAlready()
+        {
+            var testDirectory = Temp.CreateDirectory().Path;
+            var testPJ = new ProjectJsonBuilder(TestAssetsManager)
+                .FromTestAssetBase("TestAppWithMultipleFrameworksAndRuntimes")
+                .SaveToDisk(testDirectory);
+
+            var projectContexts = ProjectContext.CreateContextForEachFramework(testDirectory);
+            var mockProj = ProjectRootElement.Create();
+
+            var migrationSettings =
+                MigrationSettings.CreateMigrationSettingsTestHook(testDirectory, testDirectory, mockProj);
+            var migrationInputs = new MigrationRuleInputs(
+                projectContexts, 
+                mockProj, 
+                mockProj.AddItemGroup(), 
+                mockProj.AddPropertyGroup());
+
+            new MigrateTFMRule().Apply(migrationSettings, migrationInputs);
+
+            mockProj.Properties.Count(p => p.Name == "RuntimeIdentifiers").Should().Be(0);
+        }
+
+        [Fact]
+        public void MigratingSingleTFMProjectPopulatesTargetFramework()
         {
             var testDirectory = Temp.CreateDirectory().Path;
             var testPJ = new ProjectJsonBuilder(TestAssetsManager)


### PR DESCRIPTION
Only adding rids for full framework TFMs if the project.json does not already have Runtimes in its Runtimes section.

Fixes https://github.com/dotnet/cli/issues/4991

@piotrpMSFT @jgoshi @krwq @jonsequitur 