### PR TITLE
Small bug fixes

### DIFF
--- a/src/dotnet/CommonLocalizableStrings.cs
+++ b/src/dotnet/CommonLocalizableStrings.cs
@@ -185,5 +185,12 @@ namespace Microsoft.DotNet.Tools
         public const string ProjectNotCompatibleWithFrameworks = "Project `{0}` cannot be added due to incompatible targeted frameworks between the two projects. Please review the project you are trying to add and verify that is compatible with the following targets:";
         public const string ProjectDoesNotTargetFramework = "Project `{0}` does not target framework `{1}`.";
         public const string ProjectCouldNotBeEvaluated = "Project `{0}` could not be evaluated. Evaluation failed with following error:\n{1}";
+
+        /// common options
+        public const string VerbosityOptionDescription = "Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]";
+        public const string FrameworkOptionDescription = "Target framework to publish for. The target framework has to be specified in the project file.";
+        public const string RuntimeOptionDescription = "Publish the project for a given runtime. This is used when creating self-contained deployment. Default is to publish a framework-dependent app.";
+        public const string ConfigurationOptionDescription = "Configuration to use for building the project.  Default for most projects is  \"Debug\".";
+        public const string CmdVersionSuffixDescription = "Defines the value for the $(VersionSuffix) property in the project.";
     }
 }

--- a/src/dotnet/CommonOptions.cs
+++ b/src/dotnet/CommonOptions.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools.Common;
+using Microsoft.DotNet.Tools;
 
 namespace Microsoft.DotNet.Cli
 {
@@ -18,7 +19,7 @@ namespace Microsoft.DotNet.Cli
         public static Option VerbosityOption() =>
             Create.Option(
                 "-v|--verbosity",
-                "Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]",
+                CommonLocalizableStrings.VerbosityOptionDescription,
                 Accept.AnyOneOf(
                           "q", "quiet",
                           "m", "minimal",
@@ -30,7 +31,7 @@ namespace Microsoft.DotNet.Cli
         public static Option FrameworkOption() =>
             Create.Option(
                 "-f|--framework",
-                "Target framework to publish for. The target framework has to be specified in the project file.",
+                CommonLocalizableStrings.FrameworkOptionDescription,
                 Accept.ExactlyOneArgument()
                     .WithSuggestionsFrom(_ => Suggest.TargetFrameworksFromProjectFile())
                     .With(name: "FRAMEWORK")
@@ -39,7 +40,7 @@ namespace Microsoft.DotNet.Cli
         public static Option RuntimeOption() =>
             Create.Option(
                 "-r|--runtime",
-                "Publish the project for a given runtime. This is used when creating self-contained deployment. Default is to publish a framework-dependent app.",
+                CommonLocalizableStrings.RuntimeOptionDescription,
                 Accept.ExactlyOneArgument()
                     .WithSuggestionsFrom(_ => Suggest.RunTimesFromProjectFile())
                     .With(name: "RUNTIME_IDENTIFIER")
@@ -47,8 +48,8 @@ namespace Microsoft.DotNet.Cli
                 
         public static Option ConfigurationOption() =>
             Create.Option(
-                "-c|--configuration", 
-                "Configuration to use for building the project.  Default for most projects is  \"Debug\".",
+                "-c|--configuration",
+                CommonLocalizableStrings.ConfigurationOptionDescription,
                 Accept.ExactlyOneArgument()
                     .With(name: "CONFIGURATION")
                     .WithSuggestionsFrom("DEBUG", "RELEASE")
@@ -57,7 +58,7 @@ namespace Microsoft.DotNet.Cli
         public static Option VersionSuffixOption() =>
             Create.Option(
                 "--version-suffix",
-                "Defines the value for the $(VersionSuffix) property in the project.",
+                CommonLocalizableStrings.CmdVersionSuffixDescription,
                 Accept.ExactlyOneArgument()
                     .With(name: "VERSION_SUFFIX")
                     .ForwardAsSingle(o => $"/p:VersionSuffix={o.Arguments.Single()}"));

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -23,8 +23,6 @@ namespace Microsoft.DotNet.Tools.Restore
         {
             DebugHelper.HandleDebugSwitch(ref args);
 
-            Reporter.Output.WriteLine(string.Join(" ", args));
-
             var parser = Parser.Instance;
 
             var result = parser.ParseFrom("dotnet restore", args);


### PR DESCRIPTION
- Localization for CommonOptions
- Remove accidental debug line

**Customer scenario**

N/A

**Bugs this fixes**

[CLI #6291](https://github.com/dotnet/cli/issues/6291)

**Workarounds, if any**

N/A

**Risk**

Common command opinion help message will not be localized in the future

**Performance impact**

Low

**Root cause analysis**

N/A

**How was the bug found?**

Code review

---

**Customer scenario**

Type _dotnet restore -h_ and user will see extra line of "-h" on top of help command

**Bugs this fixes**

[CLI #6360](https://github.com/dotnet/cli/issues/6360)

**Workarounds, if any**

N/A

**Risk**

The customer will be confused by the extra line of help message.

**Performance impact**

Low

**Root cause analysis**

N/A

**How was the bug found?**

Sayed's script to print out all customer facing texts.


