### PR TITLE
Updating NuGet to 4.3.0-beta1-2342

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -5,8 +5,7 @@
     <CLI_MSBuild_Version>15.2.0-preview-000002-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
     <CLI_NETSDK_Version>1.1.0-alpha-20170228-1</CLI_NETSDK_Version>
-    <!-- non-official NuGet build taken from https://github.com/nuget/nuget.client/tree/release-4.1.0-netstandard2.0 to contain "2.0" TFMs -->
-    <CLI_NuGet_Version>4.0.1-beta-2321</CLI_NuGet_Version>
+    <CLI_NuGet_Version>4.3.0-beta1-2342</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170130-3-281</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0-preview-20170125-04</CLI_TestPlatform_Version>
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>


### PR DESCRIPTION
This change updates NuGet to 4.3.0-beta1-2342 which contains support for netstandard2.0.

The actual bits should be very similar to the previous 4.0.1-beta bits.