### PR TITLE
Migration: do not add duplicate projects

### DIFF
--- a/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/App.sln
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/App.sln
@@ -1,0 +1,39 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26006.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "src\App\App.csproj", "{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Src", "Src", "{72BFCA87-B033-4721-8712-4D12166B4A39}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Debug|x64.ActiveCfg = Debug|x64
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Debug|x64.Build.0 = Debug|x64
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Debug|x86.ActiveCfg = Debug|x86
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Debug|x86.Build.0 = Debug|x86
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Release|x64.ActiveCfg = Release|x64
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Release|x64.Build.0 = Release|x64
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Release|x86.ActiveCfg = Release|x86
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{DDF3765C-59FB-4AA6-BE83-779ED13AA64A} = {72BFCA87-B033-4721-8712-4D12166B4A39}
+	EndGlobalSection
+EndGlobal

--- a/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/App/App.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Lib\Lib.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/App/Program.cs
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/App/Program.cs
@@ -1,0 +1,10 @@
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello from the main app");
+        Console.WriteLine(Lib.Library.GetMessage());
+    }
+}

--- a/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/Lib/Lib.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/Lib/Lib.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="1.6" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/Lib/Library.cs
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/Lib/Library.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Lib
+{
+    public class Library
+    {
+        public static string GetMessage()
+        {
+            return "Message from Lib";
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/App.sln
+++ b/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/App.sln
@@ -1,0 +1,36 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26006.2
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "App", "App\App.csproj", "{7072A694-548F-4CAE-A58F-12D257D5F486}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lib", "Lib\\Lib.csproj", "{B38B1FA5-B4C9-456A-8B71-8FCD62ACF400}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.ActiveCfg = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x64.Build.0 = Debug|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.ActiveCfg = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Debug|x86.Build.0 = Debug|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.ActiveCfg = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x64.Build.0 = Release|x64
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.ActiveCfg = Release|x86
+		{7072A694-548F-4CAE-A58F-12D257D5F486}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/App/App.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Lib\Lib.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/App/Program.cs
+++ b/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/App/Program.cs
@@ -1,0 +1,10 @@
+using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello from the main app");
+        Console.WriteLine(Lib.Library.GetMessage());
+    }
+}

--- a/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/Lib/Lib.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/Lib/Lib.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.4</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NETStandard.Library" Version="1.6" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/Lib/Library.cs
+++ b/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/Lib/Library.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Lib
+{
+    public class Library
+    {
+        public static string GetMessage()
+        {
+            return "Message from Lib";
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -274,7 +274,8 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             }
             set
             {
-                _filePath = PathUtility.GetPathWithDirectorySeparator(value);
+                _filePath = PathUtility.RemoveExtraPathSeparators(
+                    PathUtility.GetPathWithDirectorySeparator(value));
             }
         }
 

--- a/src/Microsoft.DotNet.Cli.Utils/PathUtility.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/PathUtility.cs
@@ -261,6 +261,32 @@ namespace Microsoft.DotNet.Tools.Common
             }
         }
 
+        public static string RemoveExtraPathSeparators(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            var components = path.Split(Path.DirectorySeparatorChar);
+            var result = string.Empty;
+
+            foreach (var component in components)
+            {
+                if (!string.IsNullOrEmpty(component))
+                {
+                    result = Path.Combine(result, component);
+                }
+            }
+
+            if (path[path.Length-1] == Path.DirectorySeparatorChar)
+            {
+                result += Path.DirectorySeparatorChar;
+            }
+
+            return result;
+        }
+
         public static bool HasExtension(string filePath, string extension)
         {
             var comparison = StringComparison.Ordinal;

--- a/src/dotnet/SlnFileExtensions.cs
+++ b/src/dotnet/SlnFileExtensions.cs
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.Tools.Common
             this SlnFile slnFile,
             SlnPropertySet nestedProjects)
         {
-            var solutionFolderPaths = new Dictionary<string, string>();
+            var solutionFolderPaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
             var solutionFolderProjects = slnFile.Projects.GetProjectsByType(ProjectTypeGuids.SolutionFolderGuid);
             foreach (var slnProject in solutionFolderProjects)


### PR DESCRIPTION
Fixes #5694 

Duplicate solution folder projects were being added if the existing solution folder had different casing than the on-disk folder. Duplicate projects were being added if the existing solution folder had file paths with escaped directory separators.

@piotrpMSFT @livarcocc @krwq @jonsequitur @eerhardt 