### PR TITLE
Enable VB tests on all platforms

### DIFF
--- a/test/dotnet.Tests/GivenThatICareAboutVBApps.cs
+++ b/test/dotnet.Tests/GivenThatICareAboutVBApps.cs
@@ -26,8 +26,7 @@ namespace Microsoft.DotNet.Tests
                 .Should().Pass();
         }
 
-        // Enable cross-plat once https://github.com/Microsoft/msbuild/issues/422 is fixed
-        [WindowsOnlyFact]
+        [Fact]
         public void ICanBuildVBApps()
         {
             new BuildCommand()
@@ -36,8 +35,7 @@ namespace Microsoft.DotNet.Tests
                 .Should().Pass();
         }
 
-        // Enable cross-plat once https://github.com/Microsoft/msbuild/issues/422 is fixed
-        [WindowsOnlyFact]
+        [Fact]
         public void ICanRunVBApps()
         {
             new RunCommand()
@@ -46,8 +44,7 @@ namespace Microsoft.DotNet.Tests
                 .Should().Pass();
         }
 
-        // Enable cross-plat once https://github.com/Microsoft/msbuild/issues/422 is fixed
-        [WindowsOnlyFact]
+        [Fact]
         public void ICanPublicAndRunVBApps()
         {
             new PublishCommand()


### PR DESCRIPTION
This reverts commit a4c3e69c3cedc5aedfd4f76eab35e3cf05e447ba.

This should work since 28e25657cbaf03919983e33ad477eab8744a2763 picked
up the fix for Microsoft/msbuild#137.