### PR TITLE
A few small fixes in master

### DIFF
--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -205,8 +205,6 @@
 
         <!-- Removing Full CLR built TestHost assemblies from getting Crossgen as it is throwing error -->
         <SdkFilesExclude Include="$(SdkOutputDirectory)/TestHost*/**/*" />
-        <!-- Remove NuGet.LibraryModel due to https://github.com/dotnet/coreclr/issues/9118 -->
-        <SdkFilesExclude Include="$(SdkOutputDirectory)/NuGet.LibraryModel.dll" />
         <SdkFiles Include="$(SdkOutputDirectory)/**/*" Exclude="@(SdkFilesExclude)" />
         <SdkFilesWithPEMarker Remove="*" />
       </ItemGroup>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>2.0.0-beta-001486-00</CLI_SharedFrameworkVersion>
-    <CLI_CoreCLRVersion>2.0.0-beta-25002-03</CLI_CoreCLRVersion>
+    <CLI_SharedFrameworkVersion>2.0.0-beta-001507-00</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.2.0-preview-000002-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
     <CLI_NETSDK_Version>1.0.0-alpha-20170125-1</CLI_NETSDK_Version>

--- a/build/Microsoft.DotNet.Cli.Monikers.props
+++ b/build/Microsoft.DotNet.Cli.Monikers.props
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SdkBrandName>Microsoft .NET Core 1.0.3 - SDK RC 4</SdkBrandName>
-    <SharedFrameworkBrandName>Microsoft .NET Core 1.0.3 - Runtime</SharedFrameworkBrandName>
-    <SharedHostBrandName>Microsoft .NET Core 1.1.0 - Host</SharedHostBrandName>
-    <HostFxrBrandName>Microsoft .NET Core 1.1.0 - Host FX Resolver</HostFxrBrandName>
+    <SdkBrandName>Microsoft .NET Core 2.0.0 - SDK Alpha</SdkBrandName>
+    <SharedFrameworkBrandName>Microsoft .NET Core 2.0.0 - Runtime</SharedFrameworkBrandName>
+    <SharedHostBrandName>Microsoft .NET Core 2.0.0 - Host</SharedHostBrandName>
+    <HostFxrBrandName>Microsoft .NET Core 2.0.0 - Host FX Resolver</HostFxrBrandName>
     
-    <AdditionalSharedFrameworkBrandName>Microsoft .NET Core 1.1.0 - Runtime</AdditionalSharedFrameworkBrandName>
-    <AdditionalSharedHostBrandName>Microsoft .NET Core 1.1.0 - Host</AdditionalSharedHostBrandName>
-    <AdditionalHostFxrBrandName>Microsoft .NET Core 1.1.0 - Host FX Resolver</AdditionalHostFxrBrandName>
+    <AdditionalSharedFrameworkBrandName>Microsoft .NET Core 1.0.3 - Runtime</AdditionalSharedFrameworkBrandName>
+    <AdditionalSharedHostBrandName>Microsoft .NET Core 1.0.1 - Host</AdditionalSharedHostBrandName>
+    <AdditionalHostFxrBrandName>Microsoft .NET Core 1.0.1 - Host FX Resolver</AdditionalHostFxrBrandName>
 
     <SharedFrameworkNugetName>Microsoft.NETCore.App</SharedFrameworkNugetName>
   </PropertyGroup>

--- a/build/crossgen/Microsoft.DotNet.Cli.Crossgen.targets
+++ b/build/crossgen/Microsoft.DotNet.Cli.Crossgen.targets
@@ -3,17 +3,10 @@
   <Target Name="InitCrossgenProps"
           DependsOnTargets="Init">
     <PropertyGroup>
-      <CoreCLRPackageName>runtime.$(CoreCLRRid).microsoft.netcore.runtime.coreclr</CoreCLRPackageName>
-      <CrossGenPackageName>runtime.$(CoreCLRRid).microsoft.netcore.runtime.coreclr</CrossGenPackageName>
-      <LibCLRJitPackageName>runtime.$(CoreCLRRid).microsoft.netcore.jit</LibCLRJitPackageName>
+      <RuntimeNETCoreAppPackageName>runtime.$(CoreCLRRid).microsoft.netcore.app</RuntimeNETCoreAppPackageName>
 
-      <CoreCLRLibsDir>$(NuGetPackagesDir)/$(CoreCLRPackageName)/$(CLI_CoreCLRVersion)/runtimes/$(CoreCLRRid)/lib/netstandard1.0</CoreCLRLibsDir>
-      <CrossgenPath>$(NuGetPackagesDir)/$(CrossGenPackageName)/$(CLI_CoreCLRVersion)/tools/crossgen$(ExeExtension)</CrossgenPath>
-      <LibCLRJitPath>$(NuGetPackagesDir)/$(LibCLRJitPackageName)/$(CLI_CoreCLRVersion)/runtimes/$(CoreCLRRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
+      <CrossgenPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(CLI_SharedFrameworkVersion)/tools/crossgen$(ExeExtension)</CrossgenPath>
+      <LibCLRJitPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(CLI_SharedFrameworkVersion)/runtimes/$(CoreCLRRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
     </PropertyGroup>
-
-    <ItemGroup>
-      <PlatformAssemblies Include="$(CoreCLRLibsDir)" />
-    </ItemGroup>
   </Target>
 </Project>

--- a/packaging/windows/clisdk/registrykeys.wxs
+++ b/packaging/windows/clisdk/registrykeys.wxs
@@ -8,11 +8,6 @@
           <RegistryValue Action="write" Name="$(var.NugetVersion)" Type="integer" Value="1" KeyPath="yes"/>
         </RegistryKey>
       </Component>
-      <Component Id="SetupRegistry_x86_RC2_Compat_Key" Directory="TARGETDIR" Win64="no">
-        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\sdk">
-          <RegistryValue Action="write" Name="2.0.0-alpha" Type="integer" Value="1" KeyPath="yes"/>
-        </RegistryKey>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/src/tool_roslyn/tool_roslyn.csproj
+++ b/src/tool_roslyn/tool_roslyn.csproj
@@ -14,12 +14,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.4.0" />
-
-    <!-- workaround for https://github.com/dotnet/standard/issues/191 so OpenSsl native assets aren't published -->
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.2.0" />
-    <PackageReference Include="System.Security.Cryptography.Encoding" Version="4.0.0" />
-    <PackageReference Include="System.Security.Cryptography.OpenSsl" Version="4.0.0" />
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateTestApps.cs
@@ -8,7 +8,6 @@ using Microsoft.DotNet.Tools.Test.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Xunit;
 using FluentAssertions;
 using System.IO;
@@ -303,12 +302,6 @@ namespace Microsoft.DotNet.Migration.Tests
         [InlineData("PJTestLibraryWithConfiguration")]
         public void ItMigratesALibrary(string projectName)
         {
-            // running into https://github.com/dotnet/coreclr/issues/9118 with crossgen'd csc on non-Windows 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && projectName == "TestLibraryWithAnalyzer")
-            {
-                return;
-            }
-
             var projectDirectory = TestAssets
                 .GetProjectJson(projectName)
                 .CreateInstance(identifier: projectName)

--- a/tools/CrossGen.Dependencies/CrossGen.Dependencies.csproj
+++ b/tools/CrossGen.Dependencies/CrossGen.Dependencies.csproj
@@ -5,7 +5,9 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64;osx.10.10-x64;rhel.7-x64</RuntimeIdentifiers>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="$(CLI_CoreCLRVersion)" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixing 3 small issues in CLI master:

1. Updating the branding for "2.0.0", so people are not confused.
2. Update crossgen to use the tool coming from Microsoft.NETCore.App 2.0.
   - Also removing a workaround for a bug in crossgen that has been fixed.
3. Remove the workaround for https://github.com/dotnet/standard/issues/191

@livarcocc @piotrpMSFT @jonsequitur 