### PR TITLE
Modifying the docker environment variables to be upper case

### DIFF
--- a/scripts/dockerrun.sh
+++ b/scripts/dockerrun.sh
@@ -133,8 +133,8 @@ docker run $INTERACTIVE -t --rm --sig-proxy=true \
     -e CHECKSUM_STORAGE_ACCOUNT \
     -e CHECKSUM_STORAGE_CONTAINER \
     -e CLIBUILD_SKIP_TESTS \
-    -e CommitCount \
-    -e DropSuffix \
-    -e ReleaseSuffix \
+    -e COMMITCOUNT \
+    -e DROPSUFFIX \
+    -e RELEASESUFFIX \
     $DOTNET_BUILD_CONTAINER_TAG \
     $BUILD_COMMAND "$@"


### PR DESCRIPTION
Modifying the docker environment variables to be upper case, because that's how VSO passes them along.

@piotrpMSFT @jonsequitur @jgoshi @krwq 
