### PR TITLE
Don't look for Debian package dependencies when skipping installers

### DIFF
--- a/build/prepare/CheckPrereqs.targets
+++ b/build/prepare/CheckPrereqs.targets
@@ -17,7 +17,7 @@
 
     <Exec Command="dpkg -s %(UbuntuCoreclrAndCoreFxDependencies.Identity)" />
 
-    <Exec Command="dpkg -s %(DebianPackageBuildDependencies.Identity)" />
+    <Exec Command="dpkg -s %(DebianPackageBuildDependencies.Identity)" Condition="$(SkipBuildingInstallers) != 'true'" />
 
     <OnError ExecuteTargets="ShowAptGetUsage" />
   </Target>


### PR DESCRIPTION
Today, we always check to see if DebianPackageBuildDependencies are
present on the machine doing a build, because we will need them to
build the .deb files later on.

Since we now allow skipping of building packages, don't check for
these dependencies if we weren't going to use them.