### PR TITLE
Change name for DOTNET_PACKAGES to NUGET_PACKAGES

### DIFF
--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -74,7 +74,7 @@ Runs a portable app named `myapp.dll`.
 
 ## ENVIRONMENT 
 
-`DOTNET_PACKAGES`
+`NUGET_PACKAGES`
 
 The primary package cache. If not set, it defaults to $HOME/.nuget/packages on Unix or %HOME%\NuGet\Packages on Windows.
 


### PR DESCRIPTION
README was never updated in #817, making it show an obsolete variable.

This reflects the name used in the current code.

(skip ci please)