### PR TITLE
Add restore force option

### DIFF
--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.cs
@@ -33,5 +33,8 @@
         public const string CmdIgnoreFailedSourcesOptionDescription = "Treat package source failures as warnings.";
 
         public const string CmdNoDependenciesOptionDescription = "Set this flag to ignore project to project references and only restore the root project";
+
+        public const string CmdForceRestoreOptionDescription = "Set this flag to force all dependencies to be resolved even if the last restore was successful. This is equivalent to deleting project.assets.json.";
+
     }
 }

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -69,6 +69,11 @@ namespace Microsoft.DotNet.Tools.Restore
                 "--no-dependencies",
                 LocalizableStrings.CmdNoDependenciesOptionDescription,
                 CommandOptionType.NoValue);
+            
+            var forceOption = cmd.Option(
+                    $"-f|--force",
+                    LocalizableStrings.CmdForceRestoreOptionDescription,
+                    CommandOptionType.NoValue);
 
             CommandOption verbosityOption = MSBuildForwardingApp.AddVerbosityOption(cmd);
 
@@ -119,6 +124,11 @@ namespace Microsoft.DotNet.Tools.Restore
                 if (noDependenciesOption.HasValue())
                 {
                     msbuildArgs.Add($"/p:RestoreRecursive=false");
+                }
+                
+                if(forceOption.HasValue())
+                {
+                     msbuildArgs.Add($"/p:RestoreForce=true");                   
                 }
 
                 if (verbosityOption.HasValue())


### PR DESCRIPTION
Adding the force option in the CLI, added in the NuGet as part of the restore no-op work.
More info here:
https://github.com/NuGet/Home/wiki/NuGet-Restore-No-Op
&&
https://github.com/NuGet/Home/wiki/%5BSpec%5D-NuGet-settings-in-MSBuild

This flag will be used by NuGet once 4.3.0.4118 or later is inserted:

Fixes:
NuGet/Home#5080
NuGet/Home#5181

//cc
@emgarten @rrelyea @nguerrera @livarcocc