### PR TITLE
Making the tool name comparison with the package case insensitive

### DIFF
--- a/TestAssets/TestProjects/AppWithToolDependency/AppWithToolDependency.csproj
+++ b/TestAssets/TestProjects/AppWithToolDependency/AppWithToolDependency.csproj
@@ -13,6 +13,9 @@
     <DotNetCliToolReference Include="dotnet-portable">
       <Version>1.0.0</Version>
     </DotNetCliToolReference>
+    <DotNetCliToolReference Include="dotnet-PreferCliRuntime">
+      <Version>1.0.0</Version>
+    </DotNetCliToolReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -147,10 +147,9 @@ namespace Microsoft.DotNet.Cli.Utils
                 toolLockFile.Path));
 
             var toolLibrary = toolLockFile.Targets
-                .FirstOrDefault(
-                    t => t.TargetFramework.GetShortFolderName().Equals(s_toolPackageFramework.GetShortFolderName()))
-                ?.Libraries.FirstOrDefault(l => l.Name == toolLibraryRange.Name);
-
+                .FirstOrDefault(t => s_toolPackageFramework == t.TargetFramework)
+                ?.Libraries.FirstOrDefault(
+                    l => StringComparer.OrdinalIgnoreCase.Equals(l.Name, toolLibraryRange.Name));
             if (toolLibrary == null)
             {
                 Reporter.Verbose.WriteLine(string.Format(

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Tests
         private const string TestProjectName = "AppWithToolDependency";
 
         [Fact]
-        public void It_returns_null_when_CommandName_is_null()
+        public void ItReturnsNullWhenCommandNameIsNull()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void It_returns_null_when_ProjectDirectory_is_null()
+        public void ItReturnsNullWhenProjectDirectoryIsNull()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void It_returns_null_when_ProjectDirectory_does_not_contain_a_project_file()
+        public void ItReturnsNullWhenProjectDirectoryDoesNotContainAProjectFile()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void It_returns_null_when_CommandName_does_not_exist_in_ProjectTools()
+        public void ItReturnsNullWhenCommandNameDoesNotExistInProjectTools()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void It_returns_a_CommandSpec_with_DOTNET_as_FileName_and_CommandName_in_Args_when_CommandName_exists_in_ProjectTools()
+        public void ItReturnsACommandSpecWithDOTNETAsFileNameAndCommandNameInArgsWhenCommandNameExistsInProjectTools()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
@@ -126,7 +126,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void It_escapes_CommandArguments_when_returning_a_CommandSpec()
+        public void ItEscapesCommandArgumentsWhenReturningACommandSpec()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
@@ -149,7 +149,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void It_returns_a_CommandSpec_with_Args_containing_CommandPath_when_returning_a_CommandSpec_and_CommandArguments_are_null()
+        public void ItReturnsACommandSpecWithArgsContainingCommandPathWhenReturningACommandSpecAndCommandArgumentsAreNull()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
@@ -174,7 +174,32 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void It_writes_a_deps_json_file_next_to_the_lockfile()
+        public void ItReturnsACommandSpecWithArgsContainingCommandPathWhenInvokingAToolReferencedWithADifferentCasing()
+        {
+            var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
+
+            var testInstance = TestAssets.Get(TestProjectName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
+
+            var commandResolverArguments = new CommandResolverArguments()
+            {
+                CommandName = "dotnet-prefercliruntime",
+                CommandArguments = null,
+                ProjectDirectory = testInstance.Root.FullName
+            };
+
+            var result = projectToolsCommandResolver.Resolve(commandResolverArguments);
+
+            result.Should().NotBeNull();
+
+            var commandPath = result.Args.Trim('"');
+            commandPath.Should().Contain("dotnet-prefercliruntime.dll");
+        }
+
+        [Fact]
+        public void ItWritesADepsJsonFileNextToTheLockfile()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
@@ -221,7 +246,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void Generate_deps_json_method_doesnt_overwrite_when_deps_file_already_exists()
+        public void GenerateDepsJsonMethodDoesntOverwriteWhenDepsFileAlreadyExists()
         {
             var testInstance = TestAssets.Get(TestProjectName)
                 .CreateInstance()
@@ -262,7 +287,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void It_adds_fx_version_as_a_param_when_the_tool_has_the_prefercliruntime_file()
+        public void ItAddsFxVersionAsAParamWhenTheToolHasThePrefercliruntimeFile()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
@@ -286,7 +311,7 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void It_does_not_add_fx_version_as_a_param_when_the_tool_does_not_have_the_prefercliruntime_file()
+        public void ItDoesNotAddFxVersionAsAParamWhenTheToolDoesNotHaveThePrefercliruntimeFile()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 


### PR DESCRIPTION
Making the tool name comparison with the package case insensitive, so that tools are not required to be declared with the exact casing as the packages that contain them.

I just took @emgarten's fix and applied it.

Fixes https://github.com/dotnet/cli/issues/5704#issuecomment-279889045.

@piotrpMSFT @jonsequitur @jgoshi @krwq 