### PR TITLE
Updating the version test to use .version file instead of regex

### DIFF
--- a/test/dotnet.Tests/VersionTest.cs
+++ b/test/dotnet.Tests/VersionTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Tools.Test.Utilities;
@@ -18,14 +17,28 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void VersionCommandDisplaysCorrectVersion()
         {
+            var versionFilePath = Path.Combine(AppContext.BaseDirectory, ".version");
+            var version = GetVersionFromFile(versionFilePath);
+
             CommandResult result = new DotnetCommand()
                     .ExecuteWithCapturedOutput("--version");
 
             result.Should().Pass();
-            
-            Regex.IsMatch(result.StdOut.Trim(), @"[0-9]{1}\.[0-9]{1}\.[0-9]{1}-[a-zA-Z0-9]+-[0-9]{6}$").Should()
-                .BeTrue($"Unexpected dotnet sdk version - {result.StdOut}");
+            result.StdOut.Trim().Should().Be(version);
+        }
 
+        private string GetVersionFromFile(string versionFilePath)
+        {
+            using (var reader = new StreamReader(File.OpenRead(versionFilePath)))
+            {
+                SkipCommit(reader);
+                return reader.ReadLine();
+            }
+        }
+
+        private void SkipCommit(StreamReader reader)
+        {
+            reader.ReadLine();
         }
     }
 }

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -22,6 +22,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
+    <Content Include="..\..\artifacts\*\stage2\sdk\*\.version">
+      <Link>.version</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updating the version test to check that dotnet --version uses the .version file instead of using a regular expression to validate the printed version.

@piotrpMSFT @jonsequitur @krwq @jgoshi 