### PR TITLE
display CommandParsingException gracefully

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandUnknownException.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandUnknownException.cs
@@ -4,10 +4,6 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class CommandUnknownException : GracefulException
     {
-        public CommandUnknownException()
-        {
-        }
-
         public CommandUnknownException(string commandName) : base(string.Format(
             LocalizableStrings.NoExecutableFoundMatchingCommand,
             commandName))

--- a/src/Microsoft.DotNet.Cli.Utils/ExceptionExtensions.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ExceptionExtensions.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Microsoft.DotNet.Cli.Utils.ExceptionExtensions
+namespace Microsoft.DotNet.Cli.Utils
 {
     internal static class ExceptionExtensions
     {
@@ -11,5 +11,10 @@ namespace Microsoft.DotNet.Cli.Utils.ExceptionExtensions
         {
             Reporter.Verbose.WriteLine($"Warning: Ignoring exception: {e.ToString().Yellow()}");
         }
+
+        public static bool ShouldBeDisplayedAsError(this Exception e) =>
+            e.Data.Contains(CLI_User_Displayed_Exception);
+
+        internal const string CLI_User_Displayed_Exception = "CLI_User_Displayed_Exception";
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/GracefulException.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/GracefulException.cs
@@ -4,12 +4,9 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class GracefulException : Exception
     {
-        public GracefulException()
-        {
-        }
-
         public GracefulException(string message) : base(message)
         {
+            Data.Add(ExceptionExtensions.CLI_User_Displayed_Exception, true);
         }
 
         public GracefulException(string format, params string[] args) : this(string.Format(format, args))
@@ -18,6 +15,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public GracefulException(string message, Exception innerException) : base(message, innerException)
         {
+            Data.Add(ExceptionExtensions.CLI_User_Displayed_Exception, true);
         }
     }
 }

--- a/src/Microsoft.DotNet.ProjectJsonMigration/ProjectMigrator.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/ProjectMigrator.cs
@@ -10,7 +10,6 @@ using Microsoft.DotNet.Internal.ProjectModel;
 using Microsoft.DotNet.Internal.ProjectModel.Graph;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Cli.Utils.ExceptionExtensions;
 using Microsoft.DotNet.Cli.Sln.Internal;
 using Microsoft.DotNet.ProjectJsonMigration.Rules;
 using Microsoft.DotNet.Tools.Common;

--- a/src/dotnet/CommandLine/CommandParsingException.cs
+++ b/src/dotnet/CommandLine/CommandParsingException.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools;
 
 namespace Microsoft.DotNet.Cli.CommandLine
@@ -18,6 +19,8 @@ namespace Microsoft.DotNet.Cli.CommandLine
         {
             Command = command;
             _isRequireSubCommandMissing = isRequireSubCommandMissing;
+
+            Data.Add(ExceptionExtensions.CLI_User_Displayed_Exception, true);
         }
 
         public CommandLineApplication Command { get; }

--- a/src/dotnet/CommandLine/CommandParsingException.cs
+++ b/src/dotnet/CommandLine/CommandParsingException.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
             Command = command;
             _isRequireSubCommandMissing = isRequireSubCommandMissing;
 
-            Data.Add(ExceptionExtensions.CLI_User_Displayed_Exception, true);
+            Data.Add("CLI_User_Displayed_Exception", true);
         }
 
         public CommandLineApplication Command { get; }

--- a/src/dotnet/MulticoreJitActivator.cs
+++ b/src/dotnet/MulticoreJitActivator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime.Loader;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Cli.Utils.ExceptionExtensions;
 using Microsoft.DotNet.Tools.Common;
 
 namespace Microsoft.DotNet.Cli

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.DotNet.Tools.Add;
@@ -76,9 +77,11 @@ namespace Microsoft.DotNet.Cli
                     return ProcessArgs(args);
                 }
             }
-            catch (GracefulException e)
+            catch (Exception e) when (e.ShouldBeDisplayedAsError())
             {
-                Reporter.Error.WriteLine(CommandContext.IsVerbose() ? e.ToString().Red().Bold() : e.Message.Red().Bold());
+                Reporter.Error.WriteLine(CommandContext.IsVerbose() ? 
+                        e.ToString().Red().Bold() : 
+                        e.Message.Red().Bold());
 
                 return 1;
             }

--- a/test/dotnet-new.Tests/NewCommandTests.cs
+++ b/test/dotnet-new.Tests/NewCommandTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using System;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.New.Tests
+{
+    public class NewCommandTests
+    {
+		private readonly ITestOutputHelper output;
+
+		public NewCommandTests(ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+        [Fact]
+        public void WhenSwitchIsSkippedThenItPrintsError()
+        {
+            var cmd = new DotnetCommand().Execute("new Web1.1");
+
+            cmd.ExitCode.Should().NotBe(0);
+            
+			cmd.StdErr.Should().Be("Unrecognized command or argument 'Web1.1'");
+            cmd.StdOut.Should().Be("Specify --help for a list of available options and commands.");
+		}
+	}
+}

--- a/test/dotnet-new.Tests/NewCommandTests.cs
+++ b/test/dotnet-new.Tests/NewCommandTests.cs
@@ -12,13 +12,6 @@ namespace Microsoft.DotNet.New.Tests
 {
     public class NewCommandTests
     {
-		private readonly ITestOutputHelper output;
-
-		public NewCommandTests(ITestOutputHelper output)
-		{
-			this.output = output;
-		}
-
         [Fact]
         public void WhenSwitchIsSkippedThenItPrintsError()
         {


### PR DESCRIPTION
This set of changes handles `CommandParsingException` gracefully (so as not to show the user a stack trace) and generalizes graceful exception display somewhat away from being type-specific.

It specifically addresses #5470.

