### PR TITLE
Removing extra PackageReference workaround for tests

### DIFF
--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/dotnet-desktop-and-portable.csproj
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/dotnet-desktop-and-portable.csproj
@@ -19,12 +19,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <!--The below package ref is added as a workaround to issue : https://github.com/NuGet/Home/issues/4416
-      This should be removed when the issue is fixed-->
-  <ItemGroup>
-    <PackageReference Include="NewtonSoft.Json" Version="9.0.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />

--- a/TestAssets/TestProjects/DependencyContextFromTool/DependencyContextFromTool.csproj
+++ b/TestAssets/TestProjects/DependencyContextFromTool/DependencyContextFromTool.csproj
@@ -18,11 +18,6 @@
       <Version>1.0.0-*</Version>
     </DotNetCliToolReference>
   </ItemGroup>
-  <!--The below package ref is added as a workaround to issue : https://github.com/NuGet/Home/issues/4416
-      This should be removed when the issue is fixed-->
-  <ItemGroup>
-    <PackageReference Include="NewtonSoft.Json" Version="9.0.1" />
-  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE;TRACE</DefineConstants>
     <Optimize>true</Optimize>


### PR DESCRIPTION
Removing PackageReferences which were added to work around a test issue. I don't see any reason why these would be needed. When trying these locally restore works fine without the extra references.

Fixes https://github.com/NuGet/Home/issues/4416

//cc @rohit21agrawal 
