### PR TITLE
Clean up first-time run text

### DIFF
--- a/src/Microsoft.DotNet.Configurer/LocalizableStrings.cs
+++ b/src/Microsoft.DotNet.Configurer/LocalizableStrings.cs
@@ -10,14 +10,14 @@ namespace Microsoft.DotNet.Configurer
 Learn more about .NET Core @ https://aka.ms/dotnet-docs. Use dotnet --help to see available commands or go to https://aka.ms/dotnet-cli-docs.
 
 Telemetry
---------------
+---------
 The .NET Core tools collect usage data in order to improve your experience. The data is anonymous and does not include command-line arguments. The data is collected by Microsoft and shared with the community.
 You can opt out of telemetry by setting a DOTNET_CLI_TELEMETRY_OPTOUT environment variable to 1 using your favorite shell.
 You can read more about .NET Core tools telemetry @ https://aka.ms/dotnet-cli-telemetry.
 
 Configuring...
--------------------
-A command is running to initially populate your local package cache, to improve restore speed and enable offline access. This command will take up to a minute to complete and will only happen once.";
+--------------
+A command is running to populate your local package cache. This will improve restore speed and enable offline access. It will take up to a minute to complete and will only happen once.";
 
         public const string FailedToPrimeCacheError = "Failed to prime the NuGet cache. {0} failed with: {1}";
     }


### PR DESCRIPTION
Remove unnecessary split infinitive ("to initially populate"), and reduce sentence length. The "initially" is taken care of in the end of the sentence ("will only happen once").

- If this PR should not run tests please add text "skip[REMOVE_THIS]ci[REMOVE_THIS]please" (remove the marked text, no quotes).
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
