### PR TITLE
Remove import of dir.props from Signing.proj

### DIFF
--- a/build/Microsoft.DotNet.Cli.Signing.proj
+++ b/build/Microsoft.DotNet.Cli.Signing.proj
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project InitialTargets="SetSigningProperties" DefaultTargets="SignFiles" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))/dir.props" />
+  <PropertyGroup>
+    <RepoRoot>$(MSBuildThisFileDirectory)/..</RepoRoot>
+  </PropertyGroup>
+  
   <Import Project="$(RepoRoot)/build_tools/MicroBuild.Core.props" />
 
   <!-- This will be overridden if we're building with MicroBuild. -->


### PR DESCRIPTION
The build agents in our VSTS pool don't yet have MSBuild 15, so the
signing project can't import any MSBuild 15 projects. (The signing
project is built with the desktop MSBuild because MicroBuild depends on
it.)  Once the agents have MSBuild 15, this import can be added back.