### PR TITLE
Add bash shebang to dotnet-install.sh

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -1,9 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
-
-# Note: This script should be compatible with the dash shell used in Ubuntu. So avoid bashisms! See https://wiki.ubuntu.com/DashAsBinSh for more info
 
 # Stop script on NZEC
 set -e


### PR DESCRIPTION
`dotnet-install.sh` has some Bash-isms in it (at least `set -o pipefail`, and maybe others) so it doesn't currently work with some other shells such as Dash. Because of this, it should have a `/bin/bash` shebang so it always runs using Bash (unless someone wants to update it to remove Bash-isms and ensure it stays that way)