### PR TITLE
Update ASP.NET to 24801 - SetupCrossgen build 56

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,8 +12,8 @@
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
     <TemplateEngineVersion>1.0.0-beta2-20170427-205</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170427-205</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170427-205</TemplateEngineTemplate2_0Version>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170502-215</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170502-215</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.0.0-preview1-002106</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0-preview1-002106</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>

--- a/test/dotnet-migrate.Tests/NuGet.tempaspnetpatch.config
+++ b/test/dotnet-migrate.Tests/NuGet.tempaspnetpatch.config
@@ -3,11 +3,8 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
-    <add key="asp-msbuild3-feed" value="https://dotnet.myget.org/F/msbuildtools/api/v3/index.json" />
-    <add key="aspnet101" value="https://www.myget.org/F/aspnet101/api/v3/index.json" />
-    <add key="dotnet-web" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="AspNetCurrent" value="https://dotnet.myget.org/F/aspnet-feb2017-patch/api/v3/index.json" /> 
+    <add key="DotnetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" /> 
+    <add key="AspNetCurrent" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" /> 
   </packageSources>
 </configuration>

--- a/test/dotnet-new.Tests/NuGet.tempaspnetpatch.config
+++ b/test/dotnet-new.Tests/NuGet.tempaspnetpatch.config
@@ -3,10 +3,8 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
-    <add key="aspnet101" value="https://www.myget.org/F/aspnet101/api/v3/index.json" />
-    <add key="dotnet-web" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="AspNetCurrent" value="https://dotnet.myget.org/F/aspnet-feb2017-patch/api/v3/index.json" /> 
+    <add key="DotnetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" /> 
+    <add key="AspNetCurrent" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" /> 
   </packageSources>
 </configuration>


### PR DESCRIPTION
Related to #6462 and and #6460 

This aligns with SetupCrossgen build 56 with timestamps