### PR TITLE
Correct OpenSSL install guide

### DIFF
--- a/Documentation/project-docs/developer-guide.md
+++ b/Documentation/project-docs/developer-guide.md
@@ -18,8 +18,11 @@ In order to build .NET Command Line Interface, you need the following installed 
 1. Xcode
 2. git (available from http://www.git-scm.com/) on the PATH.
 3. Install OpenSSL (a .NET Core requirement)
+  - brew update
   - brew install openssl
-  - brew link --force openssl
+  - mkdir -p /usr/local/lib
+  - ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/
+  - ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/
 
 ## Building/Running
 


### PR DESCRIPTION
The previous command will not work anymore

Get error:
Warning: Refusing to link: openssl
Linking keg-only OpenSSL means you may end up linking against the insecure,
deprecated system version while using the headers from the Homebrew version.
Instead, pass the full include/library paths to your compiler

Get an instruction that worked from https://www.microsoft.com/net/core#macos

Reason is here: http://stackoverflow.com/questions/38670295/homebrew-refusing-to-link-openssl
