### PR TITLE
First run fallback folder

### DIFF
--- a/build/compile/LzmaArchive.targets
+++ b/build/compile/LzmaArchive.targets
@@ -13,7 +13,8 @@
 
       <NuGetPackagesArchiveProject>$(IntermediateDirectory)/NuGetPackagesArchiveProject</NuGetPackagesArchiveProject>
       <NuGetPackagesArchiveFolder>$(IntermediateDirectory)/NuGetPackagesArchiveFolder</NuGetPackagesArchiveFolder>
-      <LZMANuGetConfigFilePath>$(NuGetPackagesArchiveProject)/Nuget.config</LZMANuGetConfigFilePath>
+      <LZMANuGetConfigFilePath Condition=" '$(CLI_LZMA_PACKAGE_SOURCE)' != '' ">$(NuGetPackagesArchiveProject)/Nuget.config</LZMANuGetConfigFilePath>
+      <LZMANuGetConfigFilePath Condition=" '$(LZMANuGetConfigFilePath)' == '' ">$(RepoRoot)/NuGet.Config</LZMANuGetConfigFilePath>
       <ToolsOutputDirectory>$(BaseOutputDirectory)/tools</ToolsOutputDirectory>
       <ArchiverDll>$(ToolsOutputDirectory)/Archiver.dll</ArchiverDll>
       <FinalArchive>$(SdkOutputDirectory)/nuGetPackagesArchive.lzma</FinalArchive>
@@ -96,6 +97,7 @@
 
       <DotNetRestore ToolPath="$(OutputDirectory)"
                      Packages="$(NuGetPackagesArchiveFolder)"
+                     ConfigFile="$(LZMANuGetConfigFilePath)"
                      SkipInvalidConfigurations="True"
                      WorkingDirectory="$(NuGetPackagesArchiveProject)/Console" />
 

--- a/build/compile/LzmaArchive.targets
+++ b/build/compile/LzmaArchive.targets
@@ -99,7 +99,7 @@
                      SkipInvalidConfigurations="True"
                      WorkingDirectory="$(NuGetPackagesArchiveProject)/Console" />
 
-      <Delete Files="$(IntermediateArchive);$(IntermediateArchive).zip" />
+      <Delete Files="$(IntermediateArchive);$(IntermediateArchive).zip;$(NuGetPackagesArchiveFolder)/**/*.nupkg" />
 
       <Message Text="Publishing Archiver" />
 

--- a/src/Microsoft.DotNet.Configurer/CLIFallbackFolderPathCalculator.cs
+++ b/src/Microsoft.DotNet.Configurer/CLIFallbackFolderPathCalculator.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.PlatformAbstractions;
+using NuGet.Common;
 
 namespace Microsoft.DotNet.Configurer
 {
@@ -19,6 +20,14 @@ namespace Microsoft.DotNet.Configurer
                     RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "USERPROFILE" : "HOME");
 
                 return Path.Combine(profileDir, ".dotnet", "NuGetFallbackFolder");
+            }
+        }
+
+        public string NuGetUserSettingsDirectory
+        {
+            get
+            {
+                return NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
             }
         }
     }

--- a/src/Microsoft.DotNet.Configurer/CLIFallbackFolderPathCalculator.cs
+++ b/src/Microsoft.DotNet.Configurer/CLIFallbackFolderPathCalculator.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.PlatformAbstractions;
+
+namespace Microsoft.DotNet.Configurer
+{
+    public class CLIFallbackFolderPathCalculator
+    {
+        public string CLIFallbackFolderPath
+        {
+            get
+            {
+                string profileDir = Environment.GetEnvironmentVariable(
+                    RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "USERPROFILE" : "HOME");
+
+                return Path.Combine(profileDir, ".dotnet", "NuGetFallbackFolder");
+            }
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Configurer/CliFallbackFolderPathCalculator.cs
+++ b/src/Microsoft.DotNet.Configurer/CliFallbackFolderPathCalculator.cs
@@ -23,12 +23,7 @@ namespace Microsoft.DotNet.Configurer
             }
         }
 
-        public string NuGetUserSettingsDirectory
-        {
-            get
-            {
-                return NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
-            }
-        }
+        public string NuGetUserSettingsDirectory =>
+            NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
     }
 }

--- a/src/Microsoft.DotNet.Configurer/CliFallbackFolderPathCalculator.cs
+++ b/src/Microsoft.DotNet.Configurer/CliFallbackFolderPathCalculator.cs
@@ -10,9 +10,9 @@ using NuGet.Common;
 
 namespace Microsoft.DotNet.Configurer
 {
-    public class CLIFallbackFolderPathCalculator
+    public class CliFallbackFolderPathCalculator
     {
-        public string CLIFallbackFolderPath
+        public string CliFallbackFolderPath
         {
             get
             {

--- a/src/Microsoft.DotNet.Configurer/INuGetConfig.cs
+++ b/src/Microsoft.DotNet.Configurer/INuGetConfig.cs
@@ -5,6 +5,6 @@ namespace Microsoft.DotNet.Configurer
 {
     public interface INuGetConfig
     {
-        void AddCLIFallbackFolder(string fallbackFolderPath);
+        void AddCliFallbackFolder(string fallbackFolderPath);
     }
 }

--- a/src/Microsoft.DotNet.Configurer/INuGetConfig.cs
+++ b/src/Microsoft.DotNet.Configurer/INuGetConfig.cs
@@ -1,0 +1,10 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Configurer
+{
+    public interface INuGetConfig
+    {
+        void AddCLIFallbackFolder(string fallbackFolderPath);
+    }
+}

--- a/src/Microsoft.DotNet.Configurer/INuGetPackagesArchiver.cs
+++ b/src/Microsoft.DotNet.Configurer/INuGetPackagesArchiver.cs
@@ -5,10 +5,10 @@ using System;
 
 namespace Microsoft.DotNet.Configurer
 {
-    public interface INuGetPackagesArchiver : IDisposable
+    public interface INuGetPackagesArchiver
     {
         string NuGetPackagesArchive { get; }
 
-        string ExtractArchive();        
+        void ExtractArchive(string archiveDestination);        
     }
 }

--- a/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj
+++ b/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj
@@ -13,6 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NuGet.Common" Version="$(CLI_NuGet_Version)" />
+    <PackageReference Include="NuGet.Configuration" Version="$(CLI_NuGet_Version)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Microsoft.DotNet.InternalAbstractions\Microsoft.DotNet.InternalAbstractions.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Archive\Microsoft.DotNet.Archive.csproj" />

--- a/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
@@ -18,13 +18,13 @@ namespace Microsoft.DotNet.Configurer
 
         private readonly INuGetConfig _nuGetConfig;
 
-        private readonly CLIFallbackFolderPathCalculator _cliFallbackFolderPathCalculator;
+        private readonly CliFallbackFolderPathCalculator _cliFallbackFolderPathCalculator;
 
         public NuGetCachePrimer(
             INuGetPackagesArchiver nugetPackagesArchiver,
             INuGetCacheSentinel nuGetCacheSentinel,
             INuGetConfig nuGetConfig,
-            CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator)
+            CliFallbackFolderPathCalculator cliFallbackFolderPathCalculator)
             : this(nugetPackagesArchiver,
                 nuGetCacheSentinel,
                 nuGetConfig,
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Configurer
             INuGetPackagesArchiver nugetPackagesArchiver,
             INuGetCacheSentinel nuGetCacheSentinel,
             INuGetConfig nuGetConfig,
-            CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator,
+            CliFallbackFolderPathCalculator cliFallbackFolderPathCalculator,
             IFile file)
         {
             _nugetPackagesArchiver = nugetPackagesArchiver;
@@ -58,9 +58,9 @@ namespace Microsoft.DotNet.Configurer
                 return;
             }
 
-            var nuGetFallbackFolder = _cliFallbackFolderPathCalculator.CLIFallbackFolderPath;
+            var nuGetFallbackFolder = _cliFallbackFolderPathCalculator.CliFallbackFolderPath;
 
-            _nuGetConfig.AddCLIFallbackFolder(nuGetFallbackFolder);
+            _nuGetConfig.AddCliFallbackFolder(nuGetFallbackFolder);
 
             _nugetPackagesArchiver.ExtractArchive(nuGetFallbackFolder);
 

--- a/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
@@ -18,13 +18,17 @@ namespace Microsoft.DotNet.Configurer
 
         private readonly INuGetConfig _nuGetConfig;
 
+        private readonly CLIFallbackFolderPathCalculator _cliFallbackFolderPathCalculator;
+
         public NuGetCachePrimer(
             INuGetPackagesArchiver nugetPackagesArchiver,
             INuGetCacheSentinel nuGetCacheSentinel,
-            INuGetConfig nuGetConfig)
+            INuGetConfig nuGetConfig,
+            CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator)
             : this(nugetPackagesArchiver,
                 nuGetCacheSentinel,
                 nuGetConfig,
+                cliFallbackFolderPathCalculator,
                 FileSystemWrapper.Default.File)
         {
         }
@@ -33,6 +37,7 @@ namespace Microsoft.DotNet.Configurer
             INuGetPackagesArchiver nugetPackagesArchiver,
             INuGetCacheSentinel nuGetCacheSentinel,
             INuGetConfig nuGetConfig,
+            CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator,
             IFile file)
         {
             _nugetPackagesArchiver = nugetPackagesArchiver;
@@ -40,6 +45,8 @@ namespace Microsoft.DotNet.Configurer
             _nuGetCacheSentinel = nuGetCacheSentinel;
 
             _nuGetConfig = nuGetConfig;
+
+            _cliFallbackFolderPathCalculator = cliFallbackFolderPathCalculator;
 
             _file = file;
         }
@@ -51,8 +58,7 @@ namespace Microsoft.DotNet.Configurer
                 return;
             }
 
-            var cliFallbackFolderPathCalculator = new CLIFallbackFolderPathCalculator();
-            var nuGetFallbackFolder = cliFallbackFolderPathCalculator.CLIFallbackFolderPath;
+            var nuGetFallbackFolder = _cliFallbackFolderPathCalculator.CLIFallbackFolderPath;
 
             _nuGetConfig.AddCLIFallbackFolder(nuGetFallbackFolder);
 

--- a/src/Microsoft.DotNet.Configurer/NuGetCacheSentinel.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCacheSentinel.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Configurer
         {
             try
             {
-                if(!Directory.Exists(_nugetCachePath))
+                if (!Directory.Exists(_nugetCachePath))
                 {
                     Directory.CreateDirectory(_nugetCachePath);
                 }

--- a/src/Microsoft.DotNet.Configurer/NuGetCacheSentinel.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCacheSentinel.cs
@@ -17,25 +17,13 @@ namespace Microsoft.DotNet.Configurer
 
         private string _nugetCachePath;
 
-        private string NuGetCachePath
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(_nugetCachePath))
-                {
-                    _nugetCachePath = NuGetPathContext.Create(new NullSettings()).UserPackageFolder;
-                }
-
-                return _nugetCachePath;
-            }
-        }
-
-        private string SentinelPath => Path.Combine(NuGetCachePath, SENTINEL);
-        private string InProgressSentinelPath => Path.Combine(NuGetCachePath, INPROGRESS_SENTINEL);
+        private string SentinelPath => Path.Combine(_nugetCachePath, SENTINEL);
+        private string InProgressSentinelPath => Path.Combine(_nugetCachePath, INPROGRESS_SENTINEL);
 
         private Stream InProgressSentinel { get; set; }
 
-        public NuGetCacheSentinel() : this(string.Empty, FileSystemWrapper.Default.File)
+        public NuGetCacheSentinel(CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator) :
+            this(cliFallbackFolderPathCalculator.CLIFallbackFolderPath, FileSystemWrapper.Default.File)
         {
         }
 
@@ -74,9 +62,9 @@ namespace Microsoft.DotNet.Configurer
         {
             try
             {
-                if(!Directory.Exists(NuGetCachePath))
+                if(!Directory.Exists(_nugetCachePath))
                 {
-                    Directory.CreateDirectory(NuGetCachePath);
+                    Directory.CreateDirectory(_nugetCachePath);
                 }
 
                 // open an exclusive handle to the in-progress sentinel and mark it for delete on close.

--- a/src/Microsoft.DotNet.Configurer/NuGetCacheSentinel.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCacheSentinel.cs
@@ -22,8 +22,8 @@ namespace Microsoft.DotNet.Configurer
 
         private Stream InProgressSentinel { get; set; }
 
-        public NuGetCacheSentinel(CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator) :
-            this(cliFallbackFolderPathCalculator.CLIFallbackFolderPath, FileSystemWrapper.Default.File)
+        public NuGetCacheSentinel(CliFallbackFolderPathCalculator cliFallbackFolderPathCalculator) :
+            this(cliFallbackFolderPathCalculator.CliFallbackFolderPath, FileSystemWrapper.Default.File)
         {
         }
 

--- a/src/Microsoft.DotNet.Configurer/NuGetConfig.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetConfig.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Configurer
 
         private ISettings _settings;
 
-        public NuGetConfig(CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator)
+        public NuGetConfig(CliFallbackFolderPathCalculator cliFallbackFolderPathCalculator)
         {
             _settings = new Settings(cliFallbackFolderPathCalculator.NuGetUserSettingsDirectory);
         }
@@ -23,15 +23,15 @@ namespace Microsoft.DotNet.Configurer
             _settings = settings;
         }
 
-        public void AddCLIFallbackFolder(string fallbackFolderPath)
+        public void AddCliFallbackFolder(string fallbackFolderPath)
         {
-            if (!IsCLIFallbackFolderSet(fallbackFolderPath))
+            if (!IsCliFallbackFolderSet(fallbackFolderPath))
             {
-                _settings.SetValue(FallbackPackageFolders, "CLIFallbackFolder", fallbackFolderPath);
+                _settings.SetValue(FallbackPackageFolders, "CliFallbackFolder", fallbackFolderPath);
             }
         }
 
-        private bool IsCLIFallbackFolderSet(string fallbackFolderPath)
+        private bool IsCliFallbackFolderSet(string fallbackFolderPath)
         {
             return _settings.GetSettingValues(FallbackPackageFolders).Any(s => s.Value == fallbackFolderPath);
         }

--- a/src/Microsoft.DotNet.Configurer/NuGetConfig.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetConfig.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using NuGet.Common;
+using NuGet.Configuration;
+using System.Linq;
+
+namespace Microsoft.DotNet.Configurer
+{
+    public class NuGetConfig : INuGetConfig
+    {
+        public const string FallbackPackageFolders = "fallbackPackageFolders";
+
+        private ISettings _settings;
+
+        public NuGetConfig()
+        {
+            var nuGetConfigFolder = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
+            _settings = new Settings(nuGetConfigFolder);
+        }
+
+        internal NuGetConfig(ISettings settings)
+        {
+            _settings = settings;
+        }
+
+        public void AddCLIFallbackFolder(string fallbackFolderPath)
+        {
+            if (!IsCLIFallbackFolderSet(fallbackFolderPath))
+            {
+                _settings.SetValue(FallbackPackageFolders, "CLIFallbackFolder", fallbackFolderPath);
+            }
+        }
+
+        private bool IsCLIFallbackFolderSet(string fallbackFolderPath)
+        {
+            return _settings.GetSettingValues(FallbackPackageFolders).Any(s => s.Value == fallbackFolderPath);
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Configurer/NuGetConfig.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetConfig.cs
@@ -13,10 +13,9 @@ namespace Microsoft.DotNet.Configurer
 
         private ISettings _settings;
 
-        public NuGetConfig()
+        public NuGetConfig(CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator)
         {
-            var nuGetConfigFolder = NuGetEnvironment.GetFolderPath(NuGetFolderPath.UserSettingsDirectory);
-            _settings = new Settings(nuGetConfigFolder);
+            _settings = new Settings(cliFallbackFolderPathCalculator.NuGetUserSettingsDirectory);
         }
 
         internal NuGetConfig(ISettings settings)

--- a/src/Microsoft.DotNet.Configurer/NuGetPackagesArchiver.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetPackagesArchiver.cs
@@ -10,33 +10,15 @@ namespace Microsoft.DotNet.Configurer
 {
     public class NuGetPackagesArchiver : INuGetPackagesArchiver
     {
-        private ITemporaryDirectory _temporaryDirectory;
-
         public string NuGetPackagesArchive =>
             Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "nuGetPackagesArchive.lzma"));
 
-        public NuGetPackagesArchiver() : this(FileSystemWrapper.Default.Directory)
-        {
-        }
-
-        internal NuGetPackagesArchiver(IDirectory directory)
-        {
-            _temporaryDirectory = directory.CreateTemporaryDirectory();
-        }
-
-        public string ExtractArchive()
+        public void ExtractArchive(string archiveDestination)
         {
             var progress = new ConsoleProgressReport();
             var archive = new IndexedArchive();
 
-            archive.Extract(NuGetPackagesArchive, _temporaryDirectory.DirectoryPath, progress);
-
-            return _temporaryDirectory.DirectoryPath;
-        }
-
-        public void Dispose()
-        {
-            _temporaryDirectory.Dispose();
+            archive.Extract(NuGetPackagesArchive, archiveDestination, progress);
         }
     }
 }

--- a/src/Microsoft.DotNet.TestFramework/TestAssetInstance.cs
+++ b/src/Microsoft.DotNet.TestFramework/TestAssetInstance.cs
@@ -110,6 +110,7 @@ namespace Microsoft.DotNet.TestFramework
             var content = @"<?xml version=""1.0"" encoding=""utf-8""?>
             <configuration>
               <packageSources>
+                <add key=""dotnet-core"" value=""https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"" />
                 <add key=""test-packages"" value=""$fullpath$"" />
               </packageSources>
             </configuration>";

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -171,11 +171,15 @@ namespace Microsoft.DotNet.Cli
             {
                 using (var nugetPackagesArchiver = new NuGetPackagesArchiver())
                 {
+                    var cliFallbackFolderPathCalculator = new CLIFallbackFolderPathCalculator();
                     var environmentProvider = new EnvironmentProvider();
                     var commandFactory = new DotNetCommandFactory(alwaysRunOutOfProc: true);
-                    var nugetConfig = new NuGetConfi();
-                    var nugetCachePrimer = 
-                        new NuGetCachePrimer(nugetPackagesArchiver, nugetCacheSentinel, nugetConfig);
+                    var nugetConfig = new NuGetConfi(cliFallbackFolderPathCalculator);
+                    var nugetCachePrimer = new NuGetCachePrimer(
+                        nugetPackagesArchiver,
+                        nugetCacheSentinel,
+                        nugetConfig,
+                        cliFallbackFolderPathCalculator);
                     var dotnetConfigurer = new DotnetFirstTimeUseConfigurer(
                         nugetCachePrimer,
                         nugetCacheSentinel,

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Cli
             var success = true;
             var command = string.Empty;
             var lastArg = 0;
-            var cliFallbackFolderPathCalculator = new CLIFallbackFolderPathCalculator();
+            var cliFallbackFolderPathCalculator = new CliFallbackFolderPathCalculator();
             using (INuGetCacheSentinel nugetCacheSentinel = new NuGetCacheSentinel(cliFallbackFolderPathCalculator))
             {
                 for (; lastArg < args.Length; lastArg++)
@@ -168,7 +168,7 @@ namespace Microsoft.DotNet.Cli
 
         private static void ConfigureDotNetForFirstTimeUse(
             INuGetCacheSentinel nugetCacheSentinel,
-            CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator)
+            CliFallbackFolderPathCalculator cliFallbackFolderPathCalculator)
         {
             using (PerfTrace.Current.CaptureTiming())
             {

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -79,7 +79,8 @@ namespace Microsoft.DotNet.Cli
             var success = true;
             var command = string.Empty;
             var lastArg = 0;
-            using (INuGetCacheSentinel nugetCacheSentinel = new NuGetCacheSentinel())
+            var cliFallbackFolderPathCalculator = new CLIFallbackFolderPathCalculator();
+            using (INuGetCacheSentinel nugetCacheSentinel = new NuGetCacheSentinel(cliFallbackFolderPathCalculator))
             {
                 for (; lastArg < args.Length; lastArg++)
                 {
@@ -111,7 +112,7 @@ namespace Microsoft.DotNet.Cli
                     }
                     else
                     {
-                        ConfigureDotNetForFirstTimeUse(nugetCacheSentinel);
+                        ConfigureDotNetForFirstTimeUse(nugetCacheSentinel, cliFallbackFolderPathCalculator);
 
                         // It's the command, and we're done!
                         command = args[lastArg];
@@ -165,28 +166,27 @@ namespace Microsoft.DotNet.Cli
 
         }
 
-        private static void ConfigureDotNetForFirstTimeUse(INuGetCacheSentinel nugetCacheSentinel)
+        private static void ConfigureDotNetForFirstTimeUse(
+            INuGetCacheSentinel nugetCacheSentinel,
+            CLIFallbackFolderPathCalculator cliFallbackFolderPathCalculator)
         {
             using (PerfTrace.Current.CaptureTiming())
             {
-                using (var nugetPackagesArchiver = new NuGetPackagesArchiver())
-                {
-                    var cliFallbackFolderPathCalculator = new CLIFallbackFolderPathCalculator();
-                    var environmentProvider = new EnvironmentProvider();
-                    var commandFactory = new DotNetCommandFactory(alwaysRunOutOfProc: true);
-                    var nugetConfig = new NuGetConfi(cliFallbackFolderPathCalculator);
-                    var nugetCachePrimer = new NuGetCachePrimer(
-                        nugetPackagesArchiver,
-                        nugetCacheSentinel,
-                        nugetConfig,
-                        cliFallbackFolderPathCalculator);
-                    var dotnetConfigurer = new DotnetFirstTimeUseConfigurer(
-                        nugetCachePrimer,
-                        nugetCacheSentinel,
-                        environmentProvider);
+                var nugetPackagesArchiver = new NuGetPackagesArchiver();
+                var environmentProvider = new EnvironmentProvider();
+                var commandFactory = new DotNetCommandFactory(alwaysRunOutOfProc: true);
+                var nugetConfig = new NuGetConfig(cliFallbackFolderPathCalculator);
+                var nugetCachePrimer = new NuGetCachePrimer(
+                    nugetPackagesArchiver,
+                    nugetCacheSentinel,
+                    nugetConfig,
+                    cliFallbackFolderPathCalculator);
+                var dotnetConfigurer = new DotnetFirstTimeUseConfigurer(
+                    nugetCachePrimer,
+                    nugetCacheSentinel,
+                    environmentProvider);
 
-                    dotnetConfigurer.Configure();
-                }
+                dotnetConfigurer.Configure();
             }
         }
 

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -173,8 +173,9 @@ namespace Microsoft.DotNet.Cli
                 {
                     var environmentProvider = new EnvironmentProvider();
                     var commandFactory = new DotNetCommandFactory(alwaysRunOutOfProc: true);
+                    var nugetConfig = new NuGetConfi();
                     var nugetCachePrimer = 
-                        new NuGetCachePrimer(commandFactory, nugetPackagesArchiver, nugetCacheSentinel);
+                        new NuGetCachePrimer(nugetPackagesArchiver, nugetCacheSentinel, nugetConfig);
                     var dotnetConfigurer = new DotnetFirstTimeUseConfigurer(
                         nugetCachePrimer,
                         nugetCacheSentinel,

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 {
     public sealed class MSBuildLogger : Logger
     {
-        private readonly INuGetCacheSentinel _sentinel = new NuGetCacheSentinel();
+        private readonly INuGetCacheSentinel _sentinel = new NuGetCacheSentinel(new CLIFallbackFolderPathCalculator());
         private readonly ITelemetry _telemetry;
 
         public MSBuildLogger()

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
 {
     public sealed class MSBuildLogger : Logger
     {
-        private readonly INuGetCacheSentinel _sentinel = new NuGetCacheSentinel(new CLIFallbackFolderPathCalculator());
+        private readonly INuGetCacheSentinel _sentinel = new NuGetCacheSentinel(new CliFallbackFolderPathCalculator());
         private readonly ITelemetry _telemetry;
 
         public MSBuildLogger()

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -342,7 +342,8 @@ namespace Microsoft.DotNet.Tests
 
             var testInstance = TestAssets.Get("AppWithFallbackFolderToolDependency")
                 .CreateInstance()
-                .WithSourceFiles();
+                .WithSourceFiles()
+                .WithNuGetConfig(new RepoDirectoriesProvider().TestPackages);
             var testProjectDirectory = testInstance.Root.FullName;
             var fallbackFolder = Path.Combine(testProjectDirectory, "fallbackFolder");
 
@@ -378,13 +379,14 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Fact]
-        public void ItXXXWhenTheToolDllIsNotFound()
+        public void ItShowsAnErrorWhenTheToolDllIsNotFound()
         {
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();
 
             var testInstance = TestAssets.Get("AppWithFallbackFolderToolDependency")
                 .CreateInstance()
-                .WithSourceFiles();
+                .WithSourceFiles()
+                .WithNuGetConfig(new RepoDirectoriesProvider().TestPackages);
             var testProjectDirectory = testInstance.Root.FullName;
             var fallbackFolder = Path.Combine(testProjectDirectory, "fallbackFolder");
 
@@ -415,9 +417,10 @@ namespace Microsoft.DotNet.Tests
 
         private void PopulateFallbackFolder(string testProjectDirectory, string fallbackFolder)
         {
+            var nugetConfigPath = Path.Combine(testProjectDirectory, "NuGet.Config");
             new RestoreCommand()
                 .WithWorkingDirectory(testProjectDirectory)
-                .Execute($"--packages {fallbackFolder}")
+                .Execute($"--configfile {nugetConfigPath} --packages {fallbackFolder}")
                 .Should()
                 .Pass();
 

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         private Mock<INuGetPackagesArchiver> _nugetPackagesArchiverMock;
         private Mock<INuGetCacheSentinel> _nugetCacheSentinel;
         private Mock<INuGetConfig> _nugetConfigMock;
-        private CLIFallbackFolderPathCalculator _cliFallbackFolderPathCalculator;
+        private CliFallbackFolderPathCalculator _cliFallbackFolderPathCalculator;
 
         public GivenANuGetCachePrimer()
         {
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
 
             _nugetConfigMock = new Mock<INuGetConfig>();
 
-            _cliFallbackFolderPathCalculator = new CLIFallbackFolderPathCalculator();
+            _cliFallbackFolderPathCalculator = new CliFallbackFolderPathCalculator();
 
             var nugetCachePrimer = new NuGetCachePrimer(
                 _nugetPackagesArchiverMock.Object,
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         public void It_adds_the_fallback_folder_to_NuGet_Config()
         {
             _nugetConfigMock.Verify(n =>
-                n.AddCLIFallbackFolder(_cliFallbackFolderPathCalculator.CLIFallbackFolderPath),
+                n.AddCliFallbackFolder(_cliFallbackFolderPathCalculator.CliFallbackFolderPath),
                 Times.Exactly(1));
         }
 
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         public void It_extracts_the_archive_to_the_fallback_folder()
         {
             _nugetPackagesArchiverMock.Verify(n =>
-                n.ExtractArchive(_cliFallbackFolderPathCalculator.CLIFallbackFolderPath),
+                n.ExtractArchive(_cliFallbackFolderPathCalculator.CliFallbackFolderPath),
                 Times.Exactly(1));
         }
 

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
@@ -26,8 +26,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         private Mock<INuGetPackagesArchiver> _nugetPackagesArchiverMock;
         private Mock<INuGetCacheSentinel> _nugetCacheSentinel;
         private Mock<INuGetConfig> _nugetConfigMock;
-
-        private string _nuGetFallbackFolder;
+        private CLIFallbackFolderPathCalculator _cliFallbackFolderPathCalculator;
 
         public GivenANuGetCachePrimer()
         {
@@ -43,14 +42,14 @@ namespace Microsoft.DotNet.Configurer.UnitTests
 
             _nugetConfigMock = new Mock<INuGetConfig>();
 
+            _cliFallbackFolderPathCalculator = new CLIFallbackFolderPathCalculator();
+
             var nugetCachePrimer = new NuGetCachePrimer(
                 _nugetPackagesArchiverMock.Object,
                 _nugetCacheSentinel.Object,
                 _nugetConfigMock.Object,
+                _cliFallbackFolderPathCalculator,
                 _fileSystemMock.File);
-
-            var cliFallbackFolderPathCalculator = new CLIFallbackFolderPathCalculator();
-            _nuGetFallbackFolder = cliFallbackFolderPathCalculator.CLIFallbackFolderPath;
 
             nugetCachePrimer.PrimeCache();
         }
@@ -68,6 +67,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 nugetPackagesArchiverMock.Object,
                 _nugetCacheSentinel.Object,
                 _nugetConfigMock.Object,
+                _cliFallbackFolderPathCalculator,
                 fileSystemMock.File);
 
             nugetCachePrimer.PrimeCache();
@@ -78,13 +78,17 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         [Fact]
         public void It_adds_the_fallback_folder_to_NuGet_Config()
         {
-            _nugetConfigMock.Verify(n => n.AddCLIFallbackFolder(_nuGetFallbackFolder), Times.Exactly(1));
+            _nugetConfigMock.Verify(n =>
+                n.AddCLIFallbackFolder(_cliFallbackFolderPathCalculator.CLIFallbackFolderPath),
+                Times.Exactly(1));
         }
 
         [Fact]
         public void It_extracts_the_archive_to_the_fallback_folder()
         {
-            _nugetPackagesArchiverMock.Verify(n => n.ExtractArchive(_nuGetFallbackFolder), Times.Exactly(1));
+            _nugetPackagesArchiverMock.Verify(n =>
+                n.ExtractArchive(_cliFallbackFolderPathCalculator.CLIFallbackFolderPath),
+                Times.Exactly(1));
         }
 
         [Fact]
@@ -104,6 +108,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 nugetPackagesArchiveMock.Object,
                 nugetCacheSentinel.Object,
                 _nugetConfigMock.Object,
+                _cliFallbackFolderPathCalculator,
                 _fileSystemMock.File);
 
             Action action = () => nugetCachePrimer.PrimeCache();

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
@@ -21,13 +22,12 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         private const string PACKAGES_ARCHIVE_PATH = "some other path";
 
         private IFileSystem _fileSystemMock;
-        private ITemporaryDirectoryMock _temporaryDirectoryMock;
 
-        private Mock<ICommandFactory> _commandFactoryMock;
-        private Mock<ICommand> _dotnetNewCommandMock;
-        private Mock<ICommand> _dotnetRestoreCommandMock;
         private Mock<INuGetPackagesArchiver> _nugetPackagesArchiverMock;
         private Mock<INuGetCacheSentinel> _nugetCacheSentinel;
+        private Mock<INuGetConfig> _nugetConfigMock;
+
+        private string _nuGetFallbackFolder;
 
         public GivenANuGetCachePrimer()
         {
@@ -35,57 +35,24 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             fileSystemMockBuilder.TemporaryFolder = TEMPORARY_FOLDER_PATH;
             fileSystemMockBuilder.AddFile(COMPRESSED_ARCHIVE_PATH);
             _fileSystemMock = fileSystemMockBuilder.Build();
-            _temporaryDirectoryMock = (ITemporaryDirectoryMock)_fileSystemMock.Directory.CreateTemporaryDirectory();
-
-            _commandFactoryMock = SetupCommandFactoryMock();
-
+            
             _nugetPackagesArchiverMock = new Mock<INuGetPackagesArchiver>();
-            _nugetPackagesArchiverMock.Setup(n => n.ExtractArchive()).Returns(PACKAGES_ARCHIVE_PATH);
             _nugetPackagesArchiverMock.Setup(n => n.NuGetPackagesArchive).Returns(COMPRESSED_ARCHIVE_PATH);
 
             _nugetCacheSentinel = new Mock<INuGetCacheSentinel>();
 
+            _nugetConfigMock = new Mock<INuGetConfig>();
+
             var nugetCachePrimer = new NuGetCachePrimer(
-                _commandFactoryMock.Object,
                 _nugetPackagesArchiverMock.Object,
                 _nugetCacheSentinel.Object,
-                _fileSystemMock.Directory,
+                _nugetConfigMock.Object,
                 _fileSystemMock.File);
 
+            var cliFallbackFolderPathCalculator = new CLIFallbackFolderPathCalculator();
+            _nuGetFallbackFolder = cliFallbackFolderPathCalculator.CLIFallbackFolderPath;
+
             nugetCachePrimer.PrimeCache();
-        }
-
-        private Mock<ICommandFactory> SetupCommandFactoryMock()
-        {
-            var commandFactoryMock = new Mock<ICommandFactory>();
-
-            _dotnetNewCommandMock = new Mock<ICommand>();
-            SetupCommandMock(_dotnetNewCommandMock);
-
-            commandFactoryMock
-                .Setup(c => c.Create("new", new[] { "console", "--debug:ephemeral-hive" }, null, Constants.DefaultConfiguration))
-                .Returns(_dotnetNewCommandMock.Object);
-
-            _dotnetRestoreCommandMock = new Mock<ICommand>();
-            SetupCommandMock(_dotnetRestoreCommandMock);
-            commandFactoryMock
-                .Setup(c => c.Create(
-                    "restore",
-                    It.IsAny<IEnumerable<string>>(),
-                    null,
-                    Constants.DefaultConfiguration))
-                .Returns(_dotnetRestoreCommandMock.Object);
-
-            return commandFactoryMock;
-        }
-
-        private void SetupCommandMock(Mock<ICommand> commandMock)
-        {
-            commandMock
-                .Setup(c => c.WorkingDirectory(TEMPORARY_FOLDER_PATH))
-                .Returns(commandMock.Object);
-            commandMock.Setup(c => c.CaptureStdOut()).Returns(commandMock.Object);
-            commandMock.Setup(c => c.CaptureStdErr()).Returns(commandMock.Object);
         }
 
         [Fact]
@@ -94,116 +61,30 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             var fileSystemMockBuilder = FileSystemMockBuilder.Create();
             var fileSystemMock = fileSystemMockBuilder.Build();
 
-            var commandFactoryMock = SetupCommandFactoryMock();
-
             var nugetPackagesArchiverMock = new Mock<INuGetPackagesArchiver>();            
             nugetPackagesArchiverMock.Setup(n => n.NuGetPackagesArchive).Returns(COMPRESSED_ARCHIVE_PATH);
 
             var nugetCachePrimer = new NuGetCachePrimer(
-                commandFactoryMock.Object,
                 nugetPackagesArchiverMock.Object,
                 _nugetCacheSentinel.Object,
-                fileSystemMock.Directory,
+                _nugetConfigMock.Object,
                 fileSystemMock.File);
 
             nugetCachePrimer.PrimeCache();
 
-            nugetPackagesArchiverMock.Verify(n => n.ExtractArchive(), Times.Never);
-            commandFactoryMock.Verify(c => c.Create(
-                It.IsAny<string>(),
-                It.IsAny<IEnumerable<string>>(),
-                null,
-                Constants.DefaultConfiguration), Times.Never);
+            nugetPackagesArchiverMock.Verify(n => n.ExtractArchive(It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
-        public void It_disposes_the_temporary_directory_created_for_the_temporary_project_used_to_prime_the_cache()
+        public void It_adds_the_fallback_folder_to_NuGet_Config()
         {
-            _temporaryDirectoryMock.DisposedTemporaryDirectory.Should().BeTrue();
+            _nugetConfigMock.Verify(n => n.AddCLIFallbackFolder(_nuGetFallbackFolder), Times.Exactly(1));
         }
 
         [Fact]
-        public void It_runs_dotnet_new_using_the_temporary_folder()
+        public void It_extracts_the_archive_to_the_fallback_folder()
         {
-            _dotnetNewCommandMock.Verify(c => c.WorkingDirectory(TEMPORARY_FOLDER_PATH), Times.Exactly(1));
-        }
-
-        [Fact]
-        public void It_runs_dotnet_new_capturing_stdout()
-        {
-            _dotnetNewCommandMock.Verify(c => c.CaptureStdOut(), Times.Exactly(1));
-        }
-
-        [Fact]
-        public void It_runs_dotnet_new_capturing_stderr()
-        {
-            _dotnetNewCommandMock.Verify(c => c.CaptureStdErr(), Times.Exactly(1));
-        }
-
-        [Fact]
-        public void It_actually_runs_dotnet_new()
-        {
-            _dotnetNewCommandMock.Verify(c => c.Execute(), Times.Exactly(1));
-        }
-
-        [Fact]
-        public void It_uses_the_packages_archive_with_dotnet_restore()
-        {
-            _commandFactoryMock.Verify(
-                c => c.Create(
-                    "restore",
-                    new[] { "-s", $"{PACKAGES_ARCHIVE_PATH}" },
-                    null,
-                    Constants.DefaultConfiguration),
-                Times.Exactly(1));
-        }
-
-        [Fact]
-        public void It_does_not_run_restore_if_dotnet_new_fails()
-        {
-            var commandFactoryMock = SetupCommandFactoryMock();
-            _dotnetNewCommandMock.Setup(c => c.Execute()).Returns(new CommandResult(null, -1, null, null));
-
-            var nugetCachePrimer = new NuGetCachePrimer(
-                commandFactoryMock.Object,
-                _nugetPackagesArchiverMock.Object,
-                _nugetCacheSentinel.Object,
-                _fileSystemMock.Directory,
-                _fileSystemMock.File);
-
-            nugetCachePrimer.PrimeCache();
-
-            commandFactoryMock.Verify(
-                c => c.Create(
-                    "restore",
-                    It.IsAny<IEnumerable<string>>(),
-                    It.IsAny<NuGetFramework>(),
-                    It.IsAny<string>()),
-                Times.Never);
-        }
-
-        [Fact]
-        public void It_runs_dotnet_restore_using_the_temporary_folder()
-        {
-            _dotnetRestoreCommandMock.Verify(c => c.WorkingDirectory(TEMPORARY_FOLDER_PATH), Times.Exactly(1));
-        }
-
-        [Fact]
-        public void It_runs_dotnet_restore_capturing_stdout()
-        {
-            _dotnetRestoreCommandMock.Verify(c => c.CaptureStdOut(), Times.Exactly(1));
-        }
-
-        [Fact]
-        public void It_runs_dotnet_restore_capturing_stderr()
-        {
-            _dotnetRestoreCommandMock.Verify(c => c.CaptureStdErr(), Times.Exactly(1));
-        }
-
-        [Fact]
-        public void It_actually_runs_dotnet_restore()
-        {
-            _dotnetRestoreCommandMock.Verify(c => c.Execute(), Times.Exactly(1));
+            _nugetPackagesArchiverMock.Verify(n => n.ExtractArchive(_nuGetFallbackFolder), Times.Exactly(1));
         }
 
         [Fact]
@@ -213,20 +94,21 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Fact]
-        public void It_does_not_create_a_sentinel_when_restore_fails()
+        public void It_does_not_create_a_sentinel_when_extracting_the_archive_fails()
         {
             var nugetCacheSentinel = new Mock<INuGetCacheSentinel>();
-            _dotnetRestoreCommandMock.Setup(c => c.Execute()).Returns(new CommandResult(null, -1, null, null));
+            var nugetPackagesArchiveMock = new Mock<INuGetPackagesArchiver>();
+            nugetPackagesArchiveMock.Setup(n => n.ExtractArchive(It.IsAny<string>())).Throws<Exception>();
 
             var nugetCachePrimer = new NuGetCachePrimer(
-                _commandFactoryMock.Object,
-                _nugetPackagesArchiverMock.Object,
+                nugetPackagesArchiveMock.Object,
                 nugetCacheSentinel.Object,
-                _fileSystemMock.Directory,
+                _nugetConfigMock.Object,
                 _fileSystemMock.File);
 
-            nugetCachePrimer.PrimeCache();
+            Action action = () => nugetCachePrimer.PrimeCache();
 
+            action.ShouldThrow<Exception>();
             nugetCacheSentinel.Verify(n => n.CreateIfNotExists(), Times.Never);
         }
     }

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetConfig.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetConfig.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 .Setup(s => s.GetSettingValues(NuGetConfig.FallbackPackageFolders, false))
                 .Returns(new List<SettingValue>()
                 {
-                    new SettingValue("CLIFallbackFolder", PathToFallbackFolderAlreadySet, false)
+                    new SettingValue("CliFallbackFolder", PathToFallbackFolderAlreadySet, false)
                 });
 
             _nugetConfig = new NuGetConfig(_settingsMock.Object);
@@ -33,20 +33,20 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         public void ItAddsACliFallbackFolderIfOneIsNotPresentAlready()
         {
             const string FallbackFolderNotAlreadySet = "some path not already set";
-            _nugetConfig.AddCLIFallbackFolder(FallbackFolderNotAlreadySet);
+            _nugetConfig.AddCliFallbackFolder(FallbackFolderNotAlreadySet);
 
             _settingsMock.Verify(s =>
-                s.SetValue(NuGetConfig.FallbackPackageFolders, "CLIFallbackFolder", FallbackFolderNotAlreadySet),
+                s.SetValue(NuGetConfig.FallbackPackageFolders, "CliFallbackFolder", FallbackFolderNotAlreadySet),
                 Times.Exactly(1));
         }
 
         [Fact]
         public void ItDoesNotAddTheCliFallbackFolderIfItIsAlreadyPresent()
         {
-            _nugetConfig.AddCLIFallbackFolder(PathToFallbackFolderAlreadySet);
+            _nugetConfig.AddCliFallbackFolder(PathToFallbackFolderAlreadySet);
 
             _settingsMock.Verify(s => 
-                s.SetValue(NuGetConfig.FallbackPackageFolders, "CLIFallbackFolder", PathToFallbackFolderAlreadySet),
+                s.SetValue(NuGetConfig.FallbackPackageFolders, "CliFallbackFolder", PathToFallbackFolderAlreadySet),
                 Times.Never);
         }
     }

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetConfig.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetConfig.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NuGet.Configuration;
+using Xunit;
+
+namespace Microsoft.DotNet.Configurer.UnitTests
+{
+    public class GivenANuGetConfig
+    {
+        private const string PathToFallbackFolderAlreadySet = "some path to fallback folder";
+
+        private Mock<ISettings> _settingsMock;
+        private INuGetConfig _nugetConfig;
+
+        public GivenANuGetConfig()
+        {
+            _settingsMock = new Mock<ISettings>();
+            _settingsMock
+                .Setup(s => s.GetSettingValues(NuGetConfig.FallbackPackageFolders, false))
+                .Returns(new List<SettingValue>()
+                {
+                    new SettingValue("CLIFallbackFolder", PathToFallbackFolderAlreadySet, false)
+                });
+
+            _nugetConfig = new NuGetConfig(_settingsMock.Object);
+        }
+
+        [Fact]
+        public void ItAddsACliFallbackFolderIfOneIsNotPresentAlready()
+        {
+            const string FallbackFolderNotAlreadySet = "some path not already set";
+            _nugetConfig.AddCLIFallbackFolder(FallbackFolderNotAlreadySet);
+
+            _settingsMock.Verify(s =>
+                s.SetValue(NuGetConfig.FallbackPackageFolders, "CLIFallbackFolder", FallbackFolderNotAlreadySet),
+                Times.Exactly(1));
+        }
+
+        [Fact]
+        public void ItDoesNotAddTheCliFallbackFolderIfItIsAlreadyPresent()
+        {
+            _nugetConfig.AddCLIFallbackFolder(PathToFallbackFolderAlreadySet);
+
+            _settingsMock.Verify(s => 
+                s.SetValue(NuGetConfig.FallbackPackageFolders, "CLIFallbackFolder", PathToFallbackFolderAlreadySet),
+                Times.Never);
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
@@ -9,6 +9,7 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +19,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="1.6.0" />
     <PackageReference Include="FluentAssertions" Version="4.18.0" />
     <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -60,6 +60,8 @@ namespace Microsoft.DotNet.New.Tests
             string projectFolder,
             string packagesDirectory)
         {
+            var repoRootNuGetConfig = Path.Combine(RepoDirectoriesProvider.RepoRoot, "NuGet.Config");
+
             new NewCommand()
                 .WithWorkingDirectory(projectFolder)
                 .Execute($"{projectType} --debug:ephemeral-hive")
@@ -67,7 +69,7 @@ namespace Microsoft.DotNet.New.Tests
 
             new RestoreCommand()
                 .WithWorkingDirectory(projectFolder)
-                .Execute($"--packages {packagesDirectory}")
+                .Execute($"--configfile {repoRootNuGetConfig} --packages {packagesDirectory}")
                 .Should().Pass();
         }
 
@@ -88,6 +90,7 @@ namespace Microsoft.DotNet.New.Tests
             var packagesDirectory = Path.Combine(rootPath, "packages");
             var projectName = "Project";
             var expectedVersion = GetFrameworkPackageVersion();
+            var repoRootNuGetConfig = Path.Combine(RepoDirectoriesProvider.RepoRoot, "NuGet.Config");
 
             new NewCommand()
                 .WithWorkingDirectory(rootPath)
@@ -98,7 +101,7 @@ namespace Microsoft.DotNet.New.Tests
 
             new RestoreCommand()
                 .WithWorkingDirectory(rootPath)
-                .Execute($"--packages {packagesDirectory}")
+                .Execute($"--configfile {repoRootNuGetConfig} --packages {packagesDirectory}")
                 .Should().Pass();
 
             new DirectoryInfo(Path.Combine(packagesDirectory, packageName))

--- a/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -14,6 +14,8 @@ namespace Microsoft.DotNet.Restore.Tests
 {
     public class GivenThatIWantToRestoreApp : TestBase
     {
+        private static string RepoRootNuGetConfig = Path.Combine(RepoDirectoriesProvider.RepoRoot, "NuGet.Config");
+
         [Fact]
         public void ItRestoresAppToSpecificDirectory()
         {
@@ -29,7 +31,7 @@ namespace Microsoft.DotNet.Restore.Tests
                 .Should()
                 .Pass();
 
-            string args = $"--packages \"{dir}\"";
+            string args = $"--configfile {RepoRootNuGetConfig} --packages \"{dir}\"";
             new RestoreCommand()
                  .WithWorkingDirectory(rootPath)
                  .ExecuteWithCapturedOutput(args)
@@ -56,7 +58,7 @@ namespace Microsoft.DotNet.Restore.Tests
                 .Should()
                 .Pass();
 
-            string args = $"--packages \"{dir}\"";
+            string args = $"--configfile {RepoRootNuGetConfig} --packages \"{dir}\"";
             new RestoreCommand()
                 .WithWorkingDirectory(rootPath)
                 .ExecuteWithCapturedOutput(args)
@@ -76,7 +78,7 @@ namespace Microsoft.DotNet.Restore.Tests
             string dir = "pkgs";
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
-            string args = $"--packages \"{dir}\"";
+            string args = $"--configfile {RepoRootNuGetConfig} --packages \"{dir}\"";
             new RestoreCommand()
                 .WithWorkingDirectory(rootPath)
                 .ExecuteWithCapturedOutput(args)

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -30,6 +30,7 @@ namespace Microsoft.DotNet.Tests
                 .WithWorkingDirectory(testDirectory);
             command.Environment["HOME"] = testNuGetHome;
             command.Environment["USERPROFILE"] = testNuGetHome;
+            command.Environment["APPDATA"] = testNuGetHome;
             command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
             command.Environment["SkipInvalidConfigurations"] = "true";
 


### PR DESCRIPTION
Populating a nuget fallback folder during first run, instead of the nuget cache.

@dotnet/dotnet-cli 

Fixes https://github.com/dotnet/cli/issues/6100
