### PR TITLE
Removing CMake from the CLI build requirements.

### DIFF
--- a/Documentation/project-docs/developer-guide.md
+++ b/Documentation/project-docs/developer-guide.md
@@ -7,19 +7,15 @@ In order to build .NET Command Line Interface, you need the following installed 
 
 ### For Windows
 
-1. CMake (available from https://cmake.org/) on the PATH.
-2. git (available from http://www.git-scm.com/) on the PATH.
+1. git (available from http://www.git-scm.com/) on the PATH.
 
 ### For Linux
 
-1. CMake (available from https://cmake.org/) is required to build the native host `corehost`. Make sure to add it to the PATH.
-2. git (available from http://www.git-scm.com/) on the PATH.
-3. clang (available from http://clang.llvm.org) on the PATH.
+1. git (available from http://www.git-scm.com/) on the PATH.
 
 ### For OS X
 
 1. Xcode
-2. CMake (available from https://cmake.org/) on the PATH.
 3. git (available from http://www.git-scm.com/) on the PATH.
 4. Install OpenSSL (a .NET Core requirement)
   - brew install openssl

--- a/Documentation/project-docs/developer-guide.md
+++ b/Documentation/project-docs/developer-guide.md
@@ -16,8 +16,8 @@ In order to build .NET Command Line Interface, you need the following installed 
 ### For OS X
 
 1. Xcode
-3. git (available from http://www.git-scm.com/) on the PATH.
-4. Install OpenSSL (a .NET Core requirement)
+2. git (available from http://www.git-scm.com/) on the PATH.
+3. Install OpenSSL (a .NET Core requirement)
   - brew install openssl
   - brew link --force openssl
 


### PR DESCRIPTION
We needed that when we used to build the shared framework in the CLI. We don't need it anymore. Plus, we need a small change to kick off a build.

@dotnet/dotnet-cli 
