### PR TITLE
fix stack trace for unhandled exceptions in dotnet-migrate

### DIFF
--- a/src/dotnet/commands/dotnet-migrate/Program.cs
+++ b/src/dotnet/commands/dotnet-migrate/Program.cs
@@ -84,10 +84,10 @@ namespace Microsoft.DotNet.Tools.Migrate
                 Reporter.Error.WriteLine(LocalizableStrings.MigrationFailedError);
                 return 1;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 Reporter.Error.WriteLine(LocalizableStrings.MigrationFailedError);
-                throw e;
+                throw;
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/5297

This will improve debuggability of dotnet-migrate.

@jonsequitur @livarcocc @piotrpMSFT