### PR TITLE
Fix dotnet new classlib to contain the correct NETStandard.Library version.

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -24,14 +24,22 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestPackages", "TestPackage
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{89905EC4-BC0F-443B-8ADF-691321F10108}"
 	ProjectSection(SolutionItems) = preProject
+		build\Microsoft.DotNet.Cli.BundledSdks.proj = build\Microsoft.DotNet.Cli.BundledSdks.proj
 		build\Microsoft.DotNet.Cli.BundledSdks.props = build\Microsoft.DotNet.Cli.BundledSdks.props
+		build\Microsoft.DotNet.Cli.BundledTemplates.proj = build\Microsoft.DotNet.Cli.BundledTemplates.proj
+		build\Microsoft.DotNet.Cli.BundledTemplates.props = build\Microsoft.DotNet.Cli.BundledTemplates.props
 		build\Microsoft.DotNet.Cli.Compile.targets = build\Microsoft.DotNet.Cli.Compile.targets
 		build\Microsoft.DotNet.Cli.DependencyVersions.props = build\Microsoft.DotNet.Cli.DependencyVersions.props
+		build\Microsoft.DotNet.Cli.GitCommitInfo.targets = build\Microsoft.DotNet.Cli.GitCommitInfo.targets
+		build\Microsoft.DotNet.Cli.HostInfo.targets = build\Microsoft.DotNet.Cli.HostInfo.targets
+		build\Microsoft.DotNet.Cli.InitRepo.props = build\Microsoft.DotNet.Cli.InitRepo.props
+		build\Microsoft.DotNet.Cli.InitRepo.targets = build\Microsoft.DotNet.Cli.InitRepo.targets
 		build\Microsoft.DotNet.Cli.Monikers.props = build\Microsoft.DotNet.Cli.Monikers.props
 		build\Microsoft.DotNet.Cli.Package.targets = build\Microsoft.DotNet.Cli.Package.targets
 		build\Microsoft.DotNet.Cli.Prepare.targets = build\Microsoft.DotNet.Cli.Prepare.targets
 		build\Microsoft.DotNet.Cli.Publish.targets = build\Microsoft.DotNet.Cli.Publish.targets
 		build\Microsoft.DotNet.Cli.Run.targets = build\Microsoft.DotNet.Cli.Run.targets
+		build\Microsoft.DotNet.Cli.Signing.proj = build\Microsoft.DotNet.Cli.Signing.proj
 		build\Microsoft.DotNet.Cli.tasks = build\Microsoft.DotNet.Cli.tasks
 		build\Microsoft.DotNet.Cli.Test.targets = build\Microsoft.DotNet.Cli.Test.targets
 	EndProjectSection

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -11,6 +11,6 @@
     <CLI_TestPlatform_Version>15.0.0-preview-20170125-04</CLI_TestPlatform_Version>
     <TemplateEngineVersion>1.0.0-beta1-20170202-111</TemplateEngineVersion>
     <TemplateEngineTemplateVersion>1.0.0-beta1-20170131-110</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta1-20170207-114</TemplateEngineTemplate2_0Version>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta1-20170209-117</TemplateEngineTemplate2_0Version>
   </PropertyGroup>
 </Project>

--- a/src/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli;
@@ -54,6 +53,7 @@ namespace Microsoft.DotNet.Tools.New
                 { "prefs:language", "C#" },
                 { "dotnet-cli-version", Product.Version },
                 { "RuntimeFrameworkVersion", new Muxer().SharedFxVersion },
+                { "NetStandardImplicitPackageVersion", new FrameworkDependencyFile().GetNetStandardLibraryVersion() },
             };
 
             return new DefaultTemplateEngineHost(HostIdentifier, "v" + Product.Version, CultureInfo.CurrentCulture.Name, preferences, builtIns);


### PR DESCRIPTION
Fix #5638

Getting the correct NETStandard.Library version by reading the shared frameowork's deps.json file.

@dotnet/dotnet-cli 
