### PR TITLE
dotnet-install should identify all RHEL 7.x as RHEL

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -92,7 +92,7 @@ get_current_os_name() {
                     echo "opensuse.42.1"
                     return 0
                     ;;
-                "rhel.7.0" | "rhel.7.1" | "rhel.7.2")
+                "rhel.7"*)
                     echo "rhel"
                     return 0
                     ;;


### PR DESCRIPTION
New RHEL minor versions are compatible with previous RHEL minor versions. They also replace them: all users using RHEL 7.n are migrated to RHEL 7.(n+1) by a simple yum upgrade. So just treat all RHEL 7.x version as RHEL.

This only holds true for minor versions. RHEL 7 is not compatible with RHEL 6. But since .NET Core only supports RHEL 7, this shouldn't matter.

This is a port of https://github.com/dotnet/cli/pull/5411 from `master` to `rel/1.0.0`

See also https://github.com/dotnet/cli/issues/6023

cc @livarcocc 