### PR TITLE
Adding Release to the sdk defined constants so that we don't emit it anymore

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/sdkdefaults.json
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/sdkdefaults.json
@@ -128,7 +128,7 @@
     },
     {
       "Name": "DefineConstants",
-      "Value": "TRACE",
+      "Value": "RELEASE;TRACE",
       "Condition": "",
       "ParentCondition": " '$(Configuration)' == 'Release' "
     },


### PR DESCRIPTION
Adding Release to the sdk defined constants so that we don't emit it during migration anymore.

Fixes https://github.com/dotnet/cli/issues/5041

@piotrpMSFT @piotroko @eerhardt @jonsequitur @krwq @jgoshi 