### PR TITLE
bump f# sdk package version (release/2.0.0)

### DIFF
--- a/build/BundledSdks.proj
+++ b/build/BundledSdks.proj
@@ -17,9 +17,6 @@
     <Copy SourceFiles="@(SdkContent)"
           DestinationFiles="@(SdkContent->'$(SdkLayoutDirectory)/%(RecursiveDir)%(FileName)%(Extension)')" />
     
-    <!-- Remove unused directories for FSharp.NET.Sdk, just Sdk directory is needed -->
-    <RemoveDir Condition=" '$([System.IO.Path]::GetFileName($(SdkLayoutDirectory)))' == 'FSharp.NET.Sdk' " Directories="$(SdkLayoutDirectory)/build;$(SdkLayoutDirectory)/buildCrossTargeting" />
-
     <Message Text="Copied Sdk $(SdkPackageName) from $(SdkNuPkgPath) to $(SdkLayoutDirectory)."
              Importance="High" />
   </Target>

--- a/build/BundledSdks.props
+++ b/build/BundledSdks.props
@@ -5,6 +5,6 @@
     <BundledSdk Include="Microsoft.NET.Sdk.Web" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Publish" Version="$(CLI_WEBSDK_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Web.ProjectSystem" Version="$(CLI_WEBSDK_Version)" />
-    <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.0-beta-040011" />
+    <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.4-bundled-0100" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This update the bundled F# Sdk to latest version
the version `-bundled` of `FSharp.NET.Sdk` package contains only `Sdk` dir.

