### PR TITLE
Replace dotnet help parser with CliCommandLineParser

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -16,8 +16,8 @@
     <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170405-182</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
-    <CliCommandLineParserVersion>0.1.0-alpha-138</CliCommandLineParserVersion>
-    
+    <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
+
   </PropertyGroup>
 
   <!-- infrastructure and test only dependencies -->

--- a/src/dotnet/Parser.cs
+++ b/src/dotnet/Parser.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Tools.Help;
 using static System.Environment;
 using static Microsoft.DotNet.Cli.CommandLine.LocalizableStrings;
 using LocalizableStrings = Microsoft.DotNet.Tools.Run.LocalizableStrings;
@@ -47,6 +48,7 @@ namespace Microsoft.DotNet.Cli
                                     ListCommandParser.List(),
                                     NuGetCommandParser.NuGet(),
                                     CacheCommandParser.Cache(),
+                                    HelpCommandParser.Help(),
                                     Create.Command("msbuild", ""),
                                     Create.Command("vstest", ""),
                                     CompleteCommandParser.Complete(),

--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -8,53 +8,14 @@ using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli;
+using static HelpUsageText;
 
 namespace Microsoft.DotNet.Tools.Help
 {
     public class HelpCommand
     {
-        private static readonly string UsageText = $@"{LocalizableStrings.Usage}: dotnet [host-options] [command] [arguments] [common-options]
-
-{LocalizableStrings.Arguments}:
-  [command]             {LocalizableStrings.CommandDefinition}
-  [arguments]           {LocalizableStrings.ArgumentsDefinition}
-  [host-options]        {LocalizableStrings.HostOptionsDefinition}
-  [common-options]      {LocalizableStrings.OptionsDescription}
-
-{LocalizableStrings.CommonOptions}:
-  -v|--verbose          {LocalizableStrings.VerboseDefinition}
-  -h|--help             {LocalizableStrings.HelpDefinition} 
-
-{LocalizableStrings.HostOptions}:
-  -d|--diagnostics      {LocalizableStrings.DiagnosticsDefinition}
-  --version             {LocalizableStrings.VersionDescription}
-  --info                {LocalizableStrings.InfoDescription}
-
-{LocalizableStrings.Commands}:
-  new           {LocalizableStrings.NewDefinition}
-  restore       {LocalizableStrings.RestoreDefinition}
-  build         {LocalizableStrings.BuildDefinition}
-  publish       {LocalizableStrings.PublishDefinition}
-  run           {LocalizableStrings.RunDefinition}
-  test          {LocalizableStrings.TestDefinition}
-  pack          {LocalizableStrings.PackDefinition}
-  migrate       {LocalizableStrings.MigrateDefinition}
-  clean         {LocalizableStrings.CleanDefinition}
-  sln           {LocalizableStrings.SlnDefinition}
-
-Project modification commands:
-  add           Add items to the project
-  remove        Remove items from the project
-  list          List items in the project
-
-{LocalizableStrings.AdvancedCommands}:
-  nuget         {LocalizableStrings.NugetDefinition}
-  msbuild       {LocalizableStrings.MsBuildDefinition}
-  vstest        {LocalizableStrings.VsTestDefinition}";
-
         public static int Run(string[] args)
         {
-
             CommandLineApplication app = new CommandLineApplication(throwOnUnexpectedArg: false);
             app.Name = "dotnet help";
             app.FullName = LocalizableStrings.AppFullName;

--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -1,68 +1,64 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics;
-using System.Reflection;
+using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Cli;
-using static HelpUsageText;
+using Command = Microsoft.DotNet.Cli.CommandLine.Command;
+using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tools.Help
 {
     public class HelpCommand
     {
+        private readonly AppliedOption _appliedOption;
+
+        public HelpCommand(AppliedOption appliedOption)
+        {
+            _appliedOption = appliedOption;
+        }
+
         public static int Run(string[] args)
         {
-            CommandLineApplication app = new CommandLineApplication(throwOnUnexpectedArg: false);
-            app.Name = "dotnet help";
-            app.FullName = LocalizableStrings.AppFullName;
-            app.Description = LocalizableStrings.AppDescription;
+            DebugHelper.HandleDebugSwitch(ref args);
 
-            CommandArgument commandNameArgument = app.Argument($"<{LocalizableStrings.CommandArgumentName}>", LocalizableStrings.CommandArgumentDescription);
+            var parser = Parser.Instance;
+            var result = parser.ParseFrom("dotnet help", args);
+            var helpAppliedOption = result["dotnet"]["help"];
 
-            app.OnExecute(() => 
+            HelpCommand cmd;
+            try
             {
-                BuiltInCommandMetadata builtIn;
-                if (BuiltInCommandsCatalog.Commands.TryGetValue(commandNameArgument.Value, out builtIn))
-                {
-                    var process = ConfigureProcess(builtIn.DocLink);
-                    process.Start();
-                    process.WaitForExit();
-                }
-                else
-                {
-                    Reporter.Error.WriteLine(String.Format(LocalizableStrings.CommandDoesNotExist, commandNameArgument.Value));
-                    Reporter.Output.WriteLine(UsageText);
-                    return 1;
-                }
-                return 0;
-            });
-            
-            if (args.Length == 0)
+                cmd = new HelpCommand(helpAppliedOption);
+            }
+            catch (CommandCreationException e)
             {
-                PrintHelp();
-                return 0;
+                return e.ExitCode;
+            }
+
+            if (helpAppliedOption.Arguments.Any())
+            {
+                return cmd.Execute();
             }
             else
             {
-                return app.Execute(args);
+                PrintHelp();
+                return 0;
             }
         }
 
         public static void PrintHelp()
         {
             PrintVersionHeader();
-            Reporter.Output.WriteLine(UsageText);
+            Reporter.Output.WriteLine(HelpUsageText.UsageText);
         }
 
         public static void PrintVersionHeader()
         {
-            var versionString = string.IsNullOrEmpty(Product.Version) ?
-                string.Empty :
-                $" ({Product.Version})";
+            var versionString = string.IsNullOrEmpty(Product.Version) ? string.Empty : $" ({Product.Version})";
             Reporter.Output.WriteLine(Product.LongName + versionString);
         }
 
@@ -93,11 +89,34 @@ namespace Microsoft.DotNet.Tools.Help
                     Arguments = docUrl
                 };
             }
-            
+
             return new Process
             {
                 StartInfo = psInfo
             };
         }
+
+        public int Execute()
+        {
+            if (BuiltInCommandsCatalog.Commands.TryGetValue(
+                _appliedOption.Arguments.Single(),
+                out BuiltInCommandMetadata builtIn))
+            {
+                var process = ConfigureProcess(builtIn.DocLink);
+                process.Start();
+                process.WaitForExit();
+            }
+            else
+            {
+                Reporter.Error.WriteLine(
+                    string.Format(
+                        LocalizableStrings.CommandDoesNotExist,
+                        _appliedOption.Arguments.Single()));
+                Reporter.Output.WriteLine(HelpUsageText.UsageText);
+                return 1;
+            }
+            return 0;
+        }
     }
 }
+

--- a/src/dotnet/commands/dotnet-help/HelpCommandParser.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommandParser.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.DotNet.Cli.CommandLine;
+
+namespace Microsoft.DotNet.Tools.Help
+{
+    internal static class HelpCommandParser
+    {
+        public static Command Help()
+        {
+            return Create.Command(
+                "help",
+                LocalizableStrings.AppFullName,
+                Accept.ZeroOrOneArgument()
+                    .With(
+                        LocalizableStrings.CommandArgumentDescription,
+                        LocalizableStrings.CommandArgumentName),
+                Create.Option(
+                    "-h|--help|-?|/?",
+                    "Show help information",
+                    Accept.NoArguments()
+                )
+            );
+        }
+    }
+}
+

--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -1,0 +1,44 @@
+using Microsoft.DotNet.Tools.Help;
+
+internal static class HelpUsageText
+{
+    public static readonly string UsageText =
+        $@"{LocalizableStrings.Usage}: dotnet [host-options] [command] [arguments] [common-options]
+
+{LocalizableStrings.Arguments}:
+  [command]             {LocalizableStrings.CommandDefinition}
+  [arguments]           {LocalizableStrings.ArgumentsDefinition}
+  [host-options]        {LocalizableStrings.HostOptionsDefinition}
+  [common-options]      {LocalizableStrings.OptionsDescription}
+
+{LocalizableStrings.CommonOptions}:
+  -v|--verbose          {LocalizableStrings.VerboseDefinition}
+  -h|--help             {LocalizableStrings.HelpDefinition} 
+
+{LocalizableStrings.HostOptions}:
+  -d|--diagnostics      {LocalizableStrings.DiagnosticsDefinition}
+  --version             {LocalizableStrings.VersionDescription}
+  --info                {LocalizableStrings.InfoDescription}
+
+{LocalizableStrings.Commands}:
+  new           {LocalizableStrings.NewDefinition}
+  restore       {LocalizableStrings.RestoreDefinition}
+  build         {LocalizableStrings.BuildDefinition}
+  publish       {LocalizableStrings.PublishDefinition}
+  run           {LocalizableStrings.RunDefinition}
+  test          {LocalizableStrings.TestDefinition}
+  pack          {LocalizableStrings.PackDefinition}
+  migrate       {LocalizableStrings.MigrateDefinition}
+  clean         {LocalizableStrings.CleanDefinition}
+  sln           {LocalizableStrings.SlnDefinition}
+
+Project modification commands:
+  add           Add items to the project
+  remove        Remove items from the project
+  list          List items in the project
+
+{LocalizableStrings.AdvancedCommands}:
+  nuget         {LocalizableStrings.NugetDefinition}
+  msbuild       {LocalizableStrings.MsBuildDefinition}
+  vstest        {LocalizableStrings.VsTestDefinition}";
+}

--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -13,7 +13,7 @@ internal static class HelpUsageText
 
 {LocalizableStrings.CommonOptions}:
   -v|--verbose          {LocalizableStrings.VerboseDefinition}
-  -h|--help             {LocalizableStrings.HelpDefinition} 
+  -h|--help             {LocalizableStrings.HelpDefinition}
 
 {LocalizableStrings.HostOptions}:
   -d|--diagnostics      {LocalizableStrings.DiagnosticsDefinition}
@@ -42,3 +42,4 @@ Project modification commands:
   msbuild       {LocalizableStrings.MsBuildDefinition}
   vstest        {LocalizableStrings.VsTestDefinition}";
 }
+


### PR DESCRIPTION
CliCommandLineParserVersion 138 cannot use help as command and --help as
opinion at the same time, update to version 142