### PR TITLE
Adding error code 1638 as a ignore/success error when installing the VC_Redist.

### DIFF
--- a/branchinfo.txt
+++ b/branchinfo.txt
@@ -3,7 +3,7 @@
 # Each line is expected to be in the format "[Name]=[Value]".
 MAJOR_VERSION=1
 MINOR_VERSION=0
-PATCH_VERSION=2
+PATCH_VERSION=3
 RELEASE_SUFFIX=rc4
 CHANNEL=rel-1.0.1
 BRANCH_NAME=rel/1.0.1

--- a/build/Microsoft.DotNet.Cli.Monikers.props
+++ b/build/Microsoft.DotNet.Cli.Monikers.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SdkBrandName>.NET Core SDK 1.0.2</SdkBrandName>
+    <SdkBrandName>.NET Core SDK 1.0.3</SdkBrandName>
     <SharedFrameworkBrandName>Microsoft .NET Core 1.1.1 - Runtime</SharedFrameworkBrandName>
     <SharedHostBrandName>Microsoft .NET Core 1.1.0 - Host</SharedHostBrandName>
     <HostFxrBrandName>Microsoft .NET Core 1.1.0 - Host FX Resolver</HostFxrBrandName>

--- a/dir.props
+++ b/dir.props
@@ -13,6 +13,6 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
 
 
-    <CliVersionPrefix>1.0.2</CliVersionPrefix>
+    <CliVersionPrefix>1.0.3</CliVersionPrefix>
   </PropertyGroup>
 </Project>

--- a/packaging/windows/clisdk/bundle.wxs
+++ b/packaging/windows/clisdk/bundle.wxs
@@ -42,6 +42,7 @@
                        ProductName="$(var.Crt_ProductName)" 
                        Size="$(var.Crt_Size)" 
                        Version="$(var.Crt_Version)" />
+        <ExitCode Behavior="success" Value="1638" />
       </ExePackage>
       <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />


### PR DESCRIPTION
This will cause the CLI installation to continue in the case where the VC_Redist installer returns an error saying it is already installed.

@dotnet/dotnet-cli 