### PR TITLE
Adaptive help spacing

### DIFF
--- a/src/dotnet/CommandLine/CommandLineApplication.cs
+++ b/src/dotnet/CommandLine/CommandLineApplication.cs
@@ -207,7 +207,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
                 throw new CommandParsingException(
                     command,
                     "Required command missing",
-                    isRequireSubCommandMissing: true);
+                    isRequiredSubCommandMissing: true);
             }
 
             return command.Invoke();

--- a/src/dotnet/CommandLine/CommandParsingException.cs
+++ b/src/dotnet/CommandLine/CommandParsingException.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
 {
     internal class CommandParsingException : Exception
     {
-        private readonly bool _isRequireSubCommandMissing;
+        private readonly bool _isRequiredSubCommandMissing;
 
         public CommandParsingException(
             string message, 
@@ -21,11 +21,11 @@ namespace Microsoft.DotNet.Cli.CommandLine
         public CommandParsingException(
             CommandLineApplication command,
             string message,
-            bool isRequireSubCommandMissing = false)
+            bool isRequiredSubCommandMissing = false)
             : this(message)
         {
             Command = command;
-            _isRequireSubCommandMissing = isRequireSubCommandMissing;
+            _isRequiredSubCommandMissing = isRequiredSubCommandMissing;
         }
 
         public CommandLineApplication Command { get; }
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Cli.CommandLine
         {
             get
             {
-                return _isRequireSubCommandMissing
+                return _isRequiredSubCommandMissing
                            ? CommonLocalizableStrings.RequiredCommandNotPassed
                            : base.Message;
             }

--- a/src/dotnet/commands/dotnet-complete/CompleteCommand.cs
+++ b/src/dotnet/commands/dotnet-complete/CompleteCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli
                     Console.WriteLine(suggestion);
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 return 1;
             }

--- a/src/dotnet/commands/dotnet-complete/CompleteCommand.cs
+++ b/src/dotnet/commands/dotnet-complete/CompleteCommand.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 
@@ -28,11 +26,6 @@ namespace Microsoft.DotNet.Cli
 
                 var suggestions = Suggestions(complete);
 
-                var log = new StringBuilder();
-                log.AppendLine($"args: {string.Join(" ", args.Select(a => $"\"{a}\""))}");
-                log.AppendLine("diagram: " + result.Diagram());
-                File.WriteAllText("parse.log", log.ToString());
-
                 foreach (var suggestion in suggestions)
                 {
                     Console.WriteLine(suggestion);
@@ -40,8 +33,7 @@ namespace Microsoft.DotNet.Cli
             }
             catch (Exception e)
             {
-                File.WriteAllText("dotnet completion exception.log", e.ToString());
-                throw;
+                return 1;
             }
 
             return 0;

--- a/src/dotnet/commands/dotnet-complete/ParseCommand.cs
+++ b/src/dotnet/commands/dotnet-complete/ParseCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli
                 Console.WriteLine();
                 foreach (var error in result.Errors)
                 {
-                    Console.WriteLine($"[{error?.Option?.Name ?? "???"}] {error.Message}");
+                    Console.WriteLine($"[{error?.Option?.Name ?? "???"}] {error?.Message}");
                 }
             }
 

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
     <PackageReference Include="Microsoft.Build" Version="$(CLI_MSBuild_Version)" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-115" />
+    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-120" />
     <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="$(TemplateEngineVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Cli" Version="$(TemplateEngineVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="$(TemplateEngineVersion)" />

--- a/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
+++ b/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
@@ -19,12 +19,12 @@ namespace Microsoft.DotNet.Cli.Add.Reference.Tests
 Usage: dotnet add <PROJECT> reference [options] <args>
 
 Arguments:
-  <PROJECT>       The project file to operate on. If a file is not specified, the command will search the current directory for one.
-  <args>          Project to project references to add
+  <PROJECT>   The project file to operate on. If a file is not specified, the command will search the current directory for one.
+  <args>      Project to project references to add
 
 Options:
-  -h, --help                               Show help information
-  -f, --framework <FRAMEWORK>              Add reference only when targeting a specific framework
+  -h, --help                    Show help information
+  -f, --framework <FRAMEWORK>   Add reference only when targeting a specific framework
 ";
 
         const string FrameworkNet451Arg = "-f net451";

--- a/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
+++ b/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
@@ -18,10 +18,10 @@ namespace Microsoft.DotNet.Cli.List.Reference.Tests
 Usage: dotnet list <PROJECT> reference [options]
 
 Arguments:
-  <PROJECT>       The project file to operate on. If a file is not specified, the command will search the current directory for one.
+  <PROJECT>   The project file to operate on. If a file is not specified, the command will search the current directory for one.
 
 Options:
-  -h, --help                               Show help information
+  -h, --help   Show help information
 ";
 
         const string FrameworkNet451Arg = "-f net451";

--- a/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
+++ b/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
@@ -18,12 +18,12 @@ namespace Microsoft.DotNet.Cli.Remove.Reference.Tests
 Usage: dotnet remove <PROJECT> reference [options] <args>
 
 Arguments:
-  <PROJECT>       The project file to operate on. If a file is not specified, the command will search the current directory for one.
-  <args>          Project to project references to remove
+  <PROJECT>   The project file to operate on. If a file is not specified, the command will search the current directory for one.
+  <args>      Project to project references to remove
 
 Options:
-  -h, --help                               Show help information
-  -f, --framework <FRAMEWORK>              Remove reference only when targeting a specific framework
+  -h, --help                    Show help information
+  -f, --framework <FRAMEWORK>   Remove reference only when targeting a specific framework
 ";
 
         const string FrameworkNet451Arg = "-f net451";

--- a/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
+++ b/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
@@ -20,11 +20,11 @@ namespace Microsoft.DotNet.Cli.Sln.Add.Tests
 Usage: dotnet sln <SLN_FILE> add [options] <args>
 
 Arguments:
-  <SLN_FILE>      Solution file to operate on. If not specified, the command will search the current directory for one.
-  <args>          Add one or more specified projects to the solution.
+  <SLN_FILE>   Solution file to operate on. If not specified, the command will search the current directory for one.
+  <args>       Add one or more specified projects to the solution.
 
 Options:
-  -h, --help                               Show help information
+  -h, --help   Show help information
 ";
         private ITestOutputHelper _output;
 

--- a/test/dotnet-sln-list.Tests/GivenDotnetSlnList.cs
+++ b/test/dotnet-sln-list.Tests/GivenDotnetSlnList.cs
@@ -18,10 +18,10 @@ namespace Microsoft.DotNet.Cli.Sln.List.Tests
 Usage: dotnet sln <SLN_FILE> list [options]
 
 Arguments:
-  <SLN_FILE>      Solution file to operate on. If not specified, the command will search the current directory for one.
+  <SLN_FILE>   Solution file to operate on. If not specified, the command will search the current directory for one.
 
 Options:
-  -h, --help                               Show help information
+  -h, --help   Show help information
 ";
 
         [Theory]

--- a/test/dotnet-sln-remove.Tests/GivenDotnetSlnRemove.cs
+++ b/test/dotnet-sln-remove.Tests/GivenDotnetSlnRemove.cs
@@ -18,11 +18,11 @@ namespace Microsoft.DotNet.Cli.Sln.Remove.Tests
 Usage: dotnet sln <SLN_FILE> remove [options] <args>
 
 Arguments:
-  <SLN_FILE>      Solution file to operate on. If not specified, the command will search the current directory for one.
-  <args>          Remove the specified project(s) from the solution. The project is not impacted.
+  <SLN_FILE>   Solution file to operate on. If not specified, the command will search the current directory for one.
+  <args>       Remove the specified project(s) from the solution. The project is not impacted.
 
 Options:
-  -h, --help                               Show help information
+  -h, --help   Show help information
 ";
 
         private const string ExpectedSlnContentsAfterRemove = @"

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -42,6 +42,6 @@
     <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
     <PackageReference Include="xunit.netcore.extensions" Version="1.0.0-prerelease-00206" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-115" />
+    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-120" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The latest Microsoft.DotNet.Cli.CommandLine adds support for adaptive spacing in help between the columns for the options/commands lists and their descriptions. This code change pulls in that version and adjusts a number of test expectations accordingly.

There are also a few code cleanups included.