### PR TITLE
moving dependecymodel and platformabstraction to preview1-001960

### DIFF
--- a/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
+++ b/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
     <RuntimeFrameworkVersion>$(CLI_SharedFrameworkVersion)</RuntimeFrameworkVersion>
     <DotnetCliToolTargetFramework>netcoreapp2.0</DotnetCliToolTargetFramework>
   </PropertyGroup>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -14,8 +14,8 @@
     <TemplateEngineVersion>1.0.0-beta2-20170410-189</TemplateEngineVersion>
     <TemplateEngineTemplateVersion>1.0.0-beta2-20170410-189</TemplateEngineTemplateVersion>
     <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170410-189</TemplateEngineTemplate2_0Version>
-    <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
-    <DependencyModelVersion>1.0.3</DependencyModelVersion>
+    <PlatformAbstractionsVersion>2.0.0-preview1-001960</PlatformAbstractionsVersion>
+    <DependencyModelVersion>2.0.0-preview1-001960</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
 
   </PropertyGroup>

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -27,7 +27,7 @@
     <!-- This dependency was added due to an issue in restore where a lower version of this package coming from nuget.commandline.xplat
     led to an error. This is tracked as NuGet issue : https://github.com/NuGet/Home/issues/4213 -->
     <PackageReference Include="Microsoft.Build.Framework" Version="$(CLI_MSBuild_Version)" />
-    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />
+    <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="1.0.3" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="$(VersionToolsVersion)" />
  </ItemGroup>
 </Project>

--- a/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
+++ b/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             new DotnetCommand()
                 .ExecuteWithCapturedOutput(outputDll)
                 .Should().Fail()
-                .And.HaveStdErrContaining("assembly specified in the dependencies manifest was not found -- package: 'newtonsoft.json',");
+                .And.HaveStdErrContaining("assembly specified in the dependencies manifest was not found -- package: 'Newtonsoft.Json',");
         }
 
         [Fact]


### PR DESCRIPTION
@eerhardt @livarcocc PTAL, this is a step towards https://github.com/dotnet/core-setup/issues/1840
and followup on https://github.com/dotnet/core-setup/pull/1986
