### PR TITLE
Dropping a global.json when running the first run experience.

### DIFF
--- a/build/Microsoft.DotNet.Cli.Prepare.targets
+++ b/build/Microsoft.DotNet.Cli.Prepare.targets
@@ -281,7 +281,8 @@
     <CallTarget Targets="CleanSrcLockFiles" />
 
     <DotNetRestore ToolPath="$(DotNetPath)"
-                   ProjectPath="&quot;%(RestoreSrcPackagesInput.FullPath)&quot;" />
+                   ProjectPath="&quot;%(RestoreSrcPackagesInput.FullPath)&quot;"
+                   ConfigFile="$(RepoRoot)\NuGet.Config" />
 
   </Target>
 
@@ -306,7 +307,8 @@
     <CallTarget Targets="CleanToolsLockFiles" />
 
     <DotNetRestore ToolPath="$(DotNetPath)"
-                   ProjectPath="&quot;%(RestoreToolsPackagesInput.FullPath)&quot;" />
+                   ProjectPath="&quot;%(RestoreToolsPackagesInput.FullPath)&quot;"
+                   ConfigFile="$(RepoRoot)\NuGet.Config" />
 
   </Target>
 

--- a/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
@@ -96,13 +96,13 @@ namespace Microsoft.DotNet.Configurer
   </packageSources>
 </configuration>");
 
-                        File.WriteAllText(
+                        _file.WriteAllText(
                             Path.Combine(workingDirectory, "global.json"),
                             $@"{{
-                                 ""sdk"": {{
-                                    ""version"":""{Product.Version}""
-                                 }}
-                               }}");
+ ""sdk"": {{
+    ""version"":""{Product.Version}""
+ }}
+}}");
 
                         succeeded &= CreateTemporaryProject(workingDirectory, templateInfo);
 

--- a/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
@@ -85,6 +85,16 @@ namespace Microsoft.DotNet.Configurer
                     using (var temporaryDotnetNewDirectory = _directory.CreateTemporaryDirectory())
                     {
                         var workingDirectory = temporaryDotnetNewDirectory.DirectoryPath;
+                        var nugetConfigPath = Path.Combine(workingDirectory, "NuGet.Config");
+
+                        _file.WriteAllText(
+                            nugetConfigPath,
+                            $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""extractedArchive"" value=""{extractedPackagesArchiveDirectory}"" />
+  </packageSources>
+</configuration>");
 
                         File.WriteAllText(
                             Path.Combine(workingDirectory, "global.json"),
@@ -98,7 +108,7 @@ namespace Microsoft.DotNet.Configurer
 
                         if (succeeded)
                         {
-                            succeeded &= RestoreTemporaryProject(extractedPackagesArchiveDirectory, workingDirectory);
+                            succeeded &= RestoreTemporaryProject(nugetConfigPath, workingDirectory);
                         }
                     }
                 }
@@ -118,11 +128,11 @@ namespace Microsoft.DotNet.Configurer
                 workingDirectory);
         }
 
-        private bool RestoreTemporaryProject(string extractedPackagesArchiveDirectory, string workingDirectory)
+        private bool RestoreTemporaryProject(string nugetConfigPath, string workingDirectory)
         {
             return RunCommand(
                 "restore",
-                new[] { "-s", extractedPackagesArchiveDirectory },
+                new[] { "--configfile", nugetConfigPath },
                 workingDirectory);
         }
 

--- a/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCachePrimer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
@@ -85,6 +86,14 @@ namespace Microsoft.DotNet.Configurer
                     {
                         var workingDirectory = temporaryDotnetNewDirectory.DirectoryPath;
 
+                        File.WriteAllText(
+                            Path.Combine(workingDirectory, "global.json"),
+                            $@"{{
+                                 ""sdk"": {{
+                                    ""version"":""{Product.Version}""
+                                 }}
+                               }}");
+
                         succeeded &= CreateTemporaryProject(workingDirectory, templateInfo);
 
                         if (succeeded)
@@ -129,6 +138,7 @@ namespace Microsoft.DotNet.Configurer
 
             if (commandResult.ExitCode != 0)
             {
+                Reporter.Verbose.WriteLine(commandResult.StdOut);
                 Reporter.Verbose.WriteLine(commandResult.StdErr);
 
                 Reporter.Error.WriteLine(

--- a/src/Microsoft.DotNet.InternalAbstractions/FileWrapper.cs
+++ b/src/Microsoft.DotNet.InternalAbstractions/FileWrapper.cs
@@ -40,5 +40,10 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
             {
             }
         }
+
+        public void WriteAllText(string path, string content)
+        {
+            File.WriteAllText(path, content);
+        }
     }
 }

--- a/src/Microsoft.DotNet.InternalAbstractions/IFile.cs
+++ b/src/Microsoft.DotNet.InternalAbstractions/IFile.cs
@@ -22,5 +22,7 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
             FileOptions fileOptions);
 
         void CreateEmptyFile(string path);
+
+        void WriteAllText(string path, string content);
     }
 }

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.Test.Utilities.Mock;
@@ -150,12 +151,26 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Fact]
-        public void It_uses_the_packages_archive_with_dotnet_restore()
+        public void It_writes_a_config_file_with_the_extracted_archive_as_a_package_source()
         {
+            var nugetConfigPath = Path.Combine(_temporaryDirectoryMock.DirectoryPath, "NuGet.Config");
+            _fileSystemMock.File.ReadAllText(nugetConfigPath).Should().Be(
+                $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<configuration>
+  <packageSources>
+    <add key=""extractedArchive"" value=""{PACKAGES_ARCHIVE_PATH}"" />
+  </packageSources>
+</configuration>");
+        }
+
+        [Fact]
+        public void It_uses_a_config_file_with_dotnet_restore()
+        {
+            var nugetConfigPath = Path.Combine(_temporaryDirectoryMock.DirectoryPath, "NuGet.Config");
             _commandFactoryMock.Verify(
                 c => c.Create(
                     "restore",
-                    new[] { "-s", $"{PACKAGES_ARCHIVE_PATH}" },
+                    new[] { "--configfile", nugetConfigPath },
                     null,
                     Constants.DefaultConfiguration),
                 Times.Exactly(2));

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCachePrimer.cs
@@ -164,6 +164,18 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Fact]
+        public void It_writes_a_global_json_file_with_the_current_cli_version()
+        {
+            var nugetConfigPath = Path.Combine(_temporaryDirectoryMock.DirectoryPath, "global.json");
+            _fileSystemMock.File.ReadAllText(nugetConfigPath).Should().Be(
+                $@"{{
+ ""sdk"": {{
+    ""version"":""{Product.Version}""
+ }}
+}}");
+        }
+
+        [Fact]
         public void It_uses_a_config_file_with_dotnet_restore()
         {
             var nugetConfigPath = Path.Combine(_temporaryDirectoryMock.DirectoryPath, "NuGet.Config");

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCacheSentinel.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCacheSentinel.cs
@@ -175,6 +175,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             {
                 throw new NotImplementedException();
             }
+
+            public void WriteAllText(string path, string content)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         private class MockStream : MemoryStream

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Mock/FileSystemMockBuilder.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Mock/FileSystemMockBuilder.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         private class FileMock : IFile
         {
             private Dictionary<string, string> _files;
+            
             public FileMock(Dictionary<string, string> files)
             {
                 _files = files;
@@ -99,6 +100,11 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             public void CreateEmptyFile(string path)
             {
                 _files.Add(path, string.Empty);
+            }
+
+            public void WriteAllText(string path, string content)
+            {
+                _files[path] = content;
             }
         }
 

--- a/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -14,6 +14,8 @@ namespace Microsoft.DotNet.Restore.Tests
 {
     public class GivenThatIWantToRestoreApp : TestBase
     {
+        private static string RepoRootNuGetConfig = Path.Combine(RepoDirectoriesProvider.RepoRoot, "NuGet.Config");
+
         [Fact]
         public void ItRestoresAppToSpecificDirectory()
         {
@@ -29,7 +31,7 @@ namespace Microsoft.DotNet.Restore.Tests
                 .Should()
                 .Pass();
 
-            string args = $"--packages \"{dir}\"";
+            string args = $"--configfile {RepoRootNuGetConfig} --packages \"{dir}\"";
             new RestoreCommand()
                  .WithWorkingDirectory(rootPath)
                  .ExecuteWithCapturedOutput(args)
@@ -56,7 +58,7 @@ namespace Microsoft.DotNet.Restore.Tests
                 .Should()
                 .Pass();
 
-            string args = $"--packages \"{dir}\"";
+            string args = $"--configfile {RepoRootNuGetConfig} --packages \"{dir}\"";
             new RestoreCommand()
                 .WithWorkingDirectory(rootPath)
                 .ExecuteWithCapturedOutput(args)
@@ -76,7 +78,7 @@ namespace Microsoft.DotNet.Restore.Tests
             string dir = "pkgs";
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
-            string args = $"--packages \"{dir}\"";
+            string args = $"--configfile {RepoRootNuGetConfig} --packages \"{dir}\"";
             new RestoreCommand()
                 .WithWorkingDirectory(rootPath)
                 .ExecuteWithCapturedOutput(args)


### PR DESCRIPTION
Dropping a global.json when running the first run experience with a version that matches the version of the CLI being used in the command that triggered the first run.

@dotnet/dotnet-cli @MattGertz this is just porting the change that went into 1.0.1 to 1.1.0.