### PR TITLE
Fix UpdateVersionsRepo to pass file paths instead of a directory

### DIFF
--- a/build_projects/dotnet-cli-build/UpdateVersionsRepo.cs
+++ b/build_projects/dotnet-cli-build/UpdateVersionsRepo.cs
@@ -4,6 +4,7 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.DotNet.VersionTools.Automation;
+using System.IO;
 
 namespace Microsoft.DotNet.Cli.Build
 {
@@ -25,7 +26,7 @@ namespace Microsoft.DotNet.Cli.Build
             GitHubAuth auth = new GitHubAuth(GitHubPassword);
             GitHubVersionsRepoUpdater repoUpdater = new GitHubVersionsRepoUpdater(auth);
             repoUpdater.UpdateBuildInfoAsync(
-                new [] { PackagesDirectory }, 
+                Directory.GetFiles(PackagesDirectory, "*.nupkg"),
                 versionsRepoPath).Wait();
 
             return true;


### PR DESCRIPTION
Our official builds would be broken if they weren't already broken by something else.

@dagood

/cc @livarcocc @piotrpMSFT