### PR TITLE
Fix #5071: Eliminate some cross project dependencies in tests and fix local builds on windows

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/LocalizableStrings.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/LocalizableStrings.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.ProjectJsonMigration
 {
-    public class LocalizableStrings
+    internal class LocalizableStrings
     {
         public const string DoubleMigrationError = "Detected double project migration: {0}";
 

--- a/src/Microsoft.DotNet.ProjectJsonMigration/MSBuildExtensions.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/MSBuildExtensions.cs
@@ -3,17 +3,18 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Build.Construction;
+using System.IO;
 using System.Linq;
+using Microsoft.Build.Construction;
 
 namespace Microsoft.DotNet.ProjectJsonMigration
 {
-    internal static class MSBuildExtensions
+    public static class MSBuildExtensions
     {
         public static IEnumerable<string> GetEncompassedIncludes(this ProjectItemElement item, 
-            ProjectItemElement otherItem)
+            ProjectItemElement otherItem, TextWriter trace = null)
         {
-            if (otherItem.IsEquivalentToExceptIncludeAndExclude(item) && 
+            if (otherItem.IsEquivalentToExceptIncludeAndExclude(item, trace) && 
                 new HashSet<string>(otherItem.Excludes()).IsSubsetOf(new HashSet<string>(item.Excludes())))
             {
                 return otherItem.IntersectIncludes(item);
@@ -22,37 +23,31 @@ namespace Microsoft.DotNet.ProjectJsonMigration
             return Enumerable.Empty<string>();
         }
 
-        public static bool IsEquivalentTo(this ProjectItemElement item, ProjectItemElement otherItem)
+        public static bool IsEquivalentTo(this ProjectItemElement item, ProjectItemElement otherItem, TextWriter trace = null)
         {
             // Different includes
             if (item.IntersectIncludes(otherItem).Count() != item.Includes().Count())
             {
-#if !DISABLE_TRACE
-                MigrationTrace.Instance.WriteLine(String.Format(LocalizableStrings.IncludesNotEquivalent, nameof(MSBuildExtensions), nameof(IsEquivalentTo)));
-#endif
+                trace?.WriteLine(String.Format(LocalizableStrings.IncludesNotEquivalent, nameof(MSBuildExtensions), nameof(IsEquivalentTo)));
                 return false;
             }
 
             // Different Excludes
             if (item.IntersectExcludes(otherItem).Count() != item.Excludes().Count())
             {
-#if !DISABLE_TRACE
-                MigrationTrace.Instance.WriteLine(String.Format(LocalizableStrings.ExcludesNotEquivalent, nameof(MSBuildExtensions), nameof(IsEquivalentTo)));
-#endif
+                trace?.WriteLine(String.Format(LocalizableStrings.ExcludesNotEquivalent, nameof(MSBuildExtensions), nameof(IsEquivalentTo)));
                 return false;
             }
 
-            return item.IsEquivalentToExceptIncludeAndExclude(otherItem);
+            return item.IsEquivalentToExceptIncludeAndExclude(otherItem, trace);
         }
 
-        public static bool IsEquivalentToExceptIncludeAndExclude(this ProjectItemElement item, ProjectItemElement otherItem)
+        public static bool IsEquivalentToExceptIncludeAndExclude(this ProjectItemElement item, ProjectItemElement otherItem, TextWriter trace = null)
         {
             // Different remove
             if (item.Remove != otherItem.Remove)
             {
-#if !DISABLE_TRACE
-                MigrationTrace.Instance.WriteLine(String.Format(LocalizableStrings.RemovesNotEquivalent, nameof(MSBuildExtensions), nameof(IsEquivalentTo)));
-#endif
+                trace?.WriteLine(String.Format(LocalizableStrings.RemovesNotEquivalent, nameof(MSBuildExtensions), nameof(IsEquivalentTo)));
                 return false;
             }
 
@@ -67,17 +62,13 @@ namespace Microsoft.DotNet.ProjectJsonMigration
                 var otherMetadata = itemToCompare.GetMetadataWithName(metadata.Name);
                 if (otherMetadata == null)
                 {
-#if !DISABLE_TRACE
-                    MigrationTrace.Instance.WriteLine(String.Format(LocalizableStrings.MetadataDoesntExist, nameof(MSBuildExtensions), nameof(IsEquivalentTo), metadata.Name, metadata.Value));
-#endif
+                    trace?.WriteLine(String.Format(LocalizableStrings.MetadataDoesntExist, nameof(MSBuildExtensions), nameof(IsEquivalentTo), metadata.Name, metadata.Value));
                     return false;
                 }
 
                 if (!metadata.ValueEquals(otherMetadata))
                 {
-#if !DISABLE_TRACE
-                    MigrationTrace.Instance.WriteLine(String.Format(LocalizableStrings.MetadataHasAnotherValue, nameof(MSBuildExtensions), nameof(IsEquivalentTo), metadata.Name, metadata.Value, otherMetadata.Value));
-#endif
+                    trace?.WriteLine(String.Format(LocalizableStrings.MetadataHasAnotherValue, nameof(MSBuildExtensions), nameof(IsEquivalentTo), metadata.Name, metadata.Value, otherMetadata.Value));
                     return false;
                 }
             }
@@ -175,11 +166,11 @@ namespace Microsoft.DotNet.ProjectJsonMigration
             return metadata.Value.Equals(otherMetadata.Value, StringComparison.Ordinal);
         }
 
-        public static void AddMetadata(this ProjectItemElement item, ICollection<ProjectMetadataElement> metadataElements)
+        public static void AddMetadata(this ProjectItemElement item, ICollection<ProjectMetadataElement> metadataElements, TextWriter trace = null)
         {
             foreach (var metadata in metadataElements)
             {
-                item.AddMetadata(metadata);
+                item.AddMetadata(metadata, trace);
             }
         }
 
@@ -196,7 +187,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
             return item.Metadata.FirstOrDefault(m => m.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
         }
 
-        public static void AddMetadata(this ProjectItemElement item, ProjectMetadataElement metadata)
+        public static void AddMetadata(this ProjectItemElement item, ProjectMetadataElement metadata, TextWriter trace = null)
         {
             var existingMetadata = item.GetMetadataWithName(metadata.Name);
 
@@ -207,9 +198,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
 
             if (existingMetadata == default(ProjectMetadataElement))
             {
-#if !DISABLE_TRACE
-                MigrationTrace.Instance.WriteLine(String.Format(LocalizableStrings.AddingMetadataToItem, nameof(AddMetadata), item.ItemType, metadata.Name, metadata.Value, metadata.Condition));
-#endif
+                trace?.WriteLine(String.Format(LocalizableStrings.AddingMetadataToItem, nameof(AddMetadata), item.ItemType, metadata.Name, metadata.Value, metadata.Condition));
                 var metametadata = item.AddMetadata(metadata.Name, metadata.Value);
                 metametadata.Condition = metadata.Condition;
                 metametadata.ExpressedAsAttribute = metadata.ExpressedAsAttribute;

--- a/src/Microsoft.DotNet.ProjectJsonMigration/MigrationTrace.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/MigrationTrace.cs
@@ -2,37 +2,47 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
+using System.Text;
 
 namespace Microsoft.DotNet.ProjectJsonMigration
 {
-    internal class MigrationTrace
+    internal class MigrationTrace : TextWriter
     {
         public static MigrationTrace Instance { get; set; }
+
+        public string EnableEnvironmentVariable => "DOTNET_MIGRATION_TRACE";
+        public bool IsEnabled { get; private set; }
+
+        private TextWriter _underlyingWriter;
 
         static MigrationTrace ()
         {
             Instance = new MigrationTrace();
         }
 
-        public string EnableEnvironmentVariable => "DOTNET_MIGRATION_TRACE";
-
-        public bool IsEnabled
+        public MigrationTrace()
         {
-            get
-            {
-#if DEBUG
-                return true;
-#else
-                return Environment.GetEnvironmentVariable(EnableEnvironmentVariable) != null;
-#endif
-            }
+            _underlyingWriter = Console.Out;
+            IsEnabled = IsEnabledValue();
         }
 
-        public void WriteLine(string message)
+        private bool IsEnabledValue()
+        {
+#if DEBUG
+            return true;
+#else
+            return Environment.GetEnvironmentVariable(EnableEnvironmentVariable) != null;
+#endif
+        }
+
+        public override Encoding Encoding => _underlyingWriter.Encoding;
+
+        public override void Write(char value)
         {
             if (IsEnabled)
             {
-                Console.WriteLine(message);
+                _underlyingWriter.Write(value);
             }
         }
     }

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Transforms/ItemTransformApplicator.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Transforms/ItemTransformApplicator.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Transforms
             MigrationTrace.Instance.WriteLine(String.Format(LocalizableStrings.ItemTransformApplicatorAddItemHeader, nameof(ItemTransformApplicator), outputItem.ItemType, outputItem.Condition, outputItem.Include, outputItem.Exclude, outputItem.Update));
 
             itemGroup.AppendChild(outputItem);
-            outputItem.AddMetadata(item.Metadata);
+            outputItem.AddMetadata(item.Metadata, MigrationTrace.Instance);
         }
 
         private ProjectItemElement MergeWithExistingItemsWithACondition(ProjectItemElement item, ProjectItemGroupElement destinationItemGroup)
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Transforms
             foreach (var existingItem in existingItemsWithACondition)
             {
                 // If this item is encompassing items in a condition, remove the encompassed includes from the existing item
-                var encompassedIncludes = item.GetEncompassedIncludes(existingItem);
+                var encompassedIncludes = item.GetEncompassedIncludes(existingItem, MigrationTrace.Instance);
                 if (encompassedIncludes.Any())
                 {
                     MigrationTrace.Instance.WriteLine(String.Format(LocalizableStrings.ItemTransformApplicatorEncompassedIncludes, nameof(ItemTransformApplicator), string.Join(", ", encompassedIncludes)));
@@ -179,7 +179,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Transforms
             // conditionless item
             foreach (var existingItem in existingItemsWithNoCondition)
             {
-                var encompassedIncludes = existingItem.GetEncompassedIncludes(item);
+                var encompassedIncludes = existingItem.GetEncompassedIncludes(item, MigrationTrace.Instance);
                 if (encompassedIncludes.Any())
                 {
                     MigrationTrace.Instance.WriteLine(String.Format(LocalizableStrings.ItemTransformApplicatorEncompassedIncludes, nameof(ItemTransformApplicator), string.Join(", ", encompassedIncludes)));
@@ -280,7 +280,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Transforms
             mergedItem.UnionExcludes(existingItem.Excludes());
             mergedItem.UnionExcludes(item.Excludes());
 
-            mergedItem.AddMetadata(MergeMetadata(existingItem.Metadata, item.Metadata));
+            mergedItem.AddMetadata(MergeMetadata(existingItem.Metadata, item.Metadata), MigrationTrace.Instance);
 
             item.RemoveIncludes(commonIncludes);
             existingItem.RemoveIncludes(commonIncludes);

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
-    <Compile Include="..\..\src\dotnet\DotnetFiles.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
+    <Compile Include="..\..\src\dotnet\DotnetFiles.cs" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
     <Content Include="..\..\artifacts\*\stage2\sdk\*\.version">

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/StringAssertionsExtensions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/StringAssertionsExtensions.cs
@@ -24,5 +24,15 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
             return new AndConstraint<StringAssertions>(assertions);
         }
+
+        public static AndConstraint<StringAssertions> ContainVisuallySameFragment(this StringAssertions assertions, string expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(NormalizeLineEndings(assertions.Subject).Contains(NormalizeLineEndings(expected)))
+                .BecauseOf(because, becauseArgs)
+                .FailWith($"String \"{assertions.Subject}\" does not contain visually same fragment string \"{expected}\".");
+
+            return new AndConstraint<StringAssertions>(assertions);
+        }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/StringAssertionsExtensions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/StringAssertionsExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public static class StringAssertionsExtensions
+    {
+        private static string NormalizeLineEndings(string s)
+        {
+            return s.Replace("\r\n", "\n");
+        }
+
+        public static AndConstraint<StringAssertions> BeVisuallyEquivalentTo(this StringAssertions assertions, string expected, string because = "", params object[] becauseArgs)
+        {
+            Execute.Assertion
+                .ForCondition(NormalizeLineEndings(assertions.Subject) == NormalizeLineEndings(expected))
+                .BecauseOf(because, becauseArgs)
+                .FailWith($"String \"{assertions.Subject}\" is not visually equivalent to expected string \"{expected}\".");
+
+            return new AndConstraint<StringAssertions>(assertions);
+        }
+    }
+}

--- a/test/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
+++ b/test/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
@@ -6,22 +6,18 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>Msbuild.Tests.Utilities</AssemblyName>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <DefineConstants>$(DefineConstants);DISABLE_TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
-    <Compile Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\MSBuildExtensions.cs">
-        <Link>src\Microsoft.DotNet.ProjectJsonMigration\MSBuildExtensions.cs</Link>
-    </Compile>
-    <Compile Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\LocalizableStrings.cs">
-        <Link>src\Microsoft.DotNet.ProjectJsonMigration\LocalizableStrings.cs</Link>
-    </Compile>
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.TestFramework\Microsoft.DotNet.TestFramework.csproj">
+      <FromP2P>true</FromP2P>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\Microsoft.DotNet.ProjectJsonMigration.csproj">
       <FromP2P>true</FromP2P>
     </ProjectReference>
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj">

--- a/test/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
+++ b/test/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
@@ -17,9 +17,8 @@
     <ProjectReference Include="..\..\src\Microsoft.DotNet.TestFramework\Microsoft.DotNet.TestFramework.csproj">
       <FromP2P>true</FromP2P>
     </ProjectReference>
-    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\Microsoft.DotNet.ProjectJsonMigration.csproj">
-      <FromP2P>true</FromP2P>
-    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\Microsoft.DotNet.ProjectJsonMigration.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Sln.Internal\Microsoft.DotNet.Cli.Sln.Internal.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj">
       <FromP2P>true</FromP2P>
     </ProjectReference>

--- a/test/dotnet-add-p2p.Tests/GivenDotnetAddP2P.cs
+++ b/test/dotnet-add-p2p.Tests/GivenDotnetAddP2P.cs
@@ -36,7 +36,7 @@ Additional Arguments:
         const string ProjectNotCompatibleErrorMessageRegEx = "Project `[^`]*` cannot be added due to incompatible targeted frameworks between the two projects\\. Please review the project you are trying to add and verify that is compatible with the following targets\\:";
         const string ProjectDoesNotTargetFrameworkErrorMessageRegEx = "Project `[^`]*` does not target framework `[^`]*`.";
         static readonly string[] DefaultFrameworks = new string[] { "netcoreapp1.0", "net451" };
-        
+
         private TestSetup Setup([System.Runtime.CompilerServices.CallerMemberName] string callingMethod = nameof(Setup), string identifier = "")
         {
             return new TestSetup(
@@ -92,7 +92,7 @@ Additional Arguments:
         {
             var cmd = new AddP2PCommand().Execute(helpArg);
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Theory]
@@ -130,7 +130,7 @@ Additional Arguments:
                     .Execute($"\"{setup.ValidRefCsprojPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be($"Could not find project or directory `{projName}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -145,7 +145,7 @@ Additional Arguments:
                     .Execute($"\"{setup.ValidRefCsprojPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be("Project `Broken/Broken.csproj` is invalid.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -159,7 +159,7 @@ Additional Arguments:
                     .Execute($"\"{setup.ValidRefCsprojRelToOtherProjPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be($"Found more than one project in `{workingDir + Path.DirectorySeparatorChar}`. Please specify which one to use.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ Additional Arguments:
                     .Execute($"\"{setup.ValidRefCsprojPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be($"Could not find any project in `{setup.TestRoot + Path.DirectorySeparatorChar}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -489,7 +489,7 @@ Reference `DotnetAddP2PProjects\ValidRef\ValidRef.csproj` added to the project."
                 .WithProject(lib.CsProjPath)
                 .Execute($"\"{setup.LibCsprojPath}\" \"{setup.ValidRefCsprojPath}\"");
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(OutputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(OutputText);
             var csproj = lib.CsProj();
             csproj.NumberOfItemGroupsWithoutCondition().Should().Be(noCondBefore + 1);
             csproj.NumberOfProjectReferencesWithIncludeContaining(setup.ValidRefCsprojName).Should().Be(1);
@@ -511,7 +511,7 @@ Reference `DotnetAddP2PProjects\ValidRef\ValidRef.csproj` added to the project."
                 .WithProject(lib.CsProjPath)
                 .Execute($"{FrameworkNet451Arg}  \"{setup.LibCsprojPath}\" \"{setup.ValidRefCsprojPath}\"");
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(OutputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(OutputText);
             var csproj = lib.CsProj();
             csproj.NumberOfItemGroupsWithConditionContaining(ConditionFrameworkNet451).Should().Be(noCondBefore + 1);
             csproj.NumberOfProjectReferencesWithIncludeAndConditionContaining(setup.ValidRefCsprojName, ConditionFrameworkNet451).Should().Be(1);

--- a/test/dotnet-add-p2p.Tests/dotnet-add-p2p.Tests.csproj
+++ b/test/dotnet-add-p2p.Tests/dotnet-add-p2p.Tests.csproj
@@ -20,6 +20,8 @@
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj">
       <FromP2P>true</FromP2P>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Sln.Internal\Microsoft.DotNet.Cli.Sln.Internal.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\Microsoft.DotNet.ProjectJsonMigration.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj">
       <FromP2P>true</FromP2P>
     </ProjectReference>

--- a/test/dotnet-add-p2p.Tests/dotnet-add-p2p.Tests.csproj
+++ b/test/dotnet-add-p2p.Tests/dotnet-add-p2p.Tests.csproj
@@ -6,13 +6,9 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>dotnet-add-p2p.Tests</AssemblyName>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <DefineConstants>$(DefineConstants);DISABLE_TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
-    <Compile Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\MSBuildExtensions.cs">
-        <Link>src\Microsoft.DotNet.ProjectJsonMigration\MSBuildExtensions.cs</Link>
-    </Compile>
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>

--- a/test/dotnet-add-proj.Tests/GivenDotnetAddProj.cs
+++ b/test/dotnet-add-proj.Tests/GivenDotnetAddProj.cs
@@ -36,7 +36,7 @@ Additional Arguments:
             var cmd = new DotnetCommand()
                 .ExecuteWithCapturedOutput($"add project {helpArg}");
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Theory]
@@ -72,7 +72,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput($"add {solutionName} project p.csproj");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Could not find solution or directory `{solutionName}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput($"add InvalidSolution.sln project {projectToAdd}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Invalid solution `InvalidSolution.sln`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -111,7 +111,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput($"add project {projectToAdd}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Invalid solution `{solutionPath}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput(@"add App.sln project");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("You must specify at least one project to add.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -148,7 +148,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput(@"add project App.csproj");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Specified solution file {solutionPath + Path.DirectorySeparatorChar} does not exist, or there is no solution file in the directory.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -167,7 +167,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput($"add project {projectToAdd}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Found more than one solution file in {projectDirectory + Path.DirectorySeparatorChar}. Please specify which one to use.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Theory]

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -59,7 +59,8 @@ Advanced Commands:
         {
             var cmd = new DotnetCommand()
                 .ExecuteWithCapturedOutput($"{helpArg}");
-            cmd.Should().Pass().And.HaveStdOutContaining(HelpText);
+            cmd.Should().Pass();
+            cmd.StdOut.Should().ContainVisuallySameFragment(HelpText);
         }
     }
 }

--- a/test/dotnet-list-p2ps.Tests/GivenDotnetListP2Ps.cs
+++ b/test/dotnet-list-p2ps.Tests/GivenDotnetListP2Ps.cs
@@ -35,7 +35,7 @@ Options:
         {
             var cmd = new ListP2PsCommand().Execute(helpArg);
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Theory]
@@ -72,7 +72,7 @@ Options:
                     .Execute($"\"{setup.ValidRefCsprojPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be($"Could not find project or directory `{projName}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ Options:
                     .Execute($"\"{setup.ValidRefCsprojPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be("Project `Broken/Broken.csproj` is invalid.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ Options:
                     .Execute($"\"{setup.ValidRefCsprojRelToOtherProjPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be($"Found more than one project in `{workingDir + Path.DirectorySeparatorChar}`. Please specify which one to use.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ Options:
                     .Execute($"\"{setup.ValidRefCsprojPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be($"Could not find any project in `{setup.TestRoot + Path.DirectorySeparatorChar}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -144,7 +144,7 @@ Options:
                 .WithProject(lib.CsProjPath)
                 .Execute();
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(OutputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(OutputText);
         }
 
         [Fact]
@@ -169,7 +169,7 @@ Options:
                 .WithProject(lib.CsProjPath)
                 .Execute();
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(OutputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(OutputText);
         }
 
         private TestSetup Setup([System.Runtime.CompilerServices.CallerMemberName] string callingMethod = nameof(Setup), string identifier = "")

--- a/test/dotnet-list-p2ps.Tests/dotnet-list-p2ps.Tests.csproj
+++ b/test/dotnet-list-p2ps.Tests/dotnet-list-p2ps.Tests.csproj
@@ -6,7 +6,6 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>dotnet-list-p2ps.Tests</AssemblyName>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <DefineConstants>$(DefineConstants);DISABLE_TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
@@ -24,6 +23,8 @@
     <ProjectReference Include="..\..\src\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj">
       <FromP2P>true</FromP2P>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Sln.Internal\Microsoft.DotNet.Cli.Sln.Internal.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\Microsoft.DotNet.ProjectJsonMigration.csproj" />
     <ProjectReference Include="..\Msbuild.Tests.Utilities\Msbuild.Tests.Utilities.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/test/dotnet-list-proj.Tests/GivenDotnetListProj.cs
+++ b/test/dotnet-list-proj.Tests/GivenDotnetListProj.cs
@@ -31,7 +31,7 @@ Options:
             var cmd = new DotnetCommand()
                 .ExecuteWithCapturedOutput($"list projects {helpArg}");
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Theory]
@@ -66,7 +66,7 @@ Options:
                 .ExecuteWithCapturedOutput($"list {solutionName} projects");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Could not find solution or directory `{solutionName}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ Options:
                 .ExecuteWithCapturedOutput("list InvalidSolution.sln projects");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Invalid solution `InvalidSolution.sln`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -103,7 +103,7 @@ Options:
                 .ExecuteWithCapturedOutput("list projects");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Invalid solution `{solutionFullPath}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -122,7 +122,7 @@ Options:
                 .ExecuteWithCapturedOutput("list projects");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Specified solution file {solutionDir + Path.DirectorySeparatorChar} does not exist, or there is no solution file in the directory.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -140,7 +140,7 @@ Options:
                 .ExecuteWithCapturedOutput("list projects");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Found more than one solution file in {projectDirectory + Path.DirectorySeparatorChar}. Please specify which one to use.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -179,7 +179,7 @@ Options:
                 .WithWorkingDirectory(projectDirectory)
                 .ExecuteWithCapturedOutput("list projects");
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(OutputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(OutputText);
         }
     }
 }

--- a/test/dotnet-remove-p2p.Tests/GivenDotnetRemoveP2P.cs
+++ b/test/dotnet-remove-p2p.Tests/GivenDotnetRemoveP2P.cs
@@ -118,7 +118,7 @@ Additional Arguments:
         {
             var cmd = new RemoveP2PCommand().Execute(helpArg);
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Theory]
@@ -156,7 +156,7 @@ Additional Arguments:
                     .Execute($"\"{setup.ValidRefCsprojPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be($"Could not find project or directory `{projName}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -171,7 +171,7 @@ Additional Arguments:
                     .Execute($"\"{setup.ValidRefCsprojPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be("Project `Broken/Broken.csproj` is invalid.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -185,7 +185,7 @@ Additional Arguments:
                     .Execute($"\"{setup.ValidRefCsprojRelToOtherProjPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be($"Found more than one project in `{workingDir + Path.DirectorySeparatorChar}`. Please specify which one to use.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -198,7 +198,7 @@ Additional Arguments:
                     .Execute($"\"{setup.ValidRefCsprojPath}\"");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().Be($"Could not find any project in `{setup.TestRoot + Path.DirectorySeparatorChar}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -384,7 +384,7 @@ Project reference `{setup.LibCsprojRelPath}` removed.";
                 .WithProject(proj.CsProjPath)
                 .Execute($"\"{libref.CsProjPath}\"");
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(removedText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(removedText);
 
             var csproj = proj.CsProj();
             csproj.NumberOfItemGroupsWithoutCondition().Should().Be(noCondBefore - 1);
@@ -465,7 +465,7 @@ Project reference `{Path.Combine(TestSetup.ProjectName, setup.ValidRefCsprojRelP
                 .WithProject(lib.CsProjPath)
                 .Execute($"\"{libref.CsProjPath}\" \"{validref.CsProjPath}\"");
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(outputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(outputText);
             var csproj = lib.CsProj();
             csproj.NumberOfItemGroupsWithoutCondition().Should().Be(noCondBefore - 1);
             csproj.NumberOfProjectReferencesWithIncludeContaining(libref.Name).Should().Be(0);
@@ -489,7 +489,7 @@ Project reference `{Path.Combine(TestSetup.ProjectName, setup.ValidRefCsprojRelP
                 .WithProject(lib.CsProjPath)
                 .Execute($"\"{libref.CsProjPath}\" \"{validref.CsProjPath}\"");
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(OutputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(OutputText);
             var csproj = lib.CsProj();
             csproj.NumberOfItemGroupsWithoutCondition().Should().Be(noCondBefore - 1);
             csproj.NumberOfProjectReferencesWithIncludeContaining(validref.Name).Should().Be(0);

--- a/test/dotnet-remove-p2p.Tests/dotnet-remove-p2p.Tests.csproj
+++ b/test/dotnet-remove-p2p.Tests/dotnet-remove-p2p.Tests.csproj
@@ -6,13 +6,9 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>dotnet-remove-p2p.Tests</AssemblyName>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
-    <DefineConstants>$(DefineConstants);DISABLE_TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />
-    <Compile Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\MSBuildExtensions.cs">
-        <Link>src\Microsoft.DotNet.ProjectJsonMigration\MSBuildExtensions.cs</Link>
-    </Compile>
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>

--- a/test/dotnet-remove-p2p.Tests/dotnet-remove-p2p.Tests.csproj
+++ b/test/dotnet-remove-p2p.Tests/dotnet-remove-p2p.Tests.csproj
@@ -23,6 +23,8 @@
     <ProjectReference Include="..\..\src\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj">
       <FromP2P>true</FromP2P>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Sln.Internal\Microsoft.DotNet.Cli.Sln.Internal.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\Microsoft.DotNet.ProjectJsonMigration.csproj" />
     <ProjectReference Include="..\Msbuild.Tests.Utilities\Msbuild.Tests.Utilities.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/test/dotnet-remove-proj.Tests/GivenDotnetRemoveProj.cs
+++ b/test/dotnet-remove-proj.Tests/GivenDotnetRemoveProj.cs
@@ -8,7 +8,7 @@ using System;
 using System.IO;
 using Xunit;
 
-namespace Microsoft.DotNet.Cli.Remove.P2P.Tests
+namespace Microsoft.DotNet.Cli.Remove.Project.Tests
 {
     public class GivenDotnetRemoveProj : TestBase
     {
@@ -34,7 +34,7 @@ Additional Arguments:
             var cmd = new DotnetCommand()
                 .ExecuteWithCapturedOutput($"remove project {helpArg}");
             cmd.Should().Pass();
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput($"remove {solutionName} project p.csproj");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Could not find solution or directory `{solutionName}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput($"remove InvalidSolution.sln project {projectToRemove}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Invalid solution `InvalidSolution.sln`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -109,7 +109,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput($"remove project {projectToRemove}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Invalid solution `{solutionPath}`.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -127,7 +127,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput(@"remove App.sln project");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("You must specify at least one project to remove.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -146,7 +146,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput(@"remove project App.csproj");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Specified solution file {solutionPath + Path.DirectorySeparatorChar} does not exist, or there is no solution file in the directory.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -165,7 +165,7 @@ Additional Arguments:
                 .ExecuteWithCapturedOutput($"remove project {projectToRemove}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be($"Found more than one solution file in {projectDirectory + Path.DirectorySeparatorChar}. Please specify which one to use.");
-            cmd.StdOut.Should().Be(HelpText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(HelpText);
         }
 
         [Fact]
@@ -237,7 +237,7 @@ Additional Arguments:
 
             string outputText = $@"Project reference `{projectToRemove}` removed.
 Project reference `{projectToRemove}` removed.";
-            cmd.StdOut.Should().Be(outputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(outputText);
 
             slnFile = SlnFile.Read(solutionPath);
             slnFile.Projects.Count.Should().Be(1);
@@ -267,7 +267,7 @@ Project reference `{projectToRemove}` removed.";
             string outputText = $@"Project reference `idontexist.csproj` could not be found.
 Project reference `{projectToRemove}` removed.
 Project reference `idontexisteither.csproj` could not be found.";
-            cmd.StdOut.Should().Be(outputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(outputText);
 
             slnFile = SlnFile.Read(solutionPath);
             slnFile.Projects.Count.Should().Be(1);


### PR DESCRIPTION
- <s>https://github.com/dotnet/cli/issues/5070</s> (only partially - I'll address this fully in further PR(s))
- https://github.com/dotnet/cli/issues/5071
- fix some test failures which are seen on local windows machine (line ending related)

There are few  projects left:
```
build_projects\dotnet-cli-build\dotnet-cli-build.csproj
  ..\Microsoft.DotNet.Cli.Build.Framework\**\*.cs;..\shared-build-targets-utils\**\*.cs;
build_projects\update-dependencies\update-dependencies.csproj
  ..\..\src\Microsoft.DotNet.Cli.Utils\DebugHelper.cs
src\dotnet-archive\dotnet-archive.csproj
  ..\dotnet\CommandLine\*.cs;..\dotnet\CommonLocalizableStrings.cs;
test\Microsoft.DotNet.Cli.Utils.Tests\Microsoft.DotNet.Cli.Utils.Tests.csproj
  ..\..\src\dotnet\DotnetFiles.cs
test\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj
  ..\..\src\dotnet\DotnetFiles.cs
TestAssets\TestPackages\dotnet-dependency-tool-invoker\dotnet-dependency-tool-invoker.csproj
  ..\..\..\src\dotnet\CommandLine\*.cs;..\..\..\src\dotnet\CommonLocalizableStrings.cs;
tools\Archiver\Archiver.csproj
  ..\..\src\dotnet-archive\*.cs;..\..\src\dotnet\CommandLine\*.cs;..\..\src\dotnet\CommonLocalizableStrings.cs;
```

DotnetFiles.cs is particularly problematic:
- DotnetFiles is internal and lives in dotnet.dll
- dotnet.dll does not target net45 but test does
- DotnetFiles has dependency on its assembly name

I haven't figured out how to remove this cleanly yet, please share if you got any ideas