### PR TITLE
Update templates & engine, rename --skip-restore to --no-restore

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,12 +11,12 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta2-20170405-182</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170405-182</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170405-182</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20170410-189</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170410-189</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170410-189</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>
-    <CliCommandLineParserVersion>0.1.0-alpha-138</CliCommandLineParserVersion>
+    <CliCommandLineParserVersion>0.1.0-alpha-140</CliCommandLineParserVersion>
     
   </PropertyGroup>
 

--- a/build/compile/LzmaArchive.targets
+++ b/build/compile/LzmaArchive.targets
@@ -92,7 +92,7 @@
 
       <DotNetNew ToolPath="$(OutputDirectory)"
                  TemplateType="console"
-                 TemplateArgs="--debug:ephemeral-hive --skip-restore"
+                 TemplateArgs="--debug:ephemeral-hive --no-restore"
                  WorkingDirectory="$(NuGetPackagesArchiveProject)/Console" />
 
       <DotNetRestore ToolPath="$(OutputDirectory)"

--- a/build_projects/dotnet-cli-build/GenerateNuGetPackagesArchiveVersion.cs
+++ b/build_projects/dotnet-cli-build/GenerateNuGetPackagesArchiveVersion.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Cli.Build
                 {
                     ToolPath = ToolPath,
                     TemplateType = newArgs[0],
-                    TemplateArgs = newArgs[1] + $" --debug:ephemeral-hive -n TempProject -o \"{outputDir}\" --skip-restore",
+                    TemplateArgs = newArgs[1] + $" --debug:ephemeral-hive -n TempProject -o \"{outputDir}\" --no-restore",
                     HostObject = HostObject,
                     BuildEngine = BuildEngine
                 };

--- a/src/dotnet/commands/dotnet-migrate/TemporaryDotnetNewTemplateProject.cs
+++ b/src/dotnet/commands/dotnet-migrate/TemporaryDotnetNewTemplateProject.cs
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Tools.Migrate
             }
             Directory.CreateDirectory(tempDir);
 
-            RunCommand("new", new string[] { "console", "-o", tempDir, "--debug:ephemeral-hive", "--skip-restore" }, tempDir);
+            RunCommand("new", new string[] { "console", "-o", tempDir, "--debug:ephemeral-hive", "--no-restore" }, tempDir);
 
             return tempDir;
         }

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             {
                 string projectDirectory = directory.Path;
 
-                string newArgs = "console -f netcoreapp2.0 --debug:ephemeral-hive --skip-restore";
+                string newArgs = "console -f netcoreapp2.0 --debug:ephemeral-hive --no-restore";
                 new NewCommandShim()
                     .WithWorkingDirectory(projectDirectory)
                     .Execute(newArgs)

--- a/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
+++ b/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
@@ -56,7 +56,7 @@ Options:
 
             try
             {
-                string args = $"classlib -o \"{projDir.Path}\" --debug:ephemeral-hive --skip-restore";
+                string args = $"classlib -o \"{projDir.Path}\" --debug:ephemeral-hive --no-restore";
                 new NewCommandShim()
                     .WithWorkingDirectory(projDir.Path)
                     .ExecuteWithCapturedOutput(args)

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
             string dir = "pkgs";
             string args = $"--packages {dir}";
 
-            string newArgs = $"console -f netcoreapp2.0 -o \"{rootPath}\" --debug:ephemeral-hive --skip-restore";
+            string newArgs = $"console -f netcoreapp2.0 -o \"{rootPath}\" --debug:ephemeral-hive --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)

--- a/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
+++ b/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
@@ -195,7 +195,7 @@ Options:
 
             try
             {
-                string newArgs = $"classlib -o \"{dir.Path}\" --debug:ephemeral-hive --skip-restore";
+                string newArgs = $"classlib -o \"{dir.Path}\" --debug:ephemeral-hive --no-restore";
                 new NewCommandShim()
                     .WithWorkingDirectory(dir.Path)
                     .ExecuteWithCapturedOutput(newArgs)

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -21,13 +21,13 @@ namespace Microsoft.DotNet.New.Tests
 
             new NewCommand()
                 .WithWorkingDirectory(rootPath)
-                .Execute($"console --debug:ephemeral-hive --skip-restore");
+                .Execute($"console --debug:ephemeral-hive --no-restore");
 
             DateTime expectedState = Directory.GetLastWriteTime(rootPath);
 
             var result = new NewCommand()
                 .WithWorkingDirectory(rootPath)
-                .ExecuteWithCapturedOutput($"console --debug:ephemeral-hive --skip-restore");
+                .ExecuteWithCapturedOutput($"console --debug:ephemeral-hive --no-restore");
 
             DateTime actualState = Directory.GetLastWriteTime(rootPath);
 
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.New.Tests
 
             new NewCommand()
                 .WithWorkingDirectory(projectFolder)
-                .Execute($"{projectType} --debug:ephemeral-hive --skip-restore")
+                .Execute($"{projectType} --debug:ephemeral-hive --no-restore")
                 .Should().Pass();
 
             new RestoreCommand()
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.New.Tests
 
             new NewCommand()
                 .WithWorkingDirectory(rootPath)
-                .Execute($"{type} --name {projectName} -o . --debug:ephemeral-hive --skip-restore")
+                .Execute($"{type} --name {projectName} -o . --debug:ephemeral-hive --no-restore")
                 .Should().Pass();
 
             new RestoreCommand()

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.New.Tests
             string rootPath = TestAssets.CreateTestDirectory(identifier: $"{language}_{projectType}").FullName;
 
             new TestCommand("dotnet") { WorkingDirectory = rootPath }
-                .Execute($"new {projectType} -lang {language} -o {rootPath} --debug:ephemeral-hive --skip-restore")
+                .Execute($"new {projectType} -lang {language} -o {rootPath} --debug:ephemeral-hive --no-restore")
                 .Should().Pass();
 
             if (useNuGetConfigForAspNet)

--- a/test/dotnet-pack.Tests/PackTests.cs
+++ b/test/dotnet-pack.Tests/PackTests.cs
@@ -216,7 +216,7 @@ namespace Microsoft.DotNet.Tools.Pack.Tests
             string dir = "pkgs";
             string args = $"--packages {dir}";
 
-            string newArgs = $"console -o \"{rootPath}\" --skip-restore";
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -155,7 +155,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             string dir = "pkgs";
             string args = $"--packages {dir}";
 
-            string newArgs = $"console -o \"{rootPath}\" --skip-restore";
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)

--- a/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
+++ b/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
@@ -53,7 +53,7 @@ Options:
 
             try
             {
-                string newArgs = $"classlib -o \"{projDir.Path}\" --skip-restore";
+                string newArgs = $"classlib -o \"{projDir.Path}\" --no-restore";
                 new NewCommandShim()
                     .WithWorkingDirectory(projDir.Path)
                     .ExecuteWithCapturedOutput(newArgs)

--- a/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Restore.Tests
             string dir = "pkgs";
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
-            string newArgs = $"console -o \"{rootPath}\" --skip-restore";
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Restore.Tests
             string dir = "pkgs";
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
-            string newArgs = $"classlib -o \"{rootPath}\" --skip-restore";
+            string newArgs = $"classlib -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -144,7 +144,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             string dir = "pkgs";
             string args = $"--packages {dir}";
 
-            string newArgs = $"console -o \"{rootPath}\" --skip-restore";
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)


### PR DESCRIPTION
Updates the 2.0 web templates to use 2.0 package versions
A portion of the refactoring to program.cs and startup.cs for web templates
Renames --skip-restore to --no-restore
Bumps CLI parser to build 140 to fix the switch prefixing behavior
Adds support for value forms, file renames, free port number generation
