### PR TITLE
Add checked-in build definitions

### DIFF
--- a/build/Microsoft.DotNet.Cli.Prepare.targets
+++ b/build/Microsoft.DotNet.Cli.Prepare.targets
@@ -62,7 +62,7 @@
       <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />
       <Output TaskParameter="VersionBadgeMoniker" PropertyName="VersionBadgeMoniker" />
       <Output TaskParameter="Channel" PropertyName="Channel" />
-      <Output TaskParameter="BranchName" PropertyName="BranchName" />
+      <Output TaskParameter="BranchName" PropertyName="BranchName" Condition=" '$(BranchName)' == '' " />
     </GenerateBuildVersionInfo>
 
     <PropertyGroup>

--- a/build/Microsoft.DotNet.Cli.Publish.targets
+++ b/build/Microsoft.DotNet.Cli.Publish.targets
@@ -52,7 +52,7 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="PublishDebFilesToDebianRepo" Condition=" '$(OSName)' == 'ubuntu' ">
+  <Target Name="PublishDebFilesToDebianRepo" Condition=" '$(OSName)' == 'ubuntu' AND '$(SkipPublishToDebianRepo)' != 'true' ">
     <Error Condition="'$(REPO_ID)' == ''" Text="REPO_ID must be set as an environment variable for debian publishing." />
     <Error Condition="'$(REPO_USER)' == ''" Text="REPO_USER must be set as an environment variable for debian publishing." />
     <Error Condition="'$(REPO_PASS)' == ''" Text="REPO_PASS must be set as an environment variable for debian publishing." />

--- a/build/Microsoft.DotNet.Cli.Signing.proj
+++ b/build/Microsoft.DotNet.Cli.Signing.proj
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project InitialTargets="SetSigningProperties" DefaultTargets="SignFiles" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <Import Project="$(RepoRoot)/build_tools/MicroBuild.Core.props" />
+
+  <!-- This will be overridden if we're building with MicroBuild. -->
+  <Target Name="SignFiles">
+    <Message Text="Fake sign target.  Would sign: @(FilesToSign)" />
+  </Target>
+
+  <Target Name="SetSigningProperties">
+    <Error Condition="'$(Rid)' == ''" Text="Missing required property 'Rid'." />
+    <PropertyGroup>
+      <BaseOutputDirectory Condition="'$(BaseOutputDirectory)' == ''">$(RepoRoot)/artifacts/$(Rid)</BaseOutputDirectory>
+      <Stage2Directory Condition="'$(Stage2Directory)' == ''">$(BaseOutputDirectory)/stage2</Stage2Directory>
+      <Stage2CompilationDirectory Condition="'$(Stage2CompilationDirectory)' == ''">$(BaseOutputDirectory)/stage2compilation</Stage2CompilationDirectory>
+      <PackagesDirectory Condition="'$(PackagesDirectory)' == ''">$(BaseOutputDirectory)/packages</PackagesDirectory>
+
+      <!-- The OutDir and IntermediateOutputPath properties are required by MicroBuild. MicroBuild only
+           signs files that are under these paths. -->
+      <OutDir Condition="'$(OutDir)' == ''">$(BaseOutputDirectory)</OutDir>
+      <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseOutputDirectory)/intermediate</IntermediateOutputPath>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="PostCompileSign" DependsOnTargets="GetPostCompileSignFiles;SignFiles" />
+
+  <Target Name="GetPostCompileSignFiles">
+    <ItemGroup>
+      <!-- External files -->
+      <FilesToSign Include="$(Stage2Directory)/sdk/**/Newtonsoft.Json.dll;
+                            $(Stage2Directory)/shared/**/libuv.dll">
+        <Authenticode>$(ExternalCertificateId)</Authenticode>
+      </FilesToSign>
+      <!-- Built binaries -->
+      <FilesToSign Include="$(Stage2Directory)/sdk/**/csc.exe;
+                            $(Stage2Directory)/sdk/**/csc.dll;
+                            $(Stage2Directory)/sdk/**/dotnet.dll;
+                            $(Stage2Directory)/sdk/**/System.*.dll;
+                            $(Stage2Directory)/sdk/**/Microsoft.*.dll;
+                            $(Stage2Directory)/sdk/**/NuGet*.dll;
+                            $(Stage2Directory)/sdk/**/datacollector.dll;
+                            $(Stage2Directory)/sdk/**/MSBuild.dll;
+                            $(Stage2Directory)/sdk/**/testhost.dll;
+                            $(Stage2Directory)/sdk/**/vstest.console.dll">
+        <Authenticode>$(InternalCertificateId)</Authenticode>
+      </FilesToSign>
+      <!-- Built files for the packages -->
+      <FilesToSign Include="$(Stage2CompilationDirectory)/forPackaging/**/*dotnet*.dll;
+                            $(Stage2CompilationDirectory)/forPackaging/**/Microsoft.Extensions.DependencyModel.dll;
+                            $(Stage2CompilationDirectory)/forPackaging/**/Microsoft.Extensions.Testing.Abstractions.dll">
+        <Authenticode>$(InternalCertificateId)</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="SignNuPkgContents" DependsOnTargets="GetSignNuPkgContentsFiles;SignFiles" />
+
+  <Target Name="GetSignNuPkgContentsFiles">
+    <PropertyGroup>
+      <OutDir>$(RepoRoot)/src/Microsoft.DotNet.Cli.Utils</OutDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <!-- NuPkg contents -->
+      <FilesToSign Include="$(OutDir)/bin/**/Microsoft.DotNet.Cli.Utils.dll">
+        <Authenticode>$(InternalCertificateId)</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="SignMsiAndCab" DependsOnTargets="GetSignMsiAndCabFiles;SignFiles" />
+
+  <Target Name="GetSignMsiAndCabFiles">
+    <PropertyGroup>
+      <OutDir>$(PackagesDirectory)</OutDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <FilesToSign Include="$(PackagesDirectory)/**/*.msi">
+        <Authenticode>$(InternalCertificateId)</Authenticode>
+      </FilesToSign>
+      <FilesToSign Include="$(PackagesDirectory)/**/*.cab">
+        <Authenticode>$(InternalCertificateId)</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="SignEngine" DependsOnTargets="GetSignEngineFiles;SignFiles" />
+
+  <Target Name="GetSignEngineFiles">
+    <PropertyGroup>
+      <OutDir>$(PackagesDirectory)</OutDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <FilesToSign Include="$(PackagesDirectory)/**/*engine.exe">
+        <Authenticode>$(InternalCertificateId)</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="SignCliBundle" DependsOnTargets="GetSignCliBundleFiles;SignFiles" />
+
+  <Target Name="GetSignCliBundleFiles">
+    <PropertyGroup>
+      <OutDir>$(PackagesDirectory)</OutDir>
+    </PropertyGroup>
+    <ItemGroup>
+      <FilesToSign Include="$(PackagesDirectory)/**/*.exe">
+        <Authenticode>$(InternalCertificateId)</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <Import Project="$(RepoRoot)/build_tools/MicroBuild.Core.targets" />
+</Project>

--- a/buildpipeline/DotNet-CLI-CentOS-x64.json
+++ b/buildpipeline/DotNet-CLI-CentOS-x64.json
@@ -1,0 +1,172 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Shell Script build.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "build.sh",
+        "args": "$(BuildArguments)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos --targets Default",
+      "allowOverride": true
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CLIBUILD_SKIP_TESTS": {
+      "value": "true",
+      "allowOverride": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [ ],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 90,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "DotNet-CLI-CentOS-x64",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/DotNet-CLI-CentOS-x64.json
+++ b/buildpipeline/DotNet-CLI-CentOS-x64.json
@@ -69,7 +69,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker centos --targets Default /p:BranchName=sandbox",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -89,7 +89,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CHECKSUM_STORAGE_KEY": {
       "value": "PassedViaPipeBuild"
@@ -98,7 +98,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CLIBUILD_SKIP_TESTS": {
       "value": "true",

--- a/buildpipeline/DotNet-CLI-opensuse13.2-x64.json
+++ b/buildpipeline/DotNet-CLI-opensuse13.2-x64.json
@@ -1,0 +1,172 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Shell Script build.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "build.sh",
+        "args": "$(BuildArguments)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.13.2 --targets Default",
+      "allowOverride": true
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CLIBUILD_SKIP_TESTS": {
+      "value": "true",
+      "allowOverride": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [ ],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 90,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "DotNet-CLI-opensuse13.2-x64",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/DotNet-CLI-opensuse13.2-x64.json
+++ b/buildpipeline/DotNet-CLI-opensuse13.2-x64.json
@@ -69,7 +69,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.13.2 --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker opensuse.13.2 --targets Default /p:BranchName=sandbox",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -89,7 +89,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CHECKSUM_STORAGE_KEY": {
       "value": "PassedViaPipeBuild"
@@ -98,7 +98,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CLIBUILD_SKIP_TESTS": {
       "value": "true",

--- a/buildpipeline/Dotnet-CLI-Debian8-x64.json
+++ b/buildpipeline/Dotnet-CLI-Debian8-x64.json
@@ -69,7 +69,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian --targets Default /p:BranchName=sandbox",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -89,7 +89,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CHECKSUM_STORAGE_KEY": {
       "value": "PassedViaPipeBuild"
@@ -98,7 +98,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CLIBUILD_SKIP_TESTS": {
       "value": "true",

--- a/buildpipeline/Dotnet-CLI-Debian8-x64.json
+++ b/buildpipeline/Dotnet-CLI-Debian8-x64.json
@@ -1,0 +1,172 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Shell Script build.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "build.sh",
+        "args": "$(BuildArguments)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker debian --targets Default",
+      "allowOverride": true
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CLIBUILD_SKIP_TESTS": {
+      "value": "true",
+      "allowOverride": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [ ],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 90,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "Dotnet-CLI-Debian8-x64",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/Dotnet-CLI-Fedora23-x64.json
+++ b/buildpipeline/Dotnet-CLI-Fedora23-x64.json
@@ -69,7 +69,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.23 --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.23 --targets Default /p:BranchName=sandbox",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -89,7 +89,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CHECKSUM_STORAGE_KEY": {
       "value": "PassedViaPipeBuild"
@@ -98,7 +98,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CLIBUILD_SKIP_TESTS": {
       "value": "true",

--- a/buildpipeline/Dotnet-CLI-Fedora23-x64.json
+++ b/buildpipeline/Dotnet-CLI-Fedora23-x64.json
@@ -1,0 +1,172 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Shell Script build.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "build.sh",
+        "args": "$(BuildArguments)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "--skip-prereqs --configuration $(BuildConfiguration)  --docker fedora.23 --targets Default",
+      "allowOverride": true
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CLIBUILD_SKIP_TESTS": {
+      "value": "true",
+      "allowOverride": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [ ],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 90,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "Dotnet-CLI-Fedora23-x64",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/Dotnet-CLI-OSX-x64.json
+++ b/buildpipeline/Dotnet-CLI-OSX-x64.json
@@ -1,0 +1,175 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Shell Script build.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "build.sh",
+        "args": "$(BuildArguments)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
+      "allowOverride": true
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CLIBUILD_SKIP_TESTS": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "PUBLISH_LZMA_TO_AZURE_BLOB": {
+      "value": "true"
+    }
+  },
+  "demands": [
+    "Agent.OS -equals darwin"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [ ],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 90,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "Dotnet-CLI-OSX-x64",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/Dotnet-CLI-OSX-x64.json
+++ b/buildpipeline/Dotnet-CLI-OSX-x64.json
@@ -69,7 +69,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default /p:BranchName=sandbox",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -89,7 +89,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CHECKSUM_STORAGE_KEY": {
       "value": "PassedViaPipeBuild"
@@ -98,7 +98,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CLIBUILD_SKIP_TESTS": {
       "value": "true",

--- a/buildpipeline/Dotnet-CLI-RHEL7-x64.json
+++ b/buildpipeline/Dotnet-CLI-RHEL7-x64.json
@@ -1,0 +1,189 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Clean docker containers",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "bash",
+        "arguments": "-c \"docker ps -a -q -f status=exited | xargs --no-run-if-empty docker rm -v\"",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Run docker",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "docker",
+        "arguments": "run -t --rm --sig-proxy=true --name $(Build.BuildId) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CHANNEL -e CONNECTION_STRING -e REPO_ID -e REPO_USER -e REPO_PASS -e REPO_SERVER -e DOTNET_BUILD_SKIP_CROSSGEN -e PUBLISH_TO_AZURE_BLOB -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD -e ARTIFACT_STORAGE_KEY -e ARTIFACT_STORAGE_ACCOUNT -e ARTIFACT_STORAGE_CONTAINER -e CHECKSUM_STORAGE_KEY -e CHECKSUM_STORAGE_ACCOUNT -e CHECKSUM_STORAGE_CONTAINER chcosta/dotnetcore:rhel7_prereqs /bin/bash -c \"git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
+      "allowOverride": true
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CLIBUILD_SKIP_TESTS": {
+      "value": "true",
+      "allowOverride": true
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [ ],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 90,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "Dotnet-CLI-RHEL7-x64",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/Dotnet-CLI-RHEL7-x64.json
+++ b/buildpipeline/Dotnet-CLI-RHEL7-x64.json
@@ -87,7 +87,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --targets Default /p:BranchName=sandbox",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -107,7 +107,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CHECKSUM_STORAGE_KEY": {
       "value": "PassedViaPipeBuild"
@@ -116,7 +116,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CLIBUILD_SKIP_TESTS": {
       "value": "true",

--- a/buildpipeline/Dotnet-CLI-RHEL7-x64.json
+++ b/buildpipeline/Dotnet-CLI-RHEL7-x64.json
@@ -22,17 +22,18 @@
       "enabled": true,
       "continueOnError": false,
       "alwaysRun": false,
-      "displayName": "Run docker",
+      "displayName": "Run build in Docker container",
       "timeoutInMinutes": 0,
       "task": {
-        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
-        "versionSpec": "1.*",
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
         "definitionType": "task"
       },
       "inputs": {
-        "filename": "docker",
-        "arguments": "run -t --rm --sig-proxy=true --name $(Build.BuildId) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CHANNEL -e CONNECTION_STRING -e REPO_ID -e REPO_USER -e REPO_PASS -e REPO_SERVER -e DOTNET_BUILD_SKIP_CROSSGEN -e PUBLISH_TO_AZURE_BLOB -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD -e ARTIFACT_STORAGE_KEY -e ARTIFACT_STORAGE_ACCOUNT -e ARTIFACT_STORAGE_CONTAINER -e CHECKSUM_STORAGE_KEY -e CHECKSUM_STORAGE_ACCOUNT -e CHECKSUM_STORAGE_CONTAINER chcosta/dotnetcore:rhel7_prereqs /bin/bash -c \"git clean -X -d -f; ./build.sh $(BuildArguments)\"",
-        "workingFolder": "",
+        "scriptPath": "scripts/dockerrun-as-current-user.sh",
+        "args": "-t --rm --sig-proxy=true --name $(Build.BuildId) -v $(Build.SourcesDirectory):/opt/code -w /opt/code -e CHANNEL -e CONNECTION_STRING -e REPO_ID -e REPO_USER -e REPO_PASS -e REPO_SERVER -e DOTNET_BUILD_SKIP_CROSSGEN -e PUBLISH_TO_AZURE_BLOB -e NUGET_FEED_URL -e NUGET_API_KEY -e GITHUB_PASSWORD -e ARTIFACT_STORAGE_KEY -e ARTIFACT_STORAGE_ACCOUNT -e ARTIFACT_STORAGE_CONTAINER -e CHECKSUM_STORAGE_KEY -e CHECKSUM_STORAGE_ACCOUNT -e CHECKSUM_STORAGE_CONTAINER chcosta/dotnetcore:rhel7_prereqs /bin/bash -c \"HOME=/opt/code; git clean -X -d -f; ./build.sh $(BuildArguments)\"",
+        "disableAutoCwd": "false",
+        "cwd": "",
         "failOnStandardError": "false"
       }
     }

--- a/buildpipeline/Dotnet-CLI-Signing-Windows-x64.json
+++ b/buildpipeline/Dotnet-CLI-Signing-Windows-x64.json
@@ -315,7 +315,7 @@
         "scriptType": "inlineScript",
         "scriptName": "",
         "arguments": "$(MygetApiKey)",
-        "inlineScript": "$NuGetExe = Join-Path $env:BUILD_REPOSITORY_LOCALPATH \".nuget\\nuget.exe\"\n\n& $NuGetExe push -Source https://dotnet.myget.org/F/dotnet-cli/ -ApiKey $args[0] artifacts\\$env:RID\\packages\\Microsoft*.nupkg",
+        "inlineScript": "$NuGetExe = Join-Path $env:BUILD_REPOSITORY_LOCALPATH \".nuget\\nuget.exe\"\n\n& $NuGetExe push -Source https://dotnet.myget.org/F/dotnet-cli-private/ -ApiKey $args[0] artifacts\\$env:RID\\packages\\Microsoft*.nupkg",
         "workingFolder": "",
         "failOnStandardError": "true"
       }
@@ -333,7 +333,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "/p:Configuration=$(BuildConfiguration) /t:Publish",
+        "arguments": "/p:Configuration=$(BuildConfiguration) /p:BranchName=sandbox /t:Publish",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -420,7 +420,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CONNECTION_STRING": {
       "value": "PassedViaPipeBuild"
@@ -439,7 +439,7 @@
       "value": "Microsoft .NET Core 1.0.1 - SDK 1.0.0 Preview 4 (x64)"
     },
     "VS_FEED_URL": {
-      "value": "https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json"
+      "value": "https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-cli-test/nuget/v3/index.json"
     },
     "VS_FEED_PASSWORD": {
       "value": null,
@@ -456,7 +456,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CLIBUILD_SKIP_TESTS": {
       "value": "true",

--- a/buildpipeline/Dotnet-CLI-Signing-Windows-x64.json
+++ b/buildpipeline/Dotnet-CLI-Signing-Windows-x64.json
@@ -1,0 +1,547 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Install Signing Plugin",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "30666190-6959-11e5-9f96-f56098202fef",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "signType": "$(PB_SignType)",
+        "zipSources": "false",
+        "version": "",
+        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Compile",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "/p:Configuration=$(BuildConfiguration) /t:Compile",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Sign Assemblies",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "build\\Microsoft.DotNet.Cli.Signing.proj",
+        "platform": "",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/t:PostCompileSign $(MsbuildSigningArguments)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "15.0",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Sign NuPkg Contents",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "build\\Microsoft.DotNet.Cli.Signing.proj",
+        "platform": "",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/t:SignNuPkgContents $(MsbuildSigningArguments)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "15.0",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": false,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Test",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "/p:Configuration=$(BuildConfiguration) /t:Test",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Package",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "/p:Configuration=$(BuildConfiguration) /t:Package",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Sign MSI and CAB",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "build\\Microsoft.DotNet.Cli.Signing.proj",
+        "platform": "",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/t:SignMsiAndCab $(MsbuildSigningArguments)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "15.0",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Generate Bundle",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "/p:Configuration=$(BuildConfiguration) /t:Package",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Extract Engine from Bundle",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "/p:Configuration=$(BuildConfiguration) /t:ExtractEngineFromSdkBundle",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Sign Engine",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "build\\Microsoft.DotNet.Cli.Signing.proj",
+        "platform": "",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/t:SignEngine $(MsbuildSigningArguments)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "15.0",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Reattach Engine to Bundle",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "/p:Configuration=$(BuildConfiguration) /t:ReattachEngineToSdkBundle",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Sign Bundle",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "build\\Microsoft.DotNet.Cli.Signing.proj",
+        "platform": "",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/t:SignCliBundle $(MsbuildSigningArguments)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "15.0",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Perform Cleanup Tasks",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": { }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download NuGet.exe",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "inlineScript": "# Download nuget.exe to .nuget/nuget.exe\n$NuGetDir = Join-Path $env:BUILD_REPOSITORY_LOCALPATH \".nuget\"\n$NuGetExe = Join-Path $NuGetDir \"nuget.exe\"\n \nif (-not (Test-Path  $NuGetDir))\n{\n    New-Item -ItemType Directory -Force -Path $NuGetDir | Out-Null\n}\n\nif (-not (Test-Path $NuGetExe)) {\n    Write-Host 'Downloading nuget.exe to ' + $NuGetExe\n    wget https://dist.nuget.org/win-x86-commandline/v3.5.0-rc1/NuGet.exe -OutFile $NuGetExe\n}",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish NuGet Packages",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(MygetApiKey)",
+        "inlineScript": "$NuGetExe = Join-Path $env:BUILD_REPOSITORY_LOCALPATH \".nuget\\nuget.exe\"\n\n& $NuGetExe push -Source https://dotnet.myget.org/F/dotnet-cli/ -ApiKey $args[0] artifacts\\$env:RID\\packages\\Microsoft*.nupkg",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish Build Artifacts",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "/p:Configuration=$(BuildConfiguration) /t:Publish",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish Windows Installer NuPkg to VS Feed",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(VS_FEED_PASSWORD)",
+        "inlineScript": "$NuGetExe = Join-Path $env:BUILD_REPOSITORY_LOCALPATH \".nuget\\nuget.exe\"\n$Nupkg = Join-Path $env:BUILD_REPOSITORY_LOCALPATH \"artifacts\\$env:RID\\packages\\VS.Redist.Common.Net.Core.SDK.x64*.nupkg\"\n\n& $NuGetExe sources Add -Name \"VS\" -Source $env:VS_FEED_URL -username foobar -password $args[0]\n\n& $NuGetExe push -Source \"VS\" -ApiKey VSTS $Nupkg",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "-Configuration ${BuildConfiguration} -Targets Default -NoPackage",
+      "allowOverride": true
+    },
+    "COREHOST_TRACE": {
+      "value": "0",
+      "allowOverride": true
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ProductMoniker": {
+      "value": "Microsoft .NET Core 1.0.1 - SDK 1.0.0 Preview 4 (x64)"
+    },
+    "VS_FEED_URL": {
+      "value": "https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json"
+    },
+    "VS_FEED_PASSWORD": {
+      "value": null,
+      "isSecret": true
+    },
+    "MygetApiKey": {
+      "value": null,
+      "isSecret": true
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CLIBUILD_SKIP_TESTS": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "InternalCertificateId": {
+      "value": "400"
+    },
+    "ExternalCertificateId": {
+      "value": "135020001"
+    },
+    "RID": {
+      "value": "win81-x64"
+    },
+    "MsbuildSigningArguments": {
+      "value": "/p:Rid=$(RID) /p:Architecture=x64 /v:detailed"
+    },
+    "TeamName": {
+      "value": "DotNetCore"
+    },
+    "system.debug": {
+      "value": "false"
+    }
+  },
+  "demands": [
+    "Agent.OS -equals Windows_NT"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [
+        "build.SourceLabel"
+      ],
+      "artifactTypesToDelete": [ ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 120,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "Dotnet-CLI-Signing-Windows-x64",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/Dotnet-CLI-Signing-Windows-x86.json
+++ b/buildpipeline/Dotnet-CLI-Signing-Windows-x86.json
@@ -1,0 +1,498 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Install Signing Plugin",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "30666190-6959-11e5-9f96-f56098202fef",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "signType": "$(PB_SignType)",
+        "zipSources": "false",
+        "version": "",
+        "feedSource": "https://devdiv.pkgs.visualstudio.com/DefaultCollection/_packaging/MicroBuildToolset/nuget/v3/index.json"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Compile",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "-Architecture $(BuildArchitecture) /p:Configuration=$(BuildConfiguration) /t:Compile /v:normal",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Sign Assemblies",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "build\\Microsoft.DotNet.Cli.Signing.proj",
+        "platform": "",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/t:PostCompileSign $(MsbuildSigningArguments)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "15.0",
+        "msbuildArchitecture": "$(BuildArchitecture)",
+        "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": false,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Test",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "-Architecture $(BuildArchitecture) /p:Configuration=$(BuildConfiguration) /t:Compile /v:normal",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Package",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "-Architecture $(BuildArchitecture) /p:Configuration=$(BuildConfiguration) /t:Package /v:normal",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Sign MSI and CAB",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "build\\Microsoft.DotNet.Cli.Signing.proj",
+        "platform": "",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/t:SignMsiAndCab $(MsbuildSigningArguments)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "15.0",
+        "msbuildArchitecture": "$(BuildArchitecture)",
+        "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Generate Bundle",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "-Architecture $(BuildArchitecture) /p:Configuration=$(BuildConfiguration) /t:Package /v:normal",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Extract Engine from Bundle",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "-Architecture $(BuildArchitecture) /p:Configuration=$(BuildConfiguration) /t:ExtractEngineFromSdkBundle /v:normal",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Sign Engine",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "build\\Microsoft.DotNet.Cli.Signing.proj",
+        "platform": "",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/t:SignEngine $(MsbuildSigningArguments)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "15.0",
+        "msbuildArchitecture": "$(BuildArchitecture)",
+        "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Reattach Engine to Bundle",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "-Architecture $(BuildArchitecture) /p:Configuration=$(BuildConfiguration) /t:ReattachEngineToSdkBundle /v:normal",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Sign Bundle",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "build\\Microsoft.DotNet.Cli.Signing.proj",
+        "platform": "",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/t:SignCliBundle $(MsbuildSigningArguments)",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "15.0",
+        "msbuildArchitecture": "$(BuildArchitecture)",
+        "msbuildLocation": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Perform Cleanup Tasks",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "521a94ea-9e68-468a-8167-6dcf361ea776",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": { }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish Build Artifacts",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "bfc8bf76-e7ac-4a8c-9a55-a944a9f632fd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "build.cmd",
+        "arguments": "-Architecture $(BuildArchitecture) /p:Configuration=$(BuildConfiguration) /t:Publish  /v:normal",
+        "modifyEnvironment": "false",
+        "workingFolder": "",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Download NuGet.exe",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "",
+        "inlineScript": "# Download nuget.exe to .nuget/nuget.exe\n$NuGetDir = Join-Path $env:BUILD_REPOSITORY_LOCALPATH \".nuget\"\n$NuGetExe = Join-Path $NuGetDir \"nuget.exe\"\n \nif (-not (Test-Path  $NuGetDir))\n{\n    New-Item -ItemType Directory -Force -Path $NuGetDir | Out-Null\n}\n\nif (-not (Test-Path $NuGetExe)) {\n    Write-Host 'Downloading nuget.exe to ' + $NuGetExe\n    wget https://dist.nuget.org/win-x86-commandline/v3.5.0-rc1/NuGet.exe -OutFile $NuGetExe\n}",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Publish Windows Installer Nupkg to VS Feed",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(VS_FEED_PASSWORD)",
+        "inlineScript": "$NuGetExe = Join-Path $env:BUILD_REPOSITORY_LOCALPATH \".nuget\\nuget.exe\"\n$Nupkg = Join-Path $env:BUILD_REPOSITORY_LOCALPATH \"artifacts\\$env:RID\\packages\\VS.Redist.Common.Net.Core.SDK.x86*.nupkg\"\n\n& $NuGetExe sources Add -Name \"VS\" -Source $env:VS_FEED_URL -username foobar -password $args[0]\n\n& $NuGetExe push -Source \"VS\" -ApiKey VSTS $Nupkg",
+        "workingFolder": "",
+        "failOnStandardError": "true"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "-Configuration ${BuildConfiguration} -Targets Default -NoPackage",
+      "allowOverride": true
+    },
+    "COREHOST_TRACE": {
+      "value": "0",
+      "allowOverride": true
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "BuildArchitecture": {
+      "value": "x86"
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ProductMoniker": {
+      "value": "Microsoft .NET Core 1.0.1 - SDK 1.0.0 Preview 4 (x86)"
+    },
+    "VS_FEED_URL": {
+      "value": "https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json"
+    },
+    "VS_FEED_PASSWORD": {
+      "value": null,
+      "isSecret": true
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CLIBUILD_SKIP_TESTS": {
+      "value": "true"
+    },
+    "InternalCertificateId": {
+      "value": "400"
+    },
+    "ExternalCertificateId": {
+      "value": "135020001"
+    },
+    "RID": {
+      "value": "win81-x86"
+    },
+    "MsbuildSigningArguments": {
+      "value": "/p:Rid=$(RID) /p:Architecture=x86 /v:detailed"
+    },
+    "TeamName": {
+      "value": "DotNetCore"
+    },
+    "system.debug": {
+      "value": "false"
+    }
+  },
+  "demands": [
+    "Agent.OS -equals Windows_NT"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [
+        "build.SourceLabel"
+      ],
+      "artifactTypesToDelete": [ ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 120,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "Dotnet-CLI-Signing-Windows-x86",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/Dotnet-CLI-Signing-Windows-x86.json
+++ b/buildpipeline/Dotnet-CLI-Signing-Windows-x86.json
@@ -266,7 +266,7 @@
       },
       "inputs": {
         "filename": "build.cmd",
-        "arguments": "-Architecture $(BuildArchitecture) /p:Configuration=$(BuildConfiguration) /t:Publish  /v:normal",
+        "arguments": "-Architecture $(BuildArchitecture) /p:Configuration=$(BuildConfiguration) /p:BranchName=sandbox /t:Publish  /v:normal",
         "modifyEnvironment": "false",
         "workingFolder": "",
         "failOnStandardError": "false"
@@ -373,7 +373,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CONNECTION_STRING": {
       "value": "PassedViaPipeBuild"
@@ -395,7 +395,7 @@
       "value": "Microsoft .NET Core 1.0.1 - SDK 1.0.0 Preview 4 (x86)"
     },
     "VS_FEED_URL": {
-      "value": "https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json"
+      "value": "https://devdiv.pkgs.visualstudio.com/_packaging/dotnet-cli-test/nuget/v3/index.json"
     },
     "VS_FEED_PASSWORD": {
       "value": null,
@@ -408,7 +408,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CLIBUILD_SKIP_TESTS": {
       "value": "true"

--- a/buildpipeline/Dotnet-CLI-Ubuntu14.04-x64.json
+++ b/buildpipeline/Dotnet-CLI-Ubuntu14.04-x64.json
@@ -1,0 +1,182 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Shell Script build.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "build.sh",
+        "args": "$(BuildArguments)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default",
+      "allowOverride": true
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "REPO_ID": {
+      "value": "562fbfe0b2d7d0e0a43780c4"
+    },
+    "REPO_USER": {
+      "value": "dotnet"
+    },
+    "REPO_PASS": {
+      "value": "PassedViaPipeBuild"
+    },
+    "REPO_SERVER": {
+      "value": "azure-apt-cat.cloudapp.net"
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [
+        "build.SourceLabel"
+      ],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 90,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "Dotnet-CLI-Ubuntu14.04-x64",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/Dotnet-CLI-Ubuntu14.04-x64.json
+++ b/buildpipeline/Dotnet-CLI-Ubuntu14.04-x64.json
@@ -69,7 +69,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.14.04 --targets Default /p:BranchName=sandbox /p:SkipPublishToDebianRepo=true",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -101,7 +101,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CHECKSUM_STORAGE_KEY": {
       "value": "PassedViaPipeBuild"
@@ -110,7 +110,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     }
   },
   "demands": [

--- a/buildpipeline/Dotnet-CLI-Ubuntu16.04-x64.json
+++ b/buildpipeline/Dotnet-CLI-Ubuntu16.04-x64.json
@@ -1,0 +1,180 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Shell Script build.sh",
+      "timeoutInMinutes": 0,
+      "task": {
+        "id": "6c731c3c-3c68-459a-a5c9-bde6e6595b5b",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptPath": "build.sh",
+        "args": "$(BuildArguments)",
+        "disableAutoCwd": "false",
+        "cwd": "",
+        "failOnStandardError": "false"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "4777",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "BuildConfiguration": {
+      "value": "Release",
+      "allowOverride": true
+    },
+    "BuildArguments": {
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.16.04 --targets Default",
+      "allowOverride": true
+    },
+    "CONNECTION_STRING": {
+      "value": "PassedViaPipeBuild"
+    },
+    "PUBLISH_TO_AZURE_BLOB": {
+      "value": "true",
+      "allowOverride": true
+    },
+    "REPO_ID": {
+      "value": "562fbfe0b2d7d0e0a43780c4"
+    },
+    "REPO_USER": {
+      "value": "dotnet"
+    },
+    "REPO_PASS": {
+      "value": "PassedViaPipeBuild"
+    },
+    "REPO_SERVER": {
+      "value": "azure-apt-cat.cloudapp.net"
+    },
+    "GITHUB_PASSWORD": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "ARTIFACT_STORAGE_ACCOUNT": {
+      "value": "dotnetcli"
+    },
+    "ARTIFACT_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    },
+    "CHECKSUM_STORAGE_KEY": {
+      "value": "PassedViaPipeBuild"
+    },
+    "CHECKSUM_STORAGE_ACCOUNT": {
+      "value": "dotnetclichecksums"
+    },
+    "CHECKSUM_STORAGE_CONTAINER": {
+      "value": "dotnet"
+    }
+  },
+  "demands": [
+    "Agent.OS -equals linux"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [ ],
+      "artifactTypesToDelete": [
+        "FilePath",
+        "SymbolStore"
+      ],
+      "daysToKeep": 2,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "buildNumberFormat": "$(Date:yyyMMdd)$(Rev:.r)",
+  "jobAuthorizationScope": "projectCollection",
+  "jobTimeoutInMinutes": 90,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "connectedServiceId": "f4c31735-42d2-4c3a-bc47-7ac06fd0dccc",
+      "apiUrl": "https://api.github.com/repos/dotnet/cli",
+      "branchesUrl": "https://api.github.com/repos/dotnet/cli/branches",
+      "cloneUrl": "https://github.com/dotnet/cli.git",
+      "refsUrl": "https://api.github.com/repos/dotnet/cli/git/refs",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "fetchDepth": "0",
+      "cleanOptions": "0"
+    },
+    "id": "https://github.com/dotnet/cli.git",
+    "type": "GitHub",
+    "name": "dotnet/cli",
+    "url": "https://github.com/dotnet/cli.git",
+    "defaultBranch": "rel/1.0.0",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "quality": "definition",
+  "queue": {
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    },
+    "id": 36,
+    "name": "DotNet-Build"
+  },
+  "path": "\\",
+  "type": "build",
+  "id": 1,
+  "name": "Dotnet-CLI-Ubuntu16.04-x64",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/DefaultCollection/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097459
+  }
+}

--- a/buildpipeline/Dotnet-CLI-Ubuntu16.04-x64.json
+++ b/buildpipeline/Dotnet-CLI-Ubuntu16.04-x64.json
@@ -69,7 +69,7 @@
       "allowOverride": true
     },
     "BuildArguments": {
-      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.16.04 --targets Default",
+      "value": "--skip-prereqs --configuration $(BuildConfiguration) --docker ubuntu.16.04 --targets Default /p:BranchName=sandbox /p:SkipPublishToDebianRepo=true",
       "allowOverride": true
     },
     "CONNECTION_STRING": {
@@ -101,7 +101,7 @@
       "value": "dotnetcli"
     },
     "ARTIFACT_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     },
     "CHECKSUM_STORAGE_KEY": {
       "value": "PassedViaPipeBuild"
@@ -110,7 +110,7 @@
       "value": "dotnetclichecksums"
     },
     "CHECKSUM_STORAGE_CONTAINER": {
-      "value": "dotnet"
+      "value": "mlorbe"
     }
   },
   "demands": [

--- a/buildpipeline/pipeline.json
+++ b/buildpipeline/pipeline.json
@@ -1,0 +1,101 @@
+{
+  "Repository": "cli",
+  "Definitions": {
+    "Path": ".",
+    "Type": "VSTS",
+    "BaseUrl": "https://devdiv.visualstudio.com/DefaultCollection"
+  },
+  "Pipelines": [
+    {
+      "Name": "Trusted-All-Release",
+      "Parameters": {
+        "TreatWarningsAsErrors": "false"
+      },
+      "BuildParameters": {
+        "BuildConfiguration": "Release"
+      },
+      "Definitions": [
+        {
+          "Name": "DotNet-CLI-CentOS-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "CentOS 7.1",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CLI-Debian8-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "Debian 8.2",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CLI-Fedora23-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "Fedora 23",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CLI-opensuse13.2-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "OpenSuse 13.2",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CLI-OSX-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "OSX",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CLI-RHEL7-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "RedHat 7",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CLI-Signing-Windows-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CLI-Signing-Windows-x86",
+          "ReportingParameters": {
+            "OperatingSystem": "Windows",
+            "Type": "build/product/",
+            "Platform": "x86"
+          }
+        },
+        {
+          "Name": "DotNet-CLI-Ubuntu14.04-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "Ubuntu 14.04",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        },
+        {
+          "Name": "DotNet-CLI-Ubuntu16.04-x64",
+          "ReportingParameters": {
+            "OperatingSystem": "Ubuntu 16.04",
+            "Type": "build/product/",
+            "Platform": "x64"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/dockerrun-as-current-user.sh
+++ b/scripts/dockerrun-as-current-user.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+set -e
+
+docker run -u="$(id -u):$(id -g)" "$@"


### PR DESCRIPTION
These build definitions will be used by pipebuild to build the product.

The signing now uses MicroBuild because the builds are being moved to
the DevDiv VSTS instance, and the Microsoft Code Signing system which
was used in MSEng is not supported there.

MicroBuild does not support the .NET Core MSBuild, so the full-framework
MSBuild is used to build the signing targets.  However, the new build
machines do not have MSBuild 15, so they use 14. This means that
projects which use the new MSBuild 15 syntax fail to be imported.
They're not needed for the signing, so their importing is skipped by
using a new SkipMsBuild15Projects property.

Thanks to @crummel for doing most of the work on the signing logic.

/cc @piotrpMSFT @livarcocc @chcosta 