### PR TITLE
Fix passing /p:DISABLE_CROSSGEN on cli.

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -50,7 +50,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{89905EC4
 		build\OutputDirectories.props = build\OutputDirectories.props
 		build\Package.targets = build\Package.targets
 		build\Prepare.targets = build\Prepare.targets
-		build\ProjectsToPublish.props = build\ProjectsToPublish.props
 		build\Publish.targets = build\Publish.targets
 		build\Run.targets = build\Run.targets
 		build\sdks\sdks.csproj = build\sdks\sdks.csproj

--- a/build/Compile.targets
+++ b/build/Compile.targets
@@ -10,9 +10,7 @@
     <MakeDir Directories="$(OutputDirectory)"/>
 
     <!-- Publish DotNet -->
-    <DotNetPublish ToolPath="$(Stage0Directory)"
-                   Verbosity="normal"
-                   Configuration="$(Configuration)"
-                   ProjectPath="$(RootProject)" />
+    <MSBuild Projects="$(SrcDirectory)/redist/redist.csproj"
+             Targets="Publish" />
   </Target>
 </Project>

--- a/build/ProjectsToPublish.props
+++ b/build/ProjectsToPublish.props
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <RootProject>$(SrcDirectory)/redist/redist.csproj</RootProject>
-  </PropertyGroup>
-</Project>

--- a/build_projects/shared-build-targets-utils/Utils/BuildVersion.cs
+++ b/build_projects/shared-build-targets-utils/Utils/BuildVersion.cs
@@ -7,8 +7,6 @@ namespace Microsoft.DotNet.Cli.Build
 {
     public class BuildVersion : Version
     {
-        public string SimpleVersion => $"{Major}.{Minor}.{Patch}.{CommitCountString}";
         public string VersionSuffix => $"{ReleaseSuffix}-{CommitCountString}";
-        public string NuGetVersion => $"{Major}.{Minor}.{Patch}-{VersionSuffix}";
     }
 }

--- a/build_projects/shared-build-targets-utils/Utils/EnvVars.cs
+++ b/build_projects/shared-build-targets-utils/Utils/EnvVars.cs
@@ -2,37 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Microsoft.DotNet.Cli.Build.Framework;
 
 namespace Microsoft.DotNet.Cli.Build
 {
     public class EnvVars
     {
-        public static readonly bool Verbose = GetBool("DOTNET_BUILD_VERBOSE");
-
-        public static bool GetBool(string name, bool defaultValue = false)
-        {
-            var str = Environment.GetEnvironmentVariable(name);
-            if (string.IsNullOrEmpty(str))
-            {
-                return defaultValue;
-            }
-
-            switch (str.ToLowerInvariant())
-            {
-                case "true":
-                case "1":
-                case "yes":
-                    return true;
-                case "false":
-                case "0":
-                case "no":
-                    return false;
-                default:
-                    return defaultValue;
-            }
-        }
-
         public static string EnsureVariable(string variableName)
         {
             string value = Environment.GetEnvironmentVariable(variableName);

--- a/dir.props
+++ b/dir.props
@@ -30,7 +30,6 @@
   <Import Project="build/FileExtensions.props" />
   <Import Project="build/InputDirectories.props" />
   <Import Project="build/MSBuildExtensions.props" />
-  <Import Project="build/ProjectsToPublish.props" />
   <Import Project="build/OutputDirectories.props" />
   <Import Project="build/BuildDefaults.props" />
   <Import Project="build/Stage0.props" />


### PR DESCRIPTION
When passing a property using the commandline, it is not flown through to "dotnet publish" calls.  So instead of using "dotnet publish", just use the MSBuild task to invoke the Publish target on the reidst project.  This way properties flow correctly.

I also did a little cleaning of unused build logic.

NOTE: This makes the verbosity of publishing the `redist.csproj` go from 'normal' to whatever is passed on the command line (which currently is diag).  https://github.com/dotnet/cli/blob/master/run-build.ps1#L124  We may want to change this to put diagnostic output to a file in the future.

@livarcocc @nguerrera @dsplaisted 
/cc @Petermarcu 