### PR TITLE
Work around `build test.sln` race condition until fixed

### DIFF
--- a/build/Microsoft.DotNet.Cli.Test.targets
+++ b/build/Microsoft.DotNet.Cli.Test.targets
@@ -82,7 +82,8 @@
   <Target Name="BuildTests"
           DependsOnTargets="RestoreTests;">
     <DotNetBuild ToolPath="$(Stage0Directory)"
-                 ProjectPath="&quot;$(TestDirectory)/Microsoft.DotNet.Cli.Tests.sln&quot;" />
+                 ProjectPath="&quot;$(TestDirectory)/Microsoft.DotNet.Cli.Tests.sln&quot;"
+                 MaxCpuCount="1" />
   </Target>
 
   <Target Name="CreateTestAssetPackageNuPkgs"

--- a/build_projects/dotnet-cli-build/DotNetBuild.cs
+++ b/build_projects/dotnet-cli-build/DotNetBuild.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli.Build
 {
-    public class DotNetBuild : DotNetTool
+    public class DotNetBuild : DotNetMSBuildTool
     {
         protected override string Command
         {
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetRuntime()} {GetOutputPath()}"; }
+            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetRuntime()} {GetOutputPath()}"; }
         }
 
         public string BuildBasePath { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetMSBuild.cs
+++ b/build_projects/dotnet-cli-build/DotNetMSBuild.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli.Build
 {
-    public class DotNetMSBuild : DotNetTool
+    public class DotNetMSBuild : DotNetMSBuildTool
     {
         protected override string Command
         {
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{GetArguments()}"; }
+            get { return $"{base.Args} {GetArguments()}"; }
         }
 
         public string Arguments { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetMSBuildTool.cs
+++ b/build_projects/dotnet-cli-build/DotNetMSBuildTool.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+using Microsoft.DotNet.Cli.Build.Framework;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public abstract class DotNetMSBuildTool : DotNetTool
+    {
+        public DotNetMSBuildTool()
+        {
+        }
+
+        public int MaxCpuCount {get; set;} = 0;
+
+        protected override string Args 
+        { 
+            get
+            {
+                return $"{GetMaxCpuCountArg()}";
+            } 
+        }
+
+        private string GetMaxCpuCountArg()
+        {
+            if (MaxCpuCount > 0)
+            {
+                return $"/m:{MaxCpuCount}";
+            }
+
+            return null;
+        }
+    }
+}

--- a/build_projects/dotnet-cli-build/DotNetMSBuildTool.cs
+++ b/build_projects/dotnet-cli-build/DotNetMSBuildTool.cs
@@ -9,10 +9,6 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public abstract class DotNetMSBuildTool : DotNetTool
     {
-        public DotNetMSBuildTool()
-        {
-        }
-
         public int MaxCpuCount {get; set;} = 0;
 
         protected override string Args 

--- a/build_projects/dotnet-cli-build/DotNetPack.cs
+++ b/build_projects/dotnet-cli-build/DotNetPack.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli.Build
 {
-    public class DotNetPack : DotNetTool
+    public class DotNetPack : DotNetMSBuildTool
     {
         protected override string Command
         {
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{GetProjectPath()} {GetConfiguration()} {GetNoBuild()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()} {MsbuildArgs}"; }
+            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetNoBuild()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()} {MsbuildArgs}"; }
         }
 
         public string Configuration { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetPublish.cs
+++ b/build_projects/dotnet-cli-build/DotNetPublish.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli.Build
 {
-    public class DotNetPublish : DotNetTool
+    public class DotNetPublish : DotNetMSBuildTool
     {
         protected override string Command
         {
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetNativeSubdirectory()} {GetBuildBasePath()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()} {GetMSBuildArgs()}"; }
+            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetNativeSubdirectory()} {GetBuildBasePath()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()} {GetMSBuildArgs()}"; }
         }
 
         public string BuildBasePath { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetRestore.cs
+++ b/build_projects/dotnet-cli-build/DotNetRestore.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli.Build
 {
-    public class DotNetRestore : DotNetTool
+    public class DotNetRestore : DotNetMSBuildTool
     {
         protected override string Command
         {
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{GetProjectPath()} {GetConfigFile()} {GetSource()} {GetPackages()} {GetSkipInvalidConfigurations()} {GetRuntime()} {GetAdditionalParameters()}"; }
+            get { return $"{base.Args} {GetProjectPath()} {GetConfigFile()} {GetSource()} {GetPackages()} {GetSkipInvalidConfigurations()} {GetRuntime()} {GetAdditionalParameters()}"; }
         }
 
         public string ConfigFile { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetTest.cs
+++ b/build_projects/dotnet-cli-build/DotNetTest.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.DotNet.Cli.Build
 {
-    public class DotNetTest : DotNetTool
+    public class DotNetTest : DotNetMSBuildTool
     {
         protected override string Command
         {
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{GetProjectPath()} {GetConfiguration()} {GetLogger()} {GetNoBuild()}"; }
+            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetLogger()} {GetNoBuild()}"; }
         }
 
         public string Configuration { get; set; }

--- a/test/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
+++ b/test/Msbuild.Tests.Utilities/Msbuild.Tests.Utilities.csproj
@@ -1,49 +1,29 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AssemblyName>Msbuild.Tests.Utilities</AssemblyName>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.DotNet.TestFramework\Microsoft.DotNet.TestFramework.csproj">
-      <FromP2P>true</FromP2P>
-    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.TestFramework\Microsoft.DotNet.TestFramework.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.ProjectJsonMigration\Microsoft.DotNet.ProjectJsonMigration.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Sln.Internal\Microsoft.DotNet.Cli.Sln.Internal.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj">
-      <FromP2P>true</FromP2P>
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj">
-      <FromP2P>true</FromP2P>
-    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj" />
   </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Runtime">
-      <FromP2P>true</FromP2P>
-    </Reference>
+    <Reference Include="System.Runtime" />
   </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="NETStandard.Library">
-      <Version>1.6.0</Version>
-    </PackageReference>
-    <PackageReference Include="System.Runtime.Serialization.Primitives">
-      <Version>4.3.0</Version>
-    </PackageReference>
-    <PackageReference Include="FluentAssertions">
-      <Version>4.18.0</Version>
-    </PackageReference>
-    <PackageReference Include="xunit">
-      <Version>2.2.0-beta4-build3444</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Build">
-      <Version>$(CLI_MSBuild_Version)</Version>
-    </PackageReference>
+    <PackageReference Include="NETStandard.Library" Version="1.6.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+    <PackageReference Include="FluentAssertions" Version="4.18.0" />
+    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
+    <PackageReference Include="Microsoft.Build" Version="$(CLI_MSBuild_Version)" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
@livarcocc @jonsequitur 

The key line here is the removal of <GenerateRuntimeConfigurationFiles>. Not sure why we thought this was needed for a library.

The rest is incidental cleanup of the csproj file.