### PR TITLE
Handle missing VERSION_ID gracefully

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -130,6 +130,7 @@ get_distro_specific_os_name() {
     eval $invocation
 
     local uname=$(uname)
+    local osName="undefined"
     if [ "$uname" = "Darwin" ]; then
         echo "osx"
         return 0
@@ -139,7 +140,8 @@ get_distro_specific_os_name() {
     else
         if [ -e /etc/os-release ]; then
             . /etc/os-release
-            os=$(get_os_download_name_from_platform "$ID.$VERSION_ID" || echo "")
+            osName="${ID}${VERSION_ID:+.${VERSION_ID}}"
+            os=$(get_os_download_name_from_platform "${osName}" || echo "")
             if [ -n "$os" ]; then
                 echo "$os"
                 return 0
@@ -147,7 +149,7 @@ get_distro_specific_os_name() {
         fi
     fi
     
-    say_err "OS name could not be detected: $ID.$VERSION_ID"
+    say_err "OS name could not be detected: $osName"
     return 1
 }
 


### PR DESCRIPTION
I'm using Arch Linux. _/etc/os-release_ doesn't define _VERSION_ID_. Running __dotnet-install.sh__ results in:

```
→ LANG=C ./scripts/obtain/dotnet-install.sh 
./scripts/obtain/dotnet-install.sh: line 142: VERSION_ID: unbound variable
./scripts/obtain/dotnet-install.sh: line 150: VERSION_ID: unbound variable
```

According to [Freedesktop.org os-release spec](https://www.freedesktop.org/software/systemd/man/os-release.html) __VERSION_ID__ is optional:


> A lower-case string (mostly numeric, no spaces or other characters outside of 0–9, a–z, ".", "_" and "-") > identifying the operating system version, excluding any OS name information or release code name, > > and suitable for processing by scripts or usage in generated filenames. **This field is optional.** Example: > "VERSION_ID=17" or "VERSION_ID=11.04".

Result using this commit:

```
→ LANG=C ./scripts/obtain/dotnet-install.sh 
dotnet_install: Error: OS name could not be detected: arch.UNDEFINED

```

