### PR TITLE
Removed the square brackets from the dotnet-test `--logger` parameter help

### DIFF
--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">Zadejte protokolovací nástroj pro výsledky testů. 
-                                        Příklad: --logger "trx[;LogFileName=&lt;Standardně se nastaví jedinečný název souboru&gt;]"</target>
+                                        Příklad: --logger "trx;LogFileName=&lt;Standardně se nastaví jedinečný název souboru&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">Geben Sie einen Protokollierer für Testergebnisse an. 
-                                        Beispiel: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</target>
+                                        Beispiel: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">Especifica un registrador para los resultados de pruebas. 
-                                        Ejemplo: --logger "trx[;LogFileName=&lt;Se establece de manera predeterminada en el nombre de archivo único&gt;]"</target>
+                                        Ejemplo: --logger "trx;LogFileName=&lt;Se establece de manera predeterminada en el nombre de archivo único&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">Spécifiez un enregistreur pour les résultats des tests. 
-                                        Exemple : --logger "trx[;LogFileName=&lt;par défaut un nom de fichier unique&gt;]"</target>
+                                        Exemple : --logger "trx;LogFileName=&lt;par défaut un nom de fichier unique&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">Consente di specificare un logger per i risultati dei test. 
-                                        Esempio: --logger "trx[;LogFileName=&lt;l'impostazione predefinita è un nome file univoco&gt;]"</target>
+                                        Esempio: --logger "trx;LogFileName=&lt;l'impostazione predefinita è un nome file univoco&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">テスト結果のロガーを指定します。
-                                       例: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</target>
+                                       例: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">테스트 결과에 대해 로거를 지정합니다. 
-                                        예: --logger "trx[;LogFileName=&lt;고유한 파일 이름을 기본값으로 설정&gt;]"</target>
+                                        예: --logger "trx;LogFileName=&lt;고유한 파일 이름을 기본값으로 설정&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">Określ rejestratora wyników testów. 
-                                        Przykład: --logger "trx[;LogFileName=&lt;domyślnie jest to unikatowa nazwa pliku&gt;]"</target>
+                                        Przykład: --logger "trx;LogFileName=&lt;domyślnie jest to unikatowa nazwa pliku&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">Especifique um agente para os resultados de teste. 
-                                        Exemplo: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</target>
+                                        Exemplo: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">Укажите средство ведения журнала для результатов теста. 
-                                        Пример: --logger "trx[;LogFileName=&lt;по умолчанию используется уникальное имя файла&gt;]"</target>
+                                        Пример: --logger "trx;LogFileName=&lt;по умолчанию используется уникальное имя файла&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">Test sonuçları için bir günlükçü belirtin. 
-                                        Örnek: --logger "trx[;LogFileName=&lt;Varsayılan olarak benzersiz dosya adıdır&gt;]"</target>
+                                        Örnek: --logger "trx;LogFileName=&lt;Varsayılan olarak benzersiz dosya adıdır&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.xlf
@@ -56,7 +56,7 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <note></note>
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">指定测试结果的记录器。
-                                       示例: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</target>
+                                       示例: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -73,9 +73,9 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results. 
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"</source>
+                                        Example: --logger "trx;LogFileName=&lt;Defaults to unique file name&gt;"</source>
         <target state="translated">指定測試結果的記錄器。
-                                       例如: --logger "trx[;LogFileName=&lt;預設為唯一的檔案名稱&gt;]"</target>
+                                       例如: --logger "trx;LogFileName=&lt;預設為唯一的檔案名稱&gt;"</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdConfiguration">


### PR DESCRIPTION
The command line documentation `dotnet help test` currently reads:
```
 -l|--logger <LoggerUri/FriendlyName>  Specify a logger for test results.
                                        Example: --logger "trx[;LogFileName=<Defaults to unique file name>]"
```

However the example does not work. It should read `--logger "trx;LogFileName=<Defaults to unique file name>"`, ie without the `[]`. This correct usage can be seen in this [test](https://github.com/dotnet/cli/blob/70c65160f6163666dbe5f052b2331ec59582fce5/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs#L180)
