### PR TITLE
Fix for apt-get dependency and document for enabled apt-get feed wul

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ Newest SDK binaries for 2.0.0 in debian feed may be delayed due to external issu
 
 ## Obtaining binaries
 
-Add debian feed:
-
+### Add debian feed:
+Ubuntu 14.04
 ```
 sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 
@@ -144,12 +144,39 @@ sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
 sudo apt-get update
 ```
 
-Install:
+Ubuntu 16.04
+```
+sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
+
+sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+
+sudo apt-get update
+```
+
+Ubuntu 16.10
+```
+sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ yakkety main" > /etc/apt/sources.list.d/dotnetdev.list'
+
+sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+
+sudo apt-get update
+```
+
+Debian 8
+```
+sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ jessie main" > /etc/apt/sources.list.d/dotnetdev.list'
+
+sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+
+sudo apt-get update
+```
+
+### Install:
 ```
 sudo apt-get install <DebianPackageName>=<Version>
 ```
 
-To list available packages:
+### To list available packages:
 ```
 apt-cache search dotnet-sdk | grep 2.0.0
 ```
@@ -167,17 +194,17 @@ When you have the .NET Command Line Interface installed on your OS of choice, yo
 
 First, you will need to restore the packages:
 
-	dotnet restore
+    dotnet restore
 
 This will restore all of the packages that are specified in the project.json file of the given sample.
 
 Then you can either run from source or compile the sample. Running from source is straightforward:
 
-	dotnet run
+    dotnet run
 
 Compiling to IL is done using:
 
-	dotnet build
+    dotnet build
 
 This will drop an IL assembly in `./bin/[configuration]/[framework]/[binary name]`
 that you can run using `dotnet bin/[configuration]/[framework]/[binaryname.dll]`.

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>2.0.0-preview2-25319-02</CLI_SharedFrameworkVersion>
+    <CLI_SharedFrameworkVersion>2.0.0-preview2-25324-01</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000246-05</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.0-beta2-61716-09</CLI_Roslyn_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>
@@ -16,8 +16,8 @@
     <TemplateEngineVersion>1.0.0-beta2-20170523-241</TemplateEngineVersion>
     <TemplateEngineTemplateVersion>1.0.0-beta2-20170523-241</TemplateEngineTemplateVersion>
     <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170523-241</TemplateEngineTemplate2_0Version>
-    <PlatformAbstractionsVersion>2.0.0-preview2-25319-02</PlatformAbstractionsVersion>
-    <DependencyModelVersion>2.0.0-preview2-25319-02</DependencyModelVersion>
+    <PlatformAbstractionsVersion>2.0.0-preview2-25324-01</PlatformAbstractionsVersion>
+    <DependencyModelVersion>2.0.0-preview2-25324-01</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
     <CliMigrateVersion>1.2.1-alpha-002130</CliMigrateVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>


### PR DESCRIPTION
Update shared framework to version that is existed in apt-get feed, after the bug fix in shared framework publish pipeline

**Customer scenario**

Ubuntu/Debian users install CLI/SDK via apt-get

```
sudo apt-get install dotnet-dev-2.0.0-preview2-0060XX
```

apt-get will return error due to dependency _dotnet-sharedframework-microsoft.netcore.app-2.0.0-preview2-25319-02_ not met.  

**Bugs this fixes**

https://github.com/dotnet/cli/issues/6113

**Workarounds, if any**

Install CLI/SDK via install script

**Risk**

The Ubuntu/Debian users cannot get native install experience

**Performance impact**

no

**Root cause analysis**

There is not automatic test for apt-get install feed

**How was the bug found?**

While adding feature support for Debian, the existing distro support is broken.
