### PR TITLE
Updating xlf files once again

### DIFF
--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.xlf
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -1,0 +1,78 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx">
+    <body>
+      <group id="src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx" />
+      <trans-unit id="AppFullName">
+        <source>.NET Add Package reference Command</source>
+        <target state="new">.NET Add Package reference Command</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppDescription">
+        <source>Command to add package reference</source>
+        <target state="new">Command to add package reference</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="AppHelpText">
+        <source>Package references to add</source>
+        <target state="new">Package references to add</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageReference">
+        <source>Please specify one package reference to add.</source>
+        <target state="new">Please specify one package reference to add.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFrameworkDescription">
+        <source>Add reference only when targetting a specific framework</source>
+        <target state="new">Add reference only when targetting a specific framework</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdNoRestoreDescription">
+        <source>Add reference without performing restore preview and compatibility check.</source>
+        <target state="new">Add reference without performing restore preview and compatibility check.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSourceDescription">
+        <source>Use specific NuGet package sources to use during the restore.</source>
+        <target state="new">Use specific NuGet package sources to use during the restore.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectoryDescription">
+        <source>Restore the packages to this Directory .</source>
+        <target state="new">Restore the packages to this Directory .</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersionDescription">
+        <source>Version for the package to be added.</source>
+        <target state="new">Version for the package to be added.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdDGFileException">
+        <source>Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to Create Dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdVersion">
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdFramework">
+        <source>FRAMEWORK</source>
+        <target state="new">FRAMEWORK</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdSource">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdPackageDirectory">
+        <source>PACKAGE_DIRECTORY</source>
+        <target state="new">PACKAGE_DIRECTORY</target>
+        <note></note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
@@ -73,6 +73,16 @@
         <target state="translated">Když tento příznak nastavíte, ignorují se odkazy mezi projekty a obnoví se jenom kořenový projekt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
@@ -73,6 +73,16 @@
         <target state="translated">Legen Sie dieses Flag fest, um Projekt-zu-Projekt-Verweise zu ignorieren und nur das Stammprojekt wiederherzustellen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
@@ -73,6 +73,16 @@
         <target state="translated">Establezca esta marca para que se omitan las referencias de proyecto a proyecto y se restaure solo el proyecto raíz</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
@@ -73,6 +73,16 @@
         <target state="translated">Définir cet indicateur pour ignorer les références projet à projet et restaurer uniquement le projet racine</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
@@ -73,6 +73,16 @@
         <target state="translated">Impostare questo flag per ignorare i riferimenti P2P (da progetto a progetto) e ripristinare solo il progetto radice</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
@@ -73,6 +73,16 @@
         <target state="translated">project to project 参照を無視して、ルート プロジェクトのみを復元するには、このフラグを設定します</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
@@ -73,6 +73,16 @@
         <target state="translated">프로젝트 간 참조를 무시하고 루트 프로젝트만 복원하려면 이 플래그를 설정합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
@@ -73,6 +73,16 @@
         <target state="translated">Ustaw tę flagę, aby ignorować odwołania między projektami i przywrócić tylko projekt główny</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -73,6 +73,16 @@
         <target state="translated">Definir esse sinalizador para ignorar referências de projeto para projeto e restaurar apenas o projeto raiz</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
@@ -73,6 +73,16 @@
         <target state="translated">Задайте этот флаг, чтобы пропускать ссылки проектов на проекты и выполнять восстановление только корневого проекта.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
@@ -73,6 +73,16 @@
         <target state="translated">Projeden projeye başvuruları yoksaymak ve yalnızca kök projeyi geri yüklemek için bu bayrağı ayarlayın</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.xlf
@@ -5,7 +5,7 @@
       <group id="src/dotnet/commands/dotnet-restore/LocalizableStrings.resx" />
       <trans-unit id="AppFullName">
         <source>.NET dependency restorer</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="AppDescription">
         <source>restore for msbuild</source>
@@ -13,7 +13,7 @@
       </trans-unit>
       <trans-unit id="CmdArgument">
         <source>PROJECT</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CmdArgumentDescription">
         <source>Optional path to a project file or MSBuild arguments.</source>
@@ -21,7 +21,7 @@
       </trans-unit>
       <trans-unit id="CmdSourceOption">
         <source>SOURCE</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CmdSourceOptionDescription">
         <source>Specifies a NuGet package source to use during the restore.</source>
@@ -29,7 +29,7 @@
       </trans-unit>
       <trans-unit id="CmdPackagesOption">
         <source>PACKAGES_DIRECTORY</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CmdPackagesOptionDescription">
         <source>Directory to install packages in.</source>
@@ -41,7 +41,7 @@
       </trans-unit>
       <trans-unit id="CmdConfigFileOption">
         <source>FILE</source>
-        <note></note>
+        <note />
       </trans-unit>
       <trans-unit id="CmdConfigFileOptionDescription">
         <source>The NuGet configuration file to use.</source>
@@ -58,6 +58,14 @@
       <trans-unit id="CmdNoDependenciesOptionDescription">
         <source>Set this flag to ignore project to project references and only restore the root project</source>
         <note />
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <note></note>
       </trans-unit>
     </body>
   </file>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -73,6 +73,16 @@
         <target state="translated">设置此标志以忽略项目到项目引用，并仅还原根项目</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -73,6 +73,16 @@
         <target state="translated">將此旗標設定為略過專案對專案參考並僅還原根專案</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdRuntimeOption">
+        <source>RUNTIME_IDENTIFIER</source>
+        <target state="new">RUNTIME_IDENTIFIER</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="CmdRuntimeOptionDescription">
+        <source>Target runtime to restore packages for.</source>
+        <target state="new">Target runtime to restore packages for.</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Updating xlf files to incorporate the runtime option in restore and localization for dotnet add package

@piotrpMSFT @jgoshi @krwq @jonsequitur @nguerrera 

cc @srivatsn This is the extra round of loc that we need due to dotnet add package and the restore --runtime option.
