### PR TITLE
Updating CLI_NETSDK_Version and CLI_NuGet_Version

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,8 +4,8 @@
     <CLI_SharedFrameworkVersion>2.0.0-beta-001791-00</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.2.0-preview-000047-02</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>2.0.0-alpha-20170320-1</CLI_NETSDK_Version>
-    <CLI_NuGet_Version>4.3.0-beta1-2342</CLI_NuGet_Version>
+    <CLI_NETSDK_Version>2.0.0-alpha-20170323-1</CLI_NETSDK_Version>
+    <CLI_NuGet_Version>4.3.0-beta1-2418</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170130-3-281</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.1.0-preview-20170316-05</CLI_TestPlatform_Version>
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>


### PR DESCRIPTION
CLI_NETSDK_Version -> 2.0.0-alpha-20170323-1
CLI_NuGet_Version -> 4.3.0-beta1-2418

The new SDK version uses the same version of NuGet.