### PR TITLE
Consume local info support from VersionTools

### DIFF
--- a/build_projects/update-dependencies/Config.cs
+++ b/build_projects/update-dependencies/Config.cs
@@ -10,19 +10,20 @@ namespace Microsoft.DotNet.Scripts
     /// </summary>
     /// <remarks>
     /// The following Environment Variables are required by this script:
-    /// 
+    ///
     /// GITHUB_USER - The user to commit the changes as.
     /// GITHUB_EMAIL - The user's email to commit the changes as.
     /// GITHUB_PASSWORD - The password/personal access token of the GitHub user.
     ///
     /// The following Environment Variables can optionally be specified:
-    /// 
-    /// ROSLYN_VERSION_URL - The Url to get the current Roslyn version. (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/roslyn/netcore1.0")
-    /// CORESETUP_VERSION_URL - The Url to get the current dotnet/core-setup package versions. (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/core-setup/master")
+    ///
+    /// DOTNET_VERSION_URL - The Url to the root of the version information (this is combined with the fragments bellow) (ex. "https://raw.githubusercontent.com/dotnet/versions/master/build-info")
+    /// ROSLYN_VERSION_FRAGMENT - The fragment to combine with DOTNET_VERSION_URL to get the current dotnet/roslyn package versions. (ex. "dotnet/roslyn/netcore1.0")
+    /// CORESETUP_VERSION_FRAGMENT - The fragment to combine with DOTNET_VERSION_URL to get the current dotnet/core-setup package versions. (ex. "dotnet/core-setup/master")
     /// GITHUB_ORIGIN_OWNER - The owner of the GitHub fork to push the commit and create the PR from. (ex. "dotnet-bot")
     /// GITHUB_UPSTREAM_OWNER - The owner of the GitHub base repo to create the PR to. (ex. "dotnet")
     /// GITHUB_PROJECT - The repo name under the ORIGIN and UPSTREAM owners. (ex. "cli")
-    /// GITHUB_UPSTREAM_BRANCH - The branch in the GitHub base repo to create the PR to. (ex. "master")
+    /// GITHUB_UPSTREAM_BRANCH - The branch in the GitHub base repo to create the PR to. (ex. "master");
     /// GITHUB_PULL_REQUEST_NOTIFICATIONS - A semi-colon ';' separated list of GitHub users to notify on the PR.
     /// </remarks>
     public class Config
@@ -32,25 +33,26 @@ namespace Microsoft.DotNet.Scripts
         private Lazy<string> _userName = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_USER"));
         private Lazy<string> _email = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_EMAIL"));
         private Lazy<string> _password = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PASSWORD"));
-        
-        private Lazy<string> _roslynVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("ROSLYN_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/roslyn/netcore1.0"));
-        private Lazy<string> _coreSetupVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("CORESETUP_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/core-setup/master"));
+
+        private Lazy<string> _dotNetVersionUrl = new Lazy<string>(() => GetEnvironmentVariable("DOTNET_VERSION_URL", "https://raw.githubusercontent.com/dotnet/versions/master/build-info"));
+        private Lazy<string> _roslynVersionFragment = new Lazy<string>(() => GetEnvironmentVariable("ROSLYN_VERSION_FRAGMENT", "dotnet/roslyn/netcore1.0"));
+        private Lazy<string> _coreSetupVersionFragment = new Lazy<string>(() => GetEnvironmentVariable("CORESETUP_VERSION_FRAGMENT", "dotnet/core-setup/master"));
         private Lazy<string> _gitHubUpstreamOwner = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_OWNER", "dotnet"));
         private Lazy<string> _gitHubProject = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_PROJECT", "cli"));
         private Lazy<string> _gitHubUpstreamBranch = new Lazy<string>(() => GetEnvironmentVariable("GITHUB_UPSTREAM_BRANCH", "master"));
-        private Lazy<string[]> _gitHubPullRequestNotifications = new Lazy<string[]>(() => 
+        private Lazy<string[]> _gitHubPullRequestNotifications = new Lazy<string[]>(() =>
                                                 GetEnvironmentVariable("GITHUB_PULL_REQUEST_NOTIFICATIONS", "")
                                                     .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
-
         private Config()
         {
         }
 
         public string UserName => _userName.Value;
-        public string Email => _email.Value; 
+        public string Email => _email.Value;
         public string Password => _password.Value;
-        public string RoslynVersionUrl => _roslynVersionUrl.Value;
-        public string CoreSetupVersionUrl => _coreSetupVersionUrl.Value;
+        public string DotNetVersionUrl => _dotNetVersionUrl.Value;
+        public string RoslynVersionFragment => _roslynVersionFragment.Value;
+        public string CoreSetupVersionFragment => _coreSetupVersionFragment.Value;
         public string GitHubUpstreamOwner => _gitHubUpstreamOwner.Value;
         public string GitHubProject => _gitHubProject.Value;
         public string GitHubUpstreamBranch => _gitHubUpstreamBranch.Value;

--- a/build_projects/update-dependencies/Program.cs
+++ b/build_projects/update-dependencies/Program.cs
@@ -25,8 +25,8 @@ namespace Microsoft.DotNet.Scripts
 
             List<BuildInfo> buildInfos = new List<BuildInfo>();
 
-            buildInfos.Add(BuildInfo.Get("Roslyn", s_config.RoslynVersionUrl, fetchLatestReleaseFile: false));
-            buildInfos.Add(BuildInfo.Get("CoreSetup", s_config.CoreSetupVersionUrl, fetchLatestReleaseFile: false));
+            buildInfos.Add(GetBuildInfo("Roslyn", s_config.RoslynVersionFragment, fetchLatestReleaseFile: false));
+            buildInfos.Add(GetBuildInfo("CoreSetup", s_config.CoreSetupVersionFragment, fetchLatestReleaseFile: false));
 
             IEnumerable<IDependencyUpdater> updaters = GetUpdaters();
             var dependencyBuildInfos = buildInfos.Select(buildInfo =>
@@ -57,6 +57,25 @@ namespace Microsoft.DotNet.Scripts
                         suggestedMessage + $" ({upstreamBranch.Name})",
                         body)
                     .Wait();
+            }
+        }
+
+        private static BuildInfo GetBuildInfo(string name, string buildInfoFragment, bool fetchLatestReleaseFile = true)
+        {
+            const string FileUrlProtocol = "file://";
+
+            if (s_config.DotNetVersionUrl.StartsWith(FileUrlProtocol, StringComparison.Ordinal))
+            {
+                return BuildInfo.LocalFileGetAsync(
+                           name,
+                           s_config.DotNetVersionUrl.Substring(FileUrlProtocol.Length),
+                           buildInfoFragment.Replace('/', Path.DirectorySeparatorChar),
+                           fetchLatestReleaseFile)
+                       .Result;
+            }
+            else
+            {
+                return BuildInfo.Get(name, $"{s_config.DotNetVersionUrl}/{buildInfoFragment}", fetchLatestReleaseFile);
             }
         }
 

--- a/build_projects/update-dependencies/update-dependencies.csproj
+++ b/build_projects/update-dependencies/update-dependencies.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="1.0.0" />
-    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.27-prerelease-01308-02" />
+    <PackageReference Include="Microsoft.DotNet.VersionTools" Version="1.0.27-prerelease-01316-08" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Davis added support for VersionTools to be able to pull from a local
filesystem layout that looks like what we have in GitHub on
dotnet/versions.

Start to consume this so a composed build can use this logic to update
dependencies using local version information produced during the build.
