### PR TITLE
update-dependencies hard-coded values

### DIFF
--- a/build_projects/update-dependencies/Program.cs
+++ b/build_projects/update-dependencies/Program.cs
@@ -25,7 +25,6 @@ namespace Microsoft.DotNet.Scripts
 
             List<BuildInfo> buildInfos = new List<BuildInfo>();
 
-            buildInfos.Add(GetBuildInfo("Roslyn", s_config.RoslynVersionFragment, fetchLatestReleaseFile: false));
             buildInfos.Add(GetBuildInfo("CoreSetup", s_config.CoreSetupVersionFragment, fetchLatestReleaseFile: false));
 
             IEnumerable<IDependencyUpdater> updaters = GetUpdaters();


### PR DESCRIPTION
Read MSBuild property values to get GITHUB_UPSTREAM_BRANCH and CORESETUP_VERSION_FRAGMENT instead of hard-coding them in update-dependencies.

This change was already approved here: https://github.com/dotnet/cli/pull/6408.  Moving to release/2.0.0 because master is broken.

/cc @livarcocc 