### PR TITLE
Target update-dependencies to netstandard2.0

### DIFF
--- a/build_projects/update-dependencies/update-dependencies.csproj
+++ b/build_projects/update-dependencies/update-dependencies.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Description>Updates the repos dependencies</Description>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>$(CliTargetFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" Version="1.0.0" />
+    <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="$(VersionToolsVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Previously, this was 1.0 app. Since stage0 no longer contains a 1.0.X
shared framework, it would not run.

Move to 2.0.0 (instead of 1.1.X since the 1.1.X shared framework will
stop being in stage0 soon as well).