### PR TITLE
Update ASP.NET packages to version 24686

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,7 +5,7 @@
     <clear />
     <add key="templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
     <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
+    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
     <add key="websdkfeed" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,9 +11,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta2-20170425-201</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170425-203</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170425-203</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20170427-205</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170427-205</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170427-205</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.0.0-preview1-002101</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0-preview1-002101</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>


### PR DESCRIPTION
Updates ASP.NET package versions
Switches ASP.NET feeds to release
Updates test SDK version
Adds a fix for switches not being displayed in help if it has no short form
Fixes an issue where files at the root of a template could not be excluded
