### PR TITLE
Misc build changes

### DIFF
--- a/build/Microsoft.DotNet.Cli.BuildDefaults.props
+++ b/build/Microsoft.DotNet.Cli.BuildDefaults.props
@@ -2,5 +2,8 @@
   <PropertyGroup>
     <CLITargets Condition=" '$(CLITargets)' == '' ">Prepare;Compile;Test;Package;Publish</CLITargets>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <IncludeAdditionalSharedFrameworks Condition=" '$(IncludeAdditionalSharedFrameworks)' == '' ">true</IncludeAdditionalSharedFrameworks>
+    <IncludeNuGetPackageArchive Condition=" '$(IncludeNuGetPackageArchive)' == '' ">true</IncludeNuGetPackageArchive>
+    <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' ">false</SkipBuildingInstallers>
   </PropertyGroup>
 </Project>

--- a/build/Microsoft.DotNet.Cli.Package.targets
+++ b/build/Microsoft.DotNet.Cli.Package.targets
@@ -7,7 +7,8 @@
   <Import Project="$(MSBuildThisFileDirectory)/package/Microsoft.DotNet.Cli.Installer.MSI.targets" />
   <Import Project="$(MSBuildThisFileDirectory)/package/Microsoft.DotNet.Cli.Installer.PKG.targets" />
 
-  <Target Name="GenerateInstallers" 
+  <Target Name="GenerateInstallers"
+          Condition=" '$(SkipBuildingInstallers)' != 'true' "
           DependsOnTargets="Init;Layout;GeneratePkgs;GenerateDebs;GenerateMsis" />
 
   <Target Name="Package"

--- a/build/Microsoft.DotNet.Cli.Prepare.targets
+++ b/build/Microsoft.DotNet.Cli.Prepare.targets
@@ -35,7 +35,7 @@
     </PropertyGroup>
 
     <!-- Additional Shared Framework to be installed -->
-    <PropertyGroup>
+    <PropertyGroup Condition=" '$(IncludeAdditionalSharedFrameworks)' == 'true' ">
       <AdditionalCoreSetupChannel>preview</AdditionalCoreSetupChannel>
       <AdditionalSharedFrameworkVersion>1.0.3</AdditionalSharedFrameworkVersion>
       <AdditionalSharedHostVersion>1.0.1</AdditionalSharedHostVersion>
@@ -61,7 +61,7 @@
 
   <Target Name="SetupDownloadHostAndSharedFxInputsOutputs" DependsOnTargets="Init">
     <PropertyGroup>
-      <CoreSetupBlobRootUrl>https://dotnetcli.azureedge.net/dotnet/</CoreSetupBlobRootUrl>
+      <CoreSetupBlobRootUrl Condition="'$(CoreSetupBlobRootUrl)' == ''">https://dotnetcli.azureedge.net/dotnet/</CoreSetupBlobRootUrl>
       <CoreSetupBlobRootUrlWithChannel>$(CoreSetupBlobRootUrl)$(CoreSetupChannel)</CoreSetupBlobRootUrlWithChannel>
       <SharedFrameworkArchiveBlobRootUrl>$(CoreSetupBlobRootUrlWithChannel)/Binaries/$(SharedFrameworkVersion)</SharedFrameworkArchiveBlobRootUrl>
       <CoreSetupInstallerBlobRootUrl>$(CoreSetupBlobRootUrlWithChannel)/Installers</CoreSetupInstallerBlobRootUrl>
@@ -78,21 +78,21 @@
       </_DownloadAndExtractItem>
 
       <_DownloadAndExtractItem Include="DownloadedSharedFrameworkInstallerFile"
-                               Condition="!Exists('$(DownloadedSharedFrameworkInstallerFile)') And '$(InstallerExtension)' != ''">
+                               Condition="'$(SkipBuildingInstallers)' != 'true' And !Exists('$(DownloadedSharedFrameworkInstallerFile)') And '$(InstallerExtension)' != ''">
         <Url>$(CoreSetupInstallerBlobRootUrl)/$(SharedFrameworkVersion)/$(DownloadedSharedFrameworkInstallerFileName)</Url>
         <DownloadFileName>$(DownloadedSharedFrameworkInstallerFile)</DownloadFileName>
         <ExtractDestination></ExtractDestination>
       </_DownloadAndExtractItem>
 
       <_DownloadAndExtractItem Include="DownloadedSharedHostInstallerFile"
-                               Condition="!Exists('$(DownloadedSharedHostInstallerFile)') And '$(InstallerExtension)' != ''">
+                               Condition="'$(SkipBuildingInstallers)' != 'true' And !Exists('$(DownloadedSharedHostInstallerFile)') And '$(InstallerExtension)' != ''">
         <Url>$(CoreSetupInstallerBlobRootUrl)/$(SharedHostVersion)/$(DownloadedSharedHostInstallerFileName)</Url>
         <DownloadFileName>$(DownloadedSharedHostInstallerFile)</DownloadFileName>
         <ExtractDestintation></ExtractDestintation>
       </_DownloadAndExtractItem>
 
       <_DownloadAndExtractItem Include="DownloadedHostFxrInstallerFile"
-                               Condition="!Exists('$(DownloadedHostFxrInstallerFile)') And '$(InstallerExtension)' != ''">
+                               Condition="'$(SkipBuildingInstallers)' != 'true' And !Exists('$(DownloadedHostFxrInstallerFile)') And '$(InstallerExtension)' != ''">
         <Url>$(CoreSetupInstallerBlobRootUrl)/$(HostFxrVersion)/$(DownloadedHostFxrInstallerFileName)</Url>
         <DownloadFileName>$(DownloadedHostFxrInstallerFile)</DownloadFileName>
         <ExtractDestintation></ExtractDestintation>
@@ -100,7 +100,7 @@
     </ItemGroup>
 
     <!-- Additional Shared Framework to be installed -->
-    <PropertyGroup>
+    <PropertyGroup Condition=" '$(IncludeAdditionalSharedFrameworks)' != 'false' ">
       <AdditionalCoreSetupBlobRootUrlWithChannel>$(CoreSetupBlobRootUrl)$(AdditionalCoreSetupChannel)</AdditionalCoreSetupBlobRootUrlWithChannel>
       <AdditionalSharedFrameworkArchiveBlobRootUrl>$(AdditionalCoreSetupBlobRootUrlWithChannel)/Binaries/$(AdditionalSharedFrameworkVersion)</AdditionalSharedFrameworkArchiveBlobRootUrl>
       <AdditionalCoreSetupInstallerBlobRootUrl>$(AdditionalCoreSetupBlobRootUrlWithChannel)/Installers</AdditionalCoreSetupInstallerBlobRootUrl>
@@ -108,7 +108,7 @@
       <AdditionalCombinedSharedHostAndFrameworkArchive>$(AdditionalCoreSetupDownloadDirectory)/combinedSharedHostAndFrameworkArchive</AdditionalCombinedSharedHostAndFrameworkArchive>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition=" '$(IncludeAdditionalSharedFrameworks)' != 'false' ">
       <_DownloadAndExtractItem Include="AdditionalCombinedSharedHostAndFrameworkArchive"
                                Condition="!Exists('$(AdditionalCombinedSharedHostAndFrameworkArchive)')">
         <Url>$(AdditionalSharedFrameworkArchiveBlobRootUrl)/$(AdditionalCombinedFrameworkHostCompressedFileName)</Url>
@@ -119,21 +119,21 @@
       </_DownloadAndExtractItem>
 
       <_DownloadAndExtractItem Include="AdditionalDownloadedSharedFrameworkInstallerFile"
-                               Condition="!Exists('$(AdditionalDownloadedSharedFrameworkInstallerFile)') And '$(InstallerExtension)' != ''">
+                               Condition="'$(SkipBuildingInstallers)' != 'true' And !Exists('$(AdditionalDownloadedSharedFrameworkInstallerFile)') And '$(InstallerExtension)' != ''">
         <Url>$(AdditionalCoreSetupInstallerBlobRootUrl)/$(AdditionalSharedFrameworkVersion)/$(AdditionalDownloadedSharedFrameworkInstallerFileName)</Url>
         <DownloadFileName>$(AdditionalDownloadedSharedFrameworkInstallerFile)</DownloadFileName>
         <ExtractDestination></ExtractDestination>
       </_DownloadAndExtractItem>
 
       <_DownloadAndExtractItem Include="AdditionalDownloadedSharedHostInstallerFile"
-                               Condition="!Exists('$(AdditionalDownloadedSharedHostInstallerFile)') And '$(InstallerExtension)' != ''">
+                               Condition="'$(SkipBuildingInstallers)' != 'true' And !Exists('$(AdditionalDownloadedSharedHostInstallerFile)') And '$(InstallerExtension)' != ''">
         <Url>$(AdditionalCoreSetupInstallerBlobRootUrl)/$(AdditionalSharedHostVersion)/$(AdditionalDownloadedSharedHostInstallerFileName)</Url>
         <DownloadFileName>$(AdditionalDownloadedSharedHostInstallerFile)</DownloadFileName>
         <ExtractDestintation></ExtractDestintation>
       </_DownloadAndExtractItem>
 
       <_DownloadAndExtractItem Include="AdditionalDownloadedHostFxrInstallerFile"
-                               Condition="!Exists('$(AdditionalDownloadedHostFxrInstallerFile)') And '$(InstallerExtension)' != ''">
+                               Condition="'$(SkipBuildingInstallers)' != 'true' And !Exists('$(AdditionalDownloadedHostFxrInstallerFile)') And '$(InstallerExtension)' != ''">
         <Url>$(AdditionalCoreSetupInstallerBlobRootUrl)/$(AdditionalHostFxrVersion)/$(AdditionalDownloadedHostFxrInstallerFileName)</Url>
         <DownloadFileName>$(AdditionalDownloadedHostFxrInstallerFile)</DownloadFileName>
         <ExtractDestintation></ExtractDestintation>

--- a/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
+++ b/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
@@ -6,7 +6,8 @@
                               GenerateNuGetPackagesArchive;
                               UploadNuGetPackagesArchiveToAzure"
             Inputs="$(IntermediateArchive)"
-            Outputs="$(FinalArchive)">
+            Outputs="$(FinalArchive)"
+            Condition=" '$(IncludeNuGetPackageArchive)' == 'true' ">
       <Copy SourceFiles="$(IntermediateArchive)" DestinationFiles="$(FinalArchive)" />
     </Target>
 

--- a/build/package/Microsoft.DotNet.Cli.Archive.targets
+++ b/build/package/Microsoft.DotNet.Cli.Archive.targets
@@ -15,12 +15,14 @@
     <ZipFileCreateFromDirectory
         Condition=" '$(OSName)' == 'win' "
         SourceDirectory="%(GenerateArchivesInputsOutputs.InputDirectory)"
-        DestinationArchive="$(GenerateArchivesDestinationArchive)" />
+        DestinationArchive="$(GenerateArchivesDestinationArchive)"
+        OverwriteDestination="true"/>
 
     <TarGzFileCreateFromDirectory
         Condition=" '$(OSName)' != 'win' "
         SourceDirectory="%(GenerateArchivesInputsOutputs.InputDirectory)"
-        DestinationArchive="$(GenerateArchivesDestinationArchive)" />
+        DestinationArchive="$(GenerateArchivesDestinationArchive)"
+        OverwriteDestination="true"/>
 
     <ItemGroup>
       <Archives Include="$(GenerateArchivesDestinationArchive)" />


### PR DESCRIPTION
For injestion into a composed build, I'm adding some minor tweaks to
our build system:

 - Teach DownloadFile task how to consume file:// URLs so we can pass
   around artifacts using local sources.
 - Add `SkipBuildingInstallers`, an MSBuild property that can be set
   to true when installers (pkgs, msis, debs, rpms and the like) do
   not need to be built.
 - Add `IncludeAdditionalSharedFrameworks`, an MSBuild property that
   can be set to prevent additional shared frameworks (i.e. shared
   frameworks that the CLI does not use at runtime) from being
   downloaded and included in our payload.
 - Add `IncludeNuGetPackageArchive` an MSBuild property that can be
   set to prevent the lzma archive containing all the nupkgs we
   restore on first run from being included in the final output.
 - Provide a way to change the Uri used to pull down the shared
   framework archive (so that during a composed buid we can point it
   at a local source).