### PR TITLE
Remove workaround for multi-proc builds

### DIFF
--- a/build/Test.targets
+++ b/build/Test.targets
@@ -65,8 +65,7 @@
   <Target Name="BuildTests"
           DependsOnTargets="RestoreTests;">
     <DotNetBuild ToolPath="$(Stage0Directory)"
-                 ProjectPath="&quot;$(TestDirectory)/Microsoft.DotNet.Cli.Tests.sln&quot;"
-                 MaxCpuCount="1" />
+                 ProjectPath="&quot;$(TestDirectory)/Microsoft.DotNet.Cli.Tests.sln&quot;" />
   </Target>
 
   <Target Name="CreateTestAssetPackageNuPkgs"


### PR DESCRIPTION
The SDK bug with building a .sln file is now fixed.  We should remove our workaround so we test that building a .sln file works as expected, with no multi-proc issues.

This is a test infrastructure only change.  It may require the latest SDK change to be merged first, which is #5813.

@livarcocc @piotrpMSFT 
