### PR TITLE
Fix signing dependencies project

### DIFF
--- a/build/MicroBuild.props
+++ b/build/MicroBuild.props
@@ -1,5 +1,11 @@
-<Project>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="DependencyVersions.props" />
+
   <PropertyGroup>
+    <RepoRoot>$(MSBuildThisFileDirectory)/..</RepoRoot>
+    <NuGetPackagesDir>$(NUGET_PACKAGES)</NuGetPackagesDir>
+    <NuGetPackagesDir Condition=" '$(NuGetPackagesDir)' == '' ">$(RepoRoot)/.nuget/packages</NuGetPackagesDir>
+
     <MicroBuildPropsAndTargetsPath>$(NuGetPackagesDir)/microbuild.core/$(MicroBuildVersion)/build/</MicroBuildPropsAndTargetsPath>
   </PropertyGroup>
 </Project>

--- a/build/Signing.proj
+++ b/build/Signing.proj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project InitialTargets="SetSigningProperties" DefaultTargets="SignFiles" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />  
+  <Import Project="MicroBuild.props" />
   <Import Project="$(MicroBuildPropsAndTargetsPath)MicroBuild.Core.props" />
 
   <!-- This will be overridden if we're building with MicroBuild. -->

--- a/dir.props
+++ b/dir.props
@@ -35,7 +35,6 @@
   <Import Project="build/BuildDefaults.props" />
   <Import Project="build/Stage0.props" />
   <Import Project="build/CrossGen.props" />
-  <Import Project="build/MicroBuild.props" />
   <Import Project="build/VersionBadge.props" />
   <Import Project="build/BundledRuntimes.props" />
   <Import Project="build/BackwardsCompatibilityRuntimes.props" />

--- a/tools/Signing.Dependencies/Signing.Dependencies.csproj
+++ b/tools/Signing.Dependencies/Signing.Dependencies.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <PropertyGroup>


### PR DESCRIPTION
@dotnet/dotnet-cli 

This one I actually tried out in VSO. I cancelled it before we got to publishing. Signing in working again.