### PR TITLE
Add error message when tool is ivoked but not restored

### DIFF
--- a/TestAssets/NonRestoredTestProjects/AppWithNonExistingToolDependency/AppWithNonExistingToolDependency.csproj
+++ b/TestAssets/NonRestoredTestProjects/AppWithNonExistingToolDependency/AppWithNonExistingToolDependency.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+    <EmbeddedResource Include="**\*.resx" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-nonexistingtool">
+      <Version>1.0.0</Version>
+    </DotNetCliToolReference>
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/NonRestoredTestProjects/AppWithNonExistingToolDependency/Program.cs
+++ b/TestAssets/NonRestoredTestProjects/AppWithNonExistingToolDependency/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConsoleApplication
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ToolPathCalculator.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ToolPathCalculator.cs
@@ -75,6 +75,11 @@ namespace Microsoft.DotNet.Cli.Utils
             var availableVersions = new List<NuGetVersion>();
 
             var toolBase = GetBaseToolPath(packageId);
+            if (!Directory.Exists(toolBase))
+            {
+                return new NuGetVersion[0];
+            }
+            
             var versionDirectories = Directory.EnumerateDirectories(toolBase);
 
             foreach (var versionDirectory in versionDirectories)

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ToolPathCalculator.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ToolPathCalculator.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using NuGet.Frameworks;
 using NuGet.Versioning;
 
@@ -77,7 +78,7 @@ namespace Microsoft.DotNet.Cli.Utils
             var toolBase = GetBaseToolPath(packageId);
             if (!Directory.Exists(toolBase))
             {
-                return new NuGetVersion[0];
+                return Enumerable.Empty<NuGetVersion>();
             }
             
             var versionDirectories = Directory.EnumerateDirectories(toolBase);

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -124,6 +124,20 @@ namespace Microsoft.DotNet.Tests
                      .And.Pass();
         }
 
+        [Fact]
+        public void ItShowsErrorWhenToolIsNotRestored()
+        {
+            var testInstance = TestAssets.Get("NonRestoredTestProjects", "AppWithNonExistingToolDependency")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            new TestCommand("dotnet")
+                .WithWorkingDirectory(testInstance.Root)
+                .ExecuteWithCapturedOutput("nonexistingtool")
+                .Should().Fail()
+                    .And.HaveStdErrContaining("Version for package `dotnet-nonexistingtool` could not be resolved.");
+        }
+
         // need conditional theories so we can skip on non-Windows
         //[Theory(Skip="https://github.com/dotnet/cli/issues/4514")]
         //[MemberData("DependencyToolArguments")]


### PR DESCRIPTION
Fixes: https://github.com/dotnet/cli/issues/5019
- When tool was not restored we currently get stack trace or really not user friendly error - this is addressing this issue

cc: @livarcocc @piotrpMSFT @jgoshi @jonsequitur 