### PR TITLE
[WIP] use FSharp.Sdk as bundled package

### DIFF
--- a/build/Microsoft.DotNet.Cli.BundledSdks.proj
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.proj
@@ -16,9 +16,6 @@
           Outputs="@(SdkContent->'$(SdkLayoutDirectory)/%(RecursiveDir)%(FileName)%(Extension)')">
     <Copy SourceFiles="@(SdkContent)"
           DestinationFiles="@(SdkContent->'$(SdkLayoutDirectory)/%(RecursiveDir)%(FileName)%(Extension)')" />
-    
-    <!-- Remove unused directories for FSharp.NET.Sdk, just Sdk directory is needed -->
-    <RemoveDir Condition=" '$([System.IO.Path]::GetFileName($(SdkLayoutDirectory)))' == 'FSharp.NET.Sdk' " Directories="$(SdkLayoutDirectory)/build;$(SdkLayoutDirectory)/buildCrossTargeting" />
 
     <Message Text="Copied Sdk $(SdkPackageName) from $(SdkNuPkgPath) to $(SdkLayoutDirectory)."
              Importance="High" />

--- a/build/Microsoft.DotNet.Cli.BundledSdks.props
+++ b/build/Microsoft.DotNet.Cli.BundledSdks.props
@@ -7,6 +7,6 @@
     <BundledSdk Include="Microsoft.NET.Sdk.Web" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Publish" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Web.ProjectSystem" Version="$(CLI_WEBSDK_Version)" />
-    <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.0-beta-040011" />
+    <BundledSdk Include="FSharp.Sdk" Version="1.0.0-beta-060000" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Use a package (`FSharp.Sdk`) who contains only the needed files to bundle, removing workaround.

fix https://github.com/dotnet/netcorecli-fsc/issues/56

will fails tests (i hope)

- [X] bundle `FSharp.Sdk` instead of `FSharp.NET.Sdk`
- [ ] update templates
