### PR TITLE
Fixing restore so that it respects the verbosity param.

### DIFF
--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -34,9 +34,13 @@ namespace Microsoft.DotNet.Tools.Restore
             var msbuildArgs = new List<string>
             {
                 "/NoLogo",
-                "/t:Restore",
-                "/ConsoleLoggerParameters:Verbosity=Minimal"
+                "/t:Restore"
             };
+
+            if (!parsedRestore.HasOption("verbosity"))
+            {
+                msbuildArgs.Add("/ConsoleLoggerParameters:Verbosity=Minimal");
+            }
 
             msbuildArgs.AddRange(parsedRestore.OptionValuesToBeForwarded());
 

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -10,7 +10,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetRestoreInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /NoLogo /t:Restore /ConsoleLoggerParameters:Verbosity=Minimal";
+        private const string ExpectedPrefix =
+            "exec <msbuildpath> /m /v:m /NoLogo /t:Restore";
+
+        private string ExpectedPrefixWithConsoleLoggerParamaters =
+            $"{ExpectedPrefix} /ConsoleLoggerParameters:Verbosity=Minimal";
 
         [Theory]
         [InlineData(new string[] { }, "")]
@@ -26,15 +30,26 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--no-cache" }, "/p:RestoreNoCache=true")]
         [InlineData(new string[] { "--ignore-failed-sources" }, "/p:RestoreIgnoreFailedSources=true")]
         [InlineData(new string[] { "--no-dependencies" }, "/p:RestoreRecursive=false")]
-        [InlineData(new string[] { "-v", "minimal" }, @"/verbosity:minimal")]
-        [InlineData(new string[] { "--verbosity", "minimal" }, @"/verbosity:minimal")]
-        public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
+        public void MsbuildInvocationWithConsoleLoggerParametersIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
 
             var msbuildPath = "<msbuildpath>";
             RestoreCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+                .GetProcessStartInfo().Arguments
+                .Should().Be($"{ExpectedPrefixWithConsoleLoggerParamaters}{expectedAdditionalArgs}");
+        }
+
+        [InlineData(new string[] { "-v", "minimal" }, @"/verbosity:minimal")]
+        [InlineData(new string[] { "--verbosity", "minimal" }, @"/verbosity:minimal")]
+        public void MsbuildInvocationWithVerbosityIsCorrect(string[] args, string expectedAdditionalArgs)
+        {
+            expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
+
+            var msbuildPath = "<msbuildpath>";
+            RestoreCommand.FromArgs(args, msbuildPath)
+                .GetProcessStartInfo().Arguments
+                .Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
         }
     }
 }

--- a/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -89,5 +89,30 @@ namespace Microsoft.DotNet.Restore.Tests
             Directory.Exists(fullPath).Should().BeTrue();
             Directory.EnumerateFiles(fullPath, "*.dll", SearchOption.AllDirectories).Count().Should().BeGreaterThan(0);
         }
+
+        [Fact]
+        public void ItRestoresWithTheSpecifiedVerbosity()
+        {
+            var rootPath = TestAssets.CreateTestDirectory().FullName;
+
+            string dir = "pkgs";
+            string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
+
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
+            new NewCommandShim()
+                .WithWorkingDirectory(rootPath)
+                .Execute(newArgs)
+                .Should()
+                .Pass();
+
+            string args = $"--configfile {RepoRootNuGetConfig} --packages \"{dir}\" --verbosity quiet";
+            new RestoreCommand()
+                 .WithWorkingDirectory(rootPath)
+                 .ExecuteWithCapturedOutput(args)
+                 .Should()
+                 .Pass()
+                 .And.NotHaveStdErr()
+                 .And.NotHaveStdOut();
+        }
     }
 }


### PR DESCRIPTION
Fixing restore so that it respects the verbosity param. The problem was that ConsoleLoggerParameters was overwritting whatever was coming through the command line.

@dotnet/dotnet-cli 

@MattGertz for approval.

**Customer scenario**

Respects the verbosity value passed through the command when invoking dotnet restore.

**Bugs this fixes**

[CLI #5989](https://github.com/dotnet/cli/issues/5989)

**Workarounds, if any**

Run dotnet msbuild /t:restore /v:<verbosity level>

**Risk**

Small. Just removes a default parameter passed to msbuild when verbosity is specified in the command line.

**Performance impact**

N/A

**Root cause analysis**

N/A

**How was the bug found?**

Customer reported.

