### PR TITLE
Updating the badge names that we use when checking if the build changed

### DIFF
--- a/build/VersionBadge.props
+++ b/build/VersionBadge.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <VersionBadgeMoniker>$(OSName)_$(Architecture)</VersionBadgeMoniker> 
-    <VersionBadgeMoniker Condition=" '$(Rid)' == 'ubuntu.16.04-x64' ">Ubuntu_16_04_x64</VersionBadgeMoniker> 
-    <VersionBadgeMoniker Condition=" '$(Rid)' == 'fedora.23-x64' ">Fedora_23_x64</VersionBadgeMoniker> 
-    <VersionBadgeMoniker Condition=" '$(Rid)' == 'opensuse.13.2-x64' ">openSUSE_13_2_x64</VersionBadgeMoniker> 
+    <VersionBadgeMoniker Condition=" '$(Rid)' == 'ubuntu.16.04-x64' ">ubuntu_16_04_x64</VersionBadgeMoniker>
+    <VersionBadgeMoniker Condition=" '$(Rid)' == 'fedora.23-x64' ">fedora_23_x64</VersionBadgeMoniker>
+    <VersionBadgeMoniker Condition=" '$(Rid)' == 'opensuse.13.2-x64' ">openSUSE_13_2_x64</VersionBadgeMoniker>
 
     <VersionBadge>$(BaseOutputDirectory)/$(VersionBadgeMoniker)_$(Configuration)_version_badge.svg</VersionBadge> 
   </PropertyGroup>

--- a/build_projects/dotnet-cli-build/CheckIfAllBuildsHavePublished.cs
+++ b/build_projects/dotnet-cli-build/CheckIfAllBuildsHavePublished.cs
@@ -46,15 +46,15 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var badges = new Dictionary<string, bool>()
             {
-                { "Windows_x86", false },
-                { "Windows_x64", false },
-                { "Ubuntu_x64", false },
-                { "Ubuntu_16_04_x64", false },
-                { "RHEL_x64", false },
-                { "OSX_x64", false },
-                { "Debian_x64", false },
-                { "CentOS_x64", false },
-                { "Fedora_23_x64", false },
+                { "win_x86", false },
+                { "win_x64", false },
+                { "ubuntu_x64", false },
+                { "ubuntu_16_04_x64", false },
+                { "rhel_x64", false },
+                { "osx_x64", false },
+                { "debian_x64", false },
+                { "centos_x64", false },
+                { "fedora_23_x64", false },
                 { "openSUSE_13_2_x64", false }
             };
 


### PR DESCRIPTION
Updating the badge names that we use when checking if the build changed. Before, we were using an API to generate the OS names, now we are using msbuild OSName property, which names the OS differently.

@piotrpMSFT @jonsequitur @jgoshi @eerhardt 