### PR TITLE
Add dotnet help <verb> support

### DIFF
--- a/src/dotnet/BuiltInCommandMetadata.cs
+++ b/src/dotnet/BuiltInCommandMetadata.cs
@@ -5,6 +5,6 @@ namespace Microsoft.DotNet.Cli
     public class BuiltInCommandMetadata
     {
         public Func<string[], int> Command { get; set; }
-        public Uri DocLink { get; set; }
+        public string DocLink { get; set; }
     }
 }

--- a/src/dotnet/BuiltInCommandMetadata.cs
+++ b/src/dotnet/BuiltInCommandMetadata.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Microsoft.DotNet.Cli
+{
+    public class BuiltInCommandMetadata
+    {
+        public Func<string[], int> Command { get; set; }
+        public Uri DocLink { get; set; }
+    }
+}

--- a/src/dotnet/BuiltInCommandsCatalog.cs
+++ b/src/dotnet/BuiltInCommandsCatalog.cs
@@ -29,110 +29,110 @@ namespace Microsoft.DotNet.Cli
             {
                 Command = AddCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-add-reference
-                DocLink = new Uri("https://aka.ms/dotnet-add")
+                DocLink = "https://aka.ms/dotnet-add"
             },
             ["build"] = new BuiltInCommandMetadata
             {
                 Command = BuildCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-build
-                DocLink = new Uri("https://aka.ms/dotnet-build")
+                DocLink = "https://aka.ms/dotnet-build"
             },
             ["cache"] = new BuiltInCommandMetadata
             {
                 Command = CacheCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-cache
-                DocLink = new Uri("https://aka.ms/dotnet-cache")
+                DocLink = "https://aka.ms/dotnet-cache"
             },
             ["clean"] = new BuiltInCommandMetadata 
             {
                 Command = CleanCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-clean
-                DocLink = new Uri("https://aka.ms/dotnet-clean")
+                DocLink = "https://aka.ms/dotnet-clean"
             },
             ["help"] = new BuiltInCommandMetadata
             {
                 Command = HelpCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-help
-                DocLink = new Uri("https://aka.ms/dotnet-help")
+                DocLink = "https://aka.ms/dotnet-help"
             },
             ["list"] = new BuiltInCommandMetadata
             {
                 Command = ListCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-list-reference
-                DocLink = new Uri("https://aka.ms/dotnet-list")
+                DocLink = "https://aka.ms/dotnet-list"
             },
             ["migrate"] = new BuiltInCommandMetadata
             {
                 Command = MigrateCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-migrate
-                DocLink = new Uri("http://aka.ms/dotnet-migrate")
+                DocLink = "http://aka.ms/dotnet-migrate"
 
             },
             ["msbuild"] = new BuiltInCommandMetadata
             {
                 Command = MSBuildCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-msbuild
-                DocLink = new Uri("https://aka.ms/dotnet-msbuild")
+                DocLink = "https://aka.ms/dotnet-msbuild"
             },
             ["new"] = new BuiltInCommandMetadata
             {
                 Command = NewCommandShim.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-new
-                DocLink = new Uri("https://aka.ms/dotnet-new")
+                DocLink = "https://aka.ms/dotnet-new"
             },
             ["nuget"] = new BuiltInCommandMetadata
             {
                 Command = NuGetCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-nuget-locals
-                DocLink = new Uri("https://aka.ms/dotnet-nuget")
+                DocLink = "https://aka.ms/dotnet-nuget"
             },
             ["pack"] = new BuiltInCommandMetadata
             {
                 Command = PackCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-pack
-                DocLink = new Uri("https://aka.ms/dotnet-pack")
+                DocLink = "https://aka.ms/dotnet-pack"
             },
             ["publish"] = new BuiltInCommandMetadata
             {
                 Command = PublishCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-publish
-                DocLink = new Uri("https://aka.ms/dotnet-publish")
+                DocLink = "https://aka.ms/dotnet-publish"
             },
             ["remove"] = new BuiltInCommandMetadata
             {
                 Command = RemoveCommand.Run,
                 // aka.ms link: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-remove-reference
-                DocLink = new Uri("https://aka.ms/dotnet-remove")
+                DocLink = "https://aka.ms/dotnet-remove"
             },
             ["restore"] = new BuiltInCommandMetadata
             {
                 Command = RestoreCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-restore
-                DocLink = new Uri("https://aka.ms/dotnet-restore")
+                DocLink = "https://aka.ms/dotnet-restore"
             },
             ["run"] = new BuiltInCommandMetadata
             {
                 Command = RunCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-run
-                DocLink = new Uri("https://aka.ms/dotnet-run")
+                DocLink = "https://aka.ms/dotnet-run"
             },
             ["sln"] = new BuiltInCommandMetadata
             {
                 Command = SlnCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-sln
-                DocLink = new Uri("https://aka.ms/dotnet-sln")
+                DocLink = "https://aka.ms/dotnet-sln"
             },
             ["test"] = new BuiltInCommandMetadata
             {
                 Command = TestCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-test
-                DocLink = new Uri("https://aka.ms/dotnet-test")
+                DocLink = "https://aka.ms/dotnet-test"
             },
             ["vstest"] = new BuiltInCommandMetadata
             {
                 Command = VSTestCommand.Run,
                 // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-vstest
-                DocLink = new Uri("https://aka.ms/dotnet-vstest")
+                DocLink = "https://aka.ms/dotnet-vstest"
             }
         };
 

--- a/src/dotnet/BuiltInCommandsCatalog.cs
+++ b/src/dotnet/BuiltInCommandsCatalog.cs
@@ -28,92 +28,110 @@ namespace Microsoft.DotNet.Cli
             ["add"] = new BuiltInCommandMetadata
             {
                 Command = AddCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-add-reference
                 DocLink = new Uri("https://aka.ms/dotnet-add")
             },
             ["build"] = new BuiltInCommandMetadata
             {
                 Command = BuildCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-build
                 DocLink = new Uri("https://aka.ms/dotnet-build")
             },
             ["cache"] = new BuiltInCommandMetadata
             {
                 Command = CacheCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-cache
                 DocLink = new Uri("https://aka.ms/dotnet-cache")
             },
             ["clean"] = new BuiltInCommandMetadata 
             {
                 Command = CleanCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-clean
                 DocLink = new Uri("https://aka.ms/dotnet-clean")
             },
             ["help"] = new BuiltInCommandMetadata
             {
                 Command = HelpCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-help
                 DocLink = new Uri("https://aka.ms/dotnet-help")
             },
             ["list"] = new BuiltInCommandMetadata
             {
                 Command = ListCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-list-reference
                 DocLink = new Uri("https://aka.ms/dotnet-list")
             },
             ["migrate"] = new BuiltInCommandMetadata
             {
                 Command = MigrateCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-migrate
                 DocLink = new Uri("http://aka.ms/dotnet-migrate")
 
             },
             ["msbuild"] = new BuiltInCommandMetadata
             {
                 Command = MSBuildCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-msbuild
                 DocLink = new Uri("https://aka.ms/dotnet-msbuild")
             },
             ["new"] = new BuiltInCommandMetadata
             {
                 Command = NewCommandShim.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-new
                 DocLink = new Uri("https://aka.ms/dotnet-new")
             },
             ["nuget"] = new BuiltInCommandMetadata
             {
                 Command = NuGetCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-nuget-locals
                 DocLink = new Uri("https://aka.ms/dotnet-nuget")
             },
             ["pack"] = new BuiltInCommandMetadata
             {
                 Command = PackCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-pack
                 DocLink = new Uri("https://aka.ms/dotnet-pack")
             },
             ["publish"] = new BuiltInCommandMetadata
             {
                 Command = PublishCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-publish
                 DocLink = new Uri("https://aka.ms/dotnet-publish")
             },
             ["remove"] = new BuiltInCommandMetadata
             {
                 Command = RemoveCommand.Run,
+                // aka.ms link: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-remove-reference
                 DocLink = new Uri("https://aka.ms/dotnet-remove")
             },
             ["restore"] = new BuiltInCommandMetadata
             {
                 Command = RestoreCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-restore
                 DocLink = new Uri("https://aka.ms/dotnet-restore")
             },
             ["run"] = new BuiltInCommandMetadata
             {
                 Command = RunCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-run
                 DocLink = new Uri("https://aka.ms/dotnet-run")
             },
             ["sln"] = new BuiltInCommandMetadata
             {
                 Command = SlnCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-sln
                 DocLink = new Uri("https://aka.ms/dotnet-sln")
             },
             ["test"] = new BuiltInCommandMetadata
             {
                 Command = TestCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-test
                 DocLink = new Uri("https://aka.ms/dotnet-test")
             },
             ["vstest"] = new BuiltInCommandMetadata
             {
                 Command = VSTestCommand.Run,
+                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-vstest
                 DocLink = new Uri("https://aka.ms/dotnet-vstest")
             }
         };

--- a/src/dotnet/BuiltInCommandsCatalog.cs
+++ b/src/dotnet/BuiltInCommandsCatalog.cs
@@ -28,110 +28,110 @@ namespace Microsoft.DotNet.Cli
             ["add"] = new BuiltInCommandMetadata
             {
                 Command = AddCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-add-reference
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-add-reference
                 DocLink = new Uri("https://aka.ms/dotnet-add")
             },
             ["build"] = new BuiltInCommandMetadata
             {
                 Command = BuildCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-build
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-build
                 DocLink = new Uri("https://aka.ms/dotnet-build")
             },
             ["cache"] = new BuiltInCommandMetadata
             {
                 Command = CacheCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-cache
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-cache
                 DocLink = new Uri("https://aka.ms/dotnet-cache")
             },
             ["clean"] = new BuiltInCommandMetadata 
             {
                 Command = CleanCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-clean
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-clean
                 DocLink = new Uri("https://aka.ms/dotnet-clean")
             },
             ["help"] = new BuiltInCommandMetadata
             {
                 Command = HelpCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-help
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-help
                 DocLink = new Uri("https://aka.ms/dotnet-help")
             },
             ["list"] = new BuiltInCommandMetadata
             {
                 Command = ListCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-list-reference
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-list-reference
                 DocLink = new Uri("https://aka.ms/dotnet-list")
             },
             ["migrate"] = new BuiltInCommandMetadata
             {
                 Command = MigrateCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-migrate
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-migrate
                 DocLink = new Uri("http://aka.ms/dotnet-migrate")
 
             },
             ["msbuild"] = new BuiltInCommandMetadata
             {
                 Command = MSBuildCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-msbuild
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-msbuild
                 DocLink = new Uri("https://aka.ms/dotnet-msbuild")
             },
             ["new"] = new BuiltInCommandMetadata
             {
                 Command = NewCommandShim.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-new
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-new
                 DocLink = new Uri("https://aka.ms/dotnet-new")
             },
             ["nuget"] = new BuiltInCommandMetadata
             {
                 Command = NuGetCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-nuget-locals
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-nuget-locals
                 DocLink = new Uri("https://aka.ms/dotnet-nuget")
             },
             ["pack"] = new BuiltInCommandMetadata
             {
                 Command = PackCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-pack
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-pack
                 DocLink = new Uri("https://aka.ms/dotnet-pack")
             },
             ["publish"] = new BuiltInCommandMetadata
             {
                 Command = PublishCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-publish
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-publish
                 DocLink = new Uri("https://aka.ms/dotnet-publish")
             },
             ["remove"] = new BuiltInCommandMetadata
             {
                 Command = RemoveCommand.Run,
-                // aka.ms link: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-remove-reference
+                // aka.ms link: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-remove-reference
                 DocLink = new Uri("https://aka.ms/dotnet-remove")
             },
             ["restore"] = new BuiltInCommandMetadata
             {
                 Command = RestoreCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-restore
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-restore
                 DocLink = new Uri("https://aka.ms/dotnet-restore")
             },
             ["run"] = new BuiltInCommandMetadata
             {
                 Command = RunCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-run
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-run
                 DocLink = new Uri("https://aka.ms/dotnet-run")
             },
             ["sln"] = new BuiltInCommandMetadata
             {
                 Command = SlnCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-sln
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-sln
                 DocLink = new Uri("https://aka.ms/dotnet-sln")
             },
             ["test"] = new BuiltInCommandMetadata
             {
                 Command = TestCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-test
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-test
                 DocLink = new Uri("https://aka.ms/dotnet-test")
             },
             ["vstest"] = new BuiltInCommandMetadata
             {
                 Command = VSTestCommand.Run,
-                // aka.ms target: https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-vstest
+                // aka.ms target: https://docs.microsoft.com/dotnet/articles/core/tools/dotnet-vstest
                 DocLink = new Uri("https://aka.ms/dotnet-vstest")
             }
         };

--- a/src/dotnet/BuiltInCommandsCatalog.cs
+++ b/src/dotnet/BuiltInCommandsCatalog.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Tools.Add;
+using Microsoft.DotNet.Tools.Build;
+using Microsoft.DotNet.Tools.Clean;
+using Microsoft.DotNet.Tools.Help;
+using Microsoft.DotNet.Tools.List;
+using Microsoft.DotNet.Tools.Migrate;
+using Microsoft.DotNet.Tools.MSBuild;
+using Microsoft.DotNet.Tools.New;
+using Microsoft.DotNet.Tools.NuGet;
+using Microsoft.DotNet.Tools.Pack;
+using Microsoft.DotNet.Tools.Publish;
+using Microsoft.DotNet.Tools.Remove;
+using Microsoft.DotNet.Tools.Restore;
+using Microsoft.DotNet.Tools.Run;
+using Microsoft.DotNet.Tools.Sln;
+using Microsoft.DotNet.Tools.Test;
+using Microsoft.DotNet.Tools.VSTest;
+using Microsoft.DotNet.Tools.Cache;
+
+namespace Microsoft.DotNet.Cli
+{
+    public static class BuiltInCommandsCatalog
+    {
+        public static Dictionary<string, BuiltInCommandMetadata> Commands = new Dictionary<string, BuiltInCommandMetadata>
+        {
+            ["add"] = new BuiltInCommandMetadata
+            {
+                Command = AddCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-add")
+            },
+            ["build"] = new BuiltInCommandMetadata
+            {
+                Command = BuildCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-build")
+            },
+            ["cache"] = new BuiltInCommandMetadata
+            {
+                Command = CacheCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-cache")
+            },
+            ["clean"] = new BuiltInCommandMetadata 
+            {
+                Command = CleanCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-clean")
+            },
+            ["help"] = new BuiltInCommandMetadata
+            {
+                Command = HelpCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-help")
+            },
+            ["list"] = new BuiltInCommandMetadata
+            {
+                Command = ListCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-list")
+            },
+            ["migrate"] = new BuiltInCommandMetadata
+            {
+                Command = MigrateCommand.Run,
+                DocLink = new Uri("http://aka.ms/dotnet-migrate")
+
+            },
+            ["msbuild"] = new BuiltInCommandMetadata
+            {
+                Command = MSBuildCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-msbuild")
+            },
+            ["new"] = new BuiltInCommandMetadata
+            {
+                Command = NewCommandShim.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-new")
+            },
+            ["nuget"] = new BuiltInCommandMetadata
+            {
+                Command = NuGetCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-nuget")
+            },
+            ["pack"] = new BuiltInCommandMetadata
+            {
+                Command = PackCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-pack")
+            },
+            ["publish"] = new BuiltInCommandMetadata
+            {
+                Command = PublishCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-publish")
+            },
+            ["remove"] = new BuiltInCommandMetadata
+            {
+                Command = RemoveCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-remove")
+            },
+            ["restore"] = new BuiltInCommandMetadata
+            {
+                Command = RestoreCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-restore")
+            },
+            ["run"] = new BuiltInCommandMetadata
+            {
+                Command = RunCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-run")
+            },
+            ["sln"] = new BuiltInCommandMetadata
+            {
+                Command = SlnCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-sln")
+            },
+            ["test"] = new BuiltInCommandMetadata
+            {
+                Command = TestCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-test")
+            },
+            ["vstest"] = new BuiltInCommandMetadata
+            {
+                Command = VSTestCommand.Run,
+                DocLink = new Uri("https://aka.ms/dotnet-vstest")
+            }
+        };
+
+    }
+}

--- a/src/dotnet/DotNetCommandFactory.cs
+++ b/src/dotnet/DotNetCommandFactory.cs
@@ -24,13 +24,13 @@ namespace Microsoft.DotNet.Cli
         	NuGetFramework framework = null, 
         	string configuration = Constants.DefaultConfiguration)
         {
-            Func<string[], int> builtInCommand;
+            BuiltInCommandMetadata builtInCommand;
             if (!_alwaysRunOutOfProc && Program.TryGetBuiltInCommand(commandName, out builtInCommand))
             {
                 Debug.Assert(framework == null, "BuiltInCommand doesn't support the 'framework' argument.");
                 Debug.Assert(configuration == Constants.DefaultConfiguration, "BuiltInCommand doesn't support the 'configuration' argument.");
 
-                return new BuiltInCommand(commandName, args, builtInCommand);
+                return new BuiltInCommand(commandName, args, builtInCommand.Command);
             }
 
             return Command.CreateDotNet(commandName, args, framework, configuration);

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -127,8 +127,6 @@ namespace Microsoft.DotNet.Cli
             telemetryClient.TrackEvent(command, null, null);
 
             int exitCode;
-            // Func<string[], int> builtIn;
-            // if (s_builtIns.TryGetValue(command, out builtIn))
             BuiltInCommandMetadata builtIn;
             if (BuiltInCommandsCatalog.Commands.TryGetValue(command, out builtIn))
             {

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -2,60 +2,18 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.PlatformAbstractions;
-using Microsoft.DotNet.Tools.Add;
-using Microsoft.DotNet.Tools.Build;
-using Microsoft.DotNet.Tools.Clean;
 using Microsoft.DotNet.Tools.Help;
-using Microsoft.DotNet.Tools.List;
-using Microsoft.DotNet.Tools.Migrate;
-using Microsoft.DotNet.Tools.MSBuild;
-using Microsoft.DotNet.Tools.New;
-using Microsoft.DotNet.Tools.NuGet;
-using Microsoft.DotNet.Tools.Pack;
-using Microsoft.DotNet.Tools.Publish;
-using Microsoft.DotNet.Tools.Remove;
-using Microsoft.DotNet.Tools.Restore;
-using Microsoft.DotNet.Tools.RestoreProjectJson;
-using Microsoft.DotNet.Tools.Run;
-using Microsoft.DotNet.Tools.Sln;
-using Microsoft.DotNet.Tools.Test;
-using Microsoft.DotNet.Tools.VSTest;
-using Microsoft.DotNet.Tools.Cache;
 using NuGet.Frameworks;
 
 namespace Microsoft.DotNet.Cli
 {
     public class Program
     {
-        private static Dictionary<string, Func<string[], int>> s_builtIns = new Dictionary<string, Func<string[], int>>
-        {
-            ["add"] = AddCommand.Run,
-            ["build"] = BuildCommand.Run,
-            ["cache"] = CacheCommand.Run,
-            ["clean"] = CleanCommand.Run,
-            ["help"] = HelpCommand.Run,
-            ["list"] = ListCommand.Run,
-            ["migrate"] = MigrateCommand.Run,
-            ["msbuild"] = MSBuildCommand.Run,
-            ["new"] = NewCommandShim.Run,
-            ["nuget"] = NuGetCommand.Run,
-            ["pack"] = PackCommand.Run,
-            ["publish"] = PublishCommand.Run,
-            ["remove"] = RemoveCommand.Run,
-            ["restore"] = RestoreCommand.Run,
-            ["run"] = RunCommand.Run,
-            ["sln"] = SlnCommand.Run,
-            ["test"] = TestCommand.Run,
-            ["vstest"] = VSTestCommand.Run,
-        };
-
         public static int Main(string[] args)
         {
             DebugHelper.HandleDebugSwitch(ref args);
@@ -169,10 +127,12 @@ namespace Microsoft.DotNet.Cli
             telemetryClient.TrackEvent(command, null, null);
 
             int exitCode;
-            Func<string[], int> builtIn;
-            if (s_builtIns.TryGetValue(command, out builtIn))
+            // Func<string[], int> builtIn;
+            // if (s_builtIns.TryGetValue(command, out builtIn))
+            BuiltInCommandMetadata builtIn;
+            if (BuiltInCommandsCatalog.Commands.TryGetValue(command, out builtIn))
             {
-                exitCode = builtIn(appArgs.ToArray());
+                exitCode = builtIn.Command(appArgs.ToArray());
             }
             else
             {
@@ -215,9 +175,9 @@ namespace Microsoft.DotNet.Cli
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 
-        internal static bool TryGetBuiltInCommand(string commandName, out Func<string[], int> builtInCommand)
+        internal static bool TryGetBuiltInCommand(string commandName, out BuiltInCommandMetadata builtInCommand)
         {
-            return s_builtIns.TryGetValue(commandName, out builtInCommand);
+            return BuiltInCommandsCatalog.Commands.TryGetValue(commandName, out builtInCommand);
         }
 
         private static void PrintVersion()

--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Cli;
 
 namespace Microsoft.DotNet.Tools.Help
 {
@@ -63,17 +64,17 @@ Project modification commands:
 
             app.OnExecute(() => 
             {
-                Cli.BuiltInCommandMetadata builtIn;
-                if (Cli.BuiltInCommandsCatalog.Commands.TryGetValue(commandNameArgument.Value, out builtIn))
+                BuiltInCommandMetadata builtIn;
+                if (BuiltInCommandsCatalog.Commands.TryGetValue(commandNameArgument.Value, out builtIn))
                 {
-                    // var p = Process.Start(GetProcessStartInfo(builtIn));
-                    var process = ConfigureProcess(builtIn.DocLink.ToString());
+                    var process = ConfigureProcess(builtIn.DocLink);
                     process.Start();
                     process.WaitForExit();
                 }
                 else
                 {
                     Reporter.Error.WriteLine(String.Format(LocalizableStrings.CommandDoesNotExist, commandNameArgument.Value));
+                    Reporter.Output.WriteLine(UsageText);
                     return 1;
                 }
                 return 0;

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -66,5 +66,18 @@ namespace Microsoft.DotNet.Tools.Help
         public const string CleanDefinition = "Clean build output(s).";
 
         public const string SlnDefinition = "Modify solution (SLN) files.";
+
+        public const string CommandDoesNotExist = "Specified command {0} is not a valid CLI command. Please specify a valid CLI commands. For more information, run dotnet help.";
+
+        public const string AppFullName = ".NET CLI help utility";
+
+        public const string AppDescription = "Utility to get more detailed help about each of the CLI commands.";
+
+        public const string CommandArgumentName = "COMMAND_NAME";
+
+        public const string CommandArgumentDescription = "CLI command for which to view more detailed help.";
+
+
+
     }
 }

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Tools.Help
 
         public const string SlnDefinition = "Modify solution (SLN) files.";
 
-        public const string CommandDoesNotExist = "Specified command {0} is not a valid CLI command. Please specify a valid CLI commands. For more information, run dotnet help.";
+        public const string CommandDoesNotExist = "Specified command '{0}' is not a valid CLI command. Please specify a valid CLI commands. For more information, run dotnet help.";
 
         public const string AppFullName = ".NET CLI help utility";
 

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/LinuxOnlyFactAttribute.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/LinuxOnlyFactAttribute.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.PlatformAbstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public class LinuxOnlyFactAttribute : FactAttribute
+    {
+        public LinuxOnlyFactAttribute()
+        {
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Linux)
+            {
+                this.Skip = "This test requires linux to run";
+            }
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/MacOsOnlyFactAttribute.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/MacOsOnlyFactAttribute.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.PlatformAbstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public class MacOsOnlyFactAttribute : FactAttribute
+    {
+        public MacOsOnlyFactAttribute()
+        {
+            if (RuntimeEnvironment.OperatingSystemPlatform != Platform.Darwin)
+            {
+                this.Skip = "This test requires macos to run";
+            }
+        }
+    }
+}

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Construction;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 using FluentAssertions;
+using HelpActual = Microsoft.DotNet.Tools.Help;
 
 namespace Microsoft.DotNet.Help.Tests
 {
@@ -64,6 +65,40 @@ Advanced Commands:
                 .ExecuteWithCapturedOutput($"{helpArg}");
             cmd.Should().Pass();
             cmd.StdOut.Should().ContainVisuallySameFragment(HelpText);
+        }
+
+        [Fact]
+        public void WhenInvalidCommandIsPassedToDOtnetHelpItPrintsError()
+        {
+          var cmd = new DotnetCommand()
+                .ExecuteWithCapturedOutput("help invalid");
+          
+          cmd.Should().Fail();
+          cmd.StdErr.Should().ContainVisuallySameFragment($"Specified command invalid is not a valid CLI command. Please specify a valid CLI commands. For more information, run dotnet help.");
+        }
+
+        [WindowsOnlyFact]
+        public void WhenRunOnWindowsDotnetHelpCommandShouldContainProperProcessInformation()
+        {
+          var proc = HelpActual.HelpCommand.ConfigureProcess("https://aka.ms/dotnet-build");
+          Assert.Equal("cmd", proc.StartInfo.FileName);
+          Assert.Equal("/c start https://aka.ms/dotnet-build", proc.StartInfo.Arguments);
+        }
+
+        [LinuxOnlyFact]
+        public void WhenRunOnLinuxDotnetHelpCommandShouldContainProperProcessInformation()
+        {
+          var proc = HelpActual.HelpCommand.ConfigureProcess("https://aka.ms/dotnet-build");
+          Assert.Equal("xdg-open", proc.StartInfo.FileName);
+          Assert.Equal("https://aka.ms/dotnet-build", proc.StartInfo.Arguments);
+        
+        }
+        [MacOsOnlyFact]
+        public void WhenRunOnMacOsDotnetHelpCommandShouldContainProperProcessInformation()
+        {
+          var proc = HelpActual.HelpCommand.ConfigureProcess("https://aka.ms/dotnet-build");
+          Assert.Equal("open", proc.StartInfo.FileName);
+          Assert.Equal("https://aka.ms/dotnet-build", proc.StartInfo.Arguments);
         }
     }
 }

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -75,6 +75,7 @@ Advanced Commands:
           
           cmd.Should().Fail();
           cmd.StdErr.Should().ContainVisuallySameFragment($"Specified command invalid is not a valid CLI command. Please specify a valid CLI commands. For more information, run dotnet help.");
+          cmd.StdOut.Should().ContainVisuallySameFragment(HelpText);
         }
 
         [WindowsOnlyFact]

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -74,7 +74,7 @@ Advanced Commands:
                 .ExecuteWithCapturedOutput("help invalid");
           
           cmd.Should().Fail();
-          cmd.StdErr.Should().ContainVisuallySameFragment($"Specified command invalid is not a valid CLI command. Please specify a valid CLI commands. For more information, run dotnet help.");
+          cmd.StdErr.Should().ContainVisuallySameFragment($"Specified command 'invalid' is not a valid CLI command. Please specify a valid CLI commands. For more information, run dotnet help.");
           cmd.StdOut.Should().ContainVisuallySameFragment(HelpText);
         }
 

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -68,7 +68,7 @@ Advanced Commands:
         }
 
         [Fact]
-        public void WhenInvalidCommandIsPassedToDOtnetHelpItPrintsError()
+        public void WhenInvalidCommandIsPassedToDotnetHelpItPrintsError()
         {
           var cmd = new DotnetCommand()
                 .ExecuteWithCapturedOutput("help invalid");


### PR DESCRIPTION
This commit adds supports for getting more detailed help by using the `dotnet help <verb>` syntax (e.g. `dotnet help build`). This change opens up the URL that is specified for each verb in the default browser on the user's machine, so internet access is required.

The PR removes the `s_builtIns` from `dotnet/Program.cs` into a separate class and adds a class that contains the links. I went this way to minimize code changes overall as well as to create a situation where we have a single place to add a command to the built-ins dictionary so that things do not go out of sync. Another approach is that this could be a property on the `CommandLineApplication` class that each command can fill in. 

/cc @richlander 