### PR TITLE
Adding the SDK version to the hash of the lzma archive and update SDK version

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -4,7 +4,7 @@
     <CLI_SharedFrameworkVersion>1.1.1</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.1.548</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>1.0.0-alpha-20170217-2</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.0.0-alpha-20170222-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.0.0-rtm-2283</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170130-3-281</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0-preview-20170222-09</CLI_TestPlatform_Version>

--- a/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
+++ b/build/compile/Microsoft.DotNet.Cli.LzmaArchive.targets
@@ -120,7 +120,7 @@
 
     <Target Name="SetupNuGetPackagesArchiveInputsOutputs"
             DependsOnTargets="Prepare;SetupStage;SetupAzureBlobInformation">
-      <GenerateNuGetPackagesArchiveVersion ToolPath="$(Stage2Directory)">
+      <GenerateNuGetPackagesArchiveVersion ToolPath="$(Stage2Directory)" SDKVersion="$(CLI_NETSDK_Version)">
         <Output TaskParameter="Version" PropertyName="NuGetPackagesArchiveVersion"/>
       </GenerateNuGetPackagesArchiveVersion>
       <PropertyGroup>

--- a/build_projects/dotnet-cli-build/GenerateNuGetPackagesArchiveVersion.cs
+++ b/build_projects/dotnet-cli-build/GenerateNuGetPackagesArchiveVersion.cs
@@ -19,6 +19,9 @@ namespace Microsoft.DotNet.Cli.Build
         }
 
         [Required]
+        public string SDKVersion { get; set; }
+
+        [Required]
         public string ToolPath { get; set; }
 
         [Output]
@@ -69,6 +72,8 @@ namespace Microsoft.DotNet.Cli.Build
 
                 Directory.Delete(targetDir, true);
             }
+
+            dataToHash += SDKVersion;
 
             Log.LogMessage($"NuGet Packages Archive Data To Hash: '{dataToHash}'");
 

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
@@ -28,7 +28,6 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [WindowsOnlyFact]
         public void It_resolves_desktop_apps_defaulting_to_Debug_Configuration()
         {
-            var runtime = DotnetLegacyRuntimeIdentifiers.InferLegacyRestoreRuntimeIdentifier();
             var configuration = "Debug";
 
             var testInstance = TestAssets.Get(TestAssetKinds.DesktopTestProjects, "AppWithProjTool2Fx")
@@ -38,14 +37,12 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             var restoreCommand = new RestoreCommand()
                 .WithWorkingDirectory(testInstance.Root)
-                .WithRuntime(runtime)
                 .ExecuteWithCapturedOutput()
                 .Should().Pass();
 
             var buildCommand = new BuildCommand()
                 .WithWorkingDirectory(testInstance.Root)
                 .WithConfiguration(configuration)
-                .WithRuntime(runtime)
                 .WithCapturedOutput()
                 .Execute()
                 .Should().Pass();
@@ -67,7 +64,6 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [WindowsOnlyFact]
         public void It_resolves_desktop_apps_when_configuration_is_Debug()
         {
-            var runtime = DotnetLegacyRuntimeIdentifiers.InferLegacyRestoreRuntimeIdentifier();
             var configuration = "Debug";
 
             var testInstance = TestAssets.Get(TestAssetKinds.DesktopTestProjects, "AppWithProjTool2Fx")
@@ -77,14 +73,12 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             var restoreCommand = new RestoreCommand()
                 .WithWorkingDirectory(testInstance.Root)
-                .WithRuntime(runtime)
                 .ExecuteWithCapturedOutput()
                 .Should().Pass();
 
             var buildCommand = new BuildCommand()
                 .WithWorkingDirectory(testInstance.Root)
                 .WithConfiguration(configuration)
-                .WithRuntime(runtime)
                 .Execute()
                 .Should().Pass();
 
@@ -104,7 +98,6 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [WindowsOnlyFact]
         public void It_resolves_desktop_apps_when_configuration_is_Release()
         {
-            var runtime = DotnetLegacyRuntimeIdentifiers.InferLegacyRestoreRuntimeIdentifier();
             var configuration = "Debug";
 
             var testInstance = TestAssets.Get(TestAssetKinds.DesktopTestProjects, "AppWithProjTool2Fx")
@@ -114,14 +107,12 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             var restoreCommand = new RestoreCommand()
                 .WithWorkingDirectory(testInstance.Root)
-                .WithRuntime(runtime)
                 .ExecuteWithCapturedOutput()
                 .Should().Pass();
 
             var buildCommand = new BuildCommand()
                 .WithWorkingDirectory(testInstance.Root)
                 .WithConfiguration(configuration)
-                .WithRuntime(runtime)
                 .WithCapturedOutput()
                 .Execute()
                 .Should().Pass();
@@ -143,7 +134,6 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         [WindowsOnlyFact]
         public void It_resolves_desktop_apps_using_configuration_passed_to_create()
         {
-            var runtime = DotnetLegacyRuntimeIdentifiers.InferLegacyRestoreRuntimeIdentifier();
             var configuration = "Debug";
 
             var testInstance = TestAssets.Get(TestAssetKinds.DesktopTestProjects, "AppWithProjTool2Fx")
@@ -153,14 +143,12 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             var restoreCommand = new RestoreCommand()
                 .WithWorkingDirectory(testInstance.Root)
-                .WithRuntime(runtime)
                 .ExecuteWithCapturedOutput()
                 .Should().Pass();
 
             var buildCommand = new BuildCommand()
                 .WithWorkingDirectory(testInstance.Root)
                 .WithConfiguration(configuration)
-                .WithRuntime(runtime)
                 .WithCapturedOutput()
                 .Execute()
                 .Should().Pass();


### PR DESCRIPTION
Adding the SDK version to the hash of the lzma archive, since the SDK has implicit package refs in it that will impact the archive when they change.

Also updated the SDK version.

@piotrpMSFT @jonsequitur @krwq @jgoshi @dsplaisted 


