### PR TITLE
Show help info when no or wrong arguments are given

### DIFF
--- a/src/dotnet/DotNetTopLevelCommandBase.cs
+++ b/src/dotnet/DotNetTopLevelCommandBase.cs
@@ -42,14 +42,19 @@ namespace Microsoft.DotNet.Cli
             }
             catch (KeyNotFoundException)
             {
-                throw new GracefulException(CommonLocalizableStrings.RequiredCommandNotPassed);
+                return ReportError(CommonLocalizableStrings.RequiredCommandNotPassed);
             }
             catch (GracefulException e)
             {
-                Reporter.Error.WriteLine(e.Message.Red());
-                ParseResult.ShowHelp();
-                return 1;
+                return ReportError(e.Message);
             }
+        }
+
+        private int ReportError(string errorMessage)
+        {
+            Reporter.Error.WriteLine(errorMessage.Red());
+            ParseResult.ShowHelp();
+            return 1;
         }
     }
 }

--- a/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
+++ b/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
@@ -27,6 +27,21 @@ Options:
   -f, --framework <FRAMEWORK>   Add reference only when targeting a specific framework
 ";
 
+        private const string AddCommandHelpText = @".NET Add Command
+
+Usage: dotnet add [options] <PROJECT> [command]
+
+Arguments:
+  <PROJECT>   The project file to operate on. If a file is not specified, the command will search the current directory for one.
+
+Options:
+  -h, --help   Show help information
+
+Commands:
+  package <PACKAGE_NAME>   .NET Add Package reference Command
+  reference <args>         .NET Add Project to Project reference Command
+";
+
         const string FrameworkNet451Arg = "-f net451";
         const string ConditionFrameworkNet451 = "== 'net451'";
         const string FrameworkNetCoreApp10Arg = "-f netcoreapp1.0";
@@ -103,6 +118,7 @@ Options:
                 .ExecuteWithCapturedOutput($"add {commandName}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Required command was not provided.");
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(AddCommandHelpText);
         }
 
         [Fact]

--- a/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
+++ b/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
@@ -24,6 +24,20 @@ Options:
   -h, --help   Show help information
 ";
 
+        private const string ListCommandHelpText = @".NET List Command
+
+Usage: dotnet list [options] <PROJECT> [command]
+
+Arguments:
+  <PROJECT>   The project file to operate on. If a file is not specified, the command will search the current directory for one.
+
+Options:
+  -h, --help   Show help information
+
+Commands:
+  reference   .NET Core Project-to-Project dependency viewer
+";
+
         const string FrameworkNet451Arg = "-f net451";
         const string ConditionFrameworkNet451 = "== 'net451'";
         const string FrameworkNetCoreApp10Arg = "-f netcoreapp1.0";
@@ -48,6 +62,7 @@ Options:
                 .ExecuteWithCapturedOutput($"list {commandName}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Required command was not provided.");
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(ListCommandHelpText);
         }
 
         [Fact]

--- a/test/dotnet-remove-package.Tests/GivenDotnetRemovePackage.cs
+++ b/test/dotnet-remove-package.Tests/GivenDotnetRemovePackage.cs
@@ -23,6 +23,21 @@ Options:
   -h, --help   Show help information
 ";
 
+        private const string RemoveCommandHelpText = @".NET Remove Command
+
+Usage: dotnet remove [options] <PROJECT> [command]
+
+Arguments:
+  <PROJECT>   The project file to operate on. If a file is not specified, the command will search the current directory for one.
+
+Options:
+  -h, --help   Show help information
+
+Commands:
+  package <PACKAGE_NAME>   .NET Remove Package reference Command.
+  reference <args>         .NET Remove Project to Project reference Command
+";
+
         [Theory]
         [InlineData("--help")]
         [InlineData("-h")]
@@ -42,6 +57,7 @@ Options:
                 .ExecuteWithCapturedOutput($"remove {commandName}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Required command was not provided.");
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(RemoveCommandHelpText);
         }
 
         [Fact]

--- a/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
+++ b/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
@@ -26,6 +26,21 @@ Options:
   -f, --framework <FRAMEWORK>   Remove reference only when targeting a specific framework
 ";
 
+        private const string RemoveCommandHelpText = @".NET Remove Command
+
+Usage: dotnet remove [options] <PROJECT> [command]
+
+Arguments:
+  <PROJECT>   The project file to operate on. If a file is not specified, the command will search the current directory for one.
+
+Options:
+  -h, --help   Show help information
+
+Commands:
+  package <PACKAGE_NAME>   .NET Remove Package reference Command.
+  reference <args>         .NET Remove Project to Project reference Command
+";
+
         const string FrameworkNet451Arg = "-f net451";
         const string ConditionFrameworkNet451 = "== 'net451'";
         const string FrameworkNetCoreApp10Arg = "-f netcoreapp1.0";
@@ -129,6 +144,7 @@ Options:
                 .ExecuteWithCapturedOutput($"remove {commandName}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Required command was not provided.");
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(RemoveCommandHelpText);
         }
 
         [Fact]

--- a/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
+++ b/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
@@ -26,6 +26,23 @@ Arguments:
 Options:
   -h, --help   Show help information
 ";
+
+        private const string SlnCommandHelpText = @".NET modify solution file command
+
+Usage: dotnet sln [options] <SLN_FILE> [command]
+
+Arguments:
+  <SLN_FILE>   Solution file to operate on. If not specified, the command will search the current directory for one.
+
+Options:
+  -h, --help   Show help information
+
+Commands:
+  add <args>      .NET Add project(s) to a solution file Command
+  list            .NET List project(s) in a solution file Command
+  remove <args>   .NET Remove project(s) from a solution file Command
+";
+
         private ITestOutputHelper _output;
 
         public GivenDotnetSlnAdd(ITestOutputHelper output)
@@ -193,6 +210,7 @@ EndGlobal
                 .ExecuteWithCapturedOutput($"sln {commandName}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Required command was not provided.");
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(SlnCommandHelpText);
         }
 
         [Fact]

--- a/test/dotnet-sln-list.Tests/GivenDotnetSlnList.cs
+++ b/test/dotnet-sln-list.Tests/GivenDotnetSlnList.cs
@@ -24,6 +24,22 @@ Options:
   -h, --help   Show help information
 ";
 
+        private const string SlnCommandHelpText = @".NET modify solution file command
+
+Usage: dotnet sln [options] <SLN_FILE> [command]
+
+Arguments:
+  <SLN_FILE>   Solution file to operate on. If not specified, the command will search the current directory for one.
+
+Options:
+  -h, --help   Show help information
+
+Commands:
+  add <args>      .NET Add project(s) to a solution file Command
+  list            .NET List project(s) in a solution file Command
+  remove <args>   .NET Remove project(s) from a solution file Command
+";
+
         [Theory]
         [InlineData("--help")]
         [InlineData("-h")]
@@ -44,6 +60,7 @@ Options:
                 .ExecuteWithCapturedOutput($"sln {commandName}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Required command was not provided.");
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(SlnCommandHelpText);
         }
 
         [Fact]

--- a/test/dotnet-sln-remove.Tests/GivenDotnetSlnRemove.cs
+++ b/test/dotnet-sln-remove.Tests/GivenDotnetSlnRemove.cs
@@ -25,6 +25,22 @@ Options:
   -h, --help   Show help information
 ";
 
+        private const string SlnCommandHelpText = @".NET modify solution file command
+
+Usage: dotnet sln [options] <SLN_FILE> [command]
+
+Arguments:
+  <SLN_FILE>   Solution file to operate on. If not specified, the command will search the current directory for one.
+
+Options:
+  -h, --help   Show help information
+
+Commands:
+  add <args>      .NET Add project(s) to a solution file Command
+  list            .NET List project(s) in a solution file Command
+  remove <args>   .NET Remove project(s) from a solution file Command
+";
+
         private const string ExpectedSlnContentsAfterRemove = @"
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
@@ -187,6 +203,7 @@ EndGlobal
                 .ExecuteWithCapturedOutput($"sln {commandName}");
             cmd.Should().Fail();
             cmd.StdErr.Should().Be("Required command was not provided.");
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(SlnCommandHelpText);
         }
 
         [Theory]


### PR DESCRIPTION
When no arguments (or wrong arguments) are given to the following
commands then we also show the help for the command
* dotnet add
* dotnet list
* dotnet remove
* dotnet sln

Fixes #5383, fixes #5384