### PR TITLE
fixing typos

### DIFF
--- a/src/dotnet/commands/dotnet-migrate/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-migrate/LocalizableStrings.cs
@@ -17,7 +17,7 @@ Defaults to current directory if nothing is specified.";
 
         public const string CmdTemplateDescription = "Base MSBuild template to use for migrated app. The default is the project included in dotnet new.";
 
-        public const string CmdVersionDescription = "The version of the sdk package that will be referenced in the migrated app. The default is the version of the sdk in dotnet new.";
+        public const string CmdVersionDescription = "The version of the SDK package that will be referenced in the migrated app. The default is the version of the SDK in dotnet new.";
 
         public const string CmdXprojFileDescription = "The path to the xproj file to use. Required when there is more than one xproj in a project directory.";
 

--- a/src/dotnet/commands/dotnet-publish/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-publish/LocalizableStrings.cs
@@ -16,7 +16,7 @@
 
         public const string RuntimeOption = "RUNTIME_IDENTIFIER";
 
-        public const string RuntimeOptionDescription = "Publish the project for a given runtime. This is used when creating self-contained deployment. Default is to publish a framework-dependented app.";
+        public const string RuntimeOptionDescription = "Publish the project for a given runtime. This is used when creating self-contained deployment. Default is to publish a framework-dependent app.";
 
         public const string OutputOption = "OUTPUT_DIR";
 

--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.cs
@@ -53,7 +53,7 @@
 
         public const string CmdNoBuildDescription = @"Do not build project before testing.";
 
-        public const string RunSettingsArgsHelpText = @"Any extra commandline runsettings arguments that should be passed to vstest. See 'dotnet vstest --help' for available options.
+        public const string RunSettingsArgsHelpText = @"Any extra command-line runsettings arguments that should be passed to vstest. See 'dotnet vstest --help' for available options.
                                         Example: -- RunConfiguration.ResultsDirectory=""C:\users\user\desktop\Results Directory"" MSTest.DeploymentEnabled=false";
 
         public const string CmdResultsDirectoryDescription = @"The test results directory will be created in the specified path if it does not exist.


### PR DESCRIPTION
Fixing some typos I found in the localizable strings. Wasn't sure if I needed to change the XLIFF files too or if that process was automatic.