### PR TITLE
The variable was missing dollar sign parenthesis in the target file.

### DIFF
--- a/build/Microsoft.DotNet.Cli.Publish.targets
+++ b/build/Microsoft.DotNet.Cli.Publish.targets
@@ -43,7 +43,7 @@
     <ItemGroup>
       <ForPublishing Include="@(GeneratedInstallers)" />
       <ForPublishing Include="%(GenerateArchivesInputsOutputs.Outputs)" />
-      <ForPublishing Include="$(PackagesDirectory)/Microsoft*.nupkg" Condition=" 'PUBLISH_NUPKG_TO_AZURE_BLOB' != '' " />
+      <ForPublishing Include="$(PackagesDirectory)/Microsoft*.nupkg" Condition=" '$(PUBLISH_NUPKG_TO_AZURE_BLOB)' != '' " />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
@piotrpMSFT @jgoshi @jonsequitur @krwq 

@MattGertz This is a very simple infra-structure change that affects the drop suffix work.