### PR TITLE
change CommandLineApplication.Name for pack and restore to include 'dotnet'

### DIFF
--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Tools.Pack
 
             CommandLineApplication cmd = new CommandLineApplication(throwOnUnexpectedArg: false)
             {
-                Name = "pack",
+                Name = "dotnet pack",
                 FullName = LocalizableStrings.AppFullName,
                 Description = LocalizableStrings.AppDescription,
                 HandleRemainingArguments = true,

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Tools.Restore
 
             CommandLineApplication cmd = new CommandLineApplication(throwOnUnexpectedArg: false)
             {
-                Name = "restore",
+                Name = "dotnet restore",
                 FullName = LocalizableStrings.AppFullName,
                 Description = LocalizableStrings.AppDescription,
                 HandleRemainingArguments = true,

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Build.Construction;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
@@ -65,5 +66,33 @@ Advanced Commands:
             cmd.Should().Pass();
             cmd.StdOut.Should().ContainVisuallySameFragment(HelpText);
         }
+
+        [Theory]
+        [InlineData("pack", "Usage: dotnet pack [arguments] [options] [args]")]
+        [InlineData("new", "Usage: dotnet new [arguments] [options]")]
+        [InlineData("restore", "Usage: dotnet restore [arguments] [options] [args]")]
+        [InlineData("build", "Usage: dotnet build [arguments] [options] [args]")]
+        [InlineData("publish", "Usage: dotnet publish [arguments] [options] [args]")]
+        [InlineData("run", "Usage: dotnet run [options] [[--] <additional arguments>...]]")]
+        [InlineData("test", "Usage: dotnet test [arguments] [options] [args]")]
+        [InlineData("migrate", "Usage: dotnet migrate [arguments] [options]")]
+        [InlineData("clean", "Usage: dotnet clean [arguments] [options] [args]")]
+        [InlineData("sln", "Usage: dotnet sln [arguments] [options] [command]")]
+        [InlineData("sln add", "Usage: dotnet sln <SLN_FILE> add [options] [args]")]
+        [InlineData("sln list", "Usage: dotnet sln <SLN_FILE> list [options]")]
+        [InlineData("sln remove", "Usage: dotnet sln <SLN_FILE> remove [options] [args]")]
+        [InlineData("nuget", "Usage: dotnet nuget [options] [command]")]
+        // [InlineData("msbuild", "")]
+        // [InlineData("vstest", "")]
+        public void HelpOptionUsageSummaryIsConsistent(string command, string expectedUsage)
+        {
+            var cmd = new DotnetCommand()
+                .Execute($"{command} -h");
+            
+            cmd.Should().Pass();
+            
+            var actualUsage = cmd.StdOut.Split('\n').ElementAt(2);
+            actualUsage.Should().Be(expectedUsage);
+        }    
     }
 }

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -68,6 +68,9 @@ Advanced Commands:
         }
 
         [Theory]
+        [InlineData("add", "Usage: dotnet add [arguments] [options] [command]")]
+        [InlineData("add package", "Usage: dotnet add <PROJECT> package [arguments] [options]")]
+        [InlineData("add reference", "Usage: dotnet add <PROJECT> reference [options] [args]")]
         [InlineData("pack", "Usage: dotnet pack [arguments] [options] [args]")]
         [InlineData("new", "Usage: dotnet new [arguments] [options]")]
         [InlineData("restore", "Usage: dotnet restore [arguments] [options] [args]")]

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -93,9 +93,8 @@ Advanced Commands:
                 .Execute($"{command} -h");
             
             cmd.Should().Pass();
-            
-            var actualUsage = cmd.StdOut.Split('\n').ElementAt(2);
-            actualUsage.Should().Be(expectedUsage);
+          
+            cmd.StdOut.Should().Contain(Environment.NewLine + expectedUsage + Environment.NewLine);
         }    
     }
 }


### PR DESCRIPTION
This addresses a few inconsistencies in the "Usage" line of the help output for the `pack` and `restore` commands relative to most of the commands.

It addresses #4813. 