### PR TITLE
Default to C# project type guid

### DIFF
--- a/src/dotnet/ProjectInstanceExtensions.cs
+++ b/src/dotnet/ProjectInstanceExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Build.Execution;
+using Microsoft.DotNet.Cli.Sln.Internal;
 using System;
 using System.Linq;
 
@@ -37,9 +38,9 @@ namespace Microsoft.DotNet.Tools.Common
                 //ISSUE: https://github.com/dotnet/sdk/issues/522
                 //The real behavior we want (once DefaultProjectTypeGuid support is in) is to throw
                 //when we cannot find ProjectTypeGuid or DefaultProjectTypeGuid. But for now we
-                //need the same behavior we had before this change.
+                //need to default to the C# one.
                 //throw new GracefulException(CommonLocalizableStrings.UnsupportedProjectType);
-                projectTypeGuid = "{13B669BE-BB05-4DDF-9536-439F39A36129}"; // CPS guid
+                projectTypeGuid = ProjectTypeGuids.CSharpProjectTypeGuid;
             }
 
             return projectTypeGuid;

--- a/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
+++ b/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
@@ -35,7 +35,7 @@ VisualStudioVersion = 15.0.26006.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""App"", ""App\App.csproj"", ""{7072A694-548F-4CAE-A58F-12D257D5F486}""
 EndProject
-Project(""{13B669BE-BB05-4DDF-9536-439F39A36129}"") = ""Lib"", ""Lib\Lib.csproj"", ""__LIB_PROJECT_GUID__""
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Lib"", ""Lib\Lib.csproj"", ""__LIB_PROJECT_GUID__""
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -83,7 +83,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26006.2
 MinimumVisualStudioVersion = 10.0.40219.1
-Project(""{13B669BE-BB05-4DDF-9536-439F39A36129}"") = ""Lib"", ""Lib\Lib.csproj"", ""__LIB_PROJECT_GUID__""
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Lib"", ""Lib\Lib.csproj"", ""__LIB_PROJECT_GUID__""
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -120,7 +120,7 @@ Project(""{9A19103F-16F7-4668-BE54-9A1E7A4F7556}"") = ""App"", ""App.csproj"", "
 EndProject
 Project(""{2150E333-8FDC-42A3-9474-1A3956D46DE8}"") = ""src"", ""src"", ""__SRC_FOLDER_GUID__""
 EndProject
-Project(""{13B669BE-BB05-4DDF-9536-439F39A36129}"") = ""Lib"", ""src\Lib\Lib.csproj"", ""__LIB_PROJECT_GUID__""
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""Lib"", ""src\Lib\Lib.csproj"", ""__LIB_PROJECT_GUID__""
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Fixes #5688 

@piotrpMSFT @livarcocc @krwq @jonsequitur @eerhardt 

The work to have the DefaultProjectTypeGuid isn't available yet. Here is the PR:
https://github.com/Microsoft/msbuild/pull/1607

And work also has to be done for F#. What we will eventually do in the CLI is to throw if there isn't an explicit ProjectTypeGuid or a DefaultProjectTypeGuid defined. But until the work for writing DefaultProjectTypeGuid goes in we need to burn in some default. This work changes the default to be the C# one. We will still be wrong in other cases (like for a VB project or F# project or any other type of project). But at least default to C# rather than CPS.