### PR TITLE
Attempt to fix intermittent failures with ...CLIRetriesLaunchingTheCommandForAtLeastOneSecond 

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Extensions/LockFileFormatExtensions.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Extensions/LockFileFormatExtensions.cs
@@ -20,18 +20,18 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public static async Task<LockFile> ReadWithLock(this LockFileFormat subject, string path)
         {
-            if(!File.Exists(path))
-            {
-                throw new GracefulException(string.Join(
-                    Environment.NewLine,
-                    string.Format(LocalizableStrings.FileNotFound, path),
-                    LocalizableStrings.ProjectNotRestoredOrRestoreFailed));
-            }
-
             return await ConcurrencyUtilities.ExecuteWithFileLockedAsync(
                 path, 
                 lockedToken =>
                 {
+                    if (!File.Exists(path))
+                    {
+                        throw new GracefulException(string.Join(
+                            Environment.NewLine,
+                            string.Format(LocalizableStrings.FileNotFound, path),
+                            LocalizableStrings.ProjectNotRestoredOrRestoreFailed));
+                    }
+                    
                     var lockFile = FileAccessRetrier.RetryOnFileAccessFailure(() => subject.Read(path));
 
                     return lockFile;       


### PR DESCRIPTION
We are seeing some intermittent failures with WhenToolAssetsFileIsInUseThenCLIRetriesLaunchingTheCommandForAtLeastOneSecond 

I'm checking if this simple fix will help - I will retry this on CI several times so please do not merge until we can prove this is fixing the problem

My suspicion is that because we do not lock when checking if the file exists it may be failing before it tries to retry or while the file is being written