### PR TITLE
[Won't pass CI] Updating the runtime framework versions for 1.0.5 and 1.1.1

### DIFF
--- a/branchinfo.txt
+++ b/branchinfo.txt
@@ -3,7 +3,7 @@
 # Each line is expected to be in the format "[Name]=[Value]".
 MAJOR_VERSION=1
 MINOR_VERSION=0
-PATCH_VERSION=3
+PATCH_VERSION=4
 RELEASE_SUFFIX=rc4
 CHANNEL=rel-1.0.1
 BRANCH_NAME=rel/1.0.1

--- a/build.proj
+++ b/build.proj
@@ -19,12 +19,12 @@
 
     <CoreSetupChannel>release/1.1.0</CoreSetupChannel>
     <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
-    <SharedFrameworkVersion>1.1.1</SharedFrameworkVersion>
+    <SharedFrameworkVersion>1.1.2</SharedFrameworkVersion>
     <SharedHostVersion>1.1.0</SharedHostVersion>
     <HostFxrVersion>1.1.0</HostFxrVersion>
 
-    <CoreCLRVersion>1.1.1</CoreCLRVersion>
-    <JitVersion>1.1.1</JitVersion>
+    <CoreCLRVersion>1.1.2</CoreCLRVersion>
+    <JitVersion>1.1.2</JitVersion>
 
     <ExeExtension>.exe</ExeExtension>
     <ExeExtension Condition=" '$(OS)' != 'Windows_NT' "></ExeExtension>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>1.1.1</CLI_SharedFrameworkVersion>
+    <CLI_SharedFrameworkVersion>1.1.2</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.1.1012</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc5-61427-04</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>1.0.0-alpha-20170224-6</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.0.0-alpha-20170425-3</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.0.0-rtm-2283</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170130-3-281</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>

--- a/build/Microsoft.DotNet.Cli.Monikers.props
+++ b/build/Microsoft.DotNet.Cli.Monikers.props
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SdkBrandName>.NET Core SDK 1.0.3</SdkBrandName>
-    <SharedFrameworkBrandName>Microsoft .NET Core 1.1.1 - Runtime</SharedFrameworkBrandName>
+    <SdkBrandName>.NET Core SDK 1.0.4</SdkBrandName>
+    <SharedFrameworkBrandName>Microsoft .NET Core 1.1.2 - Runtime</SharedFrameworkBrandName>
     <SharedHostBrandName>Microsoft .NET Core 1.1.0 - Host</SharedHostBrandName>
     <HostFxrBrandName>Microsoft .NET Core 1.1.0 - Host FX Resolver</HostFxrBrandName>
     
-    <AdditionalSharedFrameworkBrandName>Microsoft .NET Core 1.0.4 - Runtime</AdditionalSharedFrameworkBrandName>
+    <AdditionalSharedFrameworkBrandName>Microsoft .NET Core 1.0.5 - Runtime</AdditionalSharedFrameworkBrandName>
     <AdditionalSharedHostBrandName>Microsoft .NET Core 1.0.1 - Host</AdditionalSharedHostBrandName>
     <AdditionalHostFxrBrandName>Microsoft .NET Core 1.0.1 - Host FX Resolver</AdditionalHostFxrBrandName>
 

--- a/build/Microsoft.DotNet.Cli.Prepare.targets
+++ b/build/Microsoft.DotNet.Cli.Prepare.targets
@@ -144,7 +144,7 @@
     <!-- Additional Shared Framework to be installed -->
     <PropertyGroup Condition=" '$(IncludeAdditionalSharedFrameworks)' == 'true' ">
       <AdditionalCoreSetupChannel>preview</AdditionalCoreSetupChannel>
-      <AdditionalSharedFrameworkVersion>1.0.4</AdditionalSharedFrameworkVersion>
+      <AdditionalSharedFrameworkVersion>1.0.5</AdditionalSharedFrameworkVersion>
       <AdditionalSharedHostVersion>1.0.1</AdditionalSharedHostVersion>
       <AdditionalHostFxrVersion>1.0.1</AdditionalHostFxrVersion>
 

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -17,7 +17,7 @@
       <Version>1.6.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>1.1.1</Version>
+      <Version>1.1.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
       <Version>$(CLI_MSBuild_Version)</Version>

--- a/dir.props
+++ b/dir.props
@@ -13,6 +13,6 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
 
 
-    <CliVersionPrefix>1.0.3</CliVersionPrefix>
+    <CliVersionPrefix>1.0.4</CliVersionPrefix>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -308,7 +308,7 @@ namespace Microsoft.DotNet.Tests
 
             result.Should().NotBeNull();
 
-            result.Args.Should().Contain("--fx-version 1.1.1");
+            result.Args.Should().Contain("--fx-version 1.1.2");
         }
 
         [Fact]


### PR DESCRIPTION
Updating the runtime framework versions for 1.0.5 and 1.1.1 and updating the CLI branding to 1.0.4.

@eerhardt @dotnet/dotnet-cli 
