### PR TITLE
Adding a test that verifies that running dotnet migrate solution.sln will only migrate the projects in the solution file.

### DIFF
--- a/TestAssets/NonRestoredTestProjects/PJAppWithSlnAndXprojRefs/TestApp/TestAssets/TestAsset/Program.cs
+++ b/TestAssets/NonRestoredTestProjects/PJAppWithSlnAndXprojRefs/TestApp/TestAssets/TestAsset/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace App.Tests
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/NonRestoredTestProjects/PJAppWithSlnAndXprojRefs/TestApp/TestAssets/TestAsset/project.json
+++ b/TestAssets/NonRestoredTestProjects/PJAppWithSlnAndXprojRefs/TestApp/TestAssets/TestAsset/project.json
@@ -1,0 +1,15 @@
+{
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "portable-net451+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0",
+          "type": "platform"
+        }
+      }
+    }
+  }
+}

--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateSolutions.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateSolutions.cs
@@ -52,6 +52,35 @@ namespace Microsoft.DotNet.Migration.Tests
         }
 
         [Fact]
+        public void ItOnlyMigratesProjectsInTheSlnFile()
+        {
+            var projectDirectory = TestAssets
+                .Get("NonRestoredTestProjects", "PJAppWithSlnAndXprojRefs")
+                .CreateInstance()
+                .WithSourceFiles()
+                .Root;
+
+            var solutionRelPath = Path.Combine("TestApp", "TestApp.sln");
+
+            new DotnetCommand()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute($"migrate \"{solutionRelPath}\"")
+                .Should().Pass();
+
+            new DirectoryInfo(projectDirectory.FullName)
+                .Should().HaveFiles(new []
+                    {
+                        Path.Combine("TestApp", "TestApp.csproj"),
+                        Path.Combine("TestLibrary", "TestLibrary.csproj"),
+                        Path.Combine("TestApp", "src", "subdir", "subdir.csproj"),
+                        Path.Combine("TestApp", "TestAssets", "TestAsset", "project.json")
+                    });
+ 
+            new DirectoryInfo(projectDirectory.FullName)
+                .Should().NotHaveFile(Path.Combine("TestApp", "TestAssets", "TestAsset", "TestAsset.csproj"));
+        }
+
+        [Fact]
         public void WhenDirectoryAlreadyContainsCsprojFileItMigratesAndBuildsSln()
         {
             MigrateAndBuild(


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/5304

This is actually just a test fix. This behavior is already happening.

@piotroko @piotrpMSFT @jonsequitur @krwq @jgoshi @DustinCampbell 
