### PR TITLE
escape semicolons when forwarding RestoreSources to MSBuild

### DIFF
--- a/TestAssets/TestProjects/LibraryWithUnresolvablePackageReference/LibraryWithUnresolvablePackageReference.csproj
+++ b/TestAssets/TestProjects/LibraryWithUnresolvablePackageReference/LibraryWithUnresolvablePackageReference.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.5</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+  	<PackageReference Include="Something.Nonexistent" Version="1.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -80,8 +80,10 @@ namespace Microsoft.DotNet.Tools.MSBuild
         }
 
         private static string Escape(string arg) =>
+            // this is a workaround for https://github.com/Microsoft/msbuild/issues/1622
              (arg.StartsWith("/p:RestoreSources=", StringComparison.OrdinalIgnoreCase)) ?
-                arg.Replace(";", "%3B") : // <-- this is a workaround for https://github.com/Microsoft/msbuild/issues/1622
+                arg.Replace(";", "%3B") 
+                   .Replace("://", ":%2F%2F") : 
                 arg;
 
         private static string GetMSBuildExePath()

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -42,7 +42,6 @@ namespace Microsoft.DotNet.Tools.MSBuild
                     Type loggerType = typeof(MSBuildLogger);
 
                     argsToForward = argsToForward
-                        .Select(Escape)
                         .Concat(new[]
                         {
                             $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
@@ -56,7 +55,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
             _forwardingApp = new ForwardingApp(
                 GetMSBuildExePath(),
-                _msbuildRequiredParameters.Concat(argsToForward),
+                _msbuildRequiredParameters.Concat(argsToForward.Select(Escape)),
                 environmentVariables: _msbuildRequiredEnvironmentVariables);
         }
 

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -41,10 +41,12 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 {
                     Type loggerType = typeof(MSBuildLogger);
 
-                    argsToForward = argsToForward.Concat(new[]
-                    {
-                        $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
-                    });
+                    argsToForward = argsToForward
+                        .Select(Escape)
+                        .Concat(new[]
+                        {
+                            $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
+                        });
                 }
                 catch (Exception)
                 {
@@ -76,6 +78,11 @@ namespace Microsoft.DotNet.Tools.MSBuild
         {
             return app.Option("-v|--verbosity", LocalizableStrings.VerbosityOptionDescription, CommandOptionType.SingleValue);
         }
+
+        private static string Escape(string arg) =>
+             (arg.StartsWith("/p:RestoreSources=", StringComparison.OrdinalIgnoreCase)) ?
+                arg.Replace(";", "%3B") : // <-- this is a workaround for https://github.com/Microsoft/msbuild/issues/1622
+                arg;
 
         private static string GetMSBuildExePath()
         {

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -41,7 +41,6 @@ namespace Microsoft.DotNet.Tests
                 };
             }
         }
-
         public static IEnumerable<object[]> LibraryDependencyToolArguments
         {
             get


### PR DESCRIPTION
This change adds a workaround for https://github.com/Microsoft/msbuild/issues/1622 into `MSBuildForwardingApp`.