### PR TITLE
Updating msbuild, SDK and Web SDK.

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -2,11 +2,11 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>2.0.0-preview1-002101-00</CLI_SharedFrameworkVersion>
-    <CLI_MSBuild_Version>15.3.0-preview-000111-01</CLI_MSBuild_Version>
+    <CLI_MSBuild_Version>15.3.0-preview-000117-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>2.0.0-alpha-20170428-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-alpha-20170502-2</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-beta1-2418</CLI_NuGet_Version>
-    <CLI_WEBSDK_Version>1.0.0-rel-20170413-451</CLI_WEBSDK_Version>
+    <CLI_WEBSDK_Version>1.0.0-rel-20170501-473</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.1.0-preview-20170414-04</CLI_TestPlatform_Version>
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>


### PR DESCRIPTION
@dotnet/dotnet-cli

@MattGertz this is just porting the fixes we did earlier today into the 2.0 CLI. We don't need it for the VS insertion, but we need it to test VS with 2.0 CLI.