### PR TITLE
First run experience for 1.0.4 with 2.0.0 installed

### DIFF
--- a/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App">
-      <Version>1.0.4</Version>
+      <Version>$(CLI_SharedFrameworkVersion)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyModel">
       <Version>$(DependencyModelVersion)</Version>

--- a/build/package/dotnet-deb-tool-consumer.csproj
+++ b/build/package/dotnet-deb-tool-consumer.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-deb-tool" Version="2.0.0-*" />
+    <DotNetCliToolReference Include="dotnet-deb-tool" Version="2.0.0-preview1-001877" />
   </ItemGroup>
 </Project>

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -103,8 +103,8 @@ if ($LastExitCode -ne 0)
 # install the post-PJnistic stage0
 $dotnetInstallPath = Join-Path $toolsLocalPath "dotnet-install.ps1"
 
-Write-Host "$dotnetInstallPath -Channel ""rel-1.0.1""  -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
-Invoke-Expression "$dotnetInstallPath -Channel ""rel-1.0.1"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Write-Host "$dotnetInstallPath -Version ""1.0.4""  -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Invoke-Expression "$dotnetInstallPath -Version ""1.0.4"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
 if ($LastExitCode -ne 0)
 {
     Write-Output "The .NET CLI installation failed with exit code $LastExitCode"

--- a/run-build.sh
+++ b/run-build.sh
@@ -164,8 +164,8 @@ if [ $? != 0 ]; then
 fi
 
 # now execute the script
-echo "installing CLI: $dotnetInstallPath --channel \"rel-1.0.1\" --install-dir $DOTNET_INSTALL_DIR --architecture \"$ARCHITECTURE\""
-$dotnetInstallPath --channel "rel-1.0.1" --install-dir $DOTNET_INSTALL_DIR --architecture "$ARCHITECTURE"
+echo "installing CLI: $dotnetInstallPath --version \"1.0.4\" --install-dir $DOTNET_INSTALL_DIR --architecture \"$ARCHITECTURE\""
+$dotnetInstallPath --version "1.0.4" --install-dir $DOTNET_INSTALL_DIR --architecture "$ARCHITECTURE"
 if [ $? != 0 ]; then
     echo "run-build: Error: Boot-strapping post-PJ stage0 with exit code $?." >&2
     exit $?

--- a/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
@@ -85,6 +86,14 @@ namespace Microsoft.DotNet.Configurer
                     {
                         var workingDirectory = temporaryDotnetNewDirectory.DirectoryPath;
 
+                        File.WriteAllText(
+                            Path.Combine(workingDirectory, "global.json"),
+                            $@"{{
+                                 ""sdk"": {{
+                                    ""version"":""{Product.Version}""
+                                 }}
+                               }}");
+
                         succeeded &= CreateTemporaryProject(workingDirectory, templateInfo);
 
                         if (succeeded)
@@ -129,6 +138,7 @@ namespace Microsoft.DotNet.Configurer
 
             if (commandResult.ExitCode != 0)
             {
+                Reporter.Verbose.WriteLine(commandResult.StdOut);
                 Reporter.Verbose.WriteLine(commandResult.StdErr);
 
                 Reporter.Error.WriteLine(

--- a/tools/TestAssetsDependencies/TestAssetsDependencies.csproj
+++ b/tools/TestAssetsDependencies/TestAssetsDependencies.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Basically, when we create the new project to use to restore the cache, also put a global.json in the folder so that the CLI that triggered the first run is used to also invoke dotnet new and dotnet restore, instead of the latest.

Fixes https://github.com/dotnet/cli/issues/6550

@dotnet/dotnet-cli 
