### PR TITLE
Allow resolution of SDKs without minimum msbuild version file

### DIFF
--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -91,6 +91,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 new SdkReference("Some.Test.Sdk", null, "99.99.99"),
                 new MockContext
                 {
+                    MSBuildVersion = new Version(1, 0),
                     ProjectFilePath = environment.TestDirectory.FullName
                 },
                 new MockFactory());
@@ -194,7 +195,10 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 var dir = GetSdkDirectory(programFiles, sdkName, sdkVersion);
                 dir.Create();
 
-                CreateMSBuildRequiredVersionFile(programFiles, sdkVersion, minimumMSBuildVersion);
+                if (minimumMSBuildVersion != null)
+                {
+                    CreateMSBuildRequiredVersionFile(programFiles, sdkVersion, minimumMSBuildVersion);
+                }
 
                 return dir;
             }
@@ -254,7 +258,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
 
             public MockContext()
             {
-                MSBuildVersion = new Version(1, 0);
+                MSBuildVersion = new Version(15, 3, 0);
             }
         }
 


### PR DESCRIPTION
If the resolved SDK is older than one that has an explicit minimumMSBuildVersion file, then resolution would fail.

Instead, treat such SDKs as requiring 15.3.0, which is where the first minimumMSBuildVersion ships and only goes up from here.

@MattGertz for approval

**Customer scenario**

No .NET Core SDK is installed yet with an explicit minimumMSBuild version (all but most recent 2.0.0-preview2 builds at the moment) file or global.json is pinning such a version. In both cases, resolution will fail. For non-web projects, we fall back to the default resolver and in-box 1.x SDK, but web projects will fail to load altogether in this case.

**Bugs this fixes:** 

[VSO 441969](https://devdiv.visualstudio.com/DevDiv/_workitems?id=441969&fullScreen=false&_a=edit)

Fix #6702

**Workarounds, if any**

Install latest preview 2 CLI and don't pin to lower version in global.json

**Risk**

Low

**Performance impact**

Low to none

**Is this a regression from a previous update?**

Yes, introduced by minimum msbuild version support

**Root cause analysis:**

Lack of tests for case where this file is missing. Fixed.

**How was the bug found?**

Dogfooding