### PR TITLE
Allow directories as project arguments to run command.

### DIFF
--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -134,21 +134,12 @@ namespace Microsoft.DotNet.Tools.Run
         {
             if (string.IsNullOrWhiteSpace(Project))
             {
-                string directory = Directory.GetCurrentDirectory();
-                string[] projectFiles = Directory.GetFiles(directory, "*.*proj");
-
-                if (projectFiles.Length == 0)
-                {
-                    var project = "--project";
-
-                    throw new GracefulException(LocalizableStrings.RunCommandExceptionNoProjects, directory, project);
-                }
-                else if (projectFiles.Length > 1)
-                {
-                    throw new GracefulException(LocalizableStrings.RunCommandExceptionMultipleProjects, directory);
-                }
-
-                Project = projectFiles[0];
+                Project = Directory.GetCurrentDirectory();
+            } 
+            
+            if (Directory.Exists(Project)) 
+            {
+                Project = FindSingleProjectInDirectory(Project);
             }
 
             if (Args == null)
@@ -159,6 +150,24 @@ namespace Microsoft.DotNet.Tools.Run
             {
                 _args = new List<string>(Args);
             }
+        }
+
+        private static string FindSingleProjectInDirectory(string directory)
+        {
+            string[] projectFiles = Directory.GetFiles(directory, "*.*proj");
+
+            if (projectFiles.Length == 0)
+            {
+                var project = "--project";
+
+                throw new GracefulException(LocalizableStrings.RunCommandExceptionNoProjects, directory, project);
+            }
+            else if (projectFiles.Length > 1)
+            {
+                throw new GracefulException(LocalizableStrings.RunCommandExceptionMultipleProjects, directory);
+            }
+
+            return projectFiles[0];
         }
     }
 }

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -119,6 +119,24 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
+        public void ItRunsPortableAppsFromADifferentPathSpecifyingOnlyTheDirectoryWithoutBuilding()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            new RunCommand()
+                .WithWorkingDirectory(testInstance.Root.Parent)
+                .ExecuteWithCapturedOutput($"--project {testProjectDirectory}")
+                .Should().Pass()
+                         .And.HaveStdOutContaining("Hello World!");
+        }
+
+        [Fact]
         public void ItRunsAppWhenRestoringToSpecificPackageDirectory()
         {
             var rootPath = TestAssets.CreateTestDirectory().FullName;


### PR DESCRIPTION
Fixes #5992 by checking if the project argument is a directory, then using the existing project search logic for that directory.

cc @livarcocc @piotrpMSFT 