### PR TITLE
Move Roslyn to latest 15.3 version

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -10,6 +10,7 @@
     <add key="websdkfeed" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
+    <add key="symreader-native" value="https://dotnet.myget.org/f/symreader-native/api/v3/index.json" />
     <add key="xunit" value="https://www.myget.org/F/xunit/api/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>2.0.0-preview2-25319-02</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000246-05</CLI_MSBuild_Version>
-    <CLI_Roslyn_Version>2.0.0-rc4-61325-08</CLI_Roslyn_Version>
+    <CLI_Roslyn_Version>2.3.0-beta2-61716-09</CLI_Roslyn_Version>
+    <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>
     <CLI_FSharp_Version>1.0.0-rc-170511-0</CLI_FSharp_Version>
     <CLI_NETSDK_Version>2.0.0-preview2-20170506-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview1-2500</CLI_NuGet_Version>
@@ -20,7 +21,7 @@
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
     <CliMigrateVersion>1.2.1-alpha-002130</CliMigrateVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
-  
+
     <!-- This should either be timestamped or notimestamp as appropriate -->
     <AspNetCoreRuntimePackageFlavor>timestamped</AspNetCoreRuntimePackageFlavor>
     <AspNetCoreRuntimeVersion>dev-123</AspNetCoreRuntimeVersion>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="Microsoft.TestPlatform.Build" Version="$(CLI_TestPlatform_Version)" />
     <PackageReference Include="NuGet.Packaging.Core.Types" Version="$(CLI_NuGet_Version)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(CLI_NuGet_Version)" />
+    <!-- The project json migration commands depend on an older version of Roslyn.
+         Lift the version here to match what tool_roslyn depends on (otherwise an older version will
+         be added to the TPA when we crossgen and we won't be able to crossgen tool_roslyn -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(CLI_Roslyn_Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tool_roslyn/tool_roslyn.csproj
+++ b/src/tool_roslyn/tool_roslyn.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="$(CLI_Roslyn_Version)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.4.1" />
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(CLI_DiaSymNative_Version)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,9 +30,9 @@
           AfterTargets="Publish"
           BeforeTargets="RemoveFilesAfterPublish">
     <ItemGroup>
-      <AssetsToRemoveFromDeps Include="runtimes/any/native/csc.exe" 
+      <AssetsToRemoveFromDeps Include="runtimes/any/native/csc.dll" 
                               SectionName="runtimeTargets" />
-      <AssetsToRemoveFromDeps Include="runtimes/any/native/vbc.exe" 
+      <AssetsToRemoveFromDeps Include="runtimes/any/native/vbc.dll" 
                               SectionName="runtimeTargets" />
       <AssetsToRemoveFromDeps Include="tool_roslyn.dll" 
                               SectionName="runtime"/>
@@ -42,14 +42,14 @@
                                  SectionName="%(AssetsToRemoveFromDeps.SectionName)"
                                  AssetPath="%(AssetsToRemoveFromDeps.Identity)" />
    
-    <Copy SourceFiles="$(PublishDir)/runtimes/any/native/csc.exe;
+    <Copy SourceFiles="$(PublishDir)/runtimes/any/native/csc.dll;
                        $(PublishDir)/$(TargetName).runtimeconfig.json;
                        $(PublishDir)/$(TargetName).deps.json;"
           DestinationFiles="$(PublishDir)/csc.exe;
                             $(PublishDir)/csc.runtimeconfig.json;
                             $(PublishDir)/csc.deps.json;" />
 
-    <Copy SourceFiles="$(PublishDir)/runtimes/any/native/vbc.exe;
+    <Copy SourceFiles="$(PublishDir)/runtimes/any/native/vbc.dll;
                        $(PublishDir)/$(TargetName).runtimeconfig.json;
                        $(PublishDir)/$(TargetName).deps.json;"
           DestinationFiles="$(PublishDir)/vbc.exe;


### PR DESCRIPTION
Move to the latest 15.3 versions of Roslyn.  The previous one we had was over five months old.