### PR TITLE
Fixed broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Found an issue?
 ---------------
 You can consult the [known issues page](https://github.com/dotnet/core/blob/master/cli/known-issues.md) to find out the current issues and to see the workarounds.  
 
-If you don't find your issue, please file one! However, given that this is a very high-frequency repo, we've setup some [basic guidelines](Documentation/issue-filing-guide.md) to help you. Please consult those first.
+If you don't find your issue, please file one! However, given that this is a very high-frequency repo, we've setup some [basic guidelines](Documentation/project-docs/issue-filing-guide.md) to help you. Please consult those first.
 
 This project has adopted the code of conduct defined by the [Contributor Covenant](http://contributor-covenant.org/) to clarify expected behavior in our community. For more information, see the [.NET Foundation Code of Conduct](http://www.dotnetfoundation.org/code-of-conduct).
 

--- a/src/dotnet/README.md
+++ b/src/dotnet/README.md
@@ -13,7 +13,7 @@ dotnet -- General driver for running the command-line commands
 ## DESCRIPTION
 `dotnet` is a generic driver for the Command Line Interface (CLI) toolchain. Invoked on its own, it will give out brief usage instructions. 
 
-Each specific feature is implemented as a command. In order to use the feature, the command is specified after `dotnet`, such as [`dotnet build`](commands/dotnet-build/README.md). All of the arguments following the command are its own arguments. 
+Each specific feature is implemented as a command. In order to use the feature, the command is specified after `dotnet`, such as [`dotnet build`](https://aka.ms/dotnet-build). All of the arguments following the command are its own arguments. 
 
 The only time `dotnet` is used as a command on its own is to run portable apps. Just specify a portable application DLL after the `dotnet` verb to execute the application.    
 


### PR DESCRIPTION
There is another broken link which I didn't fix: The link in [src/dotnet/README.md](https://github.com/dotnet/cli/blob/master/src/dotnet/README.md) for `dotnet-publish` is https://aka.ms/dotnet-publish, which is consistent with the other `dotnet-*` links. Except that URL redirects to https://docs.microsoft.com/en-us/dotnet/articles/core/tools/dotnet-, which is incorrect.