### PR TITLE
Update to template engine build 166 and updates to 2.0 templates

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,6 +5,7 @@
     <clear />
     <add key="templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
     <add key="xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" />

--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -2,7 +2,7 @@
   <ItemGroup>
     <BundledTemplate Include="Microsoft.DotNet.Common.ItemTemplates" Version="$(TemplateEngineTemplateVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.2.0" Version="$(TemplateEngineTemplate2_0Version)" />
-    <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates" Version="$(TemplateEngineTemplateVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates" Version="$(TemplateEngineTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.0" Version="$(TemplateEngineTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.0" Version="$(TemplateEngineTemplateVersion)" />
   </ItemGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,9 +11,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta1-20170327-169</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta1-20170327-169</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta1-20170327-169</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta1-20170327-170</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta1-20170327-170</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta1-20170327-170</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-88</CliCommandLineParserVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,9 +11,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta1-20170202-111</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta1-20170131-110</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta1-20170209-117</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta1-20170324-166</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta1-20170324-166</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta1-20170324-166</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-88</CliCommandLineParserVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,9 +11,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta1-20170327-170</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta1-20170327-170</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta1-20170327-170</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20170327-171</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170327-171</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170327-171</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-88</CliCommandLineParserVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,9 +11,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta2-20170328-173</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170328-173</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170328-173</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20170328-177</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170328-177</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170328-177</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-88</CliCommandLineParserVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,9 +11,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta2-20170327-171</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170327-171</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170327-171</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20170328-172</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170328-172</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170328-172</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-88</CliCommandLineParserVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,9 +11,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta2-20170328-172</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170328-172</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170328-172</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20170328-173</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170328-173</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170328-173</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-88</CliCommandLineParserVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,9 +11,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta1-20170324-166</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta1-20170324-166</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta1-20170324-166</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta1-20170327-169</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta1-20170327-169</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta1-20170327-169</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-88</CliCommandLineParserVersion>

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -83,7 +83,7 @@ namespace Microsoft.DotNet.New.Tests
 
             new NewCommand()
                 .WithWorkingDirectory(rootPath)
-                .Execute($"{type} --name {projectName} -o .")
+                .Execute($"{type} --name {projectName} -o . --debug:ephemeral-hive")
                 .Should().Pass();
 
             new RestoreCommand()

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -20,9 +20,9 @@ namespace Microsoft.DotNet.New.Tests
         [InlineData("C#", "classlib", false)]
         [InlineData("C#", "mstest", false)]
         [InlineData("C#", "xunit", false)]
-        [InlineData("C#", "web", true)]
-        [InlineData("C#", "mvc", true)]
-        [InlineData("C#", "webapi", true)]
+        [InlineData("C#", "web", false)]
+        [InlineData("C#", "mvc", false)]
+        [InlineData("C#", "webapi", false)]
         // Uncomment the test below once https://github.com/dotnet/netcorecli-fsc/issues/92 is fixed.
         //[InlineData("F#", "console", false)]
         //[InlineData("F#", "classlib", false)]

--- a/test/dotnet-new.Tests/NewCommandTests.cs
+++ b/test/dotnet-new.Tests/NewCommandTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.New.Tests
 
             cmd.ExitCode.Should().NotBe(0);
 
-            cmd.StdErr.Should().StartWith("No templates matched the input template name: [Web1.1]");
+            cmd.StdErr.Should().StartWith("No templates matched the input template name: Web1.1.");
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.New.Tests
 
             cmd.ExitCode.Should().NotBe(0);
 
-            cmd.StdErr.Should().StartWith("Unable to determine the desired template from the input template name: [c]");
+            cmd.StdErr.Should().StartWith("Unable to determine the desired template from the input template name: c.");
         }
     }
 }


### PR DESCRIPTION
Updates template engine to be able to disambiguate templates between 1.x & 2.0 flavors
Carries 2.0 templates
Fixes odd behavior when creating templates in directories where templates have been created
Adds overwrite warning
Fixes issue where templates get created with no name when using the implicit name and attempting generation at the root
Improves error messages and stability
Makes local development of CLI easier (no more need to repetitively --debug:reinit)
Adds more post-actions for template authors