### PR TITLE
Fix dotnet run double dash passing arguments

### DIFF
--- a/TestAssets/TestProjects/MSBuildTestApp/Program.cs
+++ b/TestAssets/TestProjects/MSBuildTestApp/Program.cs
@@ -9,9 +9,9 @@ namespace MSBuildTestApp
     {
         public static void Main(string[] args)
         {
-          if (args.Length > 0)
+            if (args.Length > 0)
             {
-                Console.WriteLine("echo args:"+ String.Join(";", args));
+                Console.WriteLine("echo args:" + string.Join(";", args));
             }
             Console.WriteLine("Hello World!");
         }

--- a/TestAssets/TestProjects/MSBuildTestApp/Program.cs
+++ b/TestAssets/TestProjects/MSBuildTestApp/Program.cs
@@ -9,6 +9,10 @@ namespace MSBuildTestApp
     {
         public static void Main(string[] args)
         {
+          if (args.Length > 0)
+            {
+                Console.WriteLine("echo args:"+ String.Join(";", args));
+            }
             Console.WriteLine("Hello World!");
         }
     }

--- a/src/dotnet/commands/dotnet-complete/ParseCommand.cs
+++ b/src/dotnet/commands/dotnet-complete/ParseCommand.cs
@@ -24,9 +24,10 @@ namespace Microsoft.DotNet.Cli
 
             Console.WriteLine(result.Diagram());
 
-            if (result.UnparsedTokens.Any()) {
+            if (result.UnparsedTokens.Any())
+            {
                 Console.WriteLine("Unparsed Tokens: ");
-                Console.WriteLine(string.Join(" ", (result.UnparsedTokens)));
+                Console.WriteLine(string.Join(" ", result.UnparsedTokens));
             }
 
             var optionValuesToBeForwarded = result.AppliedCommand()

--- a/src/dotnet/commands/dotnet-complete/ParseCommand.cs
+++ b/src/dotnet/commands/dotnet-complete/ParseCommand.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
@@ -23,6 +23,11 @@ namespace Microsoft.DotNet.Cli
             }
 
             Console.WriteLine(result.Diagram());
+
+            if (result.UnparsedTokens.Any()) {
+                Console.WriteLine("Unparsed Tokens: ");
+                Console.WriteLine(string.Join(" ", (result.UnparsedTokens)));
+            }
 
             var optionValuesToBeForwarded = result.AppliedCommand()
                                                   .OptionValuesToBeForwarded();

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -13,11 +13,11 @@ namespace Microsoft.DotNet.Tools.Run
 {
     public partial class RunCommand
     {
-        public string Configuration { get; set; }
-        public string Framework { get; set; }
-        public bool NoBuild { get; set; }
-        public string Project { get; set; }
-        public IReadOnlyCollection<string> Args { get; set; }
+        public string Configuration { get; private set; }
+        public string Framework { get; private set; }
+        public bool NoBuild { get; private set; }
+        public string Project { get; private set; }
+        public IReadOnlyCollection<string> Args { get; private set; }
 
         private List<string> _args;
         private bool ShouldBuild => !NoBuild;
@@ -36,6 +36,34 @@ namespace Microsoft.DotNet.Tools.Run
             return runCommand
                 .Execute()
                 .ExitCode;
+        }
+
+        public RunCommand(string configuration,
+            string framework,
+            bool noBuild,
+            string project,
+            IReadOnlyCollection<string> args)
+        {
+            Configuration = configuration;
+            Framework = framework;
+            NoBuild = noBuild;
+            Project = project;
+            Args = args;
+        }
+
+        public RunCommand MakeNewWithReplaced(string configuration = null,
+            string framework = null,
+            bool? noBuild = null,
+            string project = null,
+            IReadOnlyCollection<string> args = null)
+        {
+            return new RunCommand(
+                configuration ?? this.Configuration,
+                framework ?? this.Framework,
+                noBuild ?? this.NoBuild,
+                project ?? this.Project,
+                args ?? this.Args
+            );
         }
 
         private void EnsureProjectIsBuilt()

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -15,14 +15,14 @@ namespace Microsoft.DotNet.Cli
                 LocalizableStrings.AppFullName,
                 treatUnmatchedTokensAsErrors: false,
                 arguments: Accept.ZeroOrMoreArguments()
-                                 .MaterializeAs(o => new RunCommand
-                                 {
-                                     Configuration = o.SingleArgumentOrDefault("--configuration"),
-                                     Framework = o.SingleArgumentOrDefault("--framework"),
-                                     NoBuild = o.HasOption("--no-build"),
-                                     Project = o.SingleArgumentOrDefault("--project"),
-                                     Args = o.Arguments
-                                 }),
+                    .MaterializeAs(o => new RunCommand
+                    (
+                        configuration: o.SingleArgumentOrDefault("--configuration"),
+                        framework: o.SingleArgumentOrDefault("--framework"),
+                        noBuild: o.HasOption("--no-build"),
+                        project: o.SingleArgumentOrDefault("--project"),
+                        args: o.Arguments
+                    )),
                 options: new[]
                 {
                     CommonOptions.HelpOption(),

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -181,5 +181,24 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .Should().Fail()
                     .And.HaveStdErrContaining("--framework");
         }
+
+        [Fact]
+        public void ItCanPassArgumentsToSubjectAppByDoubleDash()
+        {
+            const string testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            new RunCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("-- foo bar baz")
+                .Should()
+                .Pass()
+                .And.HaveStdOutContaining("echo args:foo;bar;baz");
+        }
     }
 }

--- a/test/dotnet.Tests/ParserTests/RunParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/RunParserTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Run;
+using Xunit;
+using Xunit.Abstractions;
+using System;
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    public class RunParserTests
+    {
+        public RunParserTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        private readonly ITestOutputHelper output;
+
+        [Fact]
+        public void RunParserCanGetArguementFromDoubleDash()
+        {
+            var runCommand = RunCommand.FromArgs(new[]{ "--", "foo" });
+            runCommand.Args.Single().Should().Be("foo");
+        }
+    }
+}


### PR DESCRIPTION
When run “dotnet run -- foo”, foo should be the argument passed to the
subject app. After replacing the original parser, dotnet-run did not
utilize the “unparsedtoken” of the parsed result.

There are several more issues
Due to dotnet top command are not using the new parser, the actual token
passed to the new parser at dotnet-run level are “dotnet” “run” “ --
foo” which will not give the correct result. The tokens need to be
further tokenized to be “dotnet” “run” “--” “foo”.

To append unparsedtoken to RunCommand’s argument is not straight
forward. RunCommand has an “immutable constructor”, which is a good
thing, so I made update RunCommand’s argument following the immutable
pattern -- create a new object with the original field but only change
the arguments.
