### PR TITLE
Add Nano Server Support: Update MSBuild dependency

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_MSBuild_Version>15.1.0-preview-000458-02</CLI_MSBuild_Version>
+    <CLI_MSBuild_Version>15.1.0-preview-000503-01</CLI_MSBuild_Version>
     <CLI_NETSDK_Version>1.0.0-alpha-20161221-2</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20161205-1-154</CLI_WEBSDK_Version>
   </PropertyGroup>


### PR DESCRIPTION
The root cause for #5081 was fixed by Microsoft/msbuild#1495; this PR updates the bumps the MSBuild dependency to a version which contains that fix.