### PR TITLE
Updating the SDK to include the implicit package downgrade warnings fix.

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,7 +4,7 @@
     <CLI_SharedFrameworkVersion>2.0.0-preview1-002106-00</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000117-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>2.0.0-alpha-20170504-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-alpha-20170505-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-beta1-2418</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-rel-20170501-473</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.3.0-preview-20170502-03</CLI_TestPlatform_Version>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,7 +4,7 @@
     <CLI_SharedFrameworkVersion>2.0.0-preview1-002106-00</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000117-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>2.0.0-alpha-20170502-2</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-alpha-20170504-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-beta1-2418</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-rel-20170501-473</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.3.0-preview-20170502-03</CLI_TestPlatform_Version>


### PR DESCRIPTION
This should fix the issues with, and replace #6511.