### PR TITLE
Re-license as MIT

### DIFF
--- a/TestAssets/DesktopTestProjects/DesktopKestrelSample/src/Startup.cs
+++ b/TestAssets/DesktopTestProjects/DesktopKestrelSample/src/Startup.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.IO;


### PR DESCRIPTION
- Re-license Kestrel sample as MIT, matching the rest of repo.
- The sample came from MSFT employees, so this is fine.
- Simplifies 3PN requirements.