### PR TITLE
Adding dotnet remove package sub command

### DIFF
--- a/src/dotnet/commands/dotnet-remove/Program.cs
+++ b/src/dotnet/commands/dotnet-remove/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Tools.Remove.PackageReference;
 using Microsoft.DotNet.Tools.Remove.ProjectFromSolution;
 using Microsoft.DotNet.Tools.Remove.ProjectToProjectReference;
 
@@ -18,6 +19,7 @@ namespace Microsoft.DotNet.Tools.Remove
             {
                 RemoveProjectFromSolutionCommand.Create,
                 RemoveProjectToProjectReferenceCommand.Create,
+                RemovePackageReferenceCommand.Create
             };
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-remove/dotnet-remove-package/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-remove/dotnet-remove-package/LocalizableStrings.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Tools.Remove.PackageReference
+{
+    internal class LocalizableStrings
+    {
+        public const string AppFullName = ".NET Remove Package reference Command";
+
+        public const string AppDescription = "Command to remove package reference";
+
+        public const string AppHelpText = "Package references to remove";
+
+        public const string SpecifyExactlyOnePackageReference = "Please specify one package reference to remove";
+
+    }
+}

--- a/src/dotnet/commands/dotnet-remove/dotnet-remove-package/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-remove/dotnet-remove-package/LocalizableStrings.cs
@@ -5,13 +5,13 @@ namespace Microsoft.DotNet.Tools.Remove.PackageReference
 {
     internal class LocalizableStrings
     {
-        public const string AppFullName = ".NET Remove Package reference Command";
+        public const string AppFullName = ".NET Remove Package reference Command.";
 
-        public const string AppDescription = "Command to remove package reference";
+        public const string AppDescription = "Command to remove package reference.";
 
-        public const string AppHelpText = "Package references to remove";
+        public const string AppHelpText = "Package reference to remove.";
 
-        public const string SpecifyExactlyOnePackageReference = "Please specify one package reference to remove";
+        public const string SpecifyExactlyOnePackageReference = "Please specify only one package reference to remove.";
 
     }
 }

--- a/src/dotnet/commands/dotnet-remove/dotnet-remove-package/Program.cs
+++ b/src/dotnet/commands/dotnet-remove/dotnet-remove-package/Program.cs
@@ -1,12 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Text;
 using Microsoft.Build.Evaluation;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
@@ -15,6 +9,12 @@ using Microsoft.DotNet.Tools.Common;
 using Microsoft.DotNet.Tools.MSBuild;
 using Microsoft.DotNet.Tools.NuGet;
 using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace Microsoft.DotNet.Tools.Remove.PackageReference
 {
@@ -55,7 +55,8 @@ namespace Microsoft.DotNet.Tools.Remove.PackageReference
                 projectFilePath = fileOrDirectory;
             }
 
-            var result = NuGetCommand.Run(TransformArgs(RemainingArguments.First(), projectFilePath));
+            var packageToRemove = RemainingArguments.First();
+            var result = NuGetCommand.Run(TransformArgs(packageToRemove, projectFilePath));
 
             return result;
         }

--- a/src/dotnet/commands/dotnet-remove/dotnet-remove-package/Program.cs
+++ b/src/dotnet/commands/dotnet-remove/dotnet-remove-package/Program.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Evaluation;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Common;
+using Microsoft.DotNet.Tools.MSBuild;
+using Microsoft.DotNet.Tools.NuGet;
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.Tools.Remove.PackageReference
+{
+    internal class RemovePackageReferenceCommand : DotNetSubCommandBase
+    {
+
+        public static DotNetSubCommandBase Create()
+        {
+            var command = new RemovePackageReferenceCommand
+            {
+                Name = "package",
+                FullName = LocalizableStrings.AppFullName,
+                Description = LocalizableStrings.AppDescription,
+                HandleRemainingArguments = true,
+                ArgumentSeparatorHelpText = LocalizableStrings.AppHelpText,
+            };
+
+            command.HelpOption("-h|--help");
+
+            return command;
+        }
+
+        public override int Run(string fileOrDirectory)
+        {
+            if (RemainingArguments.Count != 1)
+            {
+                throw new GracefulException(LocalizableStrings.SpecifyExactlyOnePackageReference);
+            }
+
+            var projectFilePath = string.Empty;
+
+            if (!File.Exists(fileOrDirectory))
+            {
+                projectFilePath = MsbuildProject.GetProjectFileFromDirectory(fileOrDirectory).FullName;
+            }
+            else
+            {
+                projectFilePath = fileOrDirectory;
+            }
+
+            var result = NuGetCommand.Run(TransformArgs(RemainingArguments.First(), projectFilePath));
+
+            return result;
+        }
+
+        private string[] TransformArgs(string packageId, string projectFilePath)
+        {
+            return new string[]{
+                "package",
+                "remove",
+                "--package",
+                packageId,
+                "--project",
+                projectFilePath
+            };
+        }
+    }
+}


### PR DESCRIPTION
Adding the `dotnet remove package` sub command to remove package references.

NuGet part of the work : https://github.com/NuGet/NuGet.Client/pull/1092

Fixes remove package part of #4521 and https://github.com/NuGet/Home/issues/4101

//cc: @livarcocc @piotrpMSFT @blackdwarf @krwq @rrelyea @emgarten