### PR TITLE
Bypass powershell execution policy

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,5 +3,5 @@
 REM Copyright (c) .NET Foundation and contributors. All rights reserved.
 REM Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-powershell -NoProfile -NoLogo -Command "& \"%~dp0run-build.ps1\" %*; exit $LastExitCode;"
+powershell -ExecutionPolicy Bypass -NoProfile -NoLogo -Command "& \"%~dp0run-build.ps1\" %*; exit $LastExitCode;"
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
Allows build.cmd to work on a machine that has not configured the powershell execution.
Matches what has been done in other dotnet repos.

@livarcocc 


