### PR TITLE
Adding the runtime identifier option to dotnet clean.

### DIFF
--- a/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Cli
                         .With(name: LocalizableStrings.CmdOutputDir)
                         .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
                 CommonOptions.FrameworkOption(),
+                CommonOptions.RuntimeOption(),
                 CommonOptions.ConfigurationOption(),
                 CommonOptions.VerbosityOption());
     }

--- a/test/Microsoft.DotNet.Cli.Tests.sln
+++ b/test/Microsoft.DotNet.Cli.Tests.sln
@@ -76,8 +76,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-back-compat.Tests", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet-remove-package.Tests", "dotnet-remove-package.Tests\dotnet-remove-package.Tests.csproj", "{CF517B15-B307-4660-87D5-CC036ADECD4B}"
 EndProject
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.MSBuildSdkResolver.Tests", "Microsoft.DotNet.MSBuildSdkResolver.Tests\Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj", "{42A0CAB4-FFAD-47D4-9880-C0F4EDCF93DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet-clean.Tests", "dotnet-clean.Tests\dotnet-clean.Tests.csproj", "{D9A582B8-1FE2-45D5-B139-0BA828FE3691}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -509,6 +510,18 @@ Global
 		{42A0CAB4-FFAD-47D4-9880-C0F4EDCF93DE}.Release|x64.Build.0 = Release|Any CPU
 		{42A0CAB4-FFAD-47D4-9880-C0F4EDCF93DE}.Release|x86.ActiveCfg = Release|Any CPU
 		{42A0CAB4-FFAD-47D4-9880-C0F4EDCF93DE}.Release|x86.Build.0 = Release|Any CPU
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Debug|x64.ActiveCfg = Debug|x64
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Debug|x64.Build.0 = Debug|x64
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Debug|x86.ActiveCfg = Debug|x86
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Debug|x86.Build.0 = Debug|x86
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Release|x64.ActiveCfg = Release|x64
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Release|x64.Build.0 = Release|x64
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Release|x86.ActiveCfg = Release|x86
+		{D9A582B8-1FE2-45D5-B139-0BA828FE3691}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/DirectoryInfoAssertions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/DirectoryInfoAssertions.cs
@@ -191,6 +191,22 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return new AndConstraint<DirectoryInfoAssertions>(this);
         }
 
+        public AndConstraint<DirectoryInfoAssertions> BeEmpty()
+        {
+            Execute.Assertion.ForCondition(!_dirInfo.EnumerateFileSystemInfos().Any())
+                .FailWith($"The directory {_dirInfo.FullName} is not empty.");
+
+            return new AndConstraint<DirectoryInfoAssertions>(this);
+        }
+
+        public AndConstraint<DirectoryInfoAssertions> NotBeEmpty()
+        {
+            Execute.Assertion.ForCondition(_dirInfo.EnumerateFileSystemInfos().Any())
+                .FailWith($"The directory {_dirInfo.FullName} is empty.");
+
+            return new AndConstraint<DirectoryInfoAssertions>(this);
+        }
+
         public AndConstraint<DirectoryInfoAssertions> NotExist(string because = "", params object[] reasonArgs)
         {
             Execute.Assertion

--- a/test/dotnet-clean.Tests/GivenDotnetCleanCleansBuildArtifacts.cs
+++ b/test/dotnet-clean.Tests/GivenDotnetCleanCleansBuildArtifacts.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+using System.Linq;
+
+namespace Microsoft.DotNet.Cli.Clean.Tests
+{
+    public class GivenDotnetCleanCleansBuildArtifacts : TestBase
+    {
+        [Fact]
+        public void ItCleansAProjectBuiltWithRuntimeIdentifier()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance(testAppName)
+                .WithSourceFiles()
+                .WithRestoreFiles();
+
+            new BuildCommand()
+                .WithRuntime("win7-x64")
+                .WithWorkingDirectory(testInstance.Root)
+                .Execute()
+                .Should().Pass();
+
+            var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
+            var outputFolder = testInstance.Root.GetDirectory("bin", configuration, "netcoreapp2.0", "win7-x64");
+
+            outputFolder.Should().NotBeEmpty();
+
+            new CleanCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .Execute("-r win7-x64")
+                .Should().Pass();
+
+            outputFolder.Should().BeEmpty();
+        }
+    }
+}

--- a/test/dotnet-clean.Tests/dotnet-clean.Tests.csproj
+++ b/test/dotnet-clean.Tests/dotnet-clean.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(CliTargetFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(CLI_SharedFrameworkVersion)</RuntimeFrameworkVersion>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AssemblyName>dotnet-clean.Tests</AssemblyName>
+    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161024-02" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
**Customer scenario**

Without this, when the user builds a project passing a --runtime option, the user won't be able to do the equivalent for dotnet clean. In the case of clean, the user will have to do /p:RuntimeIdentifier. All the other commands that accept a runtime take it as an argument and this brings clean on par with the other commands.

**Bugs this fixes**

Fixes https://github.com/dotnet/cli/issues/5303

**Workarounds, if any**

N/A

**Risk**

N/A

**Performance impact**

N/A

**Root cause analysis**

N/A

**How was the bug found?**

Report by team member.

@dotnet/dotnet-cli

@MattGertz for approval.

