### PR TITLE
Fix broken links from #5928 in the documentation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,4 @@ See [Contributing](https://github.com/dotnet/corefx/blob/master/Documentation/pr
 Developers
 ==========
 
-See the [Developer Guide](Documentation/developer-guide.md) for details about developing in this repo.
+See the [Developer Guide](Documentation/project-docs/developer-guide.md) for details about developing in this repo.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -3,8 +3,8 @@ Documents Index
 
 ## Overview and general information
 
-- [Intro to .NET Core CLI](intro-to-cli.md)
-- [CLI UX Guidelines](cli-ux-guidelines.md)
+- [Intro to .NET Core CLI](general/intro-to-cli.md)
+- [CLI UX Guidelines](general/cli-ux-guidelines.md)
 - [.NET Core native pre-requisities document](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md)
 - [Roadmap and OS support](https://github.com/dotnet/core/blob/master/roadmap.md)
 - [Comprehensive CLI documentation](https://docs.microsoft.com/en-us/dotnet/articles/core/preview3/tools/)
@@ -12,7 +12,7 @@ Documents Index
 ## Working with the CLI repo
 
 - [Developer Guide](project-docs/developer-guide.md)
-- [How to file issues](project-docs/issue-filing.guide.md)
+- [How to file issues](project-docs/issue-filing-guide.md)
 
 ## Troubleshooting and issues reporting
 


### PR DESCRIPTION
This change fixes the broken links in the documentation caused by #5928.

The changes following files are changed:

in `CONTRIBUTING.md`:
* Fix the `Developer Guide` link to the new location of the developer guide.

in `Documentation/README.md`:
* Fix the `CLI UX Guidelines` link, the `Intro to .NET Core CLI` link and the `How to file issues` link to represent their new location in the `Documentation` sub tree.

skip ci please