### PR TITLE
Add RHEL 7.3 build support

### DIFF
--- a/TestAssets/DesktopTestProjects/AppWithProjTool2Fx/App.csproj
+++ b/TestAssets/DesktopTestProjects/AppWithProjTool2Fx/App.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);portable-net45+win8;dnxcore50</PackageTargetFallback>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
   </PropertyGroup>
   
   <ItemGroup>

--- a/TestAssets/DesktopTestProjects/AutoAddDesktopReferencesDuringMigrate/project.json
+++ b/TestAssets/DesktopTestProjects/AutoAddDesktopReferencesDuringMigrate/project.json
@@ -18,7 +18,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/DesktopTestProjects/TestAppWithFrameworkAssemblies/ProjectA/project.json
+++ b/TestAssets/DesktopTestProjects/TestAppWithFrameworkAssemblies/ProjectA/project.json
@@ -26,7 +26,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/NonRestoredTestProjects/AppWithProjectDependencyAsTarget/TestApp/project.json
+++ b/TestAssets/NonRestoredTestProjects/AppWithProjectDependencyAsTarget/TestApp/project.json
@@ -21,7 +21,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/NonRestoredTestProjects/PJAppWithSlnAndXprojRefs/TestApp/project.json
+++ b/TestAssets/NonRestoredTestProjects/PJAppWithSlnAndXprojRefs/TestApp/project.json
@@ -26,7 +26,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/NonRestoredTestProjects/PJAppWithSlnAndXprojRefsAndUnrelatedCsproj/TestApp/project.json
+++ b/TestAssets/NonRestoredTestProjects/PJAppWithSlnAndXprojRefsAndUnrelatedCsproj/TestApp/project.json
@@ -26,7 +26,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/NonRestoredTestProjects/TestAppWithLibraryAndMissingP2P/TestApp/project.json
+++ b/TestAssets/NonRestoredTestProjects/TestAppWithLibraryAndMissingP2P/TestApp/project.json
@@ -22,7 +22,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/TestPackages/PackageWithFakeNativeDep/PackageWithFakeNativeDep.csproj
+++ b/TestAssets/TestPackages/PackageWithFakeNativeDep/PackageWithFakeNativeDep.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>
     <AssemblyName>PackageWithFakeNativeDep</AssemblyName>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.10-x64;rhel.7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.10-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/dotnet-desktop-and-portable.csproj
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/dotnet-desktop-and-portable.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
     <AssemblyName>dotnet-desktop-and-portable</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.10-x64;rhel.7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.10-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/dotnet-hello.csproj
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/dotnet-hello.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>dotnet-hello</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/dotnet-hello.csproj
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/dotnet-hello.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>dotnet-hello</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
+++ b/TestAssets/TestProjects/AppWithOutputAssemblyName/project.json
@@ -17,7 +17,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
+++ b/TestAssets/TestProjects/FSharpTestProjects/TestApp/project.json
@@ -40,7 +40,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
+++ b/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/PJTestAppSimple/project.json
+++ b/TestAssets/TestProjects/PJTestAppSimple/project.json
@@ -17,7 +17,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/TestProjects/TestAppDependencyGraph/ProjectA/project.json
+++ b/TestAssets/TestProjects/TestAppDependencyGraph/ProjectA/project.json
@@ -26,7 +26,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibrary/TestApp/project.json
@@ -22,7 +22,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/TestProjects/TestAppWithLibraryUnderTFM/TestApp/project.json
+++ b/TestAssets/TestProjects/TestAppWithLibraryUnderTFM/TestApp/project.json
@@ -25,7 +25,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/TestAssets/TestProjects/TestAppWithUnqualifiedDependencies/ProjectA/project.json
+++ b/TestAssets/TestProjects/TestAppWithUnqualifiedDependencies/ProjectA/project.json
@@ -19,7 +19,7 @@
     "ubuntu.14.04-x64": {},
     "ubuntu.16.04-x64": {},
     "centos.7-x64": {},
-    "rhel.7.2-x64": {},
+    "rhel.7-x64": {},
     "debian.8-x64": {},
     "fedora.23-x64": {},
     "opensuse.13.2-x64": {}

--- a/build_projects/update-dependencies/update-dependencies.csproj
+++ b/build_projects/update-dependencies/update-dependencies.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <AssemblyName>update-dependencies</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -92,7 +92,7 @@ get_current_os_name() {
                     echo "opensuse.42.1"
                     return 0
                     ;;
-                "rhel.7.0" | "rhel.7.1" | "rhel.7.2")
+                rhel.7.[0-4])
                     echo "rhel"
                     return 0
                     ;;

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -92,7 +92,7 @@ get_current_os_name() {
                     echo "opensuse.42.1"
                     return 0
                     ;;
-                rhel.7.[0-4])
+                rhel.7.*)
                     echo "rhel"
                     return 0
                     ;;

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateTFMRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateTFMRule.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
     internal class MigrateTFMRule : IMigrationRule
     {
         private const string RuntimeIdentifiers =
-            "win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64";
+            "win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64";
 
         private readonly ITransformApplicator _transformApplicator;
 

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTFMs.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTFMs.cs
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
 
             mockProj.Properties.Count(p => p.Name == "RuntimeIdentifiers").Should().Be(1);
             mockProj.Properties.First(p => p.Name == "RuntimeIdentifiers")
-                .Value.Should().Be("win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64");
+                .Value.Should().Be("win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64");
         }
 
         [Fact]

--- a/tools/Archiver/Archiver.csproj
+++ b/tools/Archiver/Archiver.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.10-x64;rhel.7-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.10-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="**\*.cs" />


### PR DESCRIPTION
These modifications are needed for the CLI to compile on RHEL 7.3. Also, the change to dotnet-install.sh is needed to build from the other dotnet repos because it is used by bootstrap.sh.