### PR TITLE
Updating the Sdk to one that includes the error surfacing work.

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -4,7 +4,7 @@
     <CLI_SharedFrameworkVersion>1.1.2</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000246-05</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.0.0-rc5-61427-04</CLI_Roslyn_Version>
-    <CLI_NETSDK_Version>1.1.0-alpha-20170524-5</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.1.0-alpha-20170525-2</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview2-4082</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz this is dependency update in the CLI. Just bringing over the changes already approved in the SDK.