### PR TITLE
Skipping project dependencies check when the skip-project-references flag is passed

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/ProjectMigrator.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/ProjectMigrator.cs
@@ -37,11 +37,19 @@ namespace Microsoft.DotNet.ProjectJsonMigration
             // Try to read the project dependencies, ignore an unresolved exception for now
             MigrationRuleInputs rootInputs = ComputeMigrationRuleInputs(rootSettings);
             IEnumerable<ProjectDependency> projectDependencies = null;
+            var projectMigrationReports = new List<ProjectMigrationReport>();
 
             try
             {
                 // Verify up front so we can prefer these errors over an unresolved project dependency
                 VerifyInputs(rootInputs, rootSettings);
+
+                projectMigrationReports.Add(MigrateProject(rootSettings));
+                
+                if (skipProjectReferences)
+                {
+                    return new MigrationReport(projectMigrationReports);
+                }
 
                 projectDependencies = ResolveTransitiveClosureProjectDependencies(
                     rootSettings.ProjectDirectory, 
@@ -59,14 +67,6 @@ namespace Microsoft.DotNet.ProjectJsonMigration
                             new List<MigrationError> {e.Error},
                             null)
                     });
-            }
-
-            var projectMigrationReports = new List<ProjectMigrationReport>();
-            projectMigrationReports.Add(MigrateProject(rootSettings));
-            
-            if (skipProjectReferences)
-            {
-                return new MigrationReport(projectMigrationReports);
             }
 
             foreach(var project in projectDependencies)

--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
@@ -164,6 +164,19 @@ namespace Microsoft.DotNet.Migration.Tests
         }
 
         [Fact]
+        public void ItMigratesAProjectThatDependsOnAMigratedProjectWithTheSkipProjectReferenceFlag()
+        {
+            const string dependentProject = "ProjectA";
+            const string dependencyProject = "ProjectB";
+
+            var projectDirectory = TestAssetsManager.CreateTestInstance("TestAppDependencyGraph").Path;
+
+            MigrateProject(Path.Combine(projectDirectory, dependencyProject));
+
+            MigrateProject("--skip-project-references", Path.Combine(projectDirectory, dependentProject));
+        }
+
+        [Fact]
         public void ItAddsMicrosoftNetWebSdkToTheSdkAttributeOfAWebApp()
         {
             var testInstance = TestAssetsManager


### PR DESCRIPTION
Moving the project dependencies construction to after we check for the skip project reference check, so that we really don't look for P2P projects when the flag is passed.

This is the issue that's causing VS migration to fail, as VS migrates a project and when it tries to migrate a dependent project, we can't find the dependency anymore. With this fix, the dependency will be ignored, as it should.

@piotroko @piotrpMSFT @jonsequitur @jgoshi @krwq 
