### PR TITLE
Updating the template engine version to a version that depends on 1.6.0

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -6,6 +6,6 @@
     <CLI_NETSDK_Version>1.0.0-alpha-20170123-1</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170114-1-223</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0-preview-20170106-08</CLI_TestPlatform_Version>
-    <TemplateEngineVersion>1.0.0-beta1-20170123-94</TemplateEngineVersion>
+    <TemplateEngineVersion>1.0.0-beta1-20170126-99</TemplateEngineVersion>
   </PropertyGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -6,6 +6,6 @@
     <CLI_NETSDK_Version>1.0.0-alpha-20170123-1</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170114-1-223</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0-preview-20170106-08</CLI_TestPlatform_Version>
-    <TemplateEngineVersion>1.0.0-beta1-20170126-99</TemplateEngineVersion>
+    <TemplateEngineVersion>1.0.0-beta1-20170126-101</TemplateEngineVersion>
   </PropertyGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -6,6 +6,6 @@
     <CLI_NETSDK_Version>1.0.0-alpha-20170123-1</CLI_NETSDK_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170114-1-223</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0-preview-20170106-08</CLI_TestPlatform_Version>
-    <TemplateEngineVersion>1.0.0-beta1-20170126-101</TemplateEngineVersion>
+    <TemplateEngineVersion>1.0.0-beta1-20170126-102</TemplateEngineVersion>
   </PropertyGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.Prepare.targets
+++ b/build/Microsoft.DotNet.Cli.Prepare.targets
@@ -53,11 +53,8 @@
       <Output TaskParameter="VersionMajor" PropertyName="VersionMajor" />
       <Output TaskParameter="VersionMinor" PropertyName="VersionMinor" />
       <Output TaskParameter="VersionPatch" PropertyName="VersionPatch" />
-      <Output TaskParameter="CommitCount" PropertyName="CommitCount" />
+      <Output TaskParameter="CommitCount" PropertyName="DefaultCommitCount" />
       <Output TaskParameter="ReleaseSuffix" PropertyName="ReleaseSuffix" />
-      <Output TaskParameter="VersionSuffix" PropertyName="VersionSuffix" />
-      <Output TaskParameter="SimpleVersion" PropertyName="SimpleVersion" />
-      <Output TaskParameter="NugetVersion" PropertyName="NugetVersion" />
       <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />
       <Output TaskParameter="VersionBadgeMoniker" PropertyName="VersionBadgeMoniker" />
       <Output TaskParameter="Channel" PropertyName="Channel" />
@@ -69,6 +66,12 @@
     </GenerateNuGetPackagesArchiveVersion>
 
     <PropertyGroup>
+      <CommitCount Condition=" '$(CommitCount)' == '' ">$(DefaultCommitCount)</CommitCount>
+
+      <SimpleVersion>$(VersionMajor).$(VersionMinor).$(VersionPatch).$(CommitCount)</SimpleVersion>
+      <VersionSuffix>$(ReleaseSuffix)-$(CommitCount)</VersionSuffix>
+      <NugetVersion>$(VersionMajor).$(VersionMinor).$(VersionPatch)-$(VersionSuffix)</NugetVersion>
+
       <VersionBadge>$(BaseOutputDirectory)/$(VersionBadgeMoniker)_$(Configuration)_version_badge.svg</VersionBadge>
       <SdkVersion>$(NugetVersion)</SdkVersion>
 

--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -133,5 +133,6 @@ docker run $INTERACTIVE -t --rm --sig-proxy=true \
     -e CHECKSUM_STORAGE_ACCOUNT \
     -e CHECKSUM_STORAGE_CONTAINER \
     -e CLIBUILD_SKIP_TESTS \
+    -e CommitCount \
     $DOTNET_BUILD_CONTAINER_TAG \
     $BUILD_COMMAND "$@"


### PR DESCRIPTION
Updating the template engine version to a version that depends on 1.6.0 and updating our build scripts to allow for a commit count override.

@piotrpMSFT @jonsequitur @krwq @jgoshi @mlorbetske 
