### PR TITLE
Removing -- separator from dotnet publish task. Fixes CI.

### DIFF
--- a/build_projects/dotnet-cli-build/DotNetPublish.cs
+++ b/build_projects/dotnet-cli-build/DotNetPublish.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             if (!string.IsNullOrEmpty(MSBuildArgs))
             {
-                return $"-- {MSBuildArgs}";
+                return $"{MSBuildArgs}";
             }
 
             return null;


### PR DESCRIPTION
Removing -- separator from dotnet publish task. Dotnet publish nor any other command uses -- as a paramater separator for msbuild params.

@piotroko @piotrpMSFT @jonsequitur @jgoshi @krwq @eerhardt 
