### PR TITLE
Add restore force option

### DIFF
--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
@@ -36,5 +36,8 @@ namespace Microsoft.DotNet.Tools.Restore
         public const string CmdIgnoreFailedSourcesOptionDescription = "Treat package source failures as warnings.";
 
         public const string CmdNoDependenciesOptionDescription = "Set this flag to ignore project to project references and only restore the root project.";
+
+        public const string CmdForceRestoreOptionDescription = "Set this flag to force all dependencies to be resolved even if the last restore was successful. This is equivalent to deleting project.assets.json.";
+
     }
 }

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -60,6 +60,11 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.CmdNoDependenciesOptionDescription,
                     Accept.NoArguments()
                           .ForwardAs("/p:RestoreRecursive=false")),
+                Create.Option(
+                    "-f|--force",
+                    LocalizableStrings.CmdForceRestoreOptionDescription,
+                    Accept.NoArguments()
+                          .ForwardAs("/p:RestoreForce=true")),
                 CommonOptions.VerbosityOption());
     }
 }


### PR DESCRIPTION
Adding the force option in the CLI, added in the NuGet as part of the restore no-op work.
More info here:
https://github.com/NuGet/Home/wiki/NuGet-Restore-No-Op 
&& 
https://github.com/NuGet/Home/wiki/%5BSpec%5D-NuGet-settings-in-MSBuild

This flag will be used by NuGet once 4.3.0.4118 or later is inserted:

Fixes: 
https://github.com/NuGet/Home/issues/5080
https://github.com/NuGet/Home/issues/5181

//cc 
@emgarten @rrelyea @nguerrera @livarcocc 