### PR TITLE
Switches the fallback folder under Nuget.Config to a package source

### DIFF
--- a/src/Microsoft.DotNet.Configurer/NuGetConfig.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetConfig.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Configurer
 {
     public class NuGetConfig : INuGetConfig
     {
-        public const string FallbackPackageFolders = "fallbackPackageFolders";
+        public const string FallbackPackageFolders = "packageSources";
 
         private ISettings _settings;
 


### PR DESCRIPTION
Switches the fallback folder under Nuget.Config to a package source, since we have issues for 1.0 apps using fallback folders.

@dotnet/dotnet-cli @nguerrera 
