### PR TITLE
Remove OpenSSL from the macOS installer

### DIFF
--- a/packaging/osx/clisdk/resources/cs.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/cs.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/de.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/de.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/en.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/en.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/es.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/es.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/fr.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/fr.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/it.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/it.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/ja.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/ja.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/ko.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/ko.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/pl.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/pl.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/pt-br.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/pt-br.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/ru.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/ru.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/tr.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/tr.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/zh-hans.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/zh-hans.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>

--- a/packaging/osx/clisdk/resources/zh-hant.lproj/conclusion.html
+++ b/packaging/osx/clisdk/resources/zh-hant.lproj/conclusion.html
@@ -1,4 +1,4 @@
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -9,14 +9,6 @@
         <div align="center" style="font-family: Helvetica;">  
             <h1>The installation was successful.</h1>
             <p>.NET Core CLI was successfully installed.</p>
-        <h2>
-            Install dependencies
-        </h2>
-        <p>
-        In order to be able to use .NET Core on OS X, you need to install <b>OpenSSL</b> version <b>1.0.1/1.0.2</b>. 
-        There are many ways to install/update your libssl. Using <a href="http://www.brew.sh">Homebrew</a> is the easiest. 
-        You can view the instructions <a href="http://brewformulas.org/Openssl">here</a> or if you're updating, <a href="https://github.com/dotnet/coreclr/blob/63766f74c4a641a274cd2933b9b7fd7bbddef2dd/Documentation/building/osx-instructions.md#openssl">on this page</a>.
-        </p>
         </div>
 </body>
 </html>


### PR DESCRIPTION
Similar to https://github.com/dotnet/core-setup/pull/2043, but for the CLI.

Now that the 2.0 runtime no longer depends on OpenSSL on macOS, no reason to tell people to install it.