### PR TITLE
Make update-dependencies idempotent in the only update case

### DIFF
--- a/build_projects/update-dependencies/Program.cs
+++ b/build_projects/update-dependencies/Program.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Scripts
                     disabledPackages: Enumerable.Empty<string>()));
             DependencyUpdateResults updateResults = DependencyUpdateUtils.Update(updaters, dependencyBuildInfos);
 
-            if (updateResults.ChangesDetected() && !onlyUpdate)
+            if (!onlyUpdate && updateResults.ChangesDetected())
             {
                 GitHubAuth gitHubAuth = new GitHubAuth(s_config.Password, s_config.UserName, s_config.Email);
                 GitHubProject origin = new GitHubProject(s_config.GitHubProject, s_config.UserName);


### PR DESCRIPTION
Today, if you run update-dependencies --Update and there are no
changes that need to be made (for example, you ran it previously) and
there are pending changes (i.e. git status shows diffs) the program
crashes with an unhandled exception because some code in VersionTools
is upset that there are pending changes since it thinks there should
be none.

Re-structure the code such that we don't call the method that's going
to throw when we are just updating dependencies. This also means
devs (or the composed build) who want to run this more than once do
longer have to reset changes beforehand.