### PR TITLE
Update Sdk to 2.0.0-alpha-20170405-2

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,7 +4,7 @@
     <CLI_SharedFrameworkVersion>2.0.0-preview1-001913-00</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.2.0-preview-000093-02</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>2.0.0-alpha-20170403-2</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-alpha-20170405-2</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-beta1-2418</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-rel-20170403-420</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.1.0-preview-20170316-05</CLI_TestPlatform_Version>


### PR DESCRIPTION
The build is still running, so this will fail until the SDK is published.