### PR TITLE
Prefer Unix Shell build-in 'hash' over 'which'

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -122,8 +122,8 @@ get_current_os_name() {
 
 machine_has() {
     eval $invocation
-    
-    which "$1" > /dev/null 2>&1
+
+    hash "$1" > /dev/null 2>&1
     return $?
 }
 


### PR DESCRIPTION
`which` is an external utility. `hash` or `command -v` are built-in
General Commands.

See http://stackoverflow.com/a/677212/863980

Related: dotnet/coreclr#8823 & dotnet/corert#2831

I chose `hash` here as `run-build.sh` is already using it.