### PR TITLE
Generate auto-imported props file with bundled netcoreapp and netstandard versions

### DIFF
--- a/build/BundledVersions.targets
+++ b/build/BundledVersions.targets
@@ -1,0 +1,67 @@
+<Project>
+  <PropertyGroup>
+    <BundledVersionsIntermediateDirectory>$(IntermediateDirectory)/GeneratedMSBuildImports</BundledVersionsIntermediateDirectory>
+    <BundledVersionsPropsFolder>15.0/Imports/Microsoft.Common.props/ImportBefore</BundledVersionsPropsFolder>
+    <BundledVersionsPropsFileName>Microsoft.NETCoreSdk.BundledVersions.props</BundledVersionsPropsFileName>
+  </PropertyGroup>
+
+  <Target Name="GenerateBundledVersionsProps"
+          BeforeTargets="PublishMSBuildExtensions">
+
+    <!-- 
+      The bundled version of Microsoft.NETCore.App is determined statically from DependencyVersions.props whereas the bundled version
+      of NETStandard.Library is defined by what Microsoft.NETCore.App pulls in. This digs in to the package resolution items of
+      of our build against Microsoft.NETCore.App to find the correct NETStandard.Library version
+    -->
+    <ItemGroup>
+      <_NETStandardLibraryVersions Include="@(PackageDefinitions->'%(Version)')"
+                                   Condition="%(PackageDefinitions.Name) == 'NetStandard.Library'" />
+    </ItemGroup>
+
+    <Error Condition="@(_NETStandardLibraryVersions->Distinct()->Count()) != 1"
+           Text="Failed to determine the NETStandard.Library version pulled in Microsoft.NETCore.App" />
+
+    <PropertyGroup>
+      <_NETCoreAppPackageVersion>$(CLI_SharedFrameworkVersion)</_NETCoreAppPackageVersion>
+      <_NETStandardPackageVersion>@(_NETStandardLibraryVersions->Distinct())</_NETStandardPackageVersion>
+
+      <!-- Use only major and minor in target framework version -->
+      <_NETCoreAppTargetFrameworkVersion>$(_NETCoreAppPackageVersion.Split('.')[0]).$(_NETCoreAppPackageVersion.Split('.')[1])</_NETCoreAppTargetFrameworkVersion>
+      <_NETStandardTargetFrameworkVersion>$(_NETStandardPackageVersion.Split('.')[0]).$(_NETStandardPackageVersion.Split('.')[1])</_NETStandardTargetFrameworkVersion>
+
+      <BundledVersionsPropsContent>
+<![CDATA[
+<!--
+***********************************************************************************************
+$(BundledVersionsPropsFileName)
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+<Project>
+  <PropertyGroup>
+    <BundledNETCoreAppTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</BundledNETCoreAppTargetFrameworkVersion>
+    <BundledNETCoreAppPackageVersion>$(_NETCoreAppPackageVersion)</BundledNETCoreAppPackageVersion>
+    <BundledNETStandardTargetFrameworkVersion>$(_NETStandardTargetFrameworkVersion)</BundledNETStandardTargetFrameworkVersion>
+    <BundledNETStandardPackageVersion>$(_NETStandardPackageVersion)</BundledNETStandardPackageVersion>
+  </PropertyGroup>
+</Project>
+]]>
+    </BundledVersionsPropsContent>
+  </PropertyGroup>
+
+    <MakeDir Directories="$(BundledVersionsIntermediateDirectory)/$(BundledVersionsPropsFolder)" />
+    <WriteLinesToFile File="$(BundledVersionsIntermediateDirectory)/$(BundledVersionsPropsFolder)/$(BundledVersionsPropsFileName)"
+                      Lines="$(BundledVersionsPropsContent)"
+                      Overwrite="true" />
+
+    <!-- MSBuildExtensionsContent destination is driven by %(RecursiveDir), which is why we glob here. -->
+    <ItemGroup>
+      <MSBuildExtensionsContent Include="$(BundledVersionsIntermediateDirectory)/**/$(BundledVersionsPropsFileName)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,7 +4,7 @@
     <CLI_SharedFrameworkVersion>2.0.0-beta-001791-00</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.2.0-preview-000047-02</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>2.0.0-alpha-20170320-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-alpha-20170322-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-beta1-2342</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170130-3-281</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.1.0-preview-20170316-05</CLI_TestPlatform_Version>

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -101,8 +101,8 @@ if ($LastExitCode -ne 0)
 # install the post-PJnistic stage0
 $dotnetInstallPath = Join-Path $toolsLocalPath "dotnet-install.ps1"
 
-Write-Host "$dotnetInstallPath -Channel ""master"" -Version ""2.0.0-preview1-005390"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
-Invoke-Expression "$dotnetInstallPath -Channel ""master"" -Version ""2.0.0-preview1-005390"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Write-Host "$dotnetInstallPath -Channel ""master"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Invoke-Expression "$dotnetInstallPath -Channel ""master"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
 if ($LastExitCode -ne 0)
 {
     Write-Output "The .NET CLI installation failed with exit code $LastExitCode"

--- a/run-build.sh
+++ b/run-build.sh
@@ -167,8 +167,8 @@ if [ $? != 0 ]; then
 fi
 
 # now execute the script
-echo "installing CLI: $dotnetInstallPath --channel \"master\" --version \"2.0.0-preview1-005165\" --install-dir $DOTNET_INSTALL_DIR --architecture \"$ARCHITECTURE\" $LINUX_PORTABLE_INSTALL_ARGS"
-$dotnetInstallPath --channel "master" --version "2.0.0-preview1-005390" --install-dir $DOTNET_INSTALL_DIR --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS
+echo "installing CLI: $dotnetInstallPath --channel \"master\" --install-dir $DOTNET_INSTALL_DIR --architecture \"$ARCHITECTURE\" $LINUX_PORTABLE_INSTALL_ARGS"
+$dotnetInstallPath --channel "master" --install-dir $DOTNET_INSTALL_DIR --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS
 if [ $? != 0 ]; then
     echo "run-build: Error: Boot-strapping post-PJ stage0 with exit code $?." >&2
     exit $?

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -2,6 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.tasks" />
   <Import Project="$(RepoRoot)/build/compile/LzmaArchive.targets" />
+  <Import Project="$(RepoRoot)/build/BundledVersions.targets" />
 
   <PropertyGroup>
     <VersionPrefix>$(CliVersionPrefix)</VersionPrefix>

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -144,6 +144,8 @@ namespace Microsoft.DotNet.New.Tests
                    .SingleOrDefault();
 
                 explicitVersionNode.Should().NotBeNull();
+                explicitVersionNode.Value.Should().Be(expectedVersion);
+
                 if (deleteExplicitVersion)
                 {
                     explicitVersionNode.Remove();

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -72,8 +72,8 @@ namespace Microsoft.DotNet.New.Tests
         }
 
         [Theory]
-        [InlineData("console", "RuntimeFrameworkVersion", "Microsoft.NETCore.App")]
-        [InlineData("classlib", "NetStandardImplicitPackageVersion", "NETStandard.Library")]
+        [InlineData("console", "RuntimeFrameworkVersion", "microsoft.netcore.app")]
+        [InlineData("classlib", "NetStandardImplicitPackageVersion", "netstandard.library")]
         public void NewProjectRestoresCorrectPackageVersion(string type, string propertyName, string packageName)
         {
             // These will fail when templates stop including explicit version.
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.New.Tests
                     .EnumerateDirectories()
                     .Single(d => d.Name.StartsWith("2.0.0"));
 
-                if (packageName == "Microsoft.NETCore.App")
+                if (packageName == "microsoft.netcore.app")
                 {
                     return sharedFxDir.Name;
                 }
@@ -125,7 +125,7 @@ namespace Microsoft.DotNet.New.Tests
                     var context = reader.Read(stream);
                     var dependency = context
                         .RuntimeLibraries
-                        .Single(library => library.Name.Equals(packageName, StringComparison.OrdinalIgnoreCase));
+                        .Single(library => library.Name == packageName);
 
                     return dependency.Version;
                 }

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.Extensions.DependencyModel;
 using Xunit;
 
 namespace Microsoft.DotNet.New.Tests
@@ -70,36 +71,85 @@ namespace Microsoft.DotNet.New.Tests
                 .Should().Pass();
         }
 
-        [Fact]
-        public void NewClassLibRestoresCorrectNetStandardLibraryVersion()
+        [Theory]
+        [InlineData("console", "RuntimeFrameworkVersion", "Microsoft.NETCore.App")]
+        [InlineData("classlib", "NetStandardImplicitPackageVersion", "NETStandard.Library")]
+        public void NewProjectRestoresCorrectPackageVersion(string type, string propertyName, string packageName)
         {
-            var rootPath = TestAssets.CreateTestDirectory().FullName;
+            // These will fail when templates stop including explicit version.
+            // Collapse back to one method and remove the explicit version handling when that happens.
+            NewProjectRestoresCorrectPackageVersion(type, propertyName, packageName, deleteExplicitVersion: true);
+            NewProjectRestoresCorrectPackageVersion(type, propertyName, packageName, deleteExplicitVersion: false);
+        }
+
+        private void NewProjectRestoresCorrectPackageVersion(string type, string propertyName, string packageName, bool deleteExplicitVersion)
+        {
+            var rootPath = TestAssets.CreateTestDirectory(identifier: $"_{type}_{deleteExplicitVersion}").FullName;
             var packagesDirectory = Path.Combine(rootPath, "packages");
-            var projectName = "Library";
-            var projectFileName = $"{projectName}.csproj";
+            var projectName = "Project";
+            var expectedVersion = GetFrameworkPackageVersion();
 
             new NewCommand()
                 .WithWorkingDirectory(rootPath)
-                .Execute($"classlib --name {projectName} -o .")
+                .Execute($"{type} --name {projectName} -o .")
                 .Should().Pass();
+
+            ValidateAndRemoveExplicitVersion();
 
             new RestoreCommand()
                 .WithWorkingDirectory(rootPath)
                 .Execute($"--packages {packagesDirectory}")
                 .Should().Pass();
 
-            var expectedVersion = XDocument.Load(Path.Combine(rootPath, projectFileName))
-                .Elements("Project")
-                .Elements("PropertyGroup")
-                .Elements("NetStandardImplicitPackageVersion")
-                .FirstOrDefault()
-                ?.Value;
-
-            expectedVersion.Should().NotBeNullOrEmpty("Could not find NetStandardImplicitPackageVersion property in a new classlib.");
-
-            new DirectoryInfo(Path.Combine(packagesDirectory, "netstandard.library"))
+            new DirectoryInfo(Path.Combine(packagesDirectory, packageName))
                 .Should().Exist()
                 .And.HaveDirectory(expectedVersion);
+
+            string GetFrameworkPackageVersion()
+            {
+                var dotnetDir = new FileInfo(DotnetUnderTest.FullName).Directory;
+                var sharedFxDir = dotnetDir
+                    .GetDirectory("shared", "Microsoft.NETCore.App")
+                    .EnumerateDirectories()
+                    .Single(d => d.Name.StartsWith("2.0.0"));
+
+                if (packageName == "Microsoft.NETCore.App")
+                {
+                    return sharedFxDir.Name;
+                }
+
+                var depsFile = Path.Combine(sharedFxDir.FullName, "Microsoft.NETCore.App.deps.json");
+                using (var stream = File.OpenRead(depsFile))
+                using (var reader = new DependencyContextJsonReader())
+                {
+                    var context = reader.Read(stream);
+                    var dependency = context
+                        .RuntimeLibraries
+                        .Single(library => library.Name.Equals(packageName, StringComparison.OrdinalIgnoreCase));
+
+                    return dependency.Version;
+                }
+            }
+
+            // Remove when templates stop putting an explicit version
+            void ValidateAndRemoveExplicitVersion()
+            {
+                var projectFileName = $"{projectName}.csproj";
+                var projectPath = Path.Combine(rootPath, projectFileName);
+                var projectDocument = XDocument.Load(projectPath);
+                var explicitVersionNode = projectDocument
+                   .Elements("Project")
+                   .Elements("PropertyGroup")
+                   .Elements(propertyName)
+                   .SingleOrDefault();
+
+                explicitVersionNode.Should().NotBeNull();
+                if (deleteExplicitVersion)
+                {
+                    explicitVersionNode.Remove();
+                    projectDocument.Save(projectPath);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This is consumed by the SDK as of the SDK update in this PR.

I've manually tested that I can remove the RuntimeFrameworkVersion and NetStandardImplicitPackageVersion after dotnet new and restore, build, and run using the stage2 CLI that is built.

Follow up work will be to get this same props file into the VS insertion nupkg and into VS msbuild, then remove the versions from the templates.

I'll add test cases to the PR tomorrow to verify that the props are what we expect and that we can restore,build,run without specifying the package versions. The latter might be redundant once templates no longer set the versions explicitly.

@livarcocc @dsplaisted @eerhardt  