### PR TITLE
Updating the SDK to one that carries updated versions of the implicit 1.0 versions.

### DIFF
--- a/build/BackwardsCompatibilityRuntimes.props
+++ b/build/BackwardsCompatibilityRuntimes.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Condition=" '$(IncludeSharedFrameworksForBackwardsCompatibilityTests)' == 'true' ">
     <BackwardsCompatibility110CoreSetupChannel>release/1.1.0</BackwardsCompatibility110CoreSetupChannel>
-    <BackwardsCompatibility110SharedFrameworkVersion>1.1.1</BackwardsCompatibility110SharedFrameworkVersion>
+    <BackwardsCompatibility110SharedFrameworkVersion>1.1.2</BackwardsCompatibility110SharedFrameworkVersion>
     <BackwardsCompatibility110SharedHostVersion>1.1.0</BackwardsCompatibility110SharedHostVersion>
     <BackwardsCompatibility110HostFxrVersion>1.1.0</BackwardsCompatibility110HostFxrVersion>
 

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,7 +4,7 @@
     <CLI_SharedFrameworkVersion>2.0.0-preview1-002111-00</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000117-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>2.0.0-alpha-20170505-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-alpha-20170509-2</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-beta1-2418</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-rel-20170501-473</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.3.0-preview-20170502-03</CLI_TestPlatform_Version>

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.DotNet.Tests
                 .Execute(toolPrefersCLIRuntime ? "portable-v1-prefercli" : "portable-v1");
 
             result.Should().Pass()
-                .And.HaveStdOutContaining("I'm running on shared framework version 1.1.1!");
+                .And.HaveStdOutContaining("I'm running on shared framework version 1.1.2!");
 
         }
 
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.Tests
                     .Execute("portable-v1");
 
             result.Should().Pass()
-                .And.HaveStdOutContaining("I'm running on shared framework version 1.1.1!");
+                .And.HaveStdOutContaining("I'm running on shared framework version 1.1.2!");
         }
 
         [Fact]


### PR DESCRIPTION
Updating the SDK to one that carries updated versions of the implicit 1.0 versions.

@dotnet/dotnet-cli @nguerrera 

@MattGertz This is flowing an approved fix from SDK into the CLI.