### PR TITLE
Force integration tests to execute tests against invoking CLI, ignoring PATh

### DIFF
--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/DotnetCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/DotnetCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using Microsoft.DotNet.Cli.Utils;
 
 namespace Microsoft.DotNet.Tools.Test.Utilities
@@ -9,7 +8,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
     public sealed class DotnetCommand : TestCommand
     {
         public DotnetCommand()
-            : base("dotnet")
+            : base(DotnetUnderTest.FullName)
         {
 
         }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/DotnetUnderTest.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/DotnetUnderTest.cs
@@ -18,9 +18,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 {
                     _pathToDotnetUnderTest = new Muxer().MuxerPath;
                 }
-
-                Console.WriteLine($"Executing tests against {_pathToDotnetUnderTest}");
-
+                
                 return _pathToDotnetUnderTest;
             }
         }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/DotnetUnderTest.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/DotnetUnderTest.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public static class DotnetUnderTest
+    {
+        static string _pathToDotnetUnderTest;
+
+        public static string FullName
+        {
+            get
+            {
+                if (_pathToDotnetUnderTest == null)
+                {
+                    _pathToDotnetUnderTest = new Muxer().MuxerPath;
+                }
+
+                Console.WriteLine($"Executing tests against {_pathToDotnetUnderTest}");
+
+                return _pathToDotnetUnderTest;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This design is different from what was described this morning, but feels quite good. Thanks @jonsequitur and @eerhardt for chatting with me about this.

With this implementation, CLI integration tests will use `Muxer.cs` to find the path to the `dotnet` that is actually executing the test project, and will execute tests against that `dotnet`. This is fairly elegant, and supports the scenarios we discussed:

- Full build will execute tests running stage2, resulting in stage2 being tested
- Dev build will execute tests against the dotnet the engineer chose to run his tests. By convention, we all use stage2 on our dev boxes, so this will be fine
- We add support for executing tests separately from building the CLI. On a given machine we can copy over  a CLI and a built test library, then `/path/to/dotnet vstest /path/to/test.dll` and that test.dll will test the CLI from `/path/to/dotnet`

