### PR TITLE
replace dotnet help parser with CliCommandLineParser 

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -166,6 +166,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet.Tests", "test\dotnet
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-build.Tests", "test\dotnet-build.Tests\dotnet-build.Tests.csproj", "{BBB5A4C8-CD2D-4A6A-9159-0FEAF84B745E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet-help.Tests", "test\dotnet-help.Tests\dotnet-help.Tests.csproj", "{8AA88E83-6A98-4AD6-86EB-2ED4F6EDA17F}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-migrate.Tests", "test\dotnet-migrate.Tests\dotnet-migrate.Tests.csproj", "{726D2CB9-80E5-4496-9C86-910AC452C45E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-msbuild.Tests", "test\dotnet-msbuild.Tests\dotnet-msbuild.Tests.csproj", "{EF745C56-0350-4C42-AA22-86D592E1D8D5}"

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -16,8 +16,8 @@
     <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170410-189</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
-    <CliCommandLineParserVersion>0.1.0-alpha-140</CliCommandLineParserVersion>
-    
+    <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
+
   </PropertyGroup>
 
   <!-- infrastructure and test only dependencies -->

--- a/src/dotnet/Parser.cs
+++ b/src/dotnet/Parser.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Tools.Help;
 using static System.Environment;
 using static Microsoft.DotNet.Cli.CommandLine.LocalizableStrings;
 using LocalizableStrings = Microsoft.DotNet.Tools.Run.LocalizableStrings;
@@ -47,6 +48,7 @@ namespace Microsoft.DotNet.Cli
                                     ListCommandParser.List(),
                                     NuGetCommandParser.NuGet(),
                                     StoreCommandParser.Store(),
+                                    HelpCommandParser.Help(),
                                     Create.Command("msbuild", ""),
                                     Create.Command("vstest", ""),
                                     CompleteCommandParser.Complete(),

--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -8,53 +8,14 @@ using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli;
+using static HelpUsageText;
 
 namespace Microsoft.DotNet.Tools.Help
 {
     public class HelpCommand
     {
-        private static readonly string UsageText = $@"{LocalizableStrings.Usage}: dotnet [host-options] [command] [arguments] [common-options]
-
-{LocalizableStrings.Arguments}:
-  [command]             {LocalizableStrings.CommandDefinition}
-  [arguments]           {LocalizableStrings.ArgumentsDefinition}
-  [host-options]        {LocalizableStrings.HostOptionsDefinition}
-  [common-options]      {LocalizableStrings.OptionsDescription}
-
-{LocalizableStrings.CommonOptions}:
-  -v|--verbose          {LocalizableStrings.VerboseDefinition}
-  -h|--help             {LocalizableStrings.HelpDefinition} 
-
-{LocalizableStrings.HostOptions}:
-  -d|--diagnostics      {LocalizableStrings.DiagnosticsDefinition}
-  --version             {LocalizableStrings.VersionDescription}
-  --info                {LocalizableStrings.InfoDescription}
-
-{LocalizableStrings.Commands}:
-  new           {LocalizableStrings.NewDefinition}
-  restore       {LocalizableStrings.RestoreDefinition}
-  build         {LocalizableStrings.BuildDefinition}
-  publish       {LocalizableStrings.PublishDefinition}
-  run           {LocalizableStrings.RunDefinition}
-  test          {LocalizableStrings.TestDefinition}
-  pack          {LocalizableStrings.PackDefinition}
-  migrate       {LocalizableStrings.MigrateDefinition}
-  clean         {LocalizableStrings.CleanDefinition}
-  sln           {LocalizableStrings.SlnDefinition}
-
-Project modification commands:
-  add           Add items to the project
-  remove        Remove items from the project
-  list          List items in the project
-
-{LocalizableStrings.AdvancedCommands}:
-  nuget         {LocalizableStrings.NugetDefinition}
-  msbuild       {LocalizableStrings.MsBuildDefinition}
-  vstest        {LocalizableStrings.VsTestDefinition}";
-
         public static int Run(string[] args)
         {
-
             CommandLineApplication app = new CommandLineApplication(throwOnUnexpectedArg: false);
             app.Name = "dotnet help";
             app.FullName = LocalizableStrings.AppFullName;

--- a/src/dotnet/commands/dotnet-help/HelpCommandParser.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommandParser.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+
+namespace Microsoft.DotNet.Tools.Help
+{
+    internal static class HelpCommandParser
+    {
+        public static Command Help()
+        {
+            return Create.Command(
+                "help",
+                LocalizableStrings.AppFullName,
+                Accept.ZeroOrOneArgument()
+                    .With(
+                        LocalizableStrings.CommandArgumentDescription,
+                        LocalizableStrings.CommandArgumentName),
+                         CommonOptions.HelpOption());
+        }
+    }
+}
+

--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -1,4 +1,4 @@
-using Microsoft.DotNet.Tools.Help;
+﻿using Microsoft.DotNet.Tools.Help;
 
 internal static class HelpUsageText
 {
@@ -35,7 +35,7 @@ $@"{LocalizableStrings.Usage}: dotnet [host-options] [command] [arguments] [comm
 {LocalizableStrings.ProjectModificationCommands}:
   add           {LocalizableStrings.AddDefinition}
   remove        {LocalizableStrings.RemoveDefinition}
-  list          {LocalizableStrings.RemoveDefinition}
+  list          {LocalizableStrings.ListDefinition}
 
 {LocalizableStrings.AdvancedCommands}:
   nuget         {LocalizableStrings.NugetDefinition}

--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -1,0 +1,44 @@
+using Microsoft.DotNet.Tools.Help;
+
+internal static class HelpUsageText
+{
+    public static readonly string UsageText =
+        $@"{LocalizableStrings.Usage}: dotnet [host-options] [command] [arguments] [common-options]
+
+{LocalizableStrings.Arguments}:
+  [command]             {LocalizableStrings.CommandDefinition}
+  [arguments]           {LocalizableStrings.ArgumentsDefinition}
+  [host-options]        {LocalizableStrings.HostOptionsDefinition}
+  [common-options]      {LocalizableStrings.OptionsDescription}
+
+{LocalizableStrings.CommonOptions}:
+  -v|--verbose          {LocalizableStrings.VerboseDefinition}
+  -h|--help             {LocalizableStrings.HelpDefinition} 
+
+{LocalizableStrings.HostOptions}:
+  -d|--diagnostics      {LocalizableStrings.DiagnosticsDefinition}
+  --version             {LocalizableStrings.VersionDescription}
+  --info                {LocalizableStrings.InfoDescription}
+
+{LocalizableStrings.Commands}:
+  new           {LocalizableStrings.NewDefinition}
+  restore       {LocalizableStrings.RestoreDefinition}
+  build         {LocalizableStrings.BuildDefinition}
+  publish       {LocalizableStrings.PublishDefinition}
+  run           {LocalizableStrings.RunDefinition}
+  test          {LocalizableStrings.TestDefinition}
+  pack          {LocalizableStrings.PackDefinition}
+  migrate       {LocalizableStrings.MigrateDefinition}
+  clean         {LocalizableStrings.CleanDefinition}
+  sln           {LocalizableStrings.SlnDefinition}
+
+Project modification commands:
+  add           Add items to the project
+  remove        Remove items from the project
+  list          List items in the project
+
+{LocalizableStrings.AdvancedCommands}:
+  nuget         {LocalizableStrings.NugetDefinition}
+  msbuild       {LocalizableStrings.MsBuildDefinition}
+  vstest        {LocalizableStrings.VsTestDefinition}";
+}

--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -3,7 +3,7 @@ using Microsoft.DotNet.Tools.Help;
 internal static class HelpUsageText
 {
     public static readonly string UsageText =
-        $@"{LocalizableStrings.Usage}: dotnet [host-options] [command] [arguments] [common-options]
+$@"{LocalizableStrings.Usage}: dotnet [host-options] [command] [arguments] [common-options]
 
 {LocalizableStrings.Arguments}:
   [command]             {LocalizableStrings.CommandDefinition}
@@ -13,7 +13,7 @@ internal static class HelpUsageText
 
 {LocalizableStrings.CommonOptions}:
   -v|--verbose          {LocalizableStrings.VerboseDefinition}
-  -h|--help             {LocalizableStrings.HelpDefinition} 
+  -h|--help             {LocalizableStrings.HelpDefinition}
 
 {LocalizableStrings.HostOptions}:
   -d|--diagnostics      {LocalizableStrings.DiagnosticsDefinition}
@@ -42,3 +42,4 @@ Project modification commands:
   msbuild       {LocalizableStrings.MsBuildDefinition}
   vstest        {LocalizableStrings.VsTestDefinition}";
 }
+

--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -32,10 +32,10 @@ $@"{LocalizableStrings.Usage}: dotnet [host-options] [command] [arguments] [comm
   clean         {LocalizableStrings.CleanDefinition}
   sln           {LocalizableStrings.SlnDefinition}
 
-Project modification commands:
-  add           Add items to the project
-  remove        Remove items from the project
-  list          List items in the project
+{LocalizableStrings.ProjectModificationCommands}:
+  add           {LocalizableStrings.AddDefinition}
+  remove        {LocalizableStrings.RemoveDefinition}
+  list          {LocalizableStrings.RemoveDefinition}
 
 {LocalizableStrings.AdvancedCommands}:
   nuget         {LocalizableStrings.NugetDefinition}

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -55,6 +55,8 @@ namespace Microsoft.DotNet.Tools.Help
 
         public const string RemoveDefinition = "Remove items from the project.";
 
+	public const string ListDefinition = "List items in the project.";
+
         public const string AdvancedCommands = "Advanced Commands";
 
         public const string NugetDefinition = "Provides additional NuGet commands.";

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/HelpCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/HelpCommand.cs
@@ -9,8 +9,17 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
     {
         public override CommandResult Execute(string args = "")
         {
-            args = $"help {args}";
-            return base.Execute(args);
+            return base.Execute(AppendHelp(args));
+        }
+
+        public override CommandResult ExecuteWithCapturedOutput(string args = "")
+        {
+            return base.ExecuteWithCapturedOutput(AppendHelp(args));
+        }
+
+        private string AppendHelp(string args)
+        {
+            return args = $"help {args}";
         }
     }
 }

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -25,7 +25,7 @@ Arguments:
 
 Common options:
   -v|--verbose          Enable verbose output
-  -h|--help             Show help 
+  -h|--help             Show help
 
 Host options (passed before the command):
   -d|--diagnostics      Enable diagnostic output
@@ -68,11 +68,20 @@ Advanced Commands:
         }
 
         [Fact]
+        public void WhenHelpCommandIsPassedToDotnetItPrintsUsage()
+        {
+            var cmd = new HelpCommand()
+                .ExecuteWithCapturedOutput();
+            cmd.Should().Pass();
+            cmd.StdOut.Should().ContainVisuallySameFragment(HelpText);
+        }
+
+        [Fact]
         public void WhenInvalidCommandIsPassedToDotnetHelpItPrintsError()
         {
           var cmd = new DotnetCommand()
                 .ExecuteWithCapturedOutput("help invalid");
-          
+
           cmd.Should().Fail();
           cmd.StdErr.Should().ContainVisuallySameFragment($"Specified command 'invalid' is not a valid CLI command. Please specify a valid CLI commands. For more information, run dotnet help.");
           cmd.StdOut.Should().ContainVisuallySameFragment(HelpText);
@@ -92,7 +101,7 @@ Advanced Commands:
           var proc = HelpActual.HelpCommand.ConfigureProcess("https://aka.ms/dotnet-build");
           Assert.Equal("xdg-open", proc.StartInfo.FileName);
           Assert.Equal("https://aka.ms/dotnet-build", proc.StartInfo.Arguments);
-        
+
         }
         [MacOsOnlyFact]
         public void WhenRunOnMacOsDotnetHelpCommandShouldContainProperProcessInformation()

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -47,7 +47,7 @@ Commands:
 Project modification commands:
   add           Add items to the project.
   remove        Remove items from the project.
-  list          Remove items from the project.
+  list          List items in the project.
 
 Advanced Commands:
   nuget         Provides additional NuGet commands.

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -45,9 +45,9 @@ Commands:
   sln           Modify solution (SLN) files.
 
 Project modification commands:
-  add           Add items to the project
-  remove        Remove items from the project
-  list          List items in the project
+  add           Add items to the project.
+  remove        Remove items from the project.
+  list          Remove items from the project.
 
 Advanced Commands:
   nuget         Provides additional NuGet commands.

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetHelpCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetHelpCommand.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+using FluentAssertions;
+using HelpActual = Microsoft.DotNet.Tools.Help;
+
+namespace Microsoft.DotNet.Help.Tests
+{
+    public class GivenThatIWantToShowHelpForDotnetHelpCommand : TestBase
+    {
+        private const string HelpText =
+@".NET CLI help utility
+
+Usage: dotnet help [options] <COMMAND_NAME>
+
+Arguments:
+  <COMMAND_NAME>   CLI command for which to view more detailed help.
+
+Options:
+  -h, --help   Show help information";
+
+        [Theory]
+        [InlineData("--help")]
+        [InlineData("-h")]
+        [InlineData("-?")]
+        [InlineData("/?")]
+        public void WhenHelpOptionIsPassedToDotnetHelpCommandItPrintsUsage(string helpArg)
+        {
+            var cmd = new HelpCommand()
+                .ExecuteWithCapturedOutput($"{helpArg}");
+            cmd.Should().Pass();
+            cmd.StdOut.Should().ContainVisuallySameFragment(HelpText);
+        }
+    }
+}


### PR DESCRIPTION
CliCommandLineParserVersion 138 cannot use help as command and --help as
opinion at the same time, update to 142