### PR TITLE
use WindowsOnlyTheory where appropriate, introduce NonWindowsOnlyFactAttribute

### DIFF
--- a/test/ArgumentForwardingTests/ArgumentForwardingTests.cs
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Tests.ArgumentForwarding
         /// This is a critical scenario for the driver.
         /// </summary>
         /// <param name="testUserArgument"></param>
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData(@"""abc"" d e")]
         [InlineData(@"""abc""      d e")]
         [InlineData("\"abc\"\t\td\te")]
@@ -101,11 +101,6 @@ namespace Microsoft.DotNet.Tests.ArgumentForwarding
         [InlineData(@"a b c""def")]
         public void TestArgumentForwardingCmd(string testUserArgument)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return;
-            }
-
             // Get Baseline Argument Evaluation via Reflector
             // This does not need to be different for cmd because
             // it only establishes what the string[] args should be
@@ -148,18 +143,13 @@ namespace Microsoft.DotNet.Tests.ArgumentForwarding
             }
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData(@"a\""b c d")]
         [InlineData(@"a\\\""b c d")]
         [InlineData(@"""\a\"" \\""\\\ b c")]
         [InlineData(@"a\""b \\ cd ""\e f\"" \\""\\\")]
         public void TestArgumentForwardingCmdFailsWithUnbalancedQuote(string testArgString)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return;
-            }
-
             // Get Baseline Argument Evaluation via Reflector
             // This does not need to be different for cmd because
             // it only establishes what the string[] args should be

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/NonWindowsOnlyFactAttribute.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/NonWindowsOnlyFactAttribute.cs
@@ -1,0 +1,16 @@
+using Microsoft.DotNet.PlatformAbstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public class NonWindowsOnlyFactAttribute : FactAttribute
+    {
+        public NonWindowsOnlyFactAttribute()
+        {
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+                this.Skip = "This test requires windows to run";
+            }
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/WindowsOnlyFactAttribute.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/WindowsOnlyFactAttribute.cs
@@ -16,15 +16,4 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             }
         }
     }
-
-    public class WindowsOnlyTheoryAttribute : TheoryAttribute
-    {
-        public WindowsOnlyTheoryAttribute()
-        {
-            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Windows)
-            {
-                this.Skip = "This test requires windows to run";
-            }
-        }
-    }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/WindowsOnlyTheoryAttribute.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/WindowsOnlyTheoryAttribute.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.DotNet.PlatformAbstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public class WindowsOnlyTheoryAttribute : TheoryAttribute
+    {
+        public WindowsOnlyTheoryAttribute()
+        {
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Windows)
+            {
+                this.Skip = "This test requires windows to run";
+            }
+        }
+    }
+}

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -36,8 +36,8 @@ namespace Microsoft.DotNet.Tests
                 var projectOutputPath = $"AppWithProjTool2Fx\\bin\\Debug\\net451\\{rid}\\dotnet-desktop-and-portable.exe";
                 return new[]
                 {
-                    new object[] { "CoreFX", ".NETCoreApp,Version=v1.0", "lib\\netcoreapp1.0\\dotnet-desktop-and-portable.dll", true },
-                    new object[] { "NetFX", ".NETFramework,Version=v4.5.1", projectOutputPath, true }
+                    new object[] { "CoreFX", ".NETCoreApp,Version=v1.0", "lib\\netcoreapp1.0\\dotnet-desktop-and-portable.dll" },
+                    new object[] { "NetFX", ".NETFramework,Version=v4.5.1", projectOutputPath }
                 };
             }
         }
@@ -52,8 +52,8 @@ namespace Microsoft.DotNet.Tests
 
                 return new[]
                 {
-                    new object[] { "CoreFX", ".NETStandard,Version=v1.6", "lib\\netstandard1.6\\dotnet-desktop-and-portable.dll", true },
-                    new object[] { "NetFX", ".NETFramework,Version=v4.5.1", projectOutputPath, true }
+                    new object[] { "CoreFX", ".NETStandard,Version=v1.6", "lib\\netstandard1.6\\dotnet-desktop-and-portable.dll" },
+                    new object[] { "NetFX", ".NETFramework,Version=v4.5.1", projectOutputPath }
                 };
             }
         }
@@ -197,16 +197,10 @@ namespace Microsoft.DotNet.Tests
                 .And.NotHaveStdErr();
         }
 
-        // need conditional theories so we can skip on non-Windows
-        //[Theory(Skip="https://github.com/dotnet/cli/issues/4514")]
-        //[MemberData("DependencyToolArguments")]
-        public void TestFrameworkSpecificDependencyToolsCanBeInvoked(string identifier, string framework, string expectedDependencyToolPath, bool windowsOnly)
+        [WindowsOnlyTheory(Skip="https://github.com/dotnet/cli/issues/4514")]
+        [MemberData("DependencyToolArguments")]
+        public void TestFrameworkSpecificDependencyToolsCanBeInvoked(string identifier, string framework, string expectedDependencyToolPath)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && windowsOnly)
-            {
-                return;
-            }
-
             var testInstance = TestAssets.Get(TestAssetKinds.DesktopTestProjects, "AppWithProjTool2Fx")
                 .CreateInstance(identifier: identifier)
                 .WithSourceFiles()
@@ -228,15 +222,10 @@ namespace Microsoft.DotNet.Tests
                     .And.Pass();
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [MemberData("LibraryDependencyToolArguments")]
-        public void TestFrameworkSpecificLibraryDependencyToolsCannotBeInvoked(string identifier, string framework, string expectedDependencyToolPath, bool windowsOnly)
+        public void TestFrameworkSpecificLibraryDependencyToolsCannotBeInvoked(string identifier, string framework, string expectedDependencyToolPath)
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && windowsOnly)
-            {
-                return;
-            }
-
             var testInstance = TestAssets.Get(TestAssetKinds.DesktopTestProjects, "LibWithProjTool2Fx")
                 .CreateInstance(identifier: identifier)
                 .WithSourceFiles()


### PR DESCRIPTION
I found a few places where tests included an OS check and early return. I've replaced these with WindowsOnlyTheory. 

I've also added a `NonWindowsOnlyFactAttribute`. Once 2ea3af799d08dc156f8e908ca30acde8cb968a9e is merged to master, this can be used there to replace the same pattern.