### PR TITLE
Update MSBuild to 15.3.0-preview-000234-01

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>2.0.0-preview2-25309-07</CLI_SharedFrameworkVersion>
-    <CLI_MSBuild_Version>15.3.0-preview-000117-01</CLI_MSBuild_Version>
+    <CLI_MSBuild_Version>15.3.0-preview-000234-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
     <CLI_NETSDK_Version>2.0.0-preview2-20170506-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview1-2500</CLI_NuGet_Version>


### PR DESCRIPTION
This build has the new RuntimeInformation feature in MSBuild which allows MSBuild logic to be able to tell if you are building on OSX or Linux.

@livarcocc @nguerrera 
