### PR TITLE
Bundle SPA templates package

### DIFF
--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -5,5 +5,6 @@
     <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.2.0" Version="$(TemplateEngineTemplate2_0Version)" />
     <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.0" Version="$(TemplateEngineTemplateVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.0" Version="$(TemplateEngineTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(SpaTemplateVersion)" />
   </ItemGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -21,6 +21,7 @@
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
     <CliMigrateVersion>1.2.1-alpha-002130</CliMigrateVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
+    <SpaTemplateVersion>1.0.0-preview-000249</SpaTemplateVersion>
 
     <!-- This should either be timestamped or notimestamp as appropriate -->
     <AspNetCoreRuntimePackageFlavor>timestamped</AspNetCoreRuntimePackageFlavor>

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -16,22 +16,26 @@ namespace Microsoft.DotNet.New.Tests
     public class GivenThatIWantANewAppWithSpecifiedType : TestBase
     {
         [Theory]
-        [InlineData("C#", "console", false)]
-        [InlineData("C#", "classlib", false)]
-        [InlineData("C#", "mstest", false)]
-        [InlineData("C#", "xunit", false)]
-        [InlineData("C#", "web", false)]
-        [InlineData("C#", "mvc", false)]
-        [InlineData("C#", "webapi", false)]
-        [InlineData("F#", "console", false)]
-        [InlineData("F#", "classlib", false)]
-        [InlineData("F#", "mstest", false)]
-        [InlineData("F#", "xunit", false)]
-        [InlineData("F#", "mvc", true)]
+        [InlineData("C#", "console", false, false)]
+        [InlineData("C#", "classlib", false, false)]
+        [InlineData("C#", "mstest", false, false)]
+        [InlineData("C#", "xunit", false, false)]
+        [InlineData("C#", "web", false, false)]
+        [InlineData("C#", "mvc", false, false)]
+        [InlineData("C#", "webapi", false, false)]
+        [InlineData("C#", "angular", false, true)]
+        [InlineData("C#", "react", false, true)]
+        [InlineData("C#", "reactredux", false, true)]
+        [InlineData("F#", "console", false, false)]
+        [InlineData("F#", "classlib", false, false)]
+        [InlineData("F#", "mstest", false, false)]
+        [InlineData("F#", "xunit", false, false)]
+        [InlineData("F#", "mvc", true, false)]
         public void TemplateRestoresAndBuildsWithoutWarnings(
             string language,
             string projectType,
-            bool useNuGetConfigForAspNet)
+            bool useNuGetConfigForAspNet,
+            bool skipSpaWebpackSteps)
         {
             if (language == "F#" && !EnvironmentInfo.HasSharedFramework("netcoreapp1.0"))
             {
@@ -50,6 +54,13 @@ namespace Microsoft.DotNet.New.Tests
             {
                 var configFile = new FileInfo(Path.Combine(rootPath, "..", "..", "..", "..", "..", "NuGet.tempaspnetpatch.config"));
                 File.Copy(configFile.FullName, Path.Combine(rootPath, "NuGet.Config"));
+            }
+
+            if (skipSpaWebpackSteps)
+            {
+                // Not all CI machines have Node installed, so the build would fail if we tried
+                // to run Webpack. Bypass this by making it appear that Webpack already ran.
+                Directory.CreateDirectory(Path.Combine(rootPath, "wwwroot", "dist"));
             }
 
             new TestCommand("dotnet")


### PR DESCRIPTION
As discussed with @mlorbetske, this adds the `Microsoft.DotNet.Web.Spa.ProjectTemplates` package to `BundlesTemplates.props`. The version number will certainly change before this ships, but it would be good to start including this in builds for testing.