### PR TITLE
Remove some cross project compile includes on cs files

### DIFF
--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -10,6 +10,13 @@
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);portable-net45+win8+wp8+wpa81</PackageTargetFallback> 
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\shared-build-targets-utils\shared-build-targets-utils.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Cli.Build.Framework\Microsoft.DotNet.Cli.Build.Framework.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="NETStandard.Library">
       <Version>1.6.0</Version>
     </PackageReference>
@@ -46,9 +53,5 @@
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions">
       <Version>1.0.1-beta-000933</Version>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="**\*.cs" />
-    <Compile Include="..\Microsoft.DotNet.Cli.Build.Framework\**\*.cs;..\shared-build-targets-utils\**\*.cs;" />
   </ItemGroup>
 </Project>

--- a/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
+++ b/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             string url = CalculateRelativePathForFile(file, product, version);
             CloudBlockBlob blob = _blobContainer.GetBlockBlobReference(url);
-            blob.UploadFromFileAsync(file).Wait();
+            blob.UploadFromFileAsync(file, FileMode.Open).Wait();
             SetBlobPropertiesBasedOnFileType(blob);
             return url;
         }

--- a/build_projects/update-dependencies/update-dependencies.csproj
+++ b/build_projects/update-dependencies/update-dependencies.csproj
@@ -11,9 +11,12 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
-    <Compile Include="..\..\src\Microsoft.DotNet.Cli.Utils\DebugHelper.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs
@@ -9,7 +9,7 @@ using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.DotNet.Cli
 {
-    internal static class DotnetFiles
+    public static class DotnetFiles
     {
         private static string SdkRootFolder => Path.Combine(typeof(DotnetFiles).GetTypeInfo().Assembly.Location, "..");
 
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Cli
         /// </summary>
         public static string VersionFile => Path.GetFullPath(Path.Combine(SdkRootFolder, ".version"));
 
-        internal static DotnetVersionFile VersionFileObject
+        public static DotnetVersionFile VersionFileObject
         {
             get { return s_versionFileObject.Value; }
         }

--- a/src/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/DotnetFiles.cs
@@ -9,7 +9,7 @@ using Microsoft.DotNet.PlatformAbstractions;
 
 namespace Microsoft.DotNet.Cli
 {
-    public static class DotnetFiles
+    internal static class DotnetFiles
     {
         private static string SdkRootFolder => Path.Combine(typeof(DotnetFiles).GetTypeInfo().Assembly.Location, "..");
 
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Cli
         /// </summary>
         public static string VersionFile => Path.GetFullPath(Path.Combine(SdkRootFolder, ".version"));
 
-        public static DotnetVersionFile VersionFileObject
+        internal static DotnetVersionFile VersionFileObject
         {
             get { return s_versionFileObject.Value; }
         }

--- a/src/Microsoft.DotNet.Cli.Utils/DotnetVersionFile.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/DotnetVersionFile.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
-    internal class DotnetVersionFile
+    public class DotnetVersionFile
     {
         public bool Exists { get; set; }
 

--- a/src/Microsoft.DotNet.Cli.Utils/DotnetVersionFile.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/DotnetVersionFile.cs
@@ -6,7 +6,7 @@ using System.IO;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
-    public class DotnetVersionFile
+    internal class DotnetVersionFile
     {
         public bool Exists { get; set; }
 

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
-    <Compile Include="..\..\src\dotnet\DotnetFiles.cs" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
     <Content Include="..\..\artifacts\*\stage2\sdk\*\.version">

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
-    <Compile Include="..\..\src\dotnet\DotnetFiles.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" />
     <EmbeddedResource Include="**\*.resx" />
     <EmbeddedResource Include="compiler\resources\**\*" />
   </ItemGroup>


### PR DESCRIPTION
part of #5070 fix

Note file renames

Here is list of stuff which is left
- `D:\cli\src\dotnet-archive\dotnet-archive.csproj`
  - `..\dotnet\CommandLine\*.cs;..\dotnet\CommonLocalizableStrings.cs;`
- `D:\cli\TestAssets\TestPackages\dotnet-dependency-tool-invoker\dotnet-dependency-tool-invoker.csproj`
  - `..\..\..\src\dotnet\CommandLine\*.cs;..\..\..\src\dotnet\CommonLocalizableStrings.cs;`
- `D:\cli\tools\Archiver\Archiver.csproj`
  - `..\..\src\dotnet-archive\*.cs;..\..\src\dotnet\CommandLine\*.cs;..\..\src\dotnet\CommonLocalizableStrings.cs;`

They will be addressed separately as they require a little more work which is not fully clear yet

cc: @jgoshi @livarcocc @piotrpMSFT @jonsequitur