### PR TITLE
Update to ASP.NET 24840 packages/Archive 65

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,13 +11,16 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta2-20170427-205</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170502-215</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170502-215</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20170503-217</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170503-217</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170503-217</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.0.0-preview1-002106</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0-preview1-002106</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
-    <AspNetCoreRuntimeVersion>2.0.0-preview1-56</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>2.0.0-preview1-65</AspNetCoreRuntimeVersion>
+
+    <!-- This should either be timestamped or notimestamp as appropriate -->
+    <AspNetCoreRuntimePackageFlavor>timestamped</AspNetCoreRuntimePackageFlavor>
 
   </PropertyGroup>
 

--- a/build/compile/LzmaArchive.targets
+++ b/build/compile/LzmaArchive.targets
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
       <FinalArchive>$(SdkOutputDirectory)/nuGetPackagesArchive.lzma</FinalArchive>
-      <NugetPackagesArchiveName>nuGetPackagesArchive.notimestamp.lzma</NugetPackagesArchiveName>
+      <NugetPackagesArchiveName>nuGetPackagesArchive.$(AspNetCoreRuntimePackageFlavor).lzma</NugetPackagesArchiveName>
       <IntermediateArchive>$(IntermediateDirectory)/$(NugetPackagesArchiveName)</IntermediateArchive>
       <NugetPackagesArchiveBlobUrl>$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(NugetPackagesArchiveName)</NugetPackagesArchiveBlobUrl>
     </PropertyGroup>


### PR DESCRIPTION
Switch to time stamped cache packages and add a property for switching between "timestamped" and "notimestamp" packages easily.

Customer scenario is to be able to be able to create the latest ASP.NET Core 2.0 web projects using the fallback folder for fast/offline first restore (making both the templates and archive use the time stamped packages as no timestamps aren't available on any feeds yet). This also adds the engine feature (and template update to take advantage of the feature) to hide VB templates at the CLI while leaving them available for Visual Studio.