### PR TITLE
Don't try to uplift when we find a * version in a dependency.

### DIFF
--- a/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
+++ b/src/Microsoft.DotNet.ProjectJsonMigration/Rules/MigratePackageDependenciesAndToolsRule.cs
@@ -297,7 +297,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Rules
 
             var possibleMappings =
                 dependencyToVersionMap.Where(c => c.Key.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
-            if (possibleMappings.Any() && !string.IsNullOrEmpty(version))
+            if (possibleMappings.Any() && !string.IsNullOrEmpty(version) && minRange != null)
             {
                 var possibleVersions = possibleMappings.Select(p => VersionRange.Parse(p.Key.Version));
                 var matchVersion = possibleVersions.FirstOrDefault(p => p.Satisfies(minRange));

--- a/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackagesToTheirLTSAndFTSVersions.cs
+++ b/test/Microsoft.DotNet.ProjectJsonMigration.Tests/Rules/GivenThatIWantToMigratePackagesToTheirLTSAndFTSVersions.cs
@@ -241,6 +241,7 @@ namespace Microsoft.DotNet.ProjectJsonMigration.Tests
         [InlineData("Microsoft.CodeAnalysis.CSharp", "1.0.0", "Microsoft.CodeAnalysis.CSharp", "1.3.0")]
         [InlineData("Microsoft.CodeAnalysis.VisualBasic", "1.0.0", "Microsoft.CodeAnalysis.VisualBasic", "1.3.0")]
         [InlineData("Microsoft.CSharp", "1.0.0", "Microsoft.CSharp", "4.0.1")]
+        [InlineData("Microsoft.CSharp", "*", "Microsoft.CSharp", "*")]
         [InlineData("Microsoft.VisualBasic", "1.0.0", "Microsoft.VisualBasic", "10.0.1")]
         [InlineData("Microsoft.Win32.Primitives", "1.0.0", "Microsoft.Win32.Primitives", "4.0.1")]
         [InlineData("Microsoft.Win32.Registry", "1.0.0", "Microsoft.Win32.Registry", "4.0.0")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/5890

@piotrpMSFT @jgoshi @jonsequitur 