### PR TITLE
Read default language for `dotnet new` from env var

### DIFF
--- a/src/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -49,9 +49,11 @@ namespace Microsoft.DotNet.Tools.New
                 { new Guid("10919118-4E13-4FA9-825C-3B4DA855578E"), () => typeof(CaseChangeMacro) }
             }.ToList();
 
+            string preferredLang = Environment.GetEnvironmentVariable("DOTNET_NEW_PREFERRED_LANG") ?? "C#";
+
             var preferences = new Dictionary<string, string>
             {
-                { "prefs:language", "C#" },
+                { "prefs:language", preferredLang },
                 { "dotnet-cli-version", Product.Version }
             };
 


### PR DESCRIPTION
Read `DOTNET_NEW_PREFERRED_LANG` as default language for `dotnet new`.
If not set, the default continue to be `C#`

Currently to create F# projects, we need to specify `-lang f#` foreach `dotnet new` invocation.
It's really annoying, and atm `dotnet new` doesnt yet support set the preference property.

This option can be removed later, when `dotnet new` support set the default language (as normal config)

With this pr

```
set DOTNET_NEW_PREFERRED_LANG=F#
dotnet new console
dotnet new lib
```

/cc @cartermp @dsyme 
