### PR TITLE
Update templates to 222

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,8 +12,8 @@
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
     <TemplateEngineVersion>1.0.0-beta2-20170503-217</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170504-222</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170504-222</TemplateEngineTemplate2_0Version>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170505-222</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170505-222</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.0.0-preview1-002111</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0-preview1-002111</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,8 +12,8 @@
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
     <TemplateEngineVersion>1.0.0-beta2-20170503-217</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170504-221</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170504-221</TemplateEngineTemplate2_0Version>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170504-222</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170504-222</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.0.0-preview1-002111</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0-preview1-002111</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>


### PR DESCRIPTION
The only difference between this and the current (221) build is a [1 line change](https://github.com/dotnet/templating/pull/757/files) to for a //build demo (cc @danroth27). I talked this over with @MattGertz earlier & got preliminary approval provided that @livarcocc agrees we should take it.
