### PR TITLE
Fix official build break by referencing WindowsAzure.Storage 7.2.1 everywhere

### DIFF
--- a/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
+++ b/build_projects/shared-build-targets-utils/Publishing/AzurePublisher.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             string url = CalculateRelativePathForFile(file, product, version);
             CloudBlockBlob blob = _blobContainer.GetBlockBlobReference(url);
-            blob.UploadFromFileAsync(file, FileMode.Open).Wait();
+            blob.UploadFromFileAsync(file).Wait();
             SetBlobPropertiesBasedOnFileType(blob);
             return url;
         }

--- a/build_projects/shared-build-targets-utils/shared-build-targets-utils.csproj
+++ b/build_projects/shared-build-targets-utils/shared-build-targets-utils.csproj
@@ -34,11 +34,14 @@
     <PackageReference Include="System.Runtime.Serialization.Primitives">
       <Version>4.1.1</Version>
     </PackageReference>
+    <PackageReference Include="System.Threading.Thread">
+      <Version>4.0.0</Version>
+    </PackageReference>
     <PackageReference Include="System.Xml.XmlSerializer">
       <Version>4.0.11</Version>
     </PackageReference>
     <PackageReference Include="WindowsAzure.Storage">
-      <Version>6.2.2-preview</Version>
+      <Version>7.2.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions">
       <Version>1.0.1-beta-000933</Version>


### PR DESCRIPTION
@livarcocc 

All our official builds are now failing for error:

```
The "SetBlobPropertiesBasedOnFileType" task failed unexpectedly. [D:\DOTNET-CLI-W004\_work\3\s\build.proj]
2017-01-06T02:03:10.0584234Z                    D:\DOTNET-CLI-W004\_work\3\s\build\Microsoft.DotNet.Cli.Publish.targets(101,5): error MSB4018: System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.WindowsAzure.Storage, Version=6.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified. [D:\DOTNET-CLI-W004\_work\3\s\build.proj]
2017-01-06T02:03:10.0584234Z                    D:\DOTNET-CLI-W004\_work\3\s\build\Microsoft.DotNet.Cli.Publish.targets(101,5): error MSB4018: File name: 'Microsoft.WindowsAzure.Storage, Version=6.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' [D:\DOTNET-CLI-W004\_work\3\s\build.proj]
2017-01-06T02:03:10.0584234Z                    D:\DOTNET-CLI-W004\_work\3\s\build\Microsoft.DotNet.Cli.Publish.targets(101,5): error MSB4018:    at Microsoft.DotNet.Cli.Build.AzurePublisher..ctor(String accountName, String accountKey, String containerName) [D:\DOTNET-CLI-W004\_work\3\s\build.proj]
2017-01-06T02:03:10.0584234Z                    D:\DOTNET-CLI-W004\_work\3\s\build\Microsoft.DotNet.Cli.Publish.targets(101,5): error MSB4018:    at Microsoft.DotNet.Cli.Build.SetBlobPropertiesBasedOnFileType.get_AzurePublisherTool() in D:\DOTNET-CLI-W004\_work\3\s\build_projects\dotnet-cli-build\SetBlobPropertiesBasedOnFileTypeTask.cs:line 33 [D:\DOTNET-CLI-W004\_work\3\s\build.proj]
2017-01-06T02:03:10.0584234Z                    D:\DOTNET-CLI-W004\_work\3\s\build\Microsoft.DotNet.Cli.Publish.targets(101,5): error MSB4018:    at Microsoft.DotNet.Cli.Build.SetBlobPropertiesBasedOnFileType.Execute() in D:\DOTNET-CLI-W004\_work\3\s\build_projects\dotnet-cli-build\SetBlobPropertiesBasedOnFileTypeTask.cs:line 58 [D:\DOTNET-CLI-W004\_work\3\s\build.proj]
```

This is fixing that error by ensuring all assemblies reference the same version of the Storage assembly.