### PR TITLE
Fix Ubuntu package test

### DIFF
--- a/build/package/Microsoft.DotNet.Cli.Installer.DEB.proj
+++ b/build/package/Microsoft.DotNet.Cli.Installer.DEB.proj
@@ -101,6 +101,9 @@
       <Exec Command="sudo dpkg -i $(SdkInstallerFile)" />
 
       <!-- Run E2E -->
+      <DotNetRestore ProjectPath="$(EndToEndTestProject)" 
+                     ToolPath="$(Stage0Directory)" /> 
+ 
       <DotNetTest ProjectPath="$(EndToEndTestProject)"
                   EnvironmentVariables="@(TestSdkDebTaskEnvironmentVariables)"
                   ToolPath="$(Stage0Directory)" />


### PR DESCRIPTION
Recent PRs have rendered the Ubuntu package test useless. This wasn't caught prior to merging the causing commit because this particular test is only configured in this configuration when producing real installers in final CI. 

@MattGertz can you approve this test/infra change?

@livarcocc @jgoshi @krwq @jonsequitur for CR