### PR TITLE
Migrate compilationOptions even when other deprecated options are present

### DIFF
--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateBuildOptions.cs
@@ -17,6 +17,23 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
     public class GivenThatIWantToMigrateBuildOptions : TestBase
     {
         [Fact]
+        public void MigratingDeprecatedCompilationOptionsWithEmitEntryPointPopulatesOutputTypeField()
+        {
+            var mockProj = RunBuildOptionsRuleOnPj(@"
+                {
+                    ""compilationOptions"": {
+                        ""emitEntryPoint"": ""true""
+                    },
+                    ""exclude"": [
+                        ""node_modules""
+                    ]
+                }");
+
+            mockProj.Properties.Count(p => p.Name == "OutputType").Should().Be(1);
+            mockProj.Properties.First(p => p.Name == "OutputType").Value.Should().Be("Exe");
+        }
+
+        [Fact]
         public void SpecifiedDefaultPropertiesAreRemovedWhenTheyExistInTheCsprojTemplate()
         {
             // Setup project with default properties


### PR DESCRIPTION
Fixes #5614 

@piotrpMSFT @livarcocc @krwq @jonsequitur 