### PR TITLE
Add results directory arg to dotnet test

### DIFF
--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
@@ -55,5 +55,7 @@
 
         public const string RunSettingsArgsHelpText = @"Any extra commandline runsettings arguments that should be passed to vstest. See 'dotnet vstest --help' for available options.
                                         Example: -- RunConfiguration.ResultsDirectory=""C:\users\user\desktop\Results Directory"" MSTest.DeploymentEnabled=false";
+        public const string CmdResultsDirectoryDescription = @"Test results directory will be created in specified path if not exists.
+                                        Example: --results-directory <PATH_TO_RESULTS_DIRECTORY>";
     }
 }

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -83,6 +83,11 @@ namespace Microsoft.DotNet.Tools.Test
                LocalizableStrings.CmdNoBuildDescription,
                CommandOptionType.NoValue);
 
+            var resultsDirectoryOption = cmd.Option(
+                "-r|--results-directory",
+                LocalizableStrings.CmdResultsDirectoryDescription,
+                CommandOptionType.SingleValue);
+
             CommandOption verbosityOption = MSBuildForwardingApp.AddVerbosityOption(cmd);
 
             cmd.OnExecute(() =>
@@ -127,6 +132,11 @@ namespace Microsoft.DotNet.Tools.Test
                 if (frameworkOption.HasValue())
                 {
                     msbuildArgs.Add($"/p:TargetFramework={frameworkOption.Value()}");
+                }
+
+                if (resultsDirectoryOption.HasValue())
+                {
+                    msbuildArgs.Add($"/p:VSTestResultsDirectory={resultsDirectoryOption.Value()}");
                 }
 
                 if (outputOption.HasValue())


### PR DESCRIPTION
- Add results directory parameter as first class parameter
-  Related Issue: Microsoft/vstest#299