### PR TITLE
Changing verbose to verbosity in the help options

### DIFF
--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.DotNet.Tools.Help;
+﻿using Microsoft.DotNet.Tools;
+using Microsoft.DotNet.Tools.Help;
 
 internal static class HelpUsageText
 {
@@ -31,7 +32,7 @@ path-to-application:
   -d|--diagnostics {LocalizableStrings.SDKDiagnosticsCommandDefinition}
 
 {LocalizableStrings.CommonOptions}:
-  -v|--verbose          {LocalizableStrings.VerboseDefinition}
+  -v|--verbosity        {CommonLocalizableStrings.VerbosityOptionDescription}
   -h|--help             {LocalizableStrings.HelpDefinition}
 
 {LocalizableStrings.RunDotnetCommandHelpForMore}

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.cs
@@ -19,11 +19,9 @@ namespace Microsoft.DotNet.Tools.Help
 
         public const string CommonOptions = "Common options";
 
-        public const string VerboseDefinition = "Enable verbose output";
-
         public const string DiagnosticsDefinition = "Enable diagnostic output";
 
-        public const string HelpDefinition = "Show help";
+        public const string HelpDefinition = "Show help.";
 
         public const string HostOptions = "Host options (passed before the command)";
 

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -43,8 +43,8 @@ SDK commands:
   -d|--diagnostics Enable diagnostic output.
 
 Common options:
-  -v|--verbose          Enable verbose output
-  -h|--help             Show help
+  -v|--verbosity        Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
+  -h|--help             Show help.
 
 Run 'dotnet COMMAND --help' for more information on a command.
 


### PR DESCRIPTION
…tually use.

**Customer scenario**

Changing verbose to verbosity in the help options to match what we actually use. Without this, after typing dotnet --help a user may see verbose as the way to indicate verbosity to our commands, but in fact, that is not used anymore and the new way to do that is --verbosity. This is misleading and confusing to our users.

**Bugs this fixes**

Fixes https://github.com/dotnet/cli/issues/5502

**Workarounds, if any**

N/A

**Risk**

N/A

**Performance impact**

N/A

**Root cause analysis**

The big help text is not composed by the parser, but hand crafted. We have plans to add that to the parser, but not yet.

**How was the bug found?**

Report by team member.

@dotnet/dotnet-cli

@MattGertz for approval.

