### PR TITLE
Migration: do not inject built in compile includes that the SDK does

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.Internal.ProjectModel/Files/ProjectFilesCollection.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.Internal.ProjectModel/Files/ProjectFilesCollection.cs
@@ -9,14 +9,9 @@ namespace Microsoft.DotNet.Internal.ProjectModel.Files
 {
     internal class ProjectFilesCollection
     {
-        public static readonly string[] DefaultCompileBuiltInPatterns = new[] { @"**/*.cs" };
+        public static readonly string[] SdkInjectedDefaultCompileBuiltInPatterns = new[] { @"**/*.cs" };
         public static readonly string[] DefaultPreprocessPatterns = new[] { @"compiler/preprocess/**/*.cs" };
         public static readonly string[] DefaultSharedPatterns = new[] { @"compiler/shared/**/*.cs" };
-        public static readonly string[] DefaultResourcesBuiltInPatterns = new[] { @"compiler/resources/**/*", "**/*.resx" };
-
-        public static readonly string[] DefaultPublishExcludePatterns = new string[0];
-        public static readonly string[] DefaultContentsBuiltInPatterns = new string[0];
-
         public static readonly string[] DefaultBuiltInExcludePatterns = new[] { "bin/**", "obj/**", "**/*.xproj", "packages/**" };
 
         public static readonly string PackIncludePropertyName = "packInclude";
@@ -53,11 +48,11 @@ namespace Microsoft.DotNet.Internal.ProjectModel.Files
             var excludeBuiltIns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "excludeBuiltIn", DefaultBuiltInExcludePatterns);
             var excludePatterns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "exclude")
                                                           .Concat(excludeBuiltIns);
-            var contentBuiltIns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "contentBuiltIn", DefaultContentsBuiltInPatterns);
-            var compileBuiltIns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "compileBuiltIn", DefaultCompileBuiltInPatterns);
-            var resourceBuiltIns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "resourceBuiltIn", DefaultResourcesBuiltInPatterns);
+            var contentBuiltIns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "contentBuiltIn");
+            var compileBuiltIns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "compileBuiltIn", SdkInjectedDefaultCompileBuiltInPatterns);
+            var resourceBuiltIns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "resourceBuiltIn");
 
-            _publishExcludePatterns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "publishExclude", DefaultPublishExcludePatterns);
+            _publishExcludePatterns = PatternsCollectionHelper.GetPatternsCollection(_rawProject, _projectDirectory, _projectFilePath, "publishExclude");
 
             _sharedPatternsGroup = PatternGroup.Build(_rawProject, _projectDirectory, _projectFilePath, "shared", fallbackIncluding: DefaultSharedPatterns, additionalExcluding: excludePatterns);
 

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.Internal.ProjectModel/ProjectReader.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Microsoft.DotNet.Internal.ProjectModel/ProjectReader.cs
@@ -664,20 +664,20 @@ namespace Microsoft.DotNet.Internal.ProjectModel
                     project,
                     rawOptions,
                     "compile",
-                    defaultBuiltInInclude: ProjectFilesCollection.DefaultCompileBuiltInPatterns,
+                    defaultBuiltInInclude: ProjectFilesCollection.SdkInjectedDefaultCompileBuiltInPatterns,
                     defaultBuiltInExclude: ProjectFilesCollection.DefaultBuiltInExcludePatterns),
                 EmbedInclude = GetIncludeContext(
                     project,
                     rawOptions,
                     "embed",
-                    defaultBuiltInInclude: ProjectFilesCollection.DefaultResourcesBuiltInPatterns,
+                    defaultBuiltInInclude: null,
                     defaultBuiltInExclude: ProjectFilesCollection.DefaultBuiltInExcludePatterns),
                 CopyToOutputInclude = GetIncludeContext(
                     project,
                     rawOptions,
                     "copyToOutput",
                     defaultBuiltInInclude: null,
-                    defaultBuiltInExclude: ProjectFilesCollection.DefaultPublishExcludePatterns)
+                    defaultBuiltInExclude: null)
             };
         }
 
@@ -794,7 +794,7 @@ namespace Microsoft.DotNet.Internal.ProjectModel
                     "publishOptions",
                     rawProject,
                     defaultBuiltInInclude: null,
-                    defaultBuiltInExclude: ProjectFilesCollection.DefaultPublishExcludePatterns);
+                    defaultBuiltInExclude: null);
             }
 
             return null;

--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateBuildOptionsRule.cs
@@ -111,7 +111,11 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                     compilerOptions => compilerOptions.OutputName != null);
 
         private IncludeContextTransform CompileFilesTransform =>
-            new IncludeContextTransform("Compile", transformMappings: false, condition: ic => ic != null);
+            new IncludeContextTransform(
+                "Compile",
+                transformMappings: false,
+                condition: ic => ic != null,
+                emitBuiltInIncludes: false);
 
         private IncludeContextTransform EmbedFilesTransform =>
             new IncludeContextTransform("EmbeddedResource", transformMappings: false, condition: ic => ic != null);
@@ -396,7 +400,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                     "copyToOutput",
                     new JObject(),
                     null,
-                    ProjectFilesCollection.DefaultPublishExcludePatterns);
+                    null);
         }
 
         private string FormatLanguageVersion(string langVersion)

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
@@ -582,7 +582,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         private static IEnumerable<string> GetDefaultExcludePatterns(string group)
         {
             var defaultExcludePatterns = new List<string>(group == "copyToOutput" ?
-                                    ProjectFilesCollection.DefaultPublishExcludePatterns :
+                                    Enumerable.Empty<string>() :
                                     ProjectFilesCollection.DefaultBuiltInExcludePatterns);
 
             if (group == "embed")
@@ -595,9 +595,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
 
         private static IEnumerable<string> GetDefaultIncludePatterns(string group)
         {
-            return group == "compile" ? ProjectFilesCollection.DefaultCompileBuiltInPatterns
-                                       : group == "embed" ? ProjectFilesCollection.DefaultResourcesBuiltInPatterns
-                                       : Enumerable.Empty<string>();
+            return Enumerable.Empty<string>();
         }
 
         private static void VerifyContentMetadata(ProjectItemElement item)

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePublishOptions.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePublishOptions.cs
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
 
             // From ProjectReader #L725 (Both are empty)
             var defaultIncludePatterns = Enumerable.Empty<string>();
-            var defaultExcludePatterns = ProjectFilesCollection.DefaultPublishExcludePatterns;
+            var defaultExcludePatterns = Enumerable.Empty<string>();
 
             foreach (var item in mockProj.Items.Where(i => i.ItemType.Equals("Content", StringComparison.Ordinal)))
             {
@@ -193,7 +193,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
 
             // From ProjectReader #L725 (Both are empty)
             var defaultIncludePatterns = Enumerable.Empty<string>();
-            var defaultExcludePatterns = ProjectFilesCollection.DefaultPublishExcludePatterns;
+            var defaultExcludePatterns = Enumerable.Empty<string>();
 
             foreach (var item in mockProj.Items.Where(i => i.ItemType.Equals("Content", StringComparison.Ordinal)))
             {


### PR DESCRIPTION
@piotrpMSFT @livarcocc @krwq @jonsequitur @eerhardt @piotroko 

Fixes #5253 