### PR TITLE
Changing the order of the help text for dotnet publish

### DIFF
--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -15,14 +15,14 @@ namespace Microsoft.DotNet.Cli
                 LocalizableStrings.AppDescription,
                 Accept.ZeroOrMoreArguments(),
                 CommonOptions.HelpOption(),
-                CommonOptions.FrameworkOption(),
-                CommonOptions.RuntimeOption(),
                 Create.Option(
                     "-o|--output",
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.OutputOption)
                         .ForwardAsSingle(o => $"/p:PublishDir={o.Arguments.Single()}")),
+                CommonOptions.FrameworkOption(),
+                CommonOptions.RuntimeOption(),
                 CommonOptions.ConfigurationOption(),
                 CommonOptions.VersionSuffixOption(),
                 Create.Option(


### PR DESCRIPTION
Changing the order of the help text for dotnet publish so that it matches the order from dotnet build as well.

Fixes https://github.com/dotnet/cli/issues/2657
