### PR TITLE
Clean up chmod usage

### DIFF
--- a/build/Compile.targets
+++ b/build/Compile.targets
@@ -22,32 +22,6 @@
                    Configuration="$(Configuration)"
                    ProjectPath="$(RootProject)" />
 
-    <!-- Corehostify Binaries -->
-    <ItemGroup Condition=" '$(OSName)' != 'win' ">
-      <SdkOutputChmodTargets Remove="*" />
-      <SdkOutputChmodTargets Include="$(SdkOutputDirectory)/**/*.exe;
-                                    $(SdkOutputDirectory)/**/*.dll" >
-        <!-- Managed assemblies do not need execute -->
-        <Mode>u=rw,g=r,o=r</Mode>
-      </SdkOutputChmodTargets>
-
-      <SdkOutputChmodTargets Include="$(SdkOutputDirectory)/**/*.dylib;
-                                    $(SdkOutputDirectory)/**/*.so" >
-        <!-- Generally, dylibs and sos have 'x' -->
-        <Mode>u=rwx,g=rx,o=rx</Mode>
-      </SdkOutputChmodTargets>
-
-      <SdkOutputChmodTargets Include="$(SdkOutputDirectory)/**/*"
-                            Exclude="$(SdkOutputDirectory)/**/*.*" >
-        <!-- Executables need x -->
-        <Mode>u=rwx,g=rx,o=rx</Mode>
-      </SdkOutputChmodTargets>
-    </ItemGroup>
-
-    <Chmod Condition=" '$(OSName)' != 'win' "
-            File="%(SdkOutputChModTargets.FullPath)"
-            Mode="%(SdkOutputChModTargets.Mode)" />
-
     <ItemGroup>
       <FilesToClean Include="$(OutputDirectory)/sdk/**/vbc.exe" />
     </ItemGroup>

--- a/build/Test.targets
+++ b/build/Test.targets
@@ -65,7 +65,8 @@
   <Target Name="BuildTests"
           DependsOnTargets="RestoreTests;">
     <DotNetBuild ToolPath="$(OutputDirectory)"
-                 ProjectPath="&quot;$(TestDirectory)/Microsoft.DotNet.Cli.Tests.sln&quot;" />
+                 ProjectPath="&quot;$(TestDirectory)/Microsoft.DotNet.Cli.Tests.sln&quot;"
+                 MaxCpuCount="1" />
   </Target>
 
   <Target Name="CreateTestAssetPackageNuPkgs"

--- a/build_projects/dotnet-cli-build/Chmod.cs
+++ b/build_projects/dotnet-cli-build/Chmod.cs
@@ -9,26 +9,12 @@ namespace Microsoft.DotNet.Cli.Build
     public class Chmod : ToolTask
     {
         [Required]
-        public string File { get; set; }
+        public string Glob { get; set; }
 
         [Required]
         public string Mode { get; set; }
 
         public bool Recursive { get; set; }
-
-        protected override bool ValidateParameters()
-        {
-            base.ValidateParameters();
-
-            if (!System.IO.File.Exists(File))
-            {
-                Log.LogError($"File '{File} does not exist.");
-
-                return false;
-            }
-
-            return true;
-        }
 
         protected override string ToolName
         {
@@ -47,12 +33,12 @@ namespace Microsoft.DotNet.Cli.Build
 
         protected override string GenerateCommandLineCommands()
         {
-            return $"{GetRecursive()} {GetMode()} {GetFilePath()}";
+            return $"{GetRecursive()} {GetMode()} {GetGlob()}";
         }
 
-        private string GetFilePath()
+        private string GetGlob()
         {
-            return File;
+            return Glob;
         }
 
         private string GetMode()

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -166,5 +166,6 @@
     
     <Exec Command="find $(SdkOutputDirectory) -type d -exec chmod 755 {} \;" />
     <Exec Command="find $(SdkOutputDirectory) -type f -exec chmod 644 {} \;" />
+    <Chmod Mode="755" Glob="$(SdkOutputDirectory)/Roslyn/RunCsc.sh" />
   </Target>
 </Project>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -164,6 +164,7 @@
   <Target Name="ChmodPublishDir"
           AfterTargets="CrossgenPublishDir">
     
-    <Chmod Glob="$(SdkOutputDirectory)/**/*" Mode="u=rw,g=r,o=r" />
+    <Exec Command="find $(SdkOutputDirectory) -type d -exec chmod 755 {} \;" />
+    <Exec Command="find $(SdkOutputDirectory) -type f -exec chmod 644 {} \;" />
   </Target>
 </Project>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -144,8 +144,8 @@
 
     <!-- Ensure crossgen tool is executable.  See https://github.com/NuGet/Home/issues/4424 -->
     <Chmod Condition=" '$(OSName)' != 'win' "
-            File="$(CrossgenPath)"
-            Mode="u+x" />
+           Glob="$(CrossgenPath)"
+           Mode="u+x" />
 
     <Crossgen SourceAssembly="%(CrossgenTargets.FullPath)"
               DestinationPath="%(CrossgenTargets.FullPath)"
@@ -159,5 +159,11 @@
     <!-- Move the "1.0" assemblies back -->
     <Move SourceFiles="@(NETCore10Assemblies->'$(PublishDir)/%(Filename)%(Extension).bak')"
           DestinationFiles="@(NETCore10Assemblies)" />
+  </Target>
+
+  <Target Name="ChmodPublishDir"
+          AfterTargets="CrossgenPublishDir">
+    
+    <Chmod Glob="$(SdkOutputDirectory)/**/*" Mode="u=rw,g=r,o=r" />
   </Target>
 </Project>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -162,7 +162,8 @@
   </Target>
 
   <Target Name="ChmodPublishDir"
-          AfterTargets="CrossgenPublishDir">
+          AfterTargets="CrossgenPublishDir"
+          Condition=" '$(OSName)' != 'win' ">
     
     <Exec Command="find $(SdkOutputDirectory) -type d -exec chmod 755 {} \;" />
     <Exec Command="find $(SdkOutputDirectory) -type f -exec chmod 644 {} \;" />


### PR DESCRIPTION
This PR:
- Moves CLI chmod'ing to be a post-publish step of redist.csproj
- Removes complexity from CLI chmod'ing. We at this point have no native components in the CLI, and we no longer have any remaining executables in the `Sdk` directory. The command, therefore, puts all folders at 755 [rwxrw-rw-] for folders, 644 [rw-r--r--] for files.

I've also mostly eliminated the usage of the chmod task as it was quite slow at dealing with large numbers of files [23s last I looked].

/cc @livarcocc @jgoshi @jonsequitur @eerhardt 