### PR TITLE
Emitting a None item for App.config if one exists side-by-side to the project.json

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
@@ -130,6 +130,13 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                 project => "true",
                 project => project.GetProjectType() == ProjectType.Test);
 
+        private AddItemTransform<ProjectContext> AppConfigTransform =>
+            new AddItemTransform<ProjectContext>(
+                "None",
+                projectContext => "App.config",
+                projectContext => string.Empty,
+                projectContext => File.Exists(Path.Combine(projectContext.ProjectDirectory, "App.config")));
+
         private Func<CommonCompilerOptions, string, ProjectType, IEnumerable<ProjectItemElement>>CompileFilesTransformExecute =>
             (compilerOptions, projectDirectory, projectType) =>
                     CompileFilesTransform.Transform(GetCompileIncludeContext(compilerOptions, projectDirectory));
@@ -258,6 +265,9 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
             var transformOutput = GenerateRuntimeConfigurationFilesTransform.Transform(
                 migrationRuleInputs.DefaultProjectContext.ProjectFile);
             _transformApplicator.Execute(transformOutput, propertyGroup, mergeExisting: true);
+
+            var appConfigTransformOutput = AppConfigTransform.Transform(migrationRuleInputs.DefaultProjectContext);
+            _transformApplicator.Execute(appConfigTransformOutput, itemGroup, mergeExisting: true);
         }
 
         private void PerformConfigurationPropertyAndItemMappings(

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
@@ -553,6 +553,20 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             mockProj.Properties.Count(p => p.Name == "GenerateRuntimeConfigurationFiles").Should().Be(0);
         }
 
+        [Fact]
+        public void MigratingAnAppWithAppConfigAddsItAsNoneToTheCsProj()
+        {
+            var tempDirectory = Temp.CreateDirectory().Path;
+            File.Create(Path.Combine(tempDirectory, "App.config")).Dispose();
+            var mockProj = RunBuildOptionsRuleOnPj(@"
+                {
+                }",
+                tempDirectory);
+
+            mockProj.Items.Count(i => i.ItemType == "None").Should().Be(1);
+            mockProj.Items.First(i => i.ItemType == "None").Include.Should().Be("App.config");
+        }
+
         private static IEnumerable<string> GetDefaultExcludePatterns(string group)
         {
             var defaultExcludePatterns = new List<string>(group == "copyToOutput" ?


### PR DESCRIPTION
Emitting a None item for App.config if one exists side-by-side to the project.json

Fixes https://github.com/dotnet/cli/issues/4694

@piotrpMSFT @jonsequitur @jgoshi @krwq 