### PR TITLE
Use dotnet-install from the cli master branch

### DIFF
--- a/run-build.ps1
+++ b/run-build.ps1
@@ -85,7 +85,7 @@ if ((Test-Path $bootStrapperPath) -eq 0)
 }
 
 # now execute it
-& $bootStrapperPath -RepositoryRoot (Get-Location) -ToolsLocalPath $toolsLocalPath -CliLocalPath $env:DOTNET_INSTALL_DIR_PJ -Architecture $Architecture | Out-File (Join-Path (Get-Location) "bootstrap.log")
+& $bootStrapperPath -DotNetInstallBranch master -RepositoryRoot (Get-Location) -ToolsLocalPath $toolsLocalPath -CliLocalPath $env:DOTNET_INSTALL_DIR_PJ -Architecture $Architecture | Out-File (Join-Path (Get-Location) "bootstrap.log")
 if ($LastExitCode -ne 0)
 {
     Write-Output "Boot-strapping failed with exit code $LastExitCode, see bootstrap.log for more information."

--- a/run-build.sh
+++ b/run-build.sh
@@ -147,7 +147,7 @@ if [ ! -f $bootStrapperPath ]; then
     chmod u+x $bootStrapperPath
 fi
 
-$bootStrapperPath --repositoryRoot "$REPOROOT" --toolsLocalPath "$toolsLocalPath" --cliInstallPath $DOTNET_INSTALL_DIR_PJ --architecture $ARCHITECTURE > bootstrap.log
+$bootStrapperPath --dotNetInstallBranch master --repositoryRoot "$REPOROOT" --toolsLocalPath "$toolsLocalPath" --cliInstallPath $DOTNET_INSTALL_DIR_PJ --architecture $ARCHITECTURE > bootstrap.log
 
 if [ $? != 0 ]; then
     echo "run-build: Error: Boot-strapping failed with exit code $?, see bootstrap.log for more information." >&2


### PR DESCRIPTION
During the `cli` build, the `cli` downloads and executes the bootstrap script from `buildtools`. The bootstrap script then downloads and executes the `dotnet-install` script from `cli`, but in the `rel/1.0.0` branch, not the `master` branch.

This means that someone building `cli`'s master branch will end up using the `dotnet-install.sh` or `dotnet-install.ps1` script from cli's `rel/1.0.0` branch.

Fix that by telling the bootstrap script to download and use the version of dotnet-install script from the `master` branch (which is the current branch the user is building).

Ideally, we would just call the dotnet-install script in the current repo/branch, but because the bootstrap script sits in the middle and is part of a different repository, we can't.

This is a workaround for #5410.

With this change, I can run `./build.sh /t:Compile` on RHEL 7.3 successfully. I didn't test the build on Windows.