### PR TITLE
Fixing an issue where packages with a filter but no match were being dropped

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
@@ -291,21 +291,19 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
             {
                 var possibleVersions = possibleMappings.Select(p => VersionRange.Parse(p.Key.Version));
                 var matchVersion = possibleVersions.FirstOrDefault(p => p.Satisfies(minRange));
-                if (matchVersion == null)
+                if (matchVersion != null)
                 {
-                    return null;
+                    var dependencyInfo = possibleMappings.First(c =>
+                        c.Key.Version.Equals(matchVersion.OriginalString, StringComparison.OrdinalIgnoreCase)).Value;
+
+                    if (dependencyInfo == null)
+                    {
+                        return null;
+                    }
+
+                    name = dependencyInfo.Name;
+                    version = dependencyInfo.Version;
                 }
-
-                var dependencyInfo = possibleMappings.First(c =>
-                    c.Key.Version.Equals(matchVersion.OriginalString, StringComparison.OrdinalIgnoreCase)).Value;
-
-                if (dependencyInfo == null)
-                {
-                    return null;
-                }
-
-                name = dependencyInfo.Name;
-                version = dependencyInfo.Version;
             }
             
             return new PackageDependencyInfo

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackagesToTheirLTSVersions.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackagesToTheirLTSVersions.cs
@@ -25,6 +25,18 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Theory]
+        [InlineData("NETStandard.Library", "1.6.2-*", "NETStandard.Library", "1.6.2-*")]
+        [InlineData("System.Text.Encodings.Web", "4.4.0-*", "System.Text.Encodings.Web", "4.4.0-*")]
+        public void ItDoesNotDropDependenciesThatDoNotHaveAMatchingVersionInTheMapping(
+            string sourcePackageName,
+            string sourceVersion,
+            string targetPackageName,
+            string targetVersion)
+        {
+            ValidatePackageMigration(sourcePackageName, sourceVersion, targetPackageName, targetVersion);
+        }
+
+        [Theory]
         [InlineData("Microsoft.AspNetCore.Antiforgery", "1.0.0", "Microsoft.AspNetCore.Antiforgery", ConstantPackageVersions.AspNetLTSPackagesVersion)]
         [InlineData("Microsoft.AspNetCore.Mvc", "1.0.0", "Microsoft.AspNetCore.Mvc", ConstantPackageVersions.AspNetLTSPackagesVersion)]
         [InlineData("Microsoft.AspNetCore.Mvc.Abstractions", "1.0.0", "Microsoft.AspNetCore.Mvc.Abstractions", ConstantPackageVersions.AspNetLTSPackagesVersion)]


### PR DESCRIPTION
Fixing an issue where packages with a filter but no match were not being migrated as is, instead they were being dropped.

Fixes https://github.com/dotnet/cli/issues/5301

@piotroko @piotrpMSFT @jgoshi @jonsequitur @krwq 