### PR TITLE
Read rid from build prop

### DIFF
--- a/build/Signing.proj
+++ b/build/Signing.proj
@@ -2,6 +2,8 @@
 <Project InitialTargets="SetSigningProperties" DefaultTargets="SignFiles" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="MicroBuild.props" />
   <Import Project="$(MicroBuildPropsAndTargetsPath)MicroBuild.Core.props" />
+  <Import Project="InitRepo.props" />
+  <Import Project="$(BuildInfoProps)" />
 
   <!-- This will be overridden if we're building with MicroBuild. -->
   <Target Name="SignFiles">


### PR DESCRIPTION
issue: https://github.com/dotnet/cli/issues/6375

Read rid from BuildInfoProps to make it more reliable