### PR TITLE
Update dotnet new templates with beta5 xunit

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -6,6 +6,6 @@
     <CLI_NETSDK_Version>1.0.0-alpha-20170115-2</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170114-1-223</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0-preview-20170106-08</CLI_TestPlatform_Version>
-    <TemplateEngineVersion>1.0.0-beta1-20170108-83</TemplateEngineVersion>
+    <TemplateEngineVersion>1.0.0-beta1-20170114-89</TemplateEngineVersion>
   </PropertyGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -6,6 +6,6 @@
     <CLI_NETSDK_Version>1.0.0-alpha-20170115-2</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170114-1-223</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0-preview-20170106-08</CLI_TestPlatform_Version>
-    <TemplateEngineVersion>1.0.0-beta1-20170114-89</TemplateEngineVersion>
+    <TemplateEngineVersion>1.0.0-beta1-20170116-91</TemplateEngineVersion>
   </PropertyGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -6,6 +6,6 @@
     <CLI_NETSDK_Version>1.0.0-alpha-20170115-2</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170114-1-223</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0-preview-20170106-08</CLI_TestPlatform_Version>
-    <TemplateEngineVersion>1.0.0-beta1-20170116-91</TemplateEngineVersion>
+    <TemplateEngineVersion>1.0.0-beta1-20170108-83</TemplateEngineVersion>
   </PropertyGroup>
 </Project>

--- a/src/dotnet/commands/dotnet-new/CSharp_Xunittest/$projectName$.csproj
+++ b/src/dotnet/commands/dotnet-new/CSharp_Xunittest/$projectName$.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
   </ItemGroup>
 
 </Project>

--- a/src/dotnet/commands/dotnet-new/FSharp_Xunittest/$projectName$.fsproj
+++ b/src/dotnet/commands/dotnet-new/FSharp_Xunittest/$projectName$.fsproj
@@ -15,8 +15,8 @@
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.0-beta-*" PrivateAssets="All" />
     <PackageReference Include="Microsoft.FSharp.Core.netcore" Version="1.0.0-alpha-161023" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
-    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pulls in the latest template engine version, removes global.json from new3 templates