### PR TITLE
Re-enable telemetry for new

### DIFF
--- a/src/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -31,13 +31,18 @@ namespace Microsoft.DotNet.Tools.New
             var sessionId = Environment.GetEnvironmentVariable(MSBuildForwardingApp.TelemetrySessionIdEnvironmentVariableName);
             var telemetry = new Telemetry(new NuGetCacheSentinel(new CliFallbackFolderPathCalculator()), sessionId);
             var logger = new TelemetryLogger(null);
-            //(name, props, measures) =>
-            //{
-            //    if (telemetry.Enabled)
-            //    {
-            //        telemetry.TrackEvent(name, props, measures);
-            //    }
-            //});
+
+            if (telemetry.Enabled)
+            {
+                logger = new TelemetryLogger((name, props, measures) =>
+                {
+                    if (telemetry.Enabled)
+                    {
+                        telemetry.TrackEvent(name, props, measures);
+                    }
+                });
+            }
+
             return New3Command.Run(CommandName, CreateHost(), logger, FirstRun, args);
         }
 


### PR DESCRIPTION
Re-enables telemetry (conditioning the outer block to skip assigning the delegate when telemetry is off instead of checking each time).

@sayedihashimi 
