### PR TITLE
Add --rid option to support cross build

### DIFF
--- a/run-build.sh
+++ b/run-build.sh
@@ -90,6 +90,12 @@ while [[ $# > 0 ]]; do
             args=( "${args[@]/$2}" )
             shift
             ;;
+        --runtime-id)
+            CUSTOM_BUILD_ARGS="/p:Rid=\"$2\""
+            args=( "${args[@]/$1}" )
+            args=( "${args[@]/$2}" )
+            shift
+            ;;
         # This is here just to eat away this parameter because CI still passes this in.
         --targets)            
             args=( "${args[@]/$1}" )


### PR DESCRIPTION
When trying to cross build, Rid needs to change to the target Rid,
but architecture should use x64 as it as host.
In addition to the existing --architecture option, and additional --rid option is required.

Related issue: #5927 https://github.com/dotnet/core-setup/issues/725