### PR TITLE
Adding an extra message to the migrate result

### DIFF
--- a/src/dotnet/commands/dotnet-migrate/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-migrate/LocalizableStrings.cs
@@ -30,5 +30,7 @@ Defaults to current directory if nothing is specified.";
         public const string CmdSkipBackupDescription = "Skip moving project.json, global.json, and *.xproj to a `backup` directory after successful migration.";
 
         public const string MigrationFailedError = "Migration failed.";
+
+        public const string MigrationAdditionalHelp = "Your project has been migrated to .csproj format and can be used with this build of .NET Core Tools.  Please visit https://aka.ms/coremigration to report issues or for help.";
     }
 }

--- a/src/dotnet/commands/dotnet-migrate/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-migrate/LocalizableStrings.cs
@@ -31,6 +31,6 @@ Defaults to current directory if nothing is specified.";
 
         public const string MigrationFailedError = "Migration failed.";
 
-        public const string MigrationAdditionalHelp = "Your project has been migrated to .csproj format and can be used with this build of .NET Core Tools.  Please visit https://aka.ms/coremigration to report issues or for help.";
+        public const string MigrationAdditionalHelp = "Your project has been migrated to the .csproj format and can be used with this build of the .NET Core Tools.  Please visit https://aka.ms/coremigration to report issues or ask for help.";
     }
 }

--- a/src/dotnet/commands/dotnet-migrate/MigrateCommand.cs
+++ b/src/dotnet/commands/dotnet-migrate/MigrateCommand.cs
@@ -235,6 +235,8 @@ namespace Microsoft.DotNet.Tools.Migrate
             }
 
             Reporter.Output.WriteLine(GetReportSummary(migrationReport));
+
+            Reporter.Output.WriteLine(LocalizableStrings.MigrationAdditionalHelp);
         }
 
         private string GetReportContent(MigrationReport migrationReport, bool colored = false)


### PR DESCRIPTION
Adding an extra message to the migrate result to direct people to a place where they can get help for their migrated projects.

@piotroko @piotrpMSFT @jonsequitur @krwq @jgoshi @blackdwarf @DustinCampbell 
