### PR TITLE
Fixing the reference to dotnet-deb-tool to be correct.

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -23,5 +23,6 @@
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>
     <VersionToolsVersion>1.0.27-prerelease-01402-01</VersionToolsVersion>
+    <DotnetDebToolVersion>2.0.0-preview1-001877</DotnetDebToolVersion>
   </PropertyGroup>
 </Project>

--- a/build/package/Installer.DEB.targets
+++ b/build/package/Installer.DEB.targets
@@ -10,7 +10,7 @@
     <PropertyGroup>
       <DotnetDebToolConsumerProjectName>dotnet-deb-tool-consumer.csproj</DotnetDebToolConsumerProjectName>
       <DotnetDebToolDir>$(IntermediateDirectory)/$(DotnetDebToolConsumerProjectName)</DotnetDebToolDir>
-      <PackageTool>$(NuGetPackagesDir)/dotnet-deb-tool/2.0.0-beta-beta-001599/lib/netcoreapp1.0/tool/package_tool</PackageTool>
+      <PackageTool>$(NuGetPackagesDir)/dotnet-deb-tool/$(DotnetDebToolVersion)/lib/netcoreapp1.0/tool/package_tool</PackageTool>
     </PropertyGroup>
 
     <!-- constants -->

--- a/build/package/dotnet-deb-tool-consumer.csproj
+++ b/build/package/dotnet-deb-tool-consumer.csproj
@@ -6,6 +6,6 @@
     <RuntimeFrameworkVersion>$(CLI_SharedFrameworkVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-deb-tool" Version="2.0.0-*" />
+    <DotNetCliToolReference Include="dotnet-deb-tool" Version="$(DotnetDebToolVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
No more using * versions.  Only specify the version in a single place.

Our build is currently broken without this.

@livarcocc @nguerrera 