### PR TITLE
Change preview4 references to RC4

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 This repo contains the source code for cross-platform [.NET Core](http://github.com/dotnet/core) command line toolchain. It contains the implementation of each command, the native packages for various supported platforms as well as documentation. 
 
-Preview 4 release - MSBuild based tools
+RC 4 release - MSBuild based tools
 ---------------------------------------
 As was outlined in the ["Changes to project.json" blog post](https://blogs.msdn.microsoft.com/dotnet/2016/05/23/changes-to-project-json/), we have started work to move away from project.json to csproj and MSBuild. All the new `latest` releases from this repo (from `rel/1.0.0` branch) are MSBuild-enabled tools.
 
-The current official release of the csproj-enabled CLI tools is **CLI Preview 4**. 
+The current official release of the csproj-enabled CLI tools is **CLI RC 4**. 
 
 There are a couple of things to keep in mind:
 
-* Preview 4 CLI bits are still **in development** so some rough edges are to be expected. 
-* Preview 4 bits **do not support** project.json so you will have to either keep Preview 2 tools around or migrate your project or add a global.json file to your project to target preview2. You can find more information on this using the [project.json to csproj instructions](https://github.com/dotnet/cli/blob/rel/1.0.0/Documentation/ProjectJsonToCSProj.md). 
-* Preview 4 refers to the **CLI tools only** and does not cover Visual Studio, VS Code or Visual Studio for Mac. 
+* RC 4 CLI bits are still **in development** so some rough edges are to be expected. 
+* RC 4 bits **do not support** project.json so you will have to either keep Preview 2 tools around or migrate your project or add a global.json file to your project to target preview2. You can find more information on this using the [project.json to csproj instructions](https://github.com/dotnet/cli/blob/rel/1.0.0/Documentation/ProjectJsonToCSProj.md). 
+* RC 4 refers to the **CLI tools only** and does not cover Visual Studio, VS Code or Visual Studio for Mac. 
 * We welcome any and all issues that relate to MSBuild-based tools, so feel free to try them out and leave comments and file any bugs/problems.
 
 ### Download links


### PR DESCRIPTION
Preview4 is actually RC4 as all documentation and dotnet --info shows. I thought they were 2 separate things.

skipciplease