### PR TITLE
Archive upload path needs to be changed

### DIFF
--- a/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
+++ b/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
@@ -21,7 +21,7 @@
 
       <ItemGroup>
         <NuGetPackagesArchiveToUpload>
-          <RelativeBlobPath>$(CoreSetupChannel)/Binaries/$(NuGetPackagesArchiveVersion)/$([System.String]::Copy('%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
+          <RelativeBlobPath>$(CoreSetupChannel)/Binaries/$(SharedFrameworkVersion)/$([System.String]::Copy('%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
         </NuGetPackagesArchiveToUpload>
       </ItemGroup>
 


### PR DESCRIPTION
This is a change needed for https://github.com/dotnet/cli/pull/5124 to work properly. I messed up the upload path (so it's different than the download path). But I cannot fully verify this change until it's merged.

@srivatsn Can I go ahead and merge this? The builds following the merge will allow me to verify the correct upload/download paths.

This is FYI for 
@piotrpMSFT @livarcocc @krwq @jonsequitur 