### PR TITLE
Remove CoreCLRRid property

### DIFF
--- a/TestAssets/TestPackages/PackageWithFakeNativeDep/PackageWithFakeNativeDep.csproj
+++ b/TestAssets/TestPackages/PackageWithFakeNativeDep/PackageWithFakeNativeDep.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net45</TargetFramework>
     <AssemblyName>PackageWithFakeNativeDep</AssemblyName>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;osx.10.10-x64;rhel.7-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/CrossGen.props
+++ b/build/CrossGen.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
-    <RuntimeNETCoreAppPackageName>runtime.$(CoreCLRRid).microsoft.netcore.app</RuntimeNETCoreAppPackageName>
+    <RuntimeNETCoreAppPackageName>runtime.$(SharedFrameworkRid).microsoft.netcore.app</RuntimeNETCoreAppPackageName>
     <CrossgenPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(CLI_SharedFrameworkVersion)/tools/crossgen$(ExeExtension)</CrossgenPath>
-    <LibCLRJitPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(CLI_SharedFrameworkVersion)/runtimes/$(CoreCLRRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
+    <LibCLRJitPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(CLI_SharedFrameworkVersion)/runtimes/$(SharedFrameworkRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
     <SharedFrameworkNameVersionPath>$(OutputDirectory)/shared/$(SharedFrameworkName)/$(SharedFrameworkVersion)</SharedFrameworkNameVersionPath>
   </PropertyGroup>
 </Project>

--- a/build/Prepare.targets
+++ b/build/Prepare.targets
@@ -80,7 +80,8 @@
     <CallTarget Targets="CleanToolsLockFiles" />
 
     <DotNetRestore ToolPath="$(Stage0Directory)"
-                   ProjectPath="&quot;%(RestoreToolsPackagesInput.FullPath)&quot;" />
+                   ProjectPath="&quot;%(RestoreToolsPackagesInput.FullPath)&quot;"
+                   AdditionalParameters="/p:UsePortableLinuxSharedFramework=$(UsePortableLinuxSharedFramework)" />
 
   </Target>
 

--- a/build/Stage0.props
+++ b/build/Stage0.props
@@ -5,8 +5,5 @@
       <DotnetStage0>$(Stage0Directory)/dotnet$(ExeExtension)</DotnetStage0>
       <IsDesktopAvailable>False</IsDesktopAvailable>
       <IsDesktopAvailable Condition=" '$(OSName)' == 'win' ">True</IsDesktopAvailable>
-      <CoreCLRRid Condition=" '$(OSName)' == 'win' ">win-$(Architecture)</CoreCLRRid>
-      <CoreCLRRid Condition=" '$(OSName)' == 'osx' ">osx-x64</CoreCLRRid>
-      <CoreCLRRid Condition=" '$(CoreCLRRid)' == '' ">linux-x64</CoreCLRRid>
     </PropertyGroup>
 </Project>

--- a/build/test/TestPackageProjects.targets
+++ b/build/test/TestPackageProjects.targets
@@ -59,7 +59,6 @@
         <VersionPrefix>1.0.0</VersionPrefix>
         <VersionSuffix></VersionSuffix>
         <Clean>True</Clean>
-        <MsbuildArgs>/p:RuntimeIdentifier=$(CoreCLRRid)</MsbuildArgs>
       </BaseTestPackageProject>
       <BaseTestPackageProject Include="TestAssets/TestPackages/dotnet-dependency-context-test">
         <Name>dotnet-dependency-context-test</Name>

--- a/dir.props
+++ b/dir.props
@@ -34,9 +34,9 @@
   <Import Project="build/OutputDirectories.props" />
   <Import Project="build/BuildDefaults.props" />
   <Import Project="build/Stage0.props" />
-  <Import Project="build/CrossGen.props" />
   <Import Project="build/VersionBadge.props" />
   <Import Project="build/BundledRuntimes.props" />
+  <Import Project="build/CrossGen.props" />
   <Import Project="build/BackwardsCompatibilityRuntimes.props" />
 
   <Import Project="build/AzureInfo.props" />

--- a/tools/CrossGen.Dependencies/CrossGen.Dependencies.csproj
+++ b/tools/CrossGen.Dependencies/CrossGen.Dependencies.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeIdentifier>$(CoreCLRRid)</RuntimeIdentifier>
+    <RuntimeIdentifier>$(SharedFrameworkRid)</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This property was only legitimately by the project which wants to
restore `crossgen`. Since that now comes from
Microsoft.NETCore.App (i.e. the shared framework) use
SharedFrameworkRid instead.

I also ensured that we passed UsePortableLinuxSharedFramework to
dotnet restore when restoring the tool projects, so we can use the
platform specific RID when non portable build.