### PR TITLE
Run dotnet new command as current user in installer

### DIFF
--- a/packaging/osx/clisdk/scripts/postinstall
+++ b/packaging/osx/clisdk/scripts/postinstall
@@ -11,7 +11,8 @@ INSTALL_DESTINATION=$2
 # A temporary fix for the permissions issue(s)
 chmod -R 755 $INSTALL_DESTINATION
 
-# Run 'dotnet new' to trigger the first time experience to initialize the cache
-$INSTALL_DESTINATION/dotnet new > /dev/null 2>&1 || true
+# Run 'dotnet new' as user to trigger the first time experience to initialize the cache
+INSTALLER_USER=$(stat -f '%Su' $HOME)
+su - $INSTALLER_USER -c "$INSTALL_DESTINATION/dotnet new > /dev/null 2>&1 || true"
 
 exit 0


### PR DESCRIPTION
If not, the dotnet new will run as root and the cache folders will be in
root ownership

How to get current user
https://apple.stackexchange.com/questions/144159/how-can-i-determine-the-invoking-user-in-an-apple-installer-postinstall-script