### PR TITLE
Adds Microsoft.Docker.Sdk to CLI

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -11,5 +11,6 @@
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="AspNetCurrent" value="https://dotnet.myget.org/F/aspnet-feb2017-patch/api/v3/index.json" /> 
     <add key="vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
+    <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/TestAssets/TestProjects/docker-compose/docker-compose.ci.build.yml
+++ b/TestAssets/TestProjects/docker-compose/docker-compose.ci.build.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  ci-build:
+    image: microsoft/aspnetcore-build:1.0-1.1
+    volumes:
+      - .:/src
+    working_dir: /src
+    command: /bin/bash -c "dotnet restore ./WebApplication4.sln && dotnet publish ./WebApplication4.sln -c Release -o ./obj/Docker/publish"

--- a/TestAssets/TestProjects/docker-compose/docker-compose.dcproj
+++ b/TestAssets/TestProjects/docker-compose/docker-compose.dcproj
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" Sdk="Microsoft.Docker.Sdk">
+  <PropertyGroup Label="Globals">
+    <ProjectVersion>1.1</ProjectVersion>
+    <ProjectGuid>380948fd-dd78-4d21-94f2-055bd88886e5</ProjectGuid>
+    <DockerLaunchBrowser>True</DockerLaunchBrowser>
+    <DockerServiceUrl>http://localhost:{ServicePort}</DockerServiceUrl>
+    <DockerServiceName>webapplication4</DockerServiceName>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="docker-compose.ci.build.yml" />
+    <None Include="docker-compose.override.yml">
+      <DependentUpon>docker-compose.yml</DependentUpon>
+    </None>
+    <None Include="docker-compose.vs.debug.yml">
+      <DependentUpon>docker-compose.yml</DependentUpon>
+    </None>
+    <None Include="docker-compose.vs.release.yml">
+      <DependentUpon>docker-compose.yml</DependentUpon>
+    </None>
+    <None Include="docker-compose.yml" />
+  </ItemGroup>
+</Project>

--- a/TestAssets/TestProjects/docker-compose/docker-compose.override.yml
+++ b/TestAssets/TestProjects/docker-compose/docker-compose.override.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  webapplication4:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    ports:
+      - "80"

--- a/TestAssets/TestProjects/docker-compose/docker-compose.vs.debug.yml
+++ b/TestAssets/TestProjects/docker-compose/docker-compose.vs.debug.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  webapplication4:
+    image: webapplication4:dev
+    build:
+      args:
+        source: ${DOCKER_BUILD_SOURCE}
+    environment:
+      - DOTNET_USE_POLLING_FILE_WATCHER=1
+    volumes:
+      - ./WebApplication4:/app
+      - ${NUGET_PACKAGES}:/root/.nuget/packages:ro
+      - ${VSDBG_PATH}:/remote_debugger:ro
+    entrypoint: tail -f /dev/null
+    labels:
+      - "com.microsoft.visualstudio.targetoperatingsystem=linux"

--- a/TestAssets/TestProjects/docker-compose/docker-compose.vs.release.yml
+++ b/TestAssets/TestProjects/docker-compose/docker-compose.vs.release.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  webapplication4:
+    build:
+      args:
+        source: ${DOCKER_BUILD_SOURCE}
+    volumes:
+      - ${VSDBG_PATH}:/remote_debugger:ro
+    entrypoint: tail -f /dev/null
+    labels:
+      - "com.microsoft.visualstudio.targetoperatingsystem=linux"

--- a/TestAssets/TestProjects/docker-compose/docker-compose.yml
+++ b/TestAssets/TestProjects/docker-compose/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  webapplication4:
+    image: webapplication4
+    build:
+      context: ./WebApplication4
+      dockerfile: Dockerfile

--- a/build/BundledSdks.props
+++ b/build/BundledSdks.props
@@ -6,5 +6,6 @@
     <BundledSdk Include="Microsoft.NET.Sdk.Publish" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Web.ProjectSystem" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.0-beta-040011" />
+    <BundledSdk Include="Microsoft.Docker.Sdk" Version="1.1.0" />
   </ItemGroup>
 </Project>

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsDcproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsDcproj.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Build.Tests
+{
+    public class GivenDotnetBuildBuildsDcproj : TestBase
+    {
+        [Fact]
+        public void ItPrintsBuildSummary()
+        {
+            var testAppName = "docker-compose";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance(testAppName)
+                .WithSourceFiles()
+                .WithRestoreFiles();
+
+            string expectedBuildSummary = @"Build succeeded.
+    0 Warning(s)
+    0 Error(s)";
+
+            var cmd = new BuildCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .ExecuteWithCapturedOutput();
+            cmd.Should().Pass();
+            cmd.StdOut.Should().ContainVisuallySameFragment(expectedBuildSummary);
+        }
+    }
+}


### PR DESCRIPTION
This change is to add Sdk.props and Sdk.targets of Microsoft.Docker.Sdk into CLI. This unblocks the scenario where a VS solution contains a few .NET Core projects as well as a docker-compose.dcproj project and people want to build the solution from command line with .NET Core CLI. With the Sdk.props and Sdk.targets being present in CLI, building docker-compose.dcproj becomes no-op so it won't block building the other .NET Core projects.
