### PR TITLE
Netcoreapp2.0 targetted TestPlatform

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -10,5 +10,6 @@
     <add key="xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="AspNetCurrent" value="https://dotnet.myget.org/F/aspnet-feb2017-patch/api/v3/index.json" /> 
+    <add key="vstest" value="https://dotnet.myget.org/F/vstest/auth/967ad631-d24c-4c0e-bece-922de3064956/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -10,6 +10,6 @@
     <add key="xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="AspNetCurrent" value="https://dotnet.myget.org/F/aspnet-feb2017-patch/api/v3/index.json" /> 
-    <add key="vstest" value="https://dotnet.myget.org/F/vstest/auth/967ad631-d24c-4c0e-bece-922de3064956/api/v3/index.json" />
+    <add key="vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -7,7 +7,7 @@
     <CLI_NETSDK_Version>1.1.0-alpha-20170306-2</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-beta1-2342</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170130-3-281</CLI_WEBSDK_Version>
-    <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>
+    <CLI_TestPlatform_Version>15.1.0-preview-20170316-05</CLI_TestPlatform_Version>
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -183,10 +183,6 @@
               PlatformAssemblyPaths="@(PlatformAssemblies);
                                      @(PublishDirSubDirectories);
                                      $(SharedFrameworkNameVersionPath)" />
-
-    <!-- Move the "1.0" assemblies back -->
-    <Move SourceFiles="@(NETCore10Assemblies->'$(PublishDir)/%(Filename)%(Extension).bak')"
-          DestinationFiles="@(NETCore10Assemblies)" />
   </Target>
 
   <Target Name="RemoveVbc"

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -154,18 +154,6 @@
           Condition=" '$(DISABLE_CROSSGEN)' == '' "
           AfterTargets="PublishMSBuildExtensions">
     <ItemGroup>
-      <NETCore10Assemblies Include="$(PublishDir)/System.ComponentModel.Primitives.dll;
-                                    $(PublishDir)/System.Collections.Specialized.dll;
-                                    $(PublishDir)/System.Collections.NonGeneric.dll;
-                                    $(PublishDir)/System.Private.DataContractSerialization.dll" />
-    </ItemGroup>
-
-    <!-- Move these "1.0" assemblies that TestPlatform lays down out of the way so crossgen doesn't pick them up.
-          We need https://github.com/dotnet/cli/issues/5464 fixed, so test platform is in a separate directory -->
-    <Move SourceFiles="@(NETCore10Assemblies)"
-          DestinationFiles="@(NETCore10Assemblies->'$(PublishDir)/%(Filename)%(Extension).bak')" />
-
-    <ItemGroup>
       <!-- Removing Full CLR built TestHost assemblies from getting Crossgen as it is throwing error -->
       <SdkFiles Include="$(PublishDir)/**/*" Exclude="$(PublishDir)/TestHost*/**/*;$(PublishDir)/Sdks/**/*" />
     </ItemGroup>


### PR DESCRIPTION
- Moved vstest.console to target netcoreapp2.0.
- Removed not required anymore System.*.dlls.

@codito @livarcocc @eerhardt @sbaid 
