### PR TITLE
update CommandLineParser version for more selective option splitting

### DIFF
--- a/src/dotnet/commands/dotnet-complete/ParseCommand.cs
+++ b/src/dotnet/commands/dotnet-complete/ParseCommand.cs
@@ -24,6 +24,13 @@ namespace Microsoft.DotNet.Cli
 
             Console.WriteLine(result.Diagram());
 
+            var optionValuesToBeForwarded = result.AppliedCommand()
+                                                  .OptionValuesToBeForwarded();
+            if (optionValuesToBeForwarded.Any())
+            {
+                Console.WriteLine("Option values to be forwarded: ");
+                Console.WriteLine(string.Join(" ", optionValuesToBeForwarded));
+            }
             if (result.Errors.Any())
             {
                 Console.WriteLine();

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
     <PackageReference Include="Microsoft.Build" Version="$(CLI_MSBuild_Version)" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-120" />
+    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-125" />
     <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="$(TemplateEngineVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Cli" Version="$(TemplateEngineVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="$(TemplateEngineVersion)" />

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [Theory]
         [InlineData(new string[] { }, "/t:Build")]
         [InlineData(new string[] { "-o", "foo" }, "/t:Build /p:OutputPath=foo")]
+        [InlineData(new string[] { "-p:Verbosity=diag" }, "/t:Build -p:Verbosity=diag")]
         [InlineData(new string[] { "--output", "foo" }, "/t:Build /p:OutputPath=foo")]
         [InlineData(new string[] { "-o", "foo1 foo2" }, "/t:Build \"/p:OutputPath=foo1 foo2\"")]
         [InlineData(new string[] { "--no-incremental" }, "/t:Rebuild")]

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -42,6 +42,6 @@
     <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
     <PackageReference Include="xunit.netcore.extensions" Version="1.0.0-prerelease-00206" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-120" />
+    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-125" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This addresses https://github.com/dotnet/cli/issues/6124.

The parser change is here: https://github.com/dotnet/CliCommandLineParser/pull/51