### PR TITLE
Run dotnet new to prime cache at the end of installer

### DIFF
--- a/packaging/windows/clisdk/bundle.wxs
+++ b/packaging/windows/clisdk/bundle.wxs
@@ -26,9 +26,6 @@
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker)" bal:Overridable="no" />
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
-      <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
-        <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
-      </MsiPackage>
       <MsiPackage SourceFile="$(var.SharedFXMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
@@ -36,6 +33,9 @@
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
       <MsiPackage SourceFile="$(var.SharedHostMsiSourcePath)">
+        <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
+      </MsiPackage>
+       <MsiPackage SourceFile="$(var.CLISDKMsiSourcePath)">
         <MsiProperty Name="DOTNETHOME" Value="[DOTNETHOME]" />
       </MsiPackage>
     </Chain>

--- a/packaging/windows/clisdk/dotnet.wxs
+++ b/packaging/windows/clisdk/dotnet.wxs
@@ -19,12 +19,21 @@
         <Property Id="ProductEdition" Value="$(var.ProductEdition)" />
         <Property Id="ProductCPU" Value="$(var.Platform)" />
         <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />
-
         <Property Id="MSIFASTINSTALL" Value="7" />
 
         <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
 
         <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+
+        <CustomAction Id="RunDotnetNewToTriggerFirstTimeExperienceToPrimeCache"
+                ExeCommand="dotnet.exe new"
+                Directory="DOTNETHOME"
+                Execute="immediate"
+                Return="ignore"/>
+        <InstallExecuteSequence>
+            <Custom Action="RunDotnetNewToTriggerFirstTimeExperienceToPrimeCache"
+                After="InstallFinalize" />
+        </InstallExecuteSequence>
     </Product>
     <Fragment>
         <Directory Id="TARGETDIR" Name="SourceDir">


### PR DESCRIPTION
#6370
Windows installer will have cmd.exe windows pop up. Will fix it in an separate branch #6425

debian installer change will be a different pull request