### PR TITLE
Use the latest Stage0 in master

### DIFF
--- a/TestAssets/TestPackages/NuGet.Config
+++ b/TestAssets/TestPackages/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="testpackages" value="../../artifacts/testpackages/packages" />
+  </packageSources>
+</configuration>

--- a/build/Microsoft.DotNet.Cli.Test.targets
+++ b/build/Microsoft.DotNet.Cli.Test.targets
@@ -97,7 +97,6 @@
     </PropertyGroup>
 
     <DotNetRestore ToolPath="$(Stage2Directory)"
-                   Source="$(TestPackagesDir)"
                    ConfigFile="$(RepoRoot)\NuGet.Config"
                    ProjectPath="%(TestPackageProject.ProjectPath)" />
 

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -95,8 +95,8 @@ if ($LastExitCode -ne 0)
 # install the post-PJnistic stage0
 $dotnetInstallPath = Join-Path $toolsLocalPath "dotnet-install.ps1"
 
-Write-Host "$dotnetInstallPath -Version ""1.0.0-preview5-004422"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
-Invoke-Expression "$dotnetInstallPath -Version ""1.0.0-preview5-004422"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Write-Host "$dotnetInstallPath -Channel ""master"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Invoke-Expression "$dotnetInstallPath -Channel ""master"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
 if ($LastExitCode -ne 0)
 {
     Write-Output "The .NET CLI installation failed with exit code $LastExitCode"

--- a/run-build.sh
+++ b/run-build.sh
@@ -155,8 +155,8 @@ if [ $? != 0 ]; then
 fi
 
 # now execute the script
-echo "installing CLI: $dotnetInstallPath --version \"1.0.0-preview5-004422\" --install-dir $DOTNET_INSTALL_DIR --architecture \"$ARCHITECTURE\""
-$dotnetInstallPath --version "1.0.0-preview5-004422" --install-dir $DOTNET_INSTALL_DIR --architecture "$ARCHITECTURE"
+echo "installing CLI: $dotnetInstallPath --channel \"master\" --install-dir $DOTNET_INSTALL_DIR --architecture \"$ARCHITECTURE\""
+$dotnetInstallPath --channel "master" --install-dir $DOTNET_INSTALL_DIR --architecture "$ARCHITECTURE"
 if [ $? != 0 ]; then
     echo "run-build: Error: Boot-strapping post-PJ stage0 with exit code $?." >&2
     exit $?


### PR DESCRIPTION
/cc @livarcocc @jonsequitur @krwq @jgoshi 

The TestPackage restore change is necessary because it isn't reading all nuget sources when using the `--source` switch in restore.  `--source` overwrites what is in the nuget.config.  With old stage0, we are using an SDK with bug https://github.com/dotnet/sdk/issues/596.  Using a newer stage0 now has TestPackages use NETCore.App 1.1.0, which isn't in the cache and the restore fails.