### PR TITLE
Fix update-dependencies

### DIFF
--- a/build_projects/update-dependencies/Program.cs
+++ b/build_projects/update-dependencies/Program.cs
@@ -81,7 +81,10 @@ namespace Microsoft.DotNet.Scripts
 
         private static IEnumerable<IDependencyUpdater> GetUpdaters()
         {
-            yield return CreateRegexUpdater(Path.Combine("build", "DependencyVersions.props"), "CLI_SharedFrameworkVersion", "Microsoft.NETCore.App");
+            string dependencyVersionsPath = Path.Combine("build", "DependencyVersions.props");
+            yield return CreateRegexUpdater(dependencyVersionsPath, "CLI_SharedFrameworkVersion", "Microsoft.NETCore.App");
+            yield return CreateRegexUpdater(dependencyVersionsPath, "PlatformAbstractionsVersion", "Microsoft.DotNet.PlatformAbstractions");
+            yield return CreateRegexUpdater(dependencyVersionsPath, "DependencyModelVersion", "Microsoft.Extensions.DependencyModel");
         }
 
         private static IDependencyUpdater CreateRegexUpdater(string repoRelativePath, string propertyName, string packageId)

--- a/build_projects/update-dependencies/update-dependencies.csproj
+++ b/build_projects/update-dependencies/update-dependencies.csproj
@@ -5,6 +5,7 @@
     <Description>Updates the repos dependencies</Description>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(CliTargetFramework)</TargetFramework>
+    <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="$(VersionToolsVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Update all core-setup dependencies.
Fix the app to get its shared framework from stage0 instead of what is currently checked in to the repo (which my mis-match when many builds of core-setup come out at a time).

@livarcocc @dagood 
