### PR TITLE
Only restore crossgen for the current rid.

### DIFF
--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -7,9 +7,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>bin\$(Configuration)</OutputPath>
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wp8+wpa81</PackageTargetFallback>
-
-    <!-- Specify a RID so that the runtime package with crossgen will be restored -->
-    <RuntimeIdentifiers>$(CoreCLRRid)</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR" Version="1.0.4" />
     <PackageReference Include="Microsoft.Build" Version="$(CLI_MSBuild_Version)" />
     <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
@@ -33,9 +29,5 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(CLI_MSBuild_Version)" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="$(VersionToolsVersion)" />
-
-    <!-- This will cause the package with crossgen in it to be restored -->
-    <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
-
  </ItemGroup>
 </Project>

--- a/tools/CrossGen.Dependencies/CrossGen.Dependencies.csproj
+++ b/tools/CrossGen.Dependencies/CrossGen.Dependencies.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeIdentifiers>linux-x64;win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifier>$(Rid)</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Today we download crossgen for all supported runtime ids. This
introduces a dependency on having builds for all supported platforms
in order to build the CLI on a single platform. This is problematic
for the build from source effort because we only build artifacts for a
specific rid (the RID of the host/target).

Update the CrossGen.Dependencies project to restore for only the RID
we are building for.