### PR TITLE
Updating the branding of the CLI in master to preview3 for now

### DIFF
--- a/build/Branding.props
+++ b/build/Branding.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="14.0">
   <PropertyGroup>
-    <SdkBrandName>Microsoft .NET Core 2.0.0 - Preview 3 SDK</SdkBrandName>
+    <SdkBrandName>Microsoft .NET Core 2.1.0 - Preview 1 SDK</SdkBrandName>
     <SharedFrameworkBrandName>Microsoft .NET Core 2.0.0 - Runtime</SharedFrameworkBrandName>
     <SharedHostBrandName>Microsoft .NET Core 2.0.0 - Host</SharedHostBrandName>
     <HostFxrBrandName>Microsoft .NET Core 2.0.0 - Host FX Resolver</HostFxrBrandName>

--- a/build/Branding.props
+++ b/build/Branding.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="14.0">
   <PropertyGroup>
-    <SdkBrandName>Microsoft .NET Core 2.0.0 - Preview 2 SDK</SdkBrandName>
+    <SdkBrandName>Microsoft .NET Core 2.0.0 - Preview 3 SDK</SdkBrandName>
     <SharedFrameworkBrandName>Microsoft .NET Core 2.0.0 - Runtime</SharedFrameworkBrandName>
     <SharedHostBrandName>Microsoft .NET Core 2.0.0 - Host</SharedHostBrandName>
     <HostFxrBrandName>Microsoft .NET Core 2.0.0 - Host FX Resolver</HostFxrBrandName>

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <VersionMajor>2</VersionMajor>
-    <VersionMinor>0</VersionMinor>
+    <VersionMinor>1</VersionMinor>
     <VersionPatch>0</VersionPatch>
-    <ReleaseSuffix>preview3</ReleaseSuffix>
+    <ReleaseSuffix>preview1</ReleaseSuffix>
 
     <CliVersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)-$(ReleaseSuffix)</CliVersionPrefix>
     <SimpleVersion Condition=" '$(DropSuffix)' == '' ">$(VersionMajor).$(VersionMinor).$(VersionPatch).$(CommitCount)</SimpleVersion> 

--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
     <VersionMajor>2</VersionMajor>
     <VersionMinor>0</VersionMinor>
     <VersionPatch>0</VersionPatch>
-    <ReleaseSuffix>preview2</ReleaseSuffix>
+    <ReleaseSuffix>preview3</ReleaseSuffix>
 
     <CliVersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)-$(ReleaseSuffix)</CliVersionPrefix>
     <SimpleVersion Condition=" '$(DropSuffix)' == '' ">$(VersionMajor).$(VersionMinor).$(VersionPatch).$(CommitCount)</SimpleVersion> 


### PR DESCRIPTION
Updating the branding of the CLI in master to preview3 for now, so that it does not conflict with the release/2.0.0 CLI.

@dotnet/dotnet-cli 

@leecow Is it ok to use the preview3 branding here or do you prefer 2.1.0 or something like that?

@MattGertz for approval. This is just updating the version and branding of the CLI.
