### PR TITLE
Fix dotnet store options

### DIFF
--- a/src/dotnet/commands/dotnet-store/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-store/LocalizableStrings.cs
@@ -21,11 +21,11 @@ namespace Microsoft.DotNet.Tools.Store
 
         public const string SkipOptimizationOptionDescription = "Skips the optimization phase.";
 
+        public const string SkipSymbolsOptionDescription = "Skips creating symbol files which can be used for profiling the optimized assemblies.";
+
         public const string IntermediateWorkingDirOption = "IntermediateWorkingDir";
 
         public const string IntermediateWorkingDirOptionDescription = "The directory used by the command to execute.";
-
-        public const string PreserveIntermediateWorkingDirOptionDescription = "Preserves the intermediate working directory.";
 
         public const string SpecifyManifests = "Specify at least one manifest with --manifest.";
 

--- a/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
@@ -49,7 +49,6 @@ namespace Microsoft.DotNet.Cli
                         .With(name: LocalizableStrings.FrameworkVersionOption)
                         .ForwardAsSingle(o => $"/p:RuntimeFrameworkVersion={o.Arguments.Single()}")),
                 CommonOptions.RuntimeOption(),
-                CommonOptions.ConfigurationOption(),
                 Create.Option(
                     "-o|--output",
                     LocalizableStrings.OutputOptionDescription,
@@ -63,15 +62,15 @@ namespace Microsoft.DotNet.Cli
                         .With(name: LocalizableStrings.IntermediateWorkingDirOption)
                         .ForwardAsSingle(o => $"/p:ComposeWorkingDir={o.Arguments.Single()}")),
                 Create.Option(
-                    "--preserve-working-dir",
-                    LocalizableStrings.PreserveIntermediateWorkingDirOptionDescription,
-                    Accept.NoArguments()
-                        .ForwardAsSingle(o => $"/p:PreserveComposeWorkingDir=true")),
-                Create.Option(
                     "--skip-optimization",
                     LocalizableStrings.SkipOptimizationOptionDescription,
                     Accept.NoArguments()
                           .ForwardAs("/p:SkipOptimization=true")),
+                Create.Option(
+                    "--skip-symbols",
+                    LocalizableStrings.SkipSymbolsOptionDescription,
+                    Accept.NoArguments()
+                          .ForwardAs("/p:CreateProfilingSymbols=false")),
                 CommonOptions.VerbosityOption());
     }
 }

--- a/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
+++ b/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
                 .WithOutput(localAssemblyCache)
                 .WithRuntimeFrameworkVersion(_frameworkVersion)
                 .WithIntermediateWorkingDirectory(intermediateWorkingDirectory)
-                .Execute($"--preserve-working-dir")
+                .Execute()
                 .Should().Pass();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
@@ -143,7 +143,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
                 .WithOutput(localAssemblyCache)
                 .WithRuntimeFrameworkVersion(_frameworkVersion)
                 .WithIntermediateWorkingDirectory(intermediateWorkingDirectory)
-                .Execute($"--preserve-working-dir")
+                .Execute()
                 .Should().Pass();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";


### PR DESCRIPTION
- remove configuration
- remove preserve-working-dir
- add skip-symbols

Fix #6488
Fix #6489
Fix #6490

Also fixes #1 of https://github.com/dotnet/sdk/issues/1126#issuecomment-299173452.  And along with https://github.com/dotnet/sdk/pull/1231 should complete the feature.

@gkhanna79 @ramarag 

/cc @bleroy @dotnet/dotnet-cli 