### PR TITLE
Remove argument separator from commands 

### DIFF
--- a/src/dotnet/commands/dotnet-build/Program.cs
+++ b/src/dotnet/commands/dotnet-build/Program.cs
@@ -18,8 +18,8 @@ namespace Microsoft.DotNet.Tools.Build
             app.Name = "dotnet build";
             app.FullName = LocalizableStrings.AppFullName;
             app.Description = LocalizableStrings.AppDescription;
-            app.AllowArgumentSeparator = true;
             app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;
+            app.HandleRemainingArguments = true;            
             app.HelpOption("-h|--help");
 
             CommandArgument projectArgument = app.Argument($"<{LocalizableStrings.ProjectArgumentValueName}>", LocalizableStrings.ProjectArgumentDescription);

--- a/src/dotnet/commands/dotnet-clean/Program.cs
+++ b/src/dotnet/commands/dotnet-clean/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tools.Clean
                 Name = "dotnet clean",
                 FullName = LocalizableStrings.AppFullName,
                 Description = LocalizableStrings.AppDescription,
-                AllowArgumentSeparator = true,
+                HandleRemainingArguments = true,
                 ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText
             };
             app.HelpOption("-h|--help");

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Tools.Pack
                 FullName = LocalizableStrings.AppFullName,
                 Description = LocalizableStrings.AppDescription,
                 HandleRemainingArguments = true,
-                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText                
+                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText
             };
 
             cmd.HelpOption("-h|--help");

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -19,8 +19,8 @@ namespace Microsoft.DotNet.Tools.Pack
                 Name = "pack",
                 FullName = LocalizableStrings.AppFullName,
                 Description = LocalizableStrings.AppDescription,
-                AllowArgumentSeparator = true,
-                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText
+                HandleRemainingArguments = true,
+                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText                
             };
 
             cmd.HelpOption("-h|--help");

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -17,8 +17,8 @@ namespace Microsoft.DotNet.Tools.Publish
             app.Name = "dotnet publish";
             app.FullName = LocalizableStrings.AppFullName;
             app.Description = LocalizableStrings.AppDescription;
-            app.AllowArgumentSeparator = true;
-            app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;
+            app.HandleRemainingArguments = true;
+            app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;            
             app.HelpOption("-h|--help");
 
             CommandArgument projectArgument = app.Argument($"<{LocalizableStrings.ProjectArgument}>",

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Tools.Publish
             app.FullName = LocalizableStrings.AppFullName;
             app.Description = LocalizableStrings.AppDescription;
             app.HandleRemainingArguments = true;
-            app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;            
+            app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;
             app.HelpOption("-h|--help");
 
             CommandArgument projectArgument = app.Argument($"<{LocalizableStrings.ProjectArgument}>",

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -19,8 +19,8 @@ namespace Microsoft.DotNet.Tools.Restore
                 Name = "restore",
                 FullName = LocalizableStrings.AppFullName,
                 Description = LocalizableStrings.AppDescription,
-                AllowArgumentSeparator = true,
-                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText
+                HandleRemainingArguments = true,
+                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText                
             };
 
             cmd.HelpOption("-h|--help");

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Tools.Restore
                 FullName = LocalizableStrings.AppFullName,
                 Description = LocalizableStrings.AppDescription,
                 HandleRemainingArguments = true,
-                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText                
+                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText
             };
 
             cmd.HelpOption("-h|--help");

--- a/src/dotnet/commands/dotnet-run/Program.cs
+++ b/src/dotnet/commands/dotnet-run/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tools.Run
             app.Description = LocalizableStrings.AppDescription;
             app.HandleResponseFiles = true;
             app.AllowArgumentSeparator = true;
-            app.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;
+            app.ArgumentSeparatorHelpText = LocalizableStrings.RunCommandAdditionalArgsHelpText;
             app.HelpOption("-h|--help");
 
             CommandOption configuration = app.Option(

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -21,11 +21,11 @@ namespace Microsoft.DotNet.Tools.Test
             {
                 Name = "dotnet test",
                 FullName = LocalizableStrings.AppFullName,
-                Description = LocalizableStrings.AppDescription
+                Description = LocalizableStrings.AppDescription,
+                HandleRemainingArguments = true,
+                ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText                
             };
 
-            cmd.AllowArgumentSeparator = true;
-            cmd.ArgumentSeparatorHelpText = HelpMessageStrings.MSBuildAdditionalArgsHelpText;
             cmd.HelpOption("-h|--help");
 
             var argRoot = cmd.Argument(

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -90,7 +90,6 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             result.StdOut.Should().Contain(AppArgumentsText);
         }
 
-
         [Fact]
         public void WhenTelemetryIsEnabledTheLoggerIsAddedToTheCommandLine()
         {

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -56,7 +56,6 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData("pack", true)]
         [InlineData("publish", true)]
         [InlineData("restore", true)]
-        [InlineData("run", true)]
         public void When_help_is_invoked_Then_MSBuild_extra_options_text_is_included_in_output(string commandName, bool isMSBuildCommand)
         {
             const string MSBuildHelpText = " Any extra options that should be passed to MSBuild. See 'dotnet msbuild -h' for available options.";
@@ -76,6 +75,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 result.StdOut.Should().NotContain(MSBuildHelpText);
             }
         }
+
 
         [Fact]
         public void WhenTelemetryIsEnabledTheLoggerIsAddedToTheCommandLine()

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -76,6 +76,20 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             }
         }
 
+        [Fact]
+        public void WhenDotnetRunHelpIsInvokedAppArgumentsTextIsIncludedInOutput()
+        {
+            const string AppArgumentsText = "Arguments passed to the application that is being run.";
+
+            var projectDirectory = TestAssetsManager.CreateTestDirectory("RunContainsAppArgumentsText");
+            var result = new TestCommand("dotnet")
+                .WithWorkingDirectory(projectDirectory.Path)
+                .ExecuteWithCapturedOutput("run --help");
+            
+            result.ExitCode.Should().Be(0);
+            result.StdOut.Should().Contain(AppArgumentsText);
+        }
+
 
         [Fact]
         public void WhenTelemetryIsEnabledTheLoggerIsAddedToTheCommandLine()


### PR DESCRIPTION
Currently, the argument separator (`--`) is only supported on `dotnet run`. This PR removes it from other commands to make the help and usage of these command clearer. 

It also adds a new test to check the `dotnet run` message output and changes an existing test to not check the msbuild argument mesasge for `dotnet run` but only for others. 

/cc @livarcocc @piotrpMSFT @jonsequitur 