### PR TITLE
Minor template fixes

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -14,8 +14,8 @@
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
     <TemplateEngineVersion>1.0.0-beta2-20170531-247</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170602-250</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170602-250</TemplateEngineTemplate2_0Version>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170602-251</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170602-251</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.0.0-preview2-25402-02</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0-preview2-25402-02</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>


### PR DESCRIPTION
Fixes an issue where appsettings.json can be corrupted when the mvc template is generated
Re-adds browserlink as an optional feature for MVC and Razor Pages 2.0 templates
Exposes the option to generate a launchSettings.json file when creating a web template (the option existed, it's no longer being hidden)
Removes the unused switch from 2.0 web templates for including Application Insights