### PR TITLE
Skip uploading archive if it already exists

### DIFF
--- a/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
+++ b/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
@@ -52,6 +52,8 @@
             Inputs="$(IntermediateArchive)"
             Outputs="$(IntermediateArchive)">
 
+      <!-- I need to use the CreateProperty task in conjunction with the ValueSetByTask TaskParameter -->
+      <!-- to ensure that the property only gets set when the parent target is run. -->
       <CreateProperty Value="true">
         <Output TaskParameter="ValueSetByTask" PropertyName="UploadNuGetPackagesArchiveToAzure" />
       </CreateProperty>

--- a/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
+++ b/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
@@ -43,13 +43,18 @@
                     ContinueOnError="WarnAndContinue" />
     </Target>
 
+    <PropertyGroup>
+      <UploadNuGetPackagesArchiveToAzure>false</UploadNuGetPackagesArchiveToAzure>
+    </PropertyGroup>
+
     <Target Name="GenerateNuGetPackagesArchive"
             DependsOnTargets="SetupNuGetPackagesArchiveInputsOutputs"
             Inputs="$(IntermediateArchive)"
             Outputs="$(IntermediateArchive)">
-      <PropertyGroup>
-        <UploadNuGetPackagesArchiveToAzure>true</UploadNuGetPackagesArchiveToAzure>
-      </PropertyGroup>
+
+      <CreateProperty Value="true">
+        <Output TaskParameter="ValueSetByTask" PropertyName="UploadNuGetPackagesArchiveToAzure" />
+      </CreateProperty>
 
       <ItemGroup>
         <FilesToClean Include="$(NuGetPackagesArchiveProject)/**/*" />


### PR DESCRIPTION
@piotrpMSFT @livarcocc @krwq @jonsequitur 

I needed to use the MSBuild CreateProperty task to ensure a property value (which controls upload to azure) is only set when we need to generate the archive. I found out recently that the PropertyGroup inside a target always runs, even if the containing target is skipped. This change fixes the behavior to what we want.