### PR TITLE
Add Runtime Identifier option to dotnet-restore

### DIFF
--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
@@ -14,6 +14,10 @@
 
         public const string CmdSourceOptionDescription = "Specifies a NuGet package source to use during the restore.";
 
+        public const string CmdRuntimeOption = "RUNTIME_IDENTIFIER";
+
+        public const string CmdRuntimeOptionDescription = "Target runtime to restore packages for.";
+
         public const string CmdPackagesOption = "PACKAGES_DIRECTORY";
 
         public const string CmdPackagesOptionDescription = "Directory to install packages in.";

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -35,6 +35,11 @@ namespace Microsoft.DotNet.Tools.Restore
                     LocalizableStrings.CmdSourceOptionDescription,
                     CommandOptionType.MultipleValue);
 
+            var runtimeOption = cmd.Option(
+                    $"-r|--runtime <{LocalizableStrings.CmdRuntimeOption}>",
+                    LocalizableStrings.CmdRuntimeOptionDescription,
+                    CommandOptionType.MultipleValue);
+
             var packagesOption = cmd.Option(
                     $"--packages <{LocalizableStrings.CmdPackagesOption}>",
                     LocalizableStrings.CmdPackagesOptionDescription,
@@ -79,6 +84,11 @@ namespace Microsoft.DotNet.Tools.Restore
                 if (sourceOption.HasValue())
                 {
                     msbuildArgs.Add($"/p:RestoreSources={string.Join("%3B", sourceOption.Values)}");
+                }
+
+                if (runtimeOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:RuntimeIdentifiers={string.Join("%3B", runtimeOption.Values)}");
                 }
 
                 if (packagesOption.HasValue())


### PR DESCRIPTION
Adds an option to specify an RID when restoring
This uses the same `-r` option from the publish and build command

There's been discussion about this at issue #5038