### PR TITLE
Pinning stage0 to a version that rolls tools forward from 1.0 to 2.0

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>2.0.0-preview1-002091-00</CLI_SharedFrameworkVersion>
+    <CLI_SharedFrameworkVersion>2.0.0-preview1-002101-00</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.2.0-preview-000093-02</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
     <CLI_NETSDK_Version>2.0.0-alpha-20170428-1</CLI_NETSDK_Version>
@@ -14,8 +14,8 @@
     <TemplateEngineVersion>1.0.0-beta2-20170425-201</TemplateEngineVersion>
     <TemplateEngineTemplateVersion>1.0.0-beta2-20170425-203</TemplateEngineTemplateVersion>
     <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170425-203</TemplateEngineTemplate2_0Version>
-    <PlatformAbstractionsVersion>2.0.0-preview1-002091</PlatformAbstractionsVersion>
-    <DependencyModelVersion>2.0.0-preview1-002091</DependencyModelVersion>
+    <PlatformAbstractionsVersion>2.0.0-preview1-002101</PlatformAbstractionsVersion>
+    <DependencyModelVersion>2.0.0-preview1-002101</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
 
   </PropertyGroup>

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -104,8 +104,8 @@ if ($LastExitCode -ne 0)
 # install the post-PJnistic stage0
 $dotnetInstallPath = Join-Path $toolsLocalPath "dotnet-install.ps1"
 
-Write-Host "$dotnetInstallPath -Channel ""release/2.0.0"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
-Invoke-Expression "$dotnetInstallPath -Channel ""release/2.0.0"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Write-Host "$dotnetInstallPath -Channel ""release/2.0.0"" -Version ""2.0.0-preview1-005867"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Invoke-Expression "$dotnetInstallPath -Channel ""release/2.0.0"" -Version ""2.0.0-preview1-005867"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
 if ($LastExitCode -ne 0)
 {
     Write-Output "The .NET CLI installation failed with exit code $LastExitCode"

--- a/run-build.sh
+++ b/run-build.sh
@@ -177,8 +177,8 @@ if [ $EXIT_CODE != 0 ]; then
 fi
 
 # now execute the script
-echo "installing CLI: $dotnetInstallPath --channel \"release/2.0.0\" --install-dir $DOTNET_INSTALL_DIR --architecture \"$ARCHITECTURE\" $LINUX_PORTABLE_INSTALL_ARGS"
-$dotnetInstallPath --channel "release/2.0.0" --install-dir $DOTNET_INSTALL_DIR --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS
+echo "installing CLI: $dotnetInstallPath --channel \"release/2.0.0\" --version \"2.0.0-preview1-005867\" --install-dir $DOTNET_INSTALL_DIR --architecture \"$ARCHITECTURE\" $LINUX_PORTABLE_INSTALL_ARGS"
+$dotnetInstallPath --channel "release/2.0.0" --version "2.0.0-preview1-005867" --install-dir $DOTNET_INSTALL_DIR --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS
 EXIT_CODE=$?
 if [ $EXIT_CODE != 0 ]; then
     echo "run-build: Error: Boot-strapping post-PJ stage0 with exit code $EXIT_CODE." >&2


### PR DESCRIPTION
Pinning stage0 to a version that rolls tools forward from 1.0 to 2.0 because the deb-tool targets netcoreapp1.0.

@eerhardt @dotnet/dotnet-cli @nguerrera 

@MattGertz This is a infra-structure change only to unblock building on Ubuntu.