### PR TITLE
Remove newtonsoft.json dependency from AutoAddDesktopReferencesDuringMigrate

### DIFF
--- a/TestAssets/DesktopTestProjects/AutoAddDesktopReferencesDuringMigrate/project.json
+++ b/TestAssets/DesktopTestProjects/AutoAddDesktopReferencesDuringMigrate/project.json
@@ -4,9 +4,6 @@
     "debugType": "portable",
     "emitEntryPoint": true
   },
-  "dependencies": {
-    "Newtonsoft.Json": "9.0.1"
-  },
   "frameworks": {
     "net451": {}
   },


### PR DESCRIPTION
Remove newtonsoft.json dependency from TestAssets/DesktopTestProjects/AutoAddDesktopReferencesDuringMigrate/project.json

Fixes https://github.com/dotnet/cli/issues/5236

@dotnet/dotnet-cli 
