### PR TITLE
Fixes binding redirects generation  for project dependency tools

### DIFF
--- a/build/Microsoft.DotNet.Cli.Test.targets
+++ b/build/Microsoft.DotNet.Cli.Test.targets
@@ -93,7 +93,8 @@
     <DotNetRestore ToolPath="$(Stage2Directory)"
                    Source="$(TestPackagesDir)"
                    ConfigFile="$(RepoRoot)\NuGet.Config"
-                   ProjectPath="%(TestPackageProject.ProjectPath)" />
+                   ProjectPath="%(TestPackageProject.ProjectPath)"
+                   MsbuildArgs="%(TestPackageProjects.MsbuildArgs)" />
  
     <!-- https://github.com/NuGet/Home/issues/4063 -->
     <DotNetPack Output="$(TestPackagesDir)"

--- a/build/test/TestPackageProjects.targets
+++ b/build/test/TestPackageProjects.targets
@@ -96,6 +96,7 @@
         <VersionPrefix>1.0.0-rc-</VersionPrefix>
         <VersionSuffix>rc-$(TestPackageBuildVersionSuffix)</VersionSuffix>
         <Clean>True</Clean>
+        <RestoreArgs>/p:RuntimeIdentifier=$(CoreCLRRid)</RestoreArgs>
         <MsbuildArgs>/p:RuntimeIdentifier=$(CoreCLRRid)</MsbuildArgs>
       </BaseTestPackageProject>
       <BaseTestPackageProject Include="TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello">

--- a/build/test/TestProjects.targets
+++ b/build/test/TestProjects.targets
@@ -6,17 +6,15 @@
 
   <Target Name="SetupBuildTestProjectInputs">
     <ItemGroup>
-      <!--
+
       <PreTestProjectsToExclude Condition=" '$(IsDesktopAvailable)' != 'True' " 
-                             Include="test/binding-redirects.Tests/binding-redirects.Tests.csproj;" />
-      -->
-      <PreTestProjectsToExclude Include="test$(PathSeparator)binding-redirects.Tests$(PathSeparator)binding-redirects.Tests.csproj;" />
+                                Include="test$(PathSeparator)binding-redirects.Tests$(PathSeparator)binding-redirects.Tests.csproj;" />
 
       <PreTestProjectsToExclude Condition=" 'Non-test projects in test directory' != 'consider moving elsewhere' "
-                             Include="test$(PathSeparator)ArgumentsReflector$(PathSeparator)ArgumentsReflector.csproj;
-                                      test$(PathSeparator)Microsoft.DotNet.Tools.Tests.Utilities$(PathSeparator)Microsoft.DotNet.Tools.Tests.Utilities.csproj;
-                                      test$(PathSeparator)Msbuild.Tests.Utilities$(PathSeparator)Msbuild.Tests.Utilities.csproj;
-                                      test$(PathSeparator)Performance$(PathSeparator)Performance.csproj" />
+                                Include="test$(PathSeparator)ArgumentsReflector$(PathSeparator)ArgumentsReflector.csproj;
+                                         test$(PathSeparator)Microsoft.DotNet.Tools.Tests.Utilities$(PathSeparator)Microsoft.DotNet.Tools.Tests.Utilities.csproj;
+                                         test$(PathSeparator)Msbuild.Tests.Utilities$(PathSeparator)Msbuild.Tests.Utilities.csproj;
+                                         test$(PathSeparator)Performance$(PathSeparator)Performance.csproj" />
 
       <PreTestProjectsToExclude Condition=" 'Executed after primary test phase.' != ' Consider moving.' "
                              Include="test$(PathSeparator)Installer$(PathSeparator)Microsoft.DotNet.Cli.Msi.Tests$(PathSeparator)Microsoft.DotNet.Cli.Msi.Tests.csproj;" />

--- a/build_projects/dotnet-cli-build/DotNetBuild.cs
+++ b/build_projects/dotnet-cli-build/DotNetBuild.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetRuntime()} {GetOutputPath()}"; }
+            get { return $"{GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetRuntime()} {GetOutputPath()} {base.Args}"; }
         }
 
         public string BuildBasePath { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetMSBuild.cs
+++ b/build_projects/dotnet-cli-build/DotNetMSBuild.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{base.Args} {GetArguments()}"; }
+            get { return $"{GetArguments()} {base.Args}"; }
         }
 
         public string Arguments { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetMSBuildTool.cs
+++ b/build_projects/dotnet-cli-build/DotNetMSBuildTool.cs
@@ -11,11 +11,13 @@ namespace Microsoft.DotNet.Cli.Build
     {
         public int MaxCpuCount {get; set;} = 0;
 
+        public string MSBuildArgs { get; set; }
+
         protected override string Args 
         { 
             get
             {
-                return $"{GetMaxCpuCountArg()}";
+                return $"{GetMaxCpuCountArg()} {GetMSBuildArgs()}";
             } 
         }
 
@@ -24,6 +26,16 @@ namespace Microsoft.DotNet.Cli.Build
             if (MaxCpuCount > 0)
             {
                 return $"/m:{MaxCpuCount}";
+            }
+
+            return null;
+        }
+
+        private string GetMSBuildArgs()
+        {
+            if (!string.IsNullOrEmpty(MSBuildArgs))
+            {
+                return $"{MSBuildArgs}";
             }
 
             return null;

--- a/build_projects/dotnet-cli-build/DotNetPack.cs
+++ b/build_projects/dotnet-cli-build/DotNetPack.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetNoBuild()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()}"; }
+            get { return $"{GetProjectPath()} {GetConfiguration()} {GetNoBuild()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()} {base.Args}"; }
         }
 
         public string Configuration { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetPack.cs
+++ b/build_projects/dotnet-cli-build/DotNetPack.cs
@@ -12,14 +12,12 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetNoBuild()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()} {MsbuildArgs}"; }
+            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetNoBuild()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()}"; }
         }
 
         public string Configuration { get; set; }
 
         public bool NoBuild { get; set; }
-
-        public string MsbuildArgs { get; set; }
 
         public string Output { get; set; }
 

--- a/build_projects/dotnet-cli-build/DotNetPublish.cs
+++ b/build_projects/dotnet-cli-build/DotNetPublish.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetNativeSubdirectory()} {GetBuildBasePath()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()} {GetMSBuildArgs()}"; }
+            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetNativeSubdirectory()} {GetBuildBasePath()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()}"; }
         }
 
         public string BuildBasePath { get; set; }
@@ -22,8 +22,6 @@ namespace Microsoft.DotNet.Cli.Build
         public string Framework { get; set; }
 
         public bool NativeSubDirectory { get; set; }
-
-        public string MSBuildArgs { get; set; }
 
         public string Output { get; set; }
 
@@ -68,16 +66,6 @@ namespace Microsoft.DotNet.Cli.Build
             if (NativeSubDirectory)
             {
                 return $"--native-subdirectory";
-            }
-
-            return null;
-        }
-
-        private string GetMSBuildArgs()
-        {
-            if (!string.IsNullOrEmpty(MSBuildArgs))
-            {
-                return $"{MSBuildArgs}";
             }
 
             return null;

--- a/build_projects/dotnet-cli-build/DotNetPublish.cs
+++ b/build_projects/dotnet-cli-build/DotNetPublish.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetNativeSubdirectory()} {GetBuildBasePath()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()}"; }
+            get { return $"{GetProjectPath()} {GetConfiguration()} {GetFramework()} {GetNativeSubdirectory()} {GetBuildBasePath()} {GetOutput()} {GetVersionSuffix()} {GetRuntime()} {base.Args}"; }
         }
 
         public string BuildBasePath { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetRestore.cs
+++ b/build_projects/dotnet-cli-build/DotNetRestore.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{base.Args} {GetProjectPath()} {GetConfigFile()} {GetSource()} {GetPackages()} {GetSkipInvalidConfigurations()} {GetRuntime()} {GetAdditionalParameters()}"; }
+            get { return $"{GetProjectPath()} {GetConfigFile()} {GetSource()} {GetPackages()} {GetSkipInvalidConfigurations()} {GetRuntime()} {GetAdditionalParameters()} {base.Args}"; }
         }
 
         public string ConfigFile { get; set; }

--- a/build_projects/dotnet-cli-build/DotNetTest.cs
+++ b/build_projects/dotnet-cli-build/DotNetTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string Args
         {
-            get { return $"{base.Args} {GetProjectPath()} {GetConfiguration()} {GetLogger()} {GetNoBuild()}"; }
+            get { return $"{GetProjectPath()} {GetConfiguration()} {GetLogger()} {GetNoBuild()} {base.Args}"; }
         }
 
         public string Configuration { get; set; }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/IPackagedCommandSpecFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/IPackagedCommandSpecFactory.cs
@@ -13,7 +13,8 @@ namespace Microsoft.DotNet.Cli.Utils
             string nugetPackagesRoot,
             CommandResolutionStrategy commandResolutionStrategy,
             string depsFilePath,
-            string runtimeConfigPath);
+            string runtimeConfigPath,
+            string appConfigPath);
         
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/IProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/IProject.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         string FullOutputPath { get; }
 
+        string AppConfigPath { get; }
         Dictionary<string, string> EnvironmentVariables { get; }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 return _project
                     .AllEvaluatedProperties
                     .FirstOrDefault(p => p.Name.Equals("AppConfigForCompiler"))
-                    .EvaluatedValue;
+                    ?.EvaluatedValue;
             }
         }
 

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
@@ -41,6 +41,17 @@ namespace Microsoft.DotNet.Cli.Utils
             }
         }
 
+        public string AppConfigPath
+        {
+            get
+            {
+                return _project
+                    .AllEvaluatedProperties
+                    .FirstOrDefault(p => p.Name.Equals("AppConfigForCompiler"))
+                    .EvaluatedValue;
+            }
+        }
+
         public string FullOutputPath
         {
             get

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/PackagedCommandSpecFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/PackagedCommandSpecFactory.cs
@@ -27,7 +27,8 @@ namespace Microsoft.DotNet.Cli.Utils
             string nugetPackagesRoot,
             CommandResolutionStrategy commandResolutionStrategy,
             string depsFilePath,
-            string runtimeConfigPath)
+            string runtimeConfigPath,
+            string appConfigPath)
         {
             Reporter.Verbose.WriteLine(string.Format(
                 LocalizableStrings.AttemptingToFindCommand,
@@ -66,7 +67,8 @@ namespace Microsoft.DotNet.Cli.Utils
                 depsFilePath, 
                 commandResolutionStrategy,
                 nugetPackagesRoot,
-                runtimeConfigPath);
+                runtimeConfigPath,
+                appConfigPath);
         }
 
         private string GetCommandFilePath(
@@ -90,7 +92,8 @@ namespace Microsoft.DotNet.Cli.Utils
             string depsFilePath,
             CommandResolutionStrategy commandResolutionStrategy,
             string nugetPackagesRoot,
-            string runtimeConfigPath)
+            string runtimeConfigPath,
+            string appConfigPath)
         {
             var commandExtension = Path.GetExtension(commandPath);
 
@@ -104,7 +107,18 @@ namespace Microsoft.DotNet.Cli.Utils
                     nugetPackagesRoot,
                     runtimeConfigPath);
             }
-            
+
+            // Reporter.Verbose.WriteLine(string.Format(
+            //     LocalizableStrings.AttemptingToFindCommand,
+            //     PackagedCommandSpecFactoryName,
+            //     commandName,
+            //     toolLibrary.Name));
+Console.WriteLine($"appconfig: {appConfigPath} -> {commandPath}.config");
+            if (appConfigPath != null && File.Exists(appConfigPath))
+            {
+                File.Copy(appConfigPath, $"{commandPath}.config");
+            }
+
             return CreateCommandSpec(commandPath, commandArguments, commandResolutionStrategy);
         }
 

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectDependenciesCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectDependenciesCommandResolver.cs
@@ -120,6 +120,8 @@ namespace Microsoft.DotNet.Cli.Utils
             var normalizedNugetPackagesRoot =
                 PathUtility.EnsureNoTrailingDirectorySeparator(lockFile.PackageFolders.First().Path);
 
+            var appConfigPath = project.AppConfigPath;
+
             var commandSpec = _packagedCommandSpecFactory.CreateCommandSpecFromLibrary(
                         toolLibrary,
                         commandName,
@@ -128,7 +130,8 @@ namespace Microsoft.DotNet.Cli.Utils
                         normalizedNugetPackagesRoot,
                         s_commandResolutionStrategy,
                         depsFilePath,
-                        runtimeConfigPath);
+                        runtimeConfigPath,
+                        appConfigPath);
 
             commandSpec?.AddEnvironmentVariablesFromProject(project);
 

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -178,6 +178,7 @@ namespace Microsoft.DotNet.Cli.Utils
                     normalizedNugetPackagesRoot,
                     s_commandResolutionStrategy,
                     depsFilePath,
+                    null,
                     null);
 
             if (commandSpec == null)

--- a/test/binding-redirects.Tests/BindingRedirectTests.cs
+++ b/test/binding-redirects.Tests/BindingRedirectTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.BindingRedirects.Tests
             _appWithoutConfigProjectRoot = testSetup.AppWithoutConfigProjectRoot;
         }
 
-        [Fact(Skip="https://github.com/dotnet/cli/issues/4514")]
+        [Fact]
         public void Tool_Command_Runs_Executable_Dependency_For_App_With_Config()
         {
             new DependencyToolInvokerCommand()
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.BindingRedirects.Tests
                 .Should().Pass().And.NotHaveStdErr();
         }
 
-        [Fact(Skip="https://github.com/dotnet/cli/issues/4514")]
+        [Fact]
         public void Tool_Command_Runs_Executable_Dependency_For_App_Without_Config()
         {
             new DependencyToolInvokerCommand()


### PR DESCRIPTION
Very simple implementation, uses the app.config of the target application as the app.config of the tool in question. Future iterations may support merging the tool + app config file, or reducing the app config file to binding redirects only. However, given the very limited intended support scenario, keeping the change to a minimum is prudent.