### PR TITLE
Skip versions repo publish if auth not defined

### DIFF
--- a/build/publish/FinishBuild.targets
+++ b/build/publish/FinishBuild.targets
@@ -29,6 +29,7 @@
                        Channel="$(Channel)"
                        CommitHash="$(CommitHash)" />
 
-    <UpdateVersionsRepo BranchName="$(BranchName)" />
+    <UpdateVersionsRepo BranchName="$(BranchName)"
+                        Condition=" '$(GITHUB_PASSWORD)' != '' " />
   </Target>
 </Project>


### PR DESCRIPTION
We need to disable `UpdateVersionsRepo` when publishing to only blob storage. This adds a condition so that when `GITHUB_PASSWORD` isn't set, versions repo update is skipped.

/cc @crummel @dleeapho 