### PR TITLE
Move 2 files to use lower ver msbuild

### DIFF
--- a/build/BuildInfo.targets
+++ b/build/BuildInfo.targets
@@ -15,7 +15,7 @@
       <OSPlatform Condition=" '$(OSPlatform)' == '' ">$(HostOSPlatform)</OSPlatform>
 
       <BuildInfoPropsContent>
-&lt;Project ToolsVersion=&quot;15.0&quot;&gt;
+&lt;Project ToolsVersion=&quot;14.0&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
     &lt;PropertyGroup&gt;
         &lt;Rid&gt;$(Rid)&lt;/Rid&gt;
         &lt;Architecture&gt;$(Architecture)&lt;/Architecture&gt;

--- a/build/InitRepo.props
+++ b/build/InitRepo.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <GeneratedPropsDir>$(RepoRoot)/artifacts/obj</GeneratedPropsDir>
     <GitCommitInfoProps>$(GeneratedPropsDir)/GitCommitInfo.props</GitCommitInfoProps>


### PR DESCRIPTION
A missing commit for #6575

The build machine is using an old version of msbuild for signing.
Lower the version of these 2 files to make is available for signing
