### PR TITLE
No longer add runtime identifier when migrating apps that contain full framework

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateTFMRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigrateTFMRule.cs
@@ -50,15 +50,6 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                     propertyGroup,
                     mergeExisting: true);
             }
-
-            _transformApplicator.Execute(
-                    RuntimeIdentifiersTransform.Transform(migrationRuleInputs.ProjectContexts),
-                    propertyGroup,
-                    mergeExisting: true);
-            _transformApplicator.Execute(
-                    RuntimeIdentifierTransform.Transform(migrationRuleInputs.ProjectContexts),
-                    propertyGroup,
-                    mergeExisting: true);
         }
 
         private void CleanExistingProperties(ProjectRootElement csproj)
@@ -127,36 +118,5 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
                 "TargetFramework",
                 framework => framework.GetShortFolderName(),
                 framework => true);
-
-        private AddPropertyTransform<IEnumerable<ProjectContext>> RuntimeIdentifiersTransform =>
-            new AddPropertyTransform<IEnumerable<ProjectContext>>(
-                "RuntimeIdentifiers",
-                projectContexts => RuntimeIdentifiers,
-                projectContexts => !projectContexts.HasRuntimes() &&
-                                   !projectContexts.HasLibraryOutput() &&
-                                    projectContexts.HasBothCoreAndFullFrameworkTFMs());
-
-        private AddPropertyTransform<IEnumerable<ProjectContext>> RuntimeIdentifierTransform =>
-            new AddPropertyTransform<IEnumerable<ProjectContext>>(
-                "RuntimeIdentifier",
-                projectContexts => "win7-x86",
-                projectContexts => !projectContexts.HasRuntimes() &&
-                                   !projectContexts.HasLibraryOutput() && 
-                                    projectContexts.HasFullFrameworkTFM())
-            .WithMSBuildCondition(projectContexts =>
-                {
-                    string msBuildCondition = null;
-                    if (projectContexts.HasBothCoreAndFullFrameworkTFMs())
-                    {
-                        msBuildCondition = string.Join(
-                            " OR ",
-                            projectContexts.Where(p => p.IsFullFramework()).Select(
-                                p => $"'$(TargetFramework)' == '{p.TargetFramework.GetShortFolderName()}'"));
-
-                        msBuildCondition = $" {msBuildCondition} ";
-                    }
-
-                    return msBuildCondition;
-                });
     }
 }

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTFMs.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigrateTFMs.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Fact]
-        public void MigratingCoreAndDesktopTFMsAddsAllRuntimeIdentifiersIfTheProjectDoesNothaveAnyAlready()
+        public void MigratingCoreAndDesktopTFMsDoesNoAddRuntimeIdentifiersOrRuntimeIdentifierWhenTheProjectDoesNothaveAnyAlready()
         {
             var testDirectory = Temp.CreateDirectory().Path;
             var testPJ = new ProjectJsonBuilder(TestAssetsManager)
@@ -88,35 +88,8 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
 
             new MigrateTFMRule().Apply(migrationSettings, migrationInputs);
 
-            mockProj.Properties.Count(p => p.Name == "RuntimeIdentifiers").Should().Be(1);
-            mockProj.Properties.First(p => p.Name == "RuntimeIdentifiers")
-                .Value.Should().Be("win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64");
-        }
-
-        [Fact]
-        public void MigratingCoreAndDesktopTFMsAddsRuntimeIdentifierWithWin7x86ConditionOnAllFullFrameworksWhenNoRuntimesExistAlready()
-        {
-            var testDirectory = Temp.CreateDirectory().Path;
-            var testPJ = new ProjectJsonBuilder(TestAssetsManager)
-                .FromTestAssetBase("PJAppWithMultipleFrameworks")
-                .SaveToDisk(testDirectory);
-
-            var projectContexts = ProjectContext.CreateContextForEachFramework(testDirectory);
-            var mockProj = ProjectRootElement.Create();
-
-            var migrationSettings = MigrationSettings.CreateMigrationSettingsTestHook(testDirectory, testDirectory, mockProj);
-            var migrationInputs = new MigrationRuleInputs(
-                projectContexts, 
-                mockProj, 
-                mockProj.AddItemGroup(), 
-                mockProj.AddPropertyGroup());
-
-            new MigrateTFMRule().Apply(migrationSettings, migrationInputs);
-
-            mockProj.Properties.Count(p => p.Name == "RuntimeIdentifier").Should().Be(1);
-            var runtimeIdentifier = mockProj.Properties.First(p => p.Name == "RuntimeIdentifier");
-            runtimeIdentifier.Value.Should().Be("win7-x86");
-            runtimeIdentifier.Condition.Should().Be(" '$(TargetFramework)' == 'net20' OR '$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net40' OR '$(TargetFramework)' == 'net461' ");
+            mockProj.Properties.Count(p => p.Name == "RuntimeIdentifiers").Should().Be(0);
+            mockProj.Properties.Count(p => p.Name == "RuntimeIdentifier").Should().Be(0);
         }
 
         [Fact]
@@ -144,7 +117,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         }
 
         [Fact]
-        public void MigratingProjectWithFullFrameworkTFMsOnlyAddsARuntimeIdentifierWin7x86WhenNoRuntimesExistAlready()
+        public void MigratingProjectWithFullFrameworkTFMsDoesNotAddRuntimeIdentifiersOrRuntimeIdentiferWhenNoRuntimesExistAlready()
         {
             var testDirectory = Temp.CreateDirectory().Path;
             var testPJ = new ProjectJsonBuilder(TestAssetsManager)
@@ -165,8 +138,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
             new MigrateTFMRule().Apply(migrationSettings, migrationInputs);
 
             mockProj.Properties.Count(p => p.Name == "RuntimeIdentifiers").Should().Be(0);
-            mockProj.Properties.Where(p => p.Name == "RuntimeIdentifier").Should().HaveCount(1);
-            mockProj.Properties.Single(p => p.Name == "RuntimeIdentifier").Value.Should().Be("win7-x86");
+            mockProj.Properties.Where(p => p.Name == "RuntimeIdentifier").Should().HaveCount(0);
         }
 
         [Fact]


### PR DESCRIPTION
No longer add runtime identifier when migrating apps that contain full framework and no runtime identifiers already.

Fixes https://github.com/dotnet/cli/issues/5668.

@piotrpMSFT @jonsequitur @jgoshi @krwq 
