### PR TITLE
Remove corehost from CLI layout

### DIFF
--- a/build/Compile.targets
+++ b/build/Compile.targets
@@ -37,16 +37,6 @@
                    Configuration="$(Configuration)"
                    ProjectPath="$(SrcDirectory)/tool_roslyn/tool_roslyn.csproj" />
 
-      <!-- Copy Host to SDK Directory -->
-      <Copy SourceFiles="$(SharedFrameworkNameVersionPath)/$(DotnetHostBaseName)"
-            DestinationFiles="$(SdkOutputDirectory)/corehost$(ExeExtension)" />
-
-      <Copy SourceFiles="$(SharedFrameworkNameVersionPath)/$(DotnetHostFxrBaseName)"
-            DestinationFiles="$(SdkOutputDirectory)/$(DotnetHostFxrBaseName)" />
-
-      <Copy SourceFiles="$(SharedFrameworkNameVersionPath)/$(HostPolicyBaseName)"
-            DestinationFiles="$(SdkOutputDirectory)/$(HostPolicyBaseName)" />
-
       <!-- copy core sdk -->
       <Copy SourceFiles="@(MSBuildImportsContent)"
             DestinationFolder="$(SdkOutputDirectory)/%(RecursiveDir)" />


### PR DESCRIPTION
@davidfowl @anurse @pakrym this PR removes `corehost` from the 2.0 CLI layout. There was some intent early in CLI 1.0 to use this file for back-compat scenarios, but to the best of my knowledge no one takes advantage of it and it only creates bloat in the redist. Any concerns with removing in 2.0?

/cc @livarcocc @jonsequitur @jgoshi @krwq @blackdwarf 