### PR TITLE
Add NuGet version to DependencyVersions.props.

### DIFF
--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
@@ -1,4 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
   <PropertyGroup>
     <VersionPrefix>1.0.0-rc</VersionPrefix>
     <TargetFramework>netcoreapp1.0</TargetFramework>
@@ -24,7 +26,7 @@
       <Version>1.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.DotNet.Cli.Utils">
       <Version>$(SdkNugetVersion)</Version>

--- a/build/Microsoft.DotNet.Cli.BundledSdks.props
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.props
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <ItemGroup>
-    <BundledSdk Include="NuGet.Build.Tasks.Pack" Version="4.0.0-rc3" />
+    <BundledSdk Include="NuGet.Build.Tasks.Pack" Version="$(CLI_NuGet_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk" Version="$(CLI_NETSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Web" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Publish" Version="$(CLI_WEBSDK_Version)" />

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <CLI_MSBuild_Version>15.1.0-preview-000503-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc3-61212-03</CLI_Roslyn_Version>
+    <CLI_NuGet_Version>4.0.0-rc3</CLI_NuGet_Version>
     <CLI_NETSDK_Version>1.0.0-alpha-20170105-5</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170106-1-203</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0-preview-20170106-08</CLI_TestPlatform_Version>

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -41,7 +41,7 @@
       <Version>7.2.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine.XPlat">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Utilities.Core">
       <Version>$(CLI_MSBuild_Version)</Version>

--- a/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -18,16 +18,16 @@
       <Version>1.0.1-beta-000933</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.ProjectModel">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
       <Version>$(CLI_MSBuild_Version)</Version>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -15,7 +15,7 @@
       <Version>$(CLI_MSBuild_Version)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Build.Tasks">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.CLI">
       <Version>$(CLI_TestPlatform_Version)</Version>

--- a/src/tool_nuget/tool_nuget.csproj
+++ b/src/tool_nuget/tool_nuget.csproj
@@ -10,7 +10,7 @@
       <Version>1.0.3</Version>
     </PackageReference>
     <PackageReference Include="NuGet.CommandLine.XPlat">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
@@ -57,16 +57,16 @@
       <Version>4.1.1</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Versioning">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Packaging">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.Frameworks">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="NuGet.ProjectModel">
-      <Version>4.0.0-rc3</Version>
+      <Version>$(CLI_NuGet_Version)</Version>
     </PackageReference>
     <PackageReference Include="moq.netcore">
       <Version>4.4.0-beta8</Version>


### PR DESCRIPTION
I moved all usages of `4.0.0-rc3` that refer to the NuGet version into the DependencyVersions.props file.

Note: The line endings of DependencyVersions.props were all changed in the previous commit to that file.  This change is correcting that.

@livarcocc 