### PR TITLE
Create backup folder in the directory where 'dotnet migrate' is executed

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/MigrationBackupPlan.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/MigrationBackupPlan.cs
@@ -27,17 +27,18 @@ namespace Microsoft.DotNet.ProjectJsonMigration
                 throw new ArgumentNullException(nameof(workspaceDirectory));
             }
 
+            projectDirectory = new DirectoryInfo(projectDirectory.FullName.EnsureTrailingSlash());
+            workspaceDirectory = new DirectoryInfo(workspaceDirectory.FullName.EnsureTrailingSlash());
+
             globalJson = new FileInfo(Path.Combine(
                            workspaceDirectory.FullName,
                            "global.json"));
 
-            projectDirectory = new DirectoryInfo(projectDirectory.FullName.EnsureTrailingSlash());
-            workspaceDirectory = new DirectoryInfo(workspaceDirectory.FullName.EnsureTrailingSlash());
-
             RootBackupDirectory = new DirectoryInfo(
-                Path.Combine(
-                        workspaceDirectory.Parent.FullName,
-                        "backup")
+                GetUniqueDirectoryPath(
+                    Path.Combine(
+                        workspaceDirectory.FullName,
+                        "backup"))
                     .EnsureTrailingSlash());
 
             ProjectBackupDirectory = new DirectoryInfo(
@@ -72,9 +73,10 @@ namespace Microsoft.DotNet.ProjectJsonMigration
             {
                 PathUtility.EnsureDirectoryExists(RootBackupDirectory.FullName);
 
-                globalJson.MoveTo(Path.Combine(
-                    ProjectBackupDirectory.Parent.FullName,
-                    globalJson.Name));
+                globalJson.MoveTo(
+                    Path.Combine(
+                        ProjectBackupDirectory.Parent.FullName,
+                        globalJson.Name));
             }
 
             PathUtility.EnsureDirectoryExists(ProjectBackupDirectory.FullName);
@@ -83,8 +85,22 @@ namespace Microsoft.DotNet.ProjectJsonMigration
             {
                 file.MoveTo(
                     Path.Combine(
-                        ProjectBackupDirectory.FullName, file.Name));
+                        ProjectBackupDirectory.FullName,
+                        file.Name));
             }
+        }
+
+        private static string GetUniqueDirectoryPath(string directoryPath)
+        {
+            var candidatePath = directoryPath;
+
+            var suffix = 1;
+            while (Directory.Exists(directoryPath))
+            {
+                candidatePath = $"{directoryPath}_{suffix++}";
+            }
+
+            return candidatePath;
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectJsonMigration/MigrationBackupPlan.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/MigrationBackupPlan.cs
@@ -95,7 +95,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
             var candidatePath = directoryPath;
 
             var suffix = 1;
-            while (Directory.Exists(directoryPath))
+            while (Directory.Exists(candidatePath))
             {
                 candidatePath = $"{directoryPath}_{suffix++}";
             }

--- a/src/Microsoft.DotNet.ProjectJsonMigration/MigrationBackupPlan.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/MigrationBackupPlan.cs
@@ -12,27 +12,36 @@ namespace Microsoft.DotNet.ProjectJsonMigration
     internal class MigrationBackupPlan
     {
         private readonly FileInfo globalJson;
+        private readonly Dictionary<DirectoryInfo, IEnumerable<FileInfo>> mapOfProjectBackupDirectoryToFilesToMove;
+
+        public DirectoryInfo RootBackupDirectory { get; }
+        public DirectoryInfo[] ProjectBackupDirectories { get; }
+
+        public IEnumerable<FileInfo> FilesToMove(DirectoryInfo projectBackupDirectory)
+            => mapOfProjectBackupDirectoryToFilesToMove[projectBackupDirectory];
 
         public MigrationBackupPlan(
-            DirectoryInfo projectDirectory,
+            IEnumerable<DirectoryInfo> projectDirectories,
             DirectoryInfo workspaceDirectory,
             Func<DirectoryInfo, IEnumerable<FileInfo>> getFiles = null)
         {
-            if (projectDirectory == null)
+            if (projectDirectories == null)
             {
-                throw new ArgumentNullException(nameof(projectDirectory));
+                throw new ArgumentNullException(nameof(projectDirectories));
             }
+
             if (workspaceDirectory == null)
             {
                 throw new ArgumentNullException(nameof(workspaceDirectory));
             }
 
-            projectDirectory = new DirectoryInfo(projectDirectory.FullName.EnsureTrailingSlash());
+            projectDirectories = projectDirectories.Select(pd => new DirectoryInfo(pd.FullName.EnsureTrailingSlash()));
             workspaceDirectory = new DirectoryInfo(workspaceDirectory.FullName.EnsureTrailingSlash());
 
-            globalJson = new FileInfo(Path.Combine(
-                           workspaceDirectory.FullName,
-                           "global.json"));
+            globalJson = new FileInfo(
+                Path.Combine(
+                    workspaceDirectory.FullName,
+                    "global.json"));
 
             RootBackupDirectory = new DirectoryInfo(
                 GetUniqueDirectoryPath(
@@ -41,31 +50,21 @@ namespace Microsoft.DotNet.ProjectJsonMigration
                         "backup"))
                     .EnsureTrailingSlash());
 
-            ProjectBackupDirectory = new DirectoryInfo(
-                Path.Combine(
-                        RootBackupDirectory.FullName,
-                        projectDirectory.Name)
-                    .EnsureTrailingSlash());
+            var projectBackupDirectories = new List<DirectoryInfo>();
+            mapOfProjectBackupDirectoryToFilesToMove = new Dictionary<DirectoryInfo, IEnumerable<FileInfo>>();
+            getFiles = getFiles ?? (dir => dir.EnumerateFiles());
 
-            var relativeDirectory = PathUtility.GetRelativePath(
-                workspaceDirectory.FullName,
-                projectDirectory.FullName);
+            foreach (var projectDirectory in projectDirectories)
+            {
+                var projectBackupDirectory = ComputeProjectBackupDirectoryPath(workspaceDirectory, projectDirectory, RootBackupDirectory);
+                var filesToMove = getFiles(projectDirectory).Where(NeedsBackup);
 
-            getFiles = getFiles ??
-                       (dir => dir.EnumerateFiles());
+                projectBackupDirectories.Add(projectBackupDirectory);
+                mapOfProjectBackupDirectoryToFilesToMove.Add(projectBackupDirectory, filesToMove);
+            }
 
-            FilesToMove = getFiles(projectDirectory)
-               .Where(f => f.Name == "project.json"
-                        || f.Extension == ".xproj"
-                        || f.FullName.EndsWith(".xproj.user")
-                        || f.FullName.EndsWith(".lock.json"));
+            ProjectBackupDirectories = projectBackupDirectories.ToArray();
         }
-
-        public DirectoryInfo ProjectBackupDirectory { get; }
-
-        public DirectoryInfo RootBackupDirectory { get; }
-
-        public IEnumerable<FileInfo> FilesToMove { get; }
 
         public void PerformBackup()
         {
@@ -75,20 +74,58 @@ namespace Microsoft.DotNet.ProjectJsonMigration
 
                 globalJson.MoveTo(
                     Path.Combine(
-                        ProjectBackupDirectory.Parent.FullName,
+                        RootBackupDirectory.FullName,
                         globalJson.Name));
             }
 
-            PathUtility.EnsureDirectoryExists(ProjectBackupDirectory.FullName);
-
-            foreach (var file in FilesToMove)
+            foreach (var kvp in mapOfProjectBackupDirectoryToFilesToMove)
             {
-                file.MoveTo(
-                    Path.Combine(
-                        ProjectBackupDirectory.FullName,
-                        file.Name));
+                var projectBackupDirectory = kvp.Key;
+                var filesToMove = kvp.Value;
+
+                PathUtility.EnsureDirectoryExists(projectBackupDirectory.FullName);
+
+                foreach (var file in filesToMove)
+                {
+                    file.MoveTo(
+                        Path.Combine(
+                            projectBackupDirectory.FullName,
+                            file.Name));
+                }
             }
         }
+
+        private static DirectoryInfo ComputeProjectBackupDirectoryPath(
+            DirectoryInfo workspaceDirectory, DirectoryInfo projectDirectory, DirectoryInfo rootBackupDirectory)
+        {
+            if (PathUtility.IsChildOfDirectory(workspaceDirectory.FullName, projectDirectory.FullName))
+            {
+                var relativePath = PathUtility.GetRelativePath(
+                    workspaceDirectory.FullName,
+                    projectDirectory.FullName);
+
+                return new DirectoryInfo(
+                    Path.Combine(
+                            rootBackupDirectory.FullName,
+                            relativePath)
+                        .EnsureTrailingSlash());
+            }
+
+            // For projects whose directory is not a child of the workspace directory (is that even possible?)
+            // Ensure that we use a unique name to avoid collisions as a fallback.
+            return new DirectoryInfo(
+                GetUniqueDirectoryPath(
+                    Path.Combine(
+                            rootBackupDirectory.FullName,
+                            projectDirectory.Name)
+                        .EnsureTrailingSlash()));
+        }
+
+        private static bool NeedsBackup(FileInfo file)
+            => file.Name == "project.json"
+            || file.Extension == ".xproj"
+            || file.FullName.EndsWith(".xproj.user")
+            || file.FullName.EndsWith(".lock.json");
 
         private static string GetUniqueDirectoryPath(string directoryPath)
         {

--- a/src/Microsoft.DotNet.ProjectJsonMigration/MigrationBackupPlan.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/MigrationBackupPlan.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration
                     file.MoveTo(
                         Path.Combine(
                             projectBackupDirectory.FullName,
-                            file.Name));
+                            fileName));
                 }
             }
         }

--- a/src/Microsoft.DotNet.TestFramework/TestDirectory.cs
+++ b/src/Microsoft.DotNet.TestFramework/TestDirectory.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.TestFramework
             var testDirectory = new DirectoryInfo(path);
 
             var migrationBackupDirectory = new DirectoryInfo(
-                System.IO.Path.Combine(testDirectory.Parent.FullName, "backup"));
+                System.IO.Path.Combine(testDirectory.FullName, "backup"));
 
             if (testDirectory.Exists)
             {

--- a/src/dotnet/commands/dotnet-migrate/MigrateCommand.cs
+++ b/src/dotnet/commands/dotnet-migrate/MigrateCommand.cs
@@ -193,14 +193,17 @@ namespace Microsoft.DotNet.Tools.Migrate
 
         private void BackupProjects(MigrationReport migrationReport)
         {
+            var projectDirectories = new List<DirectoryInfo>();
             foreach (var report in migrationReport.ProjectMigrationReports)
             {
-                var backupPlan = new MigrationBackupPlan(
-                    new DirectoryInfo(report.ProjectDirectory),
-                    _workspaceDirectory);
-
-                backupPlan.PerformBackup();
+                projectDirectories.Add(new DirectoryInfo(report.ProjectDirectory));
             }
+
+            var backupPlan = new MigrationBackupPlan(
+                projectDirectories,
+                _workspaceDirectory);
+
+            backupPlan.PerformBackup();
         }
 
         private void WriteReport(MigrationReport migrationReport)

--- a/src/dotnet/commands/dotnet-migrate/MigrateCommand.cs
+++ b/src/dotnet/commands/dotnet-migrate/MigrateCommand.cs
@@ -204,6 +204,8 @@ namespace Microsoft.DotNet.Tools.Migrate
                 _workspaceDirectory);
 
             backupPlan.PerformBackup();
+
+            Reporter.Output.WriteLine($"Files backed up to {backupPlan.RootBackupDirectory.FullName}");
         }
 
         private void WriteReport(MigrationReport migrationReport)

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/MigrationBackupPlanTests.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/MigrationBackupPlanTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.DotNet.Internal.ProjectModel.Utilities;
 using Microsoft.DotNet.ProjectJsonMigration;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -14,82 +15,123 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
     public partial class MigrationBackupPlanTests
     {
         [Fact]
-        public void TheRootBackupDirectoryIsASubfolderOfTheRootProject()
+        public void TheBackupDirectoryIsASubfolderOfTheMigratedProject()
         {
-            var dir = new DirectoryInfo(Path.Combine("src", "some-proj"));
+            var workspaceDirectory = Path.Combine("src", "root");
+            var projectDirectory = Path.Combine("src", "project1");
 
-            System.Console.WriteLine(dir.FullName);
-
-            WhenMigrating(
-                projectDirectory: dir.FullName,
-                workspaceDirectory: Path.Combine("src", "RootProject"))
-            .RootBackupDirectory
-            .FullName
-            .Should()
-            .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup")).FullName.EnsureTrailingSlash());
+            WhenMigrating(projectDirectory, workspaceDirectory)
+                .RootBackupDirectory
+                .FullName
+                .Should()
+                .Be(new DirectoryInfo(Path.Combine("src", "project1", "backup")).FullName.EnsureTrailingSlash());
         }
 
         [Fact]
-        public void TheRootProjectsBackupDirectoryIsASubfolderOfTheRootBackupDirectory()
+        public void TheBackupDirectoryIsASubfolderOfTheMigratedProjectWhenInitiatedFromProjectFolder()
         {
-            WhenMigrating(
-                projectDirectory: Path.Combine("src", "RootProject"),
-                workspaceDirectory: Path.Combine("src", "RootProject"))
-            .ProjectBackupDirectories.Single()
-            .FullName
-            .Should()
-            .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup")).FullName.EnsureTrailingSlash());
+            var workspaceDirectory = Path.Combine("src", "root");
+            var projectDirectory = Path.Combine("src", "root");
+
+            WhenMigrating(projectDirectory, workspaceDirectory)
+                .ProjectBackupDirectories.Single()
+                .FullName
+                .Should()
+                .Be(new DirectoryInfo(Path.Combine("src", "root", "backup")).FullName.EnsureTrailingSlash());
         }
 
         [Fact]
-        public void ADependentProjectsMigrationBackupDirectoryIsASubfolderOfTheRootBackupDirectory()
+        public void TheBackupDirectoryIsInTheCommonRootOfTwoProjectFoldersWhenInitiatedFromProjectFolder()
         {
-            WhenMigrating(
-                projectDirectory: Path.Combine("src", "Dependency"),
-                workspaceDirectory: Path.Combine("src", "RootProject"))
-            .ProjectBackupDirectories.Single()
-            .FullName
-            .Should()
-            .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup", "Dependency")).FullName.EnsureTrailingSlash());
+            var projectDirectories = new []
+            {
+                Path.Combine("root", "project1"),
+                Path.Combine("root", "project2")
+            };
+
+            var workspaceDirectory = Path.Combine("root", "project1");
+
+            WhenMigrating(projectDirectories, workspaceDirectory)
+                .RootBackupDirectory
+                .FullName
+                .Should()
+                .Be(new DirectoryInfo(Path.Combine("root", "backup")).FullName.EnsureTrailingSlash());
         }
 
         [Fact]
-        public void FilesToBackUpAreIdentifiedInTheTheRootProjectDirectory()
+        public void TheBackupDirectoryIsInTheCommonRootOfTwoProjectFoldersWhenInitiatedFromCommonRoot()
         {
-            var root = new DirectoryInfo(Path.Combine("src", "RootProject"));
+            var projectDirectories = new []
+            {
+                Path.Combine("root", "project1"),
+                Path.Combine("root", "project2")
+            };
 
-            var whenMigrating = WhenMigrating(
-                projectDirectory: root.FullName,
-                workspaceDirectory: root.FullName);
+            var workspaceDirectory = Path.Combine("root");
+
+            WhenMigrating(projectDirectories, workspaceDirectory)
+                .RootBackupDirectory
+                .FullName
+                .Should()
+                .Be(new DirectoryInfo(Path.Combine("root", "backup")).FullName.EnsureTrailingSlash());
+        }
+
+        [Fact]
+        public void TheBackupDirectoryIsInTheCommonRootOfTwoProjectFoldersAtDifferentLevelsWhenInitiatedFromProjectFolder()
+        {
+            var projectDirectories = new []
+            {
+                Path.Combine("root", "tests", "inner", "project1"),
+                Path.Combine("root", "src", "project2")
+            };
+
+            var workspaceDirectory = Path.Combine("root", "tests", "inner");
+
+            WhenMigrating(projectDirectories, workspaceDirectory)
+                .RootBackupDirectory
+                .FullName
+                .Should()
+                .Be(new DirectoryInfo(Path.Combine("root", "backup")).FullName.EnsureTrailingSlash());
+        }
+
+        [Fact]
+        public void FilesToBackUpAreIdentifiedInTheRootProjectDirectory()
+        {
+            var workspaceDirectory = Path.Combine("src", "root");
+            var projectDirectory = Path.Combine("src", "root");
+
+            var whenMigrating = WhenMigrating(projectDirectory, workspaceDirectory);
 
             whenMigrating
-            .FilesToMove(whenMigrating.ProjectBackupDirectories.Single())
-            .Should()
-            .Contain(_ => _.FullName == Path.Combine(root.FullName, "project.json"));
+                .FilesToMove(whenMigrating.ProjectBackupDirectories.Single())
+                .Should()
+                .Contain(_ => _.FullName == Path.Combine(new DirectoryInfo(workspaceDirectory).FullName, "project.json"));
         }
 
         [Fact]
-        public void FilesToBackUpAreIdentifiedInTheTheDependencyProjectDirectory()
+        public void FilesToBackUpAreIdentifiedInTheDependencyProjectDirectory()
         {
-            var root = new DirectoryInfo(Path.Combine("src", "RootProject"));
-            var dependency = new DirectoryInfo(Path.Combine("src", "RootProject"));
+            var workspaceDirectory = Path.Combine("src", "root");
+            var projectDirectory = Path.Combine("src", "root");
 
-            var whenMigrating = WhenMigrating(
-                projectDirectory: dependency.FullName,
-                workspaceDirectory: root.FullName);
+            var whenMigrating = WhenMigrating(projectDirectory, workspaceDirectory);
 
             whenMigrating
-            .FilesToMove(whenMigrating.ProjectBackupDirectories.Single())
-            .Should()
-            .Contain(_ => _.FullName == Path.Combine(dependency.FullName, "project.json"));
+                .FilesToMove(whenMigrating.ProjectBackupDirectories.Single())
+                .Should()
+                .Contain(_ => _.FullName == Path.Combine(new DirectoryInfo(projectDirectory).FullName, "project.json"));
         }
 
-        private MigrationBackupPlan WhenMigrating(
-            string projectDirectory,
-            string workspaceDirectory) =>
+        private MigrationBackupPlan WhenMigrating(string projectDirectory, string workspaceDirectory) =>
             new MigrationBackupPlan(
                 new [] { new DirectoryInfo(projectDirectory) },
                 new DirectoryInfo(workspaceDirectory),
-                dir => new[] { new FileInfo(Path.Combine(dir.FullName, "project.json")) });
+                dir => new [] { new FileInfo(Path.Combine(dir.FullName, "project.json")) });
+
+        private MigrationBackupPlan WhenMigrating(string[] projectDirectories, string workspaceDirectory) =>
+            new MigrationBackupPlan(
+                projectDirectories.Select(p => new DirectoryInfo(p)),
+                new DirectoryInfo(workspaceDirectory),
+                dir => new [] { new FileInfo(Path.Combine(dir.FullName, "project.json")) });
     }
 }

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/MigrationBackupPlanTests.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/MigrationBackupPlanTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
     public partial class MigrationBackupPlanTests
     {
         [Fact]
-        public void TheRootBackupDirectoryIsASiblingOfTheRootProject()
+        public void TheRootBackupDirectoryIsASubfolderOfTheRootProject()
         {
             var dir = new DirectoryInfo(Path.Combine("src", "some-proj"));
 
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             .RootBackupDirectory
             .FullName
             .Should()
-            .Be(new DirectoryInfo(Path.Combine("src", "backup")).FullName.EnsureTrailingSlash());
+            .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup")).FullName.EnsureTrailingSlash());
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             .ProjectBackupDirectory
             .FullName
             .Should()
-            .Be(new DirectoryInfo(Path.Combine("src", "backup", "RootProject")).FullName.EnsureTrailingSlash());
+            .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup", "RootProject")).FullName.EnsureTrailingSlash());
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
              .ProjectBackupDirectory
              .FullName
              .Should()
-             .Be(new DirectoryInfo(Path.Combine("src", "backup", "Dependency")).FullName.EnsureTrailingSlash());
+             .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup", "Dependency")).FullName.EnsureTrailingSlash());
         }
 
         [Fact]
@@ -64,7 +64,6 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             .FilesToMove
             .Should()
             .Contain(_ => _.FullName == Path.Combine(root.FullName, "project.json"));
-
         }
 
         [Fact]
@@ -79,7 +78,6 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             .FilesToMove
             .Should()
             .Contain(_ => _.FullName == Path.Combine(dependency.FullName, "project.json"));
-
         }
 
         private MigrationBackupPlan WhenMigrating(

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/MigrationBackupPlanTests.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/MigrationBackupPlanTests.cs
@@ -35,22 +35,22 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             WhenMigrating(
                 projectDirectory: Path.Combine("src", "RootProject"),
                 workspaceDirectory: Path.Combine("src", "RootProject"))
-            .ProjectBackupDirectory
+            .ProjectBackupDirectories.Single()
             .FullName
             .Should()
-            .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup", "RootProject")).FullName.EnsureTrailingSlash());
+            .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup")).FullName.EnsureTrailingSlash());
         }
 
         [Fact]
         public void ADependentProjectsMigrationBackupDirectoryIsASubfolderOfTheRootBackupDirectory()
         {
             WhenMigrating(
-                 projectDirectory: Path.Combine("src", "Dependency"),
-                 workspaceDirectory: Path.Combine("src", "RootProject"))
-             .ProjectBackupDirectory
-             .FullName
-             .Should()
-             .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup", "Dependency")).FullName.EnsureTrailingSlash());
+                projectDirectory: Path.Combine("src", "Dependency"),
+                workspaceDirectory: Path.Combine("src", "RootProject"))
+            .ProjectBackupDirectories.Single()
+            .FullName
+            .Should()
+            .Be(new DirectoryInfo(Path.Combine("src", "RootProject", "backup", "Dependency")).FullName.EnsureTrailingSlash());
         }
 
         [Fact]
@@ -58,10 +58,12 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         {
             var root = new DirectoryInfo(Path.Combine("src", "RootProject"));
 
-            WhenMigrating(
+            var whenMigrating = WhenMigrating(
                 projectDirectory: root.FullName,
-                workspaceDirectory: root.FullName)
-            .FilesToMove
+                workspaceDirectory: root.FullName);
+
+            whenMigrating
+            .FilesToMove(whenMigrating.ProjectBackupDirectories.Single())
             .Should()
             .Contain(_ => _.FullName == Path.Combine(root.FullName, "project.json"));
         }
@@ -72,10 +74,12 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             var root = new DirectoryInfo(Path.Combine("src", "RootProject"));
             var dependency = new DirectoryInfo(Path.Combine("src", "RootProject"));
 
-            WhenMigrating(
+            var whenMigrating = WhenMigrating(
                 projectDirectory: dependency.FullName,
-                workspaceDirectory: root.FullName)
-            .FilesToMove
+                workspaceDirectory: root.FullName);
+
+            whenMigrating
+            .FilesToMove(whenMigrating.ProjectBackupDirectories.Single())
             .Should()
             .Contain(_ => _.FullName == Path.Combine(dependency.FullName, "project.json"));
         }
@@ -84,9 +88,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             string projectDirectory,
             string workspaceDirectory) =>
             new MigrationBackupPlan(
-                new DirectoryInfo(projectDirectory),
+                new [] { new DirectoryInfo(projectDirectory) },
                 new DirectoryInfo(workspaceDirectory),
                 dir => new[] { new FileInfo(Path.Combine(dir.FullName, "project.json")) });
-
     }
 }

--- a/test/dotnet-migrate.Tests/GivenThatAnAppWasMigrated.cs
+++ b/test/dotnet-migrate.Tests/GivenThatAnAppWasMigrated.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Migration.Tests
                 .CreateTestInstance(testProjectName)
                 .Path;
 
-            var backupRoot = Path.Combine(testRoot, "backup", testProjectName);
+            var backupRoot = Path.Combine(testRoot, "backup");
 
             var migratableArtifacts = GetProjectJsonArtifacts(testRoot);
 

--- a/test/dotnet-migrate.Tests/GivenThatAnAppWasMigrated.cs
+++ b/test/dotnet-migrate.Tests/GivenThatAnAppWasMigrated.cs
@@ -19,9 +19,7 @@ namespace Microsoft.DotNet.Migration.Tests
                 .CreateTestInstance(testProjectName)
                 .Path;
 
-            var testRootParent = new DirectoryInfo(testRoot).Parent.FullName;
-
-            var backupRoot = Path.Combine(testRootParent, "backup");
+            var backupRoot = Path.Combine(testRoot, "backup");
 
             var migratableArtifacts = GetProjectJsonArtifacts(testRoot);
 
@@ -47,9 +45,7 @@ namespace Microsoft.DotNet.Migration.Tests
                 .CreateTestInstance(testProjectName)
                 .Path;
 
-            var testRootParent = new DirectoryInfo(testRoot).Parent.FullName;
-
-            var backupRoot = Path.Combine(testRootParent, "backup", testProjectName);
+            var backupRoot = Path.Combine(testRoot, "backup", testProjectName);
 
             var migratableArtifacts = GetProjectJsonArtifacts(testRoot);
 

--- a/test/dotnet-migrate.Tests/GivenThatAnAppWasMigrated.cs
+++ b/test/dotnet-migrate.Tests/GivenThatAnAppWasMigrated.cs
@@ -19,7 +19,9 @@ namespace Microsoft.DotNet.Migration.Tests
                 .CreateTestInstance(testProjectName)
                 .Path;
 
-            var backupRoot = Path.Combine(testRoot, "backup");
+            var testRootParent = new DirectoryInfo(testRoot).Parent.FullName;
+
+            var backupRoot = Path.Combine(testRootParent, "backup");
 
             var migratableArtifacts = GetProjectJsonArtifacts(testRoot);
 
@@ -45,7 +47,9 @@ namespace Microsoft.DotNet.Migration.Tests
                 .CreateTestInstance(testProjectName)
                 .Path;
 
-            var backupRoot = Path.Combine(testRoot, "backup", testProjectName);
+            var testRootParent = new DirectoryInfo(testRoot).Parent.FullName;
+
+            var backupRoot = Path.Combine(testRootParent, "backup", testProjectName);
 
             var migratableArtifacts = GetProjectJsonArtifacts(testRoot);
 

--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Build.Construction;
 using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Common;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using System;
 using System.Collections.Generic;
@@ -573,7 +574,10 @@ namespace Microsoft.DotNet.Migration.Tests
 
         private void VerifyMigration(IEnumerable<string> expectedProjects, string rootDir)
          {
+             var backupDir = Path.Combine(rootDir, "backup");
+
              var migratedProjects = Directory.EnumerateFiles(rootDir, "*.csproj", SearchOption.AllDirectories)
+                                             .Where(s => !PathUtility.IsChildOfDirectory(backupDir, s))
                                              .Where(s => Directory.EnumerateFiles(Path.GetDirectoryName(s), "*.csproj").Count() == 1)
                                              .Where(s => Path.GetFileName(Path.GetDirectoryName(s)).Contains("Project"))
                                              .Select(s => Path.GetFileName(Path.GetDirectoryName(s)));


### PR DESCRIPTION
Fixes #5224 

With this change, 'dotnet migrate' will create the backup folder in the workspace directory rather than the parent of the workspace directory. This solves two problems:

1. It makes it easier for the user where the backup is -- it's in the directory they targeted with 'dotnet migrate'.
2. It solves a problem of file oollisions with global.json files when migrating multiple projects. Consider the following directory structure:

    ```
    root
        |
        project1
            |
            global.json
            |
            src
                |
                project1
        project2
            |
            global.json
            |
            src
                |
                project2
    ```

    Prior to this change, running 'dotnet migrate' project1 and then running it again in project2 would have caused an exception to be thrown because the migration would try to produce a backup folder like so:

    ```
    root
        |
        backup
        |  |
        |   global.json
        |   |
        |   project1
        |   |
        |   project2
        |
        |
        project1
            |
            src
                |
                project1
        project2
            |
            src
                |
                project2
    ```

    Now, we produce the following structure, which has no collisions:

    ```
    root
        |
        project1
            |
            backup
            |   |
            |   global.json
            |   |
            |   project1
            |
            src
                |
                project1
        |
        project2
            |
            backup
            |   |
            |   global.json
            |   |
            |   project2
            |
            src
                |
                project2
    ```

In addition, to help avoid further collisions, a number is appened to the backup folder's name if
it already exists. So, if the user runs dotnet migrate again for some reason, they'll see backup_1,
backup_2, etc.