### PR TITLE
Updating the version of the ASP.NET packages that we migrate to, to the RTM version.

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/ConstantPackageVersions.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/ConstantPackageVersions.cs
@@ -5,8 +5,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration
 {
     internal class ConstantPackageVersions
     {
-        public const string AspNetToolsVersion = "1.0.0-msbuild3-final";
-        public const string AspNet110ToolsVersion = "1.1.0-msbuild3-final";
+        public const string AspNetToolsVersion = "1.0.0";
+        public const string AspNet110ToolsVersion = "1.1.0";
         public const string AspNetLTSPackagesVersion = "1.0.2";
         public const string EntityFrameworkLTSPackagesVersion = "1.0.2";
         public const string TestSdkPackageVersion = "15.0.0-preview-20170106-08";
@@ -15,6 +15,5 @@ namespace Microsoft.DotNet.ProjectJsonMigration
         public const string MstestTestAdapterVersion = "1.1.8-rc";
         public const string MstestTestFrameworkVersion = "1.0.8-rc";
         public const string BundleMinifierToolVersion = "2.2.301";
-        public const string WebSdkPackageVersion = "1.0.0-alpha-20161205-1-154" ;
     }
 }

--- a/src/Microsoft.DotNet.ProjectJsonMigration/SupportedPackageVersions.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/SupportedPackageVersions.cs
@@ -56,6 +56,17 @@ namespace Microsoft.DotNet.ProjectJsonMigration
                 {
                     new PackageDependencyInfo
                     {
+                        Name = "Microsoft.EntityFrameworkCore.Tools.DotNet",
+                        Version = "[1.0.0-*,)"
+                    },
+                    new PackageDependencyInfo {
+                        Name = "Microsoft.EntityFrameworkCore.Tools.DotNet",
+                        Version = ConstantPackageVersions.AspNetToolsVersion
+                    }
+                },
+                {
+                    new PackageDependencyInfo
+                    {
                         Name = "Microsoft.AspNetCore.Razor.Tools",
                         Version = "[1.0.0-*,)"
                     },

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTools.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTools.cs
@@ -59,6 +59,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Theory]
+        [InlineData("Microsoft.EntityFrameworkCore.Tools.DotNet", "Microsoft.EntityFrameworkCore.Tools.DotNet", ConstantPackageVersions.AspNetToolsVersion)]
         [InlineData("Microsoft.EntityFrameworkCore.Tools", "Microsoft.EntityFrameworkCore.Tools.DotNet", ConstantPackageVersions.AspNetToolsVersion)]
         [InlineData("Microsoft.VisualStudio.Web.CodeGeneration.Tools", "Microsoft.VisualStudio.Web.CodeGeneration.Tools", ConstantPackageVersions.AspNetToolsVersion)]
         [InlineData("Microsoft.DotNet.Watcher.Tools", "Microsoft.DotNet.Watcher.Tools", ConstantPackageVersions.AspNetToolsVersion)]
@@ -89,6 +90,14 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
                 }");
 
             var packageRef = mockProj.Items.Where(i => i.ItemType == "DotNetCliToolReference").Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItMergesEntityFrameworkCoreToolsAndEntityFrameworkCoreToolsDotNet()
+        {
+            var mockProj = RunPackageDependenciesRuleOnPj("{ \"tools\": { \"Microsoft.EntityFrameworkCore.Tools\": \"1.0.0-preview4-final\", \"Microsoft.EntityFrameworkCore.Tools.DotNet\": \"1.0.0-preview4-final\" } }");
+
+            EmitsToolReferences(mockProj, Tuple.Create("Microsoft.EntityFrameworkCore.Tools.DotNet", ConstantPackageVersions.AspNetToolsVersion));
         }
     }
 }


### PR DESCRIPTION
Updating the version of the ASP.NET packages that we migrate to, to the RTM package versions.

Fixes https://github.com/dotnet/cli/issues/5414.

@piotrpMSFT @jonsequitur @krwq @jgoshi 