### PR TITLE
Updating the websdk version to 2.0.0-rel-20170518-512

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -7,7 +7,7 @@
     <CLI_FSharp_Version>1.0.0-rc-170511-0</CLI_FSharp_Version>
     <CLI_NETSDK_Version>2.0.0-preview2-20170506-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview1-2500</CLI_NuGet_Version>
-    <CLI_WEBSDK_Version>1.0.0-rel-20170501-473</CLI_WEBSDK_Version>
+    <CLI_WEBSDK_Version>2.0.0-rel-20170518-512</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.3.0-preview-20170502-03</CLI_TestPlatform_Version>
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>


### PR DESCRIPTION
Merging the changes from release\2.0.0 branch
https://github.com/dotnet/cli/blob/release/2.0.0/build/DependencyVersions.props#L9

@mlorbetske @livarcocc 