### PR TITLE
Fix the download of the LZMA archive on dev machines and in Jenkins CI.

### DIFF
--- a/build/Microsoft.DotNet.Cli.Publish.targets
+++ b/build/Microsoft.DotNet.Cli.Publish.targets
@@ -28,8 +28,10 @@
     <PropertyGroup>
       <Product>Sdk</Product>
       <ArtifactContainerName>$(ARTIFACT_STORAGE_CONTAINER)</ArtifactContainerName>
+      <ArtifactContainerName Condition="'$(ArtifactContainerName)' == ''">dotnet</ArtifactContainerName>
       <ArtifactCloudDropAccessToken>$(ARTIFACT_STORAGE_KEY)</ArtifactCloudDropAccessToken>
       <ArtifactCloudDropAccountName>$(ARTIFACT_STORAGE_ACCOUNT)</ArtifactCloudDropAccountName>
+      <ArtifactCloudDropAccountName Condition="'$(ArtifactCloudDropAccountName)' == ''">dotnetcli</ArtifactCloudDropAccountName>
       <DotnetBlobRootUrl>https://$(ArtifactCloudDropAccountName).blob.core.windows.net/$(ArtifactContainerName)</DotnetBlobRootUrl>
       <ChecksumContainerName>$(CHECKSUM_STORAGE_CONTAINER)</ChecksumContainerName>
       <ChecksumCloudDropAccessToken>$(CHECKSUM_STORAGE_KEY)</ChecksumCloudDropAccessToken>


### PR DESCRIPTION
We are always archiving the LZMA file on dev and Jenkins machines because of this failure:

```
Task "DownloadFile" (TaskId:399)
19:00:38                      Task Parameter:Uri=https://.blob.core.windows.net//Sdk/NuGetPackagesArchives/nuGetPackagesArchive.e61c6006b18ad4ced666ff83c7d51c7fd96ec4628e6519c85a48444437f72bea.lzma (TaskId:399)
19:00:38                      Task Parameter:DestinationPath=D:\j\workspace\release_windo---f861f43b\/artifacts/win81-x64/intermediate/nuGetPackagesArchive.e61c6006b18ad4ced666ff83c7d51c7fd96ec4628e6519c85a48444437f72bea.lzma (TaskId:399)
19:00:38                      Downloading 'https://.blob.core.windows.net//Sdk/NuGetPackagesArchives/nuGetPackagesArchive.e61c6006b18ad4ced666ff83c7d51c7fd96ec4628e6519c85a48444437f72bea.lzma' to 'D:\j\workspace\release_windo---f861f43b\/artifacts/win81-x64/intermediate/nuGetPackagesArchive.e61c6006b18ad4ced666ff83c7d51c7fd96ec4628e6519c85a48444437f72bea.lzma' (TaskId:399)
19:00:38 19:00:38.539     1>D:\j\workspace\release_windo---f861f43b\build\compile\Microsoft.DotNet.Cli.LzmaArchive.targets(41,7): warning MSB4018: The "DownloadFile" task failed unexpectedly. [D:\j\workspace\release_windo---f861f43b\build.proj]
19:00:38 D:\j\workspace\release_windo---f861f43b\build\compile\Microsoft.DotNet.Cli.LzmaArchive.targets(41,7): warning MSB4018: System.UriFormatException: Invalid URI: The hostname could not be parsed. [D:\j\workspace\release_windo---f861f43b\build.proj]
```

This fixes the build to look in the right spot when not on our official builds.

@livarcocc 