### PR TITLE
Fixing a first run test that checks the version of the mvc package.

### DIFF
--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -118,7 +118,7 @@ A command is running to initially populate your local package cache, to improve 
 
             _nugetCacheFolder
                 .GetDirectory("microsoft.aspnetcore.mvc")
-                .Should().HaveDirectories(new string[] { "1.0.3", "1.1.2" });
+                .Should().HaveDirectories(new string[] { "1.0.4", "1.1.3" });
         }
 
         private string GetDotnetVersion()


### PR DESCRIPTION
Fixing a first run test that checks the version of the mvc package. It checked for 1.0.3 and 1.1.2 and it needs to check for 1.0.4 and 1.1.3 now.

@mlorbetske @crummel @dotnet/dotnet-cli 