### PR TITLE
Add dotnet sln create command

### DIFF
--- a/TestAssets/TestProjects/AppsWithNoSln/App/App.csproj
+++ b/TestAssets/TestProjects/AppsWithNoSln/App/App.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/TestProjects/AppsWithNoSln/App/Program.cs
+++ b/TestAssets/TestProjects/AppsWithNoSln/App/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace App
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/SlnFileWithNoProjects/SlnFileWithNoProjects.sln
+++ b/TestAssets/TestProjects/SlnFileWithNoProjects/SlnFileWithNoProjects.sln
@@ -1,0 +1,17 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26006.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/dotnet/commands/dotnet-sln/Program.cs
+++ b/src/dotnet/commands/dotnet-sln/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Sln.Add;
 using Microsoft.DotNet.Tools.Sln.List;
 using Microsoft.DotNet.Tools.Sln.Remove;
+using Microsoft.DotNet.Tools.Sln.Create;
 
 namespace Microsoft.DotNet.Tools.Sln
 {
@@ -22,7 +23,9 @@ namespace Microsoft.DotNet.Tools.Sln
             {
                 AddProjectToSolutionCommand.Create,
                 ListProjectsInSolutionCommand.Create,
-                RemoveProjectFromSolutionCommand.Create
+                RemoveProjectFromSolutionCommand.Create,
+                CreateSlnFileSolutionCommand.Create
+
             };
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-sln/create/Program.cs
+++ b/src/dotnet/commands/dotnet-sln/create/Program.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Sln.Internal;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Common;
+using Microsoft.DotNet.Tools.Sln;
+
+namespace Microsoft.DotNet.Tools.Sln.Create
+{
+    internal class CreateSlnFileSolutionCommand : DotNetSubCommandBase
+    {
+            private const string slnFile = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26118.1
+MinimumVisualStudioVersion = 15.0.26118.1
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal";
+        public static DotNetSubCommandBase Create()
+        {
+            var command = new CreateSlnFileSolutionCommand()
+            {
+                Name = "create",
+                FullName = LocalizableStrings.CreateAppFullName,
+                Description = LocalizableStrings.CreateSubcommandHelpText,
+                HandleRemainingArguments = true
+            };
+
+            command.HelpOption("-h|--help");
+
+            return command;
+        }
+
+        public override int Run(string fileOrDirectory)
+        {
+
+            var currentDir = Directory.GetCurrentDirectory();
+            var slnFileName = (RemainingArguments.Count > 0) ? RemainingArguments[0] : $"{Path.GetFileName(currentDir)}.sln";
+            if (!PathUtility.HasExtension(slnFileName, ".sln"))
+            {
+                slnFileName += ".sln";
+            }
+
+            if (File.Exists(Path.Combine(currentDir, slnFileName)))
+            {
+                Reporter.Error.WriteLine(String.Format(CommonLocalizableStrings.XAlreadyHasY, currentDir, slnFileName));
+                return 1;
+            }
+            else
+            {
+                try
+                {
+                    File.WriteAllText(slnFileName, slnFile);
+                    Reporter.Output.WriteLine(String.Format(CommonLocalizableStrings.TemplateCreatedSuccessfully, slnFileName));
+                }
+                catch (Exception e)
+                {
+                    throw new GracefulException(CommonLocalizableStrings.OperationInvalid, e);
+                }
+            }
+            return 0;
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Cli.Tests.sln
+++ b/test/Microsoft.DotNet.Cli.Tests.sln
@@ -72,6 +72,10 @@ Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "dotnet-sln-remove.Tests", "
 EndProject
 Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "dotnet-add-package.Tests", "dotnet-add-package.Tests\dotnet-add-package.Tests.csproj", "{3501AB72-3E05-45EE-9000-9515F5A139AC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dotnet-sln-create.Tests", "dotnet-sln-create.Tests", "{852533F9-A299-4036-B57F-1C5259C11C64}"
+EndProject
+Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "dotnet-sln-create.Tests", "dotnet-sln-create.Tests\dotnet-sln-create.Tests.csproj", "{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -230,6 +234,7 @@ Global
 		{92BA9F90-E25B-4A1C-9598-2295D3DFC12F}.Release|x64.Build.0 = Release|x64
 		{92BA9F90-E25B-4A1C-9598-2295D3DFC12F}.Release|x86.ActiveCfg = Release|x86
 		{92BA9F90-E25B-4A1C-9598-2295D3DFC12F}.Release|x86.Build.0 = Release|x86
+<<<<<<< 45727ab4e3dd6dd65a012732788cd108f81da089
 		{3501AB72-3E05-45EE-9000-9515F5A139AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3501AB72-3E05-45EE-9000-9515F5A139AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3501AB72-3E05-45EE-9000-9515F5A139AC}.Debug|x64.ActiveCfg = Debug|x64
@@ -242,6 +247,20 @@ Global
 		{3501AB72-3E05-45EE-9000-9515F5A139AC}.Release|x64.Build.0 = Release|x64
 		{3501AB72-3E05-45EE-9000-9515F5A139AC}.Release|x86.ActiveCfg = Release|x86
 		{3501AB72-3E05-45EE-9000-9515F5A139AC}.Release|x86.Build.0 = Release|x86
+=======
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Debug|x64.ActiveCfg = Debug|x64
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Debug|x64.Build.0 = Debug|x64
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Debug|x86.ActiveCfg = Debug|x86
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Debug|x86.Build.0 = Debug|x86
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Release|x64.ActiveCfg = Release|x64
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Release|x64.Build.0 = Release|x64
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Release|x86.ActiveCfg = Release|x86
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1}.Release|x86.Build.0 = Release|x86
+>>>>>>> Add dotnet sln create command
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -250,5 +269,6 @@ Global
 		{FC849626-89C9-4F50-A2CA-53C4315A87F8} = {5FF48976-B083-4E3B-A8E7-6FCD225D5C8E}
 		{5767D8F0-4ED9-4083-8BDC-ED9E65AA86EF} = {15DDC326-69C3-4081-8AA1-B578B2BDE2C6}
 		{92BA9F90-E25B-4A1C-9598-2295D3DFC12F} = {BB393A93-1770-4753-B7D6-56F0DD378177}
+		{E3EF818A-9E8D-4763-B5E3-6EB6FCA6FFC1} = {852533F9-A299-4036-B57F-1C5259C11C64}
 	EndGlobalSection
 EndGlobal

--- a/test/dotnet-sln-create.Tests/GivenDotnetSlnCreate.cs
+++ b/test/dotnet-sln-create.Tests/GivenDotnetSlnCreate.cs
@@ -1,0 +1,125 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.Build.Construction;
+using Microsoft.DotNet.Cli.Sln.Internal;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Sln.Create.Tests
+{
+    public class GivenDotnetSlnCreate : TestBase
+    {
+        private const string slnFileContents = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26118.1
+MinimumVisualStudioVersion = 15.0.26118.1
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal";
+
+        [Fact]
+        public void WhenEmptyDirectoryIsUsedSlnFileIsCreated()
+        {
+            var directoryRoot = TestAssets.CreateTestDirectory()
+                .FullName;
+
+            var slnFile = $"{Path.GetFileName(directoryRoot)}.sln";
+
+            var cmd = new DotnetCommand()
+                .WithWorkingDirectory(directoryRoot)
+                .ExecuteWithCapturedOutput("sln create");
+
+            cmd.Should().Pass();
+            cmd.StdOut.Should().Be($"The template {Path.GetFileName(directoryRoot)}.sln created successfully. Please run \"dotnet restore\" to get started!");
+            new DirectoryInfo(directoryRoot).Should().HaveFile(slnFile);
+            File.ReadAllText(Path.Combine(directoryRoot, slnFile)).Should().BeVisuallyEquivalentTo(slnFileContents);
+        }
+
+        [Fact]
+        public void WhenANameIsGivenTheSlnIsCreatedWithThatName()
+        {
+            var directoryRoot = TestAssets.CreateTestDirectory()
+                .FullName;
+
+            var cmd = new DotnetCommand()
+                .WithWorkingDirectory(directoryRoot)
+                .ExecuteWithCapturedOutput("sln create test.sln");
+
+            cmd.Should().Pass();
+            cmd.StdOut.Should().Be("The template test.sln created successfully. Please run \"dotnet restore\" to get started!");
+            new DirectoryInfo(directoryRoot).Should().HaveFile("test.sln");
+            File.ReadAllText(Path.Combine(directoryRoot, "test.sln")).Should().BeVisuallyEquivalentTo(slnFileContents);
+        }
+
+        [Fact]
+        public void WhenSlnWithTheSameNameExistsItShouldFail()
+        {
+            var slnRoot = TestAssets.Get("TestAppWithEmptySln")
+                .CreateInstance()
+                .WithSourceFiles()
+                .Root
+                .FullName;
+
+            var cmd = new DotnetCommand()
+                .WithWorkingDirectory(slnRoot)
+                .ExecuteWithCapturedOutput("sln create App.sln");
+            
+            cmd.Should().Fail();
+            cmd.StdErr.Should().Be($"{slnRoot} already has App.sln.");
+        }
+
+        [Fact]
+        public void WhenSlnIsCreatedAddingAProjectPasses()
+        {
+            var slnRoot = TestAssets.Get("AppsWithNoSln")
+                .CreateInstance()
+                .WithSourceFiles()
+                .Root
+                .FullName;
+
+            var projectToAdd = Path.Combine("App", "App.csproj");
+
+            var cmdCreate = new DotnetCommand()
+                .WithWorkingDirectory(slnRoot)
+                .ExecuteWithCapturedOutput("sln create");
+
+            var cmdAdd = new DotnetCommand()
+                .WithWorkingDirectory(slnRoot)
+                .ExecuteWithCapturedOutput($"sln add {projectToAdd}");
+
+            cmdCreate.Should().Pass();
+            cmdAdd.Should().Pass();
+        }
+
+        [Fact]
+        public void WhenNameSpecifiedWithNoExtensionSlnExtensionIsAdded()
+        {
+            var directoryRoot = TestAssets.CreateTestDirectory()
+                .FullName;
+
+            var cmd = new DotnetCommand()
+                .WithWorkingDirectory(directoryRoot)
+                .ExecuteWithCapturedOutput("sln create NoExtension");
+
+            cmd.Should().Pass();
+            cmd.StdOut.Should().Be("The template NoExtension.sln created successfully. Please run \"dotnet restore\" to get started!");
+            new DirectoryInfo(directoryRoot).Should().HaveFile("NoExtension.sln");
+        }
+    }
+}

--- a/test/dotnet-sln-create.Tests/dotnet-sln-create.Tests.csproj
+++ b/test/dotnet-sln-create.Tests/dotnet-sln-create.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>dotnet-sln-create.Tests</AssemblyName>
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Sln.Internal\Microsoft.DotNet.Cli.Sln.Internal.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.TestFramework\Microsoft.DotNet.TestFramework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk">
+      <Version>15.0.0-preview-20161024-02</Version>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <Version>2.2.0-beta4-build1194</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.App">
+      <Version>1.0.3</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.2.0-beta4-build3444</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Build">
+      <Version>$(CLI_MSBuild_Version)</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR adds a create subcommand within the dotnet sln command. It will
drop a predefined SLN file to disk. The commands accepts one parameter
and that is the name of the file w/ an extension. This is a pretty basic
implementation for this first turn of the crank.

Fixed #5259