### PR TITLE
Generating the Microsoft.NETCoreSdk.BundledVersions.props file in a new location

### DIFF
--- a/TestAssets/TestProjects/TestAppSimple/TestAppSimple.csproj
+++ b/TestAssets/TestProjects/TestAppSimple/TestAppSimple.csproj
@@ -5,5 +5,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <RuntimeFrameworkVersion>$(CLI_SharedFrameworkVersion)</RuntimeFrameworkVersion>
+    <!-- Issue: https://github.com/dotnet/sdk/issues/1150 -->
+    <DisableImplicitPackageTargetFallback>true</DisableImplicitPackageTargetFallback>
   </PropertyGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,7 +4,7 @@
     <CLI_SharedFrameworkVersion>2.0.0-preview1-002061-00</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.2.0-preview-000093-02</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>2.0.0-alpha-20170420-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-alpha-20170425-6</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-beta1-2418</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-rel-20170413-451</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.1.0-preview-20170414-04</CLI_TestPlatform_Version>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -64,7 +64,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                       Lines="$(BundledVersionsPropsContent)"
                       Overwrite="true" />
     <Copy
-      DestinationFiles="$(SdkOutputDirectory)/$(BundledVersionsPropsFileName)"
-      SourceFiles="$(GeneratedMSBuildExtensionsDirectory)/$(BundledVersionsPropsFolder)/$(BundledVersionsPropsFileName)" />
+      SourceFiles="$(GeneratedMSBuildExtensionsDirectory)/$(BundledVersionsPropsFolder)/$(BundledVersionsPropsFileName)"
+      DestinationFiles="$(SdkOutputDirectory)/$(BundledVersionsPropsFileName)" />
   </Target>
 </Project>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -63,6 +63,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <WriteLinesToFile File="$(GeneratedMSBuildExtensionsDirectory)/$(BundledVersionsPropsFolder)/$(BundledVersionsPropsFileName)"
                       Lines="$(BundledVersionsPropsContent)"
                       Overwrite="true" />
-
+    <Copy
+      DestinationFiles="$(SdkOutputDirectory)/$(BundledVersionsPropsFileName)"
+      SourceFiles="$(GeneratedMSBuildExtensionsDirectory)/$(BundledVersionsPropsFolder)/$(BundledVersionsPropsFileName)" />
   </Target>
 </Project>


### PR DESCRIPTION
Generating the Microsoft.NETCoreSdk.BundledVersions.props file in the CLI folder, so that it can be picked up by the SDK.

We can remove the other Microsoft.NETCoreSdk.BundledVersions.props file once we do the VS Resolver. If you want to remove it now, let me know, but I wanted to keep it around so that we can insert the CLI in case we need to.

@nguerrera @dotnet/dotnet-cli 
