### PR TITLE
Added links to project system uses of serialized objects.

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/MigrationError.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/MigrationError.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.DotNet.ProjectJsonMigration
 {
+    /// Any changes to this need to be reflected in roslyn-project-system
+    // https://github.com/dotnet/roslyn-project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrationError.cs
     internal class MigrationError
     {
         public string ErrorCode { get; }

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Report/MigrationReport.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Report/MigrationReport.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace Microsoft.DotNet.ProjectJsonMigration
 {
     /// Any changes to this need to be reflected in roslyn-project-system
-    /// TODO add link
+    /// https://github.com/dotnet/roslyn-project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrationReport.cs
     internal class MigrationReport
     {
         public List<ProjectMigrationReport> ProjectMigrationReports { get; }

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Report/ProjectMigrationReport.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Report/ProjectMigrationReport.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 namespace Microsoft.DotNet.ProjectJsonMigration
 {
+    /// Any changes to this need to be reflected in roslyn-project-system
+    /// https://github.com/dotnet/roslyn-project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/ProjectMigrationReport.cs
     internal class ProjectMigrationReport
     {
         public string ProjectDirectory { get; }
@@ -22,7 +24,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
         public bool Skipped { get; }
 
         public bool Failed => Errors.Any();
-        
+
         public bool Succeeded => !Errors.Any();
 
         public ProjectMigrationReport(string projectDirectory, string projectName, bool skipped)


### PR DESCRIPTION
This adds links to the parts of the project system where we're deserializing JSON objects defined by CLI. We need to make sure that these are kept up date with each other. Tagging @livarcocc @piotrpMSFT for review.

skip ci please