### PR TITLE
Add Implicit restore to run/build/publish/pack/test

### DIFF
--- a/src/dotnet/CommonLocalizableStrings.resx
+++ b/src/dotnet/CommonLocalizableStrings.resx
@@ -520,4 +520,7 @@
   <data name="ShowHelpDescription" xml:space="preserve">
     <value>Show help information.</value>
   </data>
+  <data name="NoRestoreDescription" xml:space="preserve">
+    <value>Does not do an implicit restore when executing the command.</value>
+  </data>
 </root>

--- a/src/dotnet/CommonOptions.cs
+++ b/src/dotnet/CommonOptions.cs
@@ -65,5 +65,11 @@ namespace Microsoft.DotNet.Cli
 
         public static ArgumentsRule DefaultToCurrentDirectory(this ArgumentsRule rule) =>
             rule.With(defaultValue: () => PathUtility.EnsureTrailingSlash(Directory.GetCurrentDirectory()));
+
+        public static Option NoRestoreOption() =>
+            Create.Option(
+                "--no-restore",
+                CommonLocalizableStrings.NoRestoreDescription,
+                Accept.NoArguments());
     }
 }

--- a/src/dotnet/commands/CommandWithRestoreOptions.cs
+++ b/src/dotnet/commands/CommandWithRestoreOptions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Tools.MSBuild;
+using Microsoft.DotNet.Tools.Restore;
+
+namespace Microsoft.DotNet.Tools
+{
+    public static class CreateWithRestoreOptions
+    {
+        public static Command Command(
+            string name,
+            string help,
+            ArgumentsRule arguments,
+            params Option[] options)
+        {
+            return Create.Command(name, help, arguments, RestoreCommandParser.AddImplicitRestoreOptions(options));
+        }
+
+        public static Command Command(
+            string name,
+            string help,
+            ArgumentsRule arguments,
+            bool treatUnmatchedTokensAsErrors,
+            params Option[] options)
+        {
+            return Create.Command(
+                name,
+                help,
+                arguments,
+                treatUnmatchedTokensAsErrors,
+                RestoreCommandParser.AddImplicitRestoreOptions(options));
+        }
+    }
+}

--- a/src/dotnet/commands/RestoringCommand.cs
+++ b/src/dotnet/commands/RestoringCommand.cs
@@ -14,23 +14,20 @@ namespace Microsoft.DotNet.Tools
 
         private IEnumerable<string> ArgsToForward { get; }
 
-        private IEnumerable<string> ArgsToForwardToRestore
+        private IEnumerable<string> ArgsToForwardToRestore()
         {
-            get
+            var restoreArguments = ArgsToForward.Where(a =>
+                !a.StartsWith("/t:") &&
+                !a.StartsWith("/target:") &&
+                !a.StartsWith("/ConsoleLoggerParameters:") &&
+                !a.StartsWith("/clp:"));
+
+            if (!restoreArguments.Any(a => a.StartsWith("/v:") || a.StartsWith("/verbosity:")))
             {
-                var restoreArguments = ArgsToForward.Where(a =>
-                    !a.StartsWith("/t:") &&
-                    !a.StartsWith("/target:") &&
-                    !a.StartsWith("/ConsoleLoggerParameters:") &&
-                    !a.StartsWith("/clp:"));
-
-                if (!restoreArguments.Any(a => a.StartsWith("/v:") || a.StartsWith("/verbosity:")))
-                {
-                    restoreArguments = restoreArguments.Concat(new string[] { "/v:q" });
-                }
-
-                return restoreArguments;
+                restoreArguments = restoreArguments.Concat(new string[] { "/v:q" });
             }
+
+            return restoreArguments;
         }
 
         private bool ShouldRunImplicitRestore => !NoRestore;
@@ -46,7 +43,7 @@ namespace Microsoft.DotNet.Tools
         {
             if (ShouldRunImplicitRestore)
             {
-                int exitCode = RestoreCommand.Run(ArgsToForwardToRestore.ToArray());
+                int exitCode = RestoreCommand.Run(ArgsToForwardToRestore().ToArray());
                 if (exitCode != 0)
                 {
                     return exitCode;

--- a/src/dotnet/commands/RestoringCommand.cs
+++ b/src/dotnet/commands/RestoringCommand.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.Tools.MSBuild;
+using Microsoft.DotNet.Tools.Restore;
+
+namespace Microsoft.DotNet.Tools
+{
+    public class RestoringCommand : MSBuildForwardingApp
+    {
+        private bool NoRestore { get; }
+
+        private IEnumerable<string> ArgsToForward { get; }
+
+        public RestoringCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
+            : base(msbuildArgs, msbuildPath)
+        {
+            NoRestore = noRestore;
+            ArgsToForward = msbuildArgs;
+        }
+
+        public override int Execute()
+        {
+            if (ShouldRunImplicitRestore)
+            {
+                int exitCode = RestoreCommand.Run(ArgsToForward.ToArray());
+                if (exitCode != 0)
+                {
+                    return exitCode;
+                }
+            }
+
+            return base.Execute();
+        }
+
+        private bool ShouldRunImplicitRestore => !NoRestore;
+    }
+}

--- a/src/dotnet/commands/dotnet-build/BuildCommand.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommand.cs
@@ -2,18 +2,21 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.MSBuild;
+using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Tools.Restore;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tools.Build
 {
-    public class BuildCommand : MSBuildForwardingApp
+    public class BuildCommand : RestoringCommand
     {
-        public BuildCommand(IEnumerable<string> msbuildArgs, string msbuildPath = null)
-            : base(msbuildArgs, msbuildPath)
+        public BuildCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
+            : base(msbuildArgs, noRestore, msbuildPath)
         {
         }
 
@@ -44,7 +47,9 @@ namespace Microsoft.DotNet.Tools.Build
 
             msbuildArgs.Add($"/clp:Summary");
 
-            return new BuildCommand(msbuildArgs, msbuildPath);
+            bool noRestore = appliedBuildOptions.HasOption("--no-restore");
+
+            return new BuildCommand(msbuildArgs, noRestore, msbuildPath);
         }
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.NoDependenciesOptionDescription,
                     Accept.NoArguments()
                           .ForwardAs("/p:BuildProjectReferences=false")),
+                CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());
     }
 }

--- a/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -12,49 +12,33 @@ namespace Microsoft.DotNet.Cli
     internal static class BuildCommandParser
     {
         public static Command Build() =>
-            Create.Command(
+            CreateWithRestoreOptions.Command(
                 "build",
                 LocalizableStrings.AppFullName,
                 Accept.ZeroOrMoreArguments()
                       .With(name: CommonLocalizableStrings.CmdProjectFile,
                             description:
                             "The MSBuild project file to build. If a project file is not specified, MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file."),
-                FullBuildOptions
-                );
-
-        private static Option[] FullBuildOptions
-        {
-            get
-            {
-                var fullBuildOptions = new List<Option>
-                {
-                    CommonOptions.HelpOption(),
-                    Create.Option(
-                        "-o|--output",
-                        LocalizableStrings.OutputOptionDescription,
-                        Accept.ExactlyOneArgument()
-                              .With(name: LocalizableStrings.OutputOptionName)
-                              .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
-                    CommonOptions.FrameworkOption(),
-                    CommonOptions.RuntimeOption(),
-                    CommonOptions.ConfigurationOption(),
-                    CommonOptions.VersionSuffixOption(),
-                    Create.Option(
-                        "--no-incremental",
-                        LocalizableStrings.NoIncrementialOptionDescription),
-                    Create.Option(
-                        "--no-dependencies",
-                        LocalizableStrings.NoDependenciesOptionDescription,
-                        Accept.NoArguments()
-                              .ForwardAs("/p:BuildProjectReferences=false")),
-                    CommonOptions.NoRestoreOption(),
-                    CommonOptions.VerbosityOption()
-                };
-
-                RestoreCommandParser.AddImplicitRestoreOptions(fullBuildOptions);
-
-                return fullBuildOptions.ToArray();
-            }
-        }
+                CommonOptions.HelpOption(),
+                Create.Option(
+                    "-o|--output",
+                    LocalizableStrings.OutputOptionDescription,
+                    Accept.ExactlyOneArgument()
+                          .With(name: LocalizableStrings.OutputOptionName)
+                          .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
+                CommonOptions.FrameworkOption(),
+                CommonOptions.RuntimeOption(),
+                CommonOptions.ConfigurationOption(),
+                CommonOptions.VersionSuffixOption(),
+                Create.Option(
+                    "--no-incremental",
+                    LocalizableStrings.NoIncrementialOptionDescription),
+                Create.Option(
+                    "--no-dependencies",
+                    LocalizableStrings.NoDependenciesOptionDescription,
+                    Accept.NoArguments()
+                          .ForwardAs("/p:BuildProjectReferences=false")),
+                CommonOptions.NoRestoreOption(),
+                CommonOptions.VerbosityOption());
     }
 }

--- a/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools;
@@ -18,26 +19,42 @@ namespace Microsoft.DotNet.Cli
                       .With(name: CommonLocalizableStrings.CmdProjectFile,
                             description:
                             "The MSBuild project file to build. If a project file is not specified, MSBuild searches the current working directory for a file that has a file extension that ends in `proj` and uses that file."),
-                CommonOptions.HelpOption(),
-                Create.Option(
-                    "-o|--output",
-                    LocalizableStrings.OutputOptionDescription,
-                    Accept.ExactlyOneArgument()
-                          .With(name: LocalizableStrings.OutputOptionName)
-                          .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
-                CommonOptions.FrameworkOption(),
-                CommonOptions.RuntimeOption(),
-                CommonOptions.ConfigurationOption(),
-                CommonOptions.VersionSuffixOption(),
-                Create.Option(
-                    "--no-incremental",
-                    LocalizableStrings.NoIncrementialOptionDescription),
-                Create.Option(
-                    "--no-dependencies",
-                    LocalizableStrings.NoDependenciesOptionDescription,
-                    Accept.NoArguments()
-                          .ForwardAs("/p:BuildProjectReferences=false")),
-                CommonOptions.NoRestoreOption(),
-                CommonOptions.VerbosityOption());
+                FullBuildOptions
+                );
+
+        private static Option[] FullBuildOptions
+        {
+            get
+            {
+                var fullBuildOptions = new List<Option>
+                {
+                    CommonOptions.HelpOption(),
+                    Create.Option(
+                        "-o|--output",
+                        LocalizableStrings.OutputOptionDescription,
+                        Accept.ExactlyOneArgument()
+                              .With(name: LocalizableStrings.OutputOptionName)
+                              .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
+                    CommonOptions.FrameworkOption(),
+                    CommonOptions.RuntimeOption(),
+                    CommonOptions.ConfigurationOption(),
+                    CommonOptions.VersionSuffixOption(),
+                    Create.Option(
+                        "--no-incremental",
+                        LocalizableStrings.NoIncrementialOptionDescription),
+                    Create.Option(
+                        "--no-dependencies",
+                        LocalizableStrings.NoDependenciesOptionDescription,
+                        Accept.NoArguments()
+                              .ForwardAs("/p:BuildProjectReferences=false")),
+                    CommonOptions.NoRestoreOption(),
+                    CommonOptions.VerbosityOption()
+                };
+
+                RestoreCommandParser.AddImplicitRestoreOptions(fullBuildOptions);
+
+                return fullBuildOptions.ToArray();
+            }
+        }
     }
 }

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             return ret;
         }
 
-        public int Execute()
+        public virtual int Execute()
         {
             return GetProcessStartInfo().Execute();
         }

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -5,16 +5,17 @@ using System.Collections.Generic;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools.MSBuild;
+using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Cli;
 using System.Diagnostics;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tools.Pack
 {
-    public class PackCommand : MSBuildForwardingApp
+    public class PackCommand : RestoringCommand
     {
-        public PackCommand(IEnumerable<string> msbuildArgs, string msbuildPath = null)
-            : base(msbuildArgs, msbuildPath)
+        public PackCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
+            : base(msbuildArgs, noRestore, msbuildPath)
         {
         }
 
@@ -30,14 +31,16 @@ namespace Microsoft.DotNet.Tools.Pack
           
             var msbuildArgs = new List<string>()
             {
-                    "/t:pack"
+                "/t:pack"
             };
 
             msbuildArgs.AddRange(parsedPack.OptionValuesToBeForwarded());
 
             msbuildArgs.AddRange(parsedPack.Arguments);
 
-            return new PackCommand(msbuildArgs, msbuildPath);
+            bool noRestore = parsedPack.HasOption("--no-restore");
+
+            return new PackCommand(msbuildArgs, noRestore, msbuildPath);
         }
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Tools;
 using LocalizableStrings = Microsoft.DotNet.Tools.Pack.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli
@@ -11,51 +12,36 @@ namespace Microsoft.DotNet.Cli
     internal static class PackCommandParser
     {
         public static Command Pack() =>
-            Create.Command(
+            CreateWithRestoreOptions.Command(
                 "pack",
                 LocalizableStrings.AppFullName,
                 Accept.ZeroOrMoreArguments(),
-                FullPackOptions);
-
-        private static Option[] FullPackOptions
-        {
-            get
-            {
-                var fullPackOptions = new List<Option>
-                {
-                    CommonOptions.HelpOption(),
-                    Create.Option(
-                        "-o|--output",
-                        LocalizableStrings.CmdOutputDirDescription,
-                        Accept.ExactlyOneArgument()
-                            .With(name: LocalizableStrings.CmdOutputDir)
-                            .ForwardAsSingle(o => $"/p:PackageOutputPath={o.Arguments.Single()}")),
-                    Create.Option(
-                        "--no-build",
-                        LocalizableStrings.CmdNoBuildOptionDescription,
-                        Accept.NoArguments().ForwardAs("/p:NoBuild=true")),
-                    Create.Option(
-                        "--include-symbols",
-                        LocalizableStrings.CmdIncludeSymbolsDescription,
-                        Accept.NoArguments().ForwardAs("/p:IncludeSymbols=true")),
-                    Create.Option(
-                        "--include-source",
-                        LocalizableStrings.CmdIncludeSourceDescription,
-                        Accept.NoArguments().ForwardAs("/p:IncludeSource=true")),
-                    CommonOptions.ConfigurationOption(),
-                    CommonOptions.VersionSuffixOption(),
-                    Create.Option(
-                        "-s|--serviceable",
-                        LocalizableStrings.CmdServiceableDescription,
-                        Accept.NoArguments().ForwardAs("/p:Serviceable=true")),
-                    CommonOptions.NoRestoreOption(),
-                    CommonOptions.VerbosityOption()
-                };
-
-                RestoreCommandParser.AddImplicitRestoreOptions(fullPackOptions);
-
-                return fullPackOptions.ToArray();
-            }
-        }
+                CommonOptions.HelpOption(),
+                Create.Option(
+                    "-o|--output",
+                    LocalizableStrings.CmdOutputDirDescription,
+                    Accept.ExactlyOneArgument()
+                        .With(name: LocalizableStrings.CmdOutputDir)
+                        .ForwardAsSingle(o => $"/p:PackageOutputPath={o.Arguments.Single()}")),
+                Create.Option(
+                    "--no-build",
+                    LocalizableStrings.CmdNoBuildOptionDescription,
+                    Accept.NoArguments().ForwardAs("/p:NoBuild=true")),
+                Create.Option(
+                    "--include-symbols",
+                    LocalizableStrings.CmdIncludeSymbolsDescription,
+                    Accept.NoArguments().ForwardAs("/p:IncludeSymbols=true")),
+                Create.Option(
+                    "--include-source",
+                    LocalizableStrings.CmdIncludeSourceDescription,
+                    Accept.NoArguments().ForwardAs("/p:IncludeSource=true")),
+                CommonOptions.ConfigurationOption(),
+                CommonOptions.VersionSuffixOption(),
+                Create.Option(
+                    "-s|--serviceable",
+                    LocalizableStrings.CmdServiceableDescription,
+                    Accept.NoArguments().ForwardAs("/p:Serviceable=true")),
+                CommonOptions.NoRestoreOption(),
+                CommonOptions.VerbosityOption());
     }
 }

--- a/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -39,6 +39,7 @@ namespace Microsoft.DotNet.Cli
                     "-s|--serviceable",
                     LocalizableStrings.CmdServiceableDescription,
                     Accept.NoArguments().ForwardAs("/p:Serviceable=true")),
+                CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());
     }
 }

--- a/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using LocalizableStrings = Microsoft.DotNet.Tools.Pack.LocalizableStrings;
@@ -14,32 +15,47 @@ namespace Microsoft.DotNet.Cli
                 "pack",
                 LocalizableStrings.AppFullName,
                 Accept.ZeroOrMoreArguments(),
-                CommonOptions.HelpOption(),
-                Create.Option(
-                    "-o|--output",
-                    LocalizableStrings.CmdOutputDirDescription,
-                    Accept.ExactlyOneArgument()
-                        .With(name: LocalizableStrings.CmdOutputDir)
-                        .ForwardAsSingle(o => $"/p:PackageOutputPath={o.Arguments.Single()}")),
-                Create.Option(
-                    "--no-build",
-                    LocalizableStrings.CmdNoBuildOptionDescription,
-                    Accept.NoArguments().ForwardAs("/p:NoBuild=true")),
-                Create.Option(
-                    "--include-symbols",
-                    LocalizableStrings.CmdIncludeSymbolsDescription,
-                    Accept.NoArguments().ForwardAs("/p:IncludeSymbols=true")),
-                Create.Option(
-                    "--include-source",
-                    LocalizableStrings.CmdIncludeSourceDescription,
-                    Accept.NoArguments().ForwardAs("/p:IncludeSource=true")),
-                CommonOptions.ConfigurationOption(),
-                CommonOptions.VersionSuffixOption(),
-                Create.Option(
-                    "-s|--serviceable",
-                    LocalizableStrings.CmdServiceableDescription,
-                    Accept.NoArguments().ForwardAs("/p:Serviceable=true")),
-                CommonOptions.NoRestoreOption(),
-                CommonOptions.VerbosityOption());
+                FullPackOptions);
+
+        private static Option[] FullPackOptions
+        {
+            get
+            {
+                var fullPackOptions = new List<Option>
+                {
+                    CommonOptions.HelpOption(),
+                    Create.Option(
+                        "-o|--output",
+                        LocalizableStrings.CmdOutputDirDescription,
+                        Accept.ExactlyOneArgument()
+                            .With(name: LocalizableStrings.CmdOutputDir)
+                            .ForwardAsSingle(o => $"/p:PackageOutputPath={o.Arguments.Single()}")),
+                    Create.Option(
+                        "--no-build",
+                        LocalizableStrings.CmdNoBuildOptionDescription,
+                        Accept.NoArguments().ForwardAs("/p:NoBuild=true")),
+                    Create.Option(
+                        "--include-symbols",
+                        LocalizableStrings.CmdIncludeSymbolsDescription,
+                        Accept.NoArguments().ForwardAs("/p:IncludeSymbols=true")),
+                    Create.Option(
+                        "--include-source",
+                        LocalizableStrings.CmdIncludeSourceDescription,
+                        Accept.NoArguments().ForwardAs("/p:IncludeSource=true")),
+                    CommonOptions.ConfigurationOption(),
+                    CommonOptions.VersionSuffixOption(),
+                    Create.Option(
+                        "-s|--serviceable",
+                        LocalizableStrings.CmdServiceableDescription,
+                        Accept.NoArguments().ForwardAs("/p:Serviceable=true")),
+                    CommonOptions.NoRestoreOption(),
+                    CommonOptions.VerbosityOption()
+                };
+
+                RestoreCommandParser.AddImplicitRestoreOptions(fullPackOptions);
+
+                return fullPackOptions.ToArray();
+            }
+        }
     }
 }

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -5,15 +5,16 @@ using System.Collections.Generic;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.MSBuild;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tools.Publish
 {
-    public class PublishCommand : MSBuildForwardingApp
+    public class PublishCommand : RestoringCommand
     {
-        private PublishCommand(IEnumerable<string> msbuildArgs, string msbuildPath = null)
-            : base(msbuildArgs, msbuildPath)
+        private PublishCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
+            : base(msbuildArgs, noRestore, msbuildPath)
         {
         }
 
@@ -37,7 +38,9 @@ namespace Microsoft.DotNet.Tools.Publish
 
             msbuildArgs.AddRange(appliedPublishOption.Arguments);
 
-            return new PublishCommand(msbuildArgs, msbuildPath);
+            bool noRestore = appliedPublishOption.HasOption("--no-restore");
+
+            return new PublishCommand(msbuildArgs, noRestore, msbuildPath);
         }
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using LocalizableStrings = Microsoft.DotNet.Tools.Publish.LocalizableStrings;
@@ -14,34 +15,49 @@ namespace Microsoft.DotNet.Cli
                 "publish",
                 LocalizableStrings.AppDescription,
                 Accept.ZeroOrMoreArguments(),
-                CommonOptions.HelpOption(),
-                Create.Option(
-                    "-o|--output",
-                    LocalizableStrings.OutputOptionDescription,
-                    Accept.ExactlyOneArgument()
-                        .With(name: LocalizableStrings.OutputOption)
-                        .ForwardAsSingle(o => $"/p:PublishDir={o.Arguments.Single()}")),
-                CommonOptions.FrameworkOption(),
-                CommonOptions.RuntimeOption(),
-                CommonOptions.ConfigurationOption(),
-                CommonOptions.VersionSuffixOption(),
-                Create.Option(
-                    "--manifest",
-                    LocalizableStrings.ManifestOptionDescription,
-                    Accept.OneOrMoreArguments()
-                        .With(name: LocalizableStrings.ManifestOption)
-                        .ForwardAsSingle(o => $"/p:TargetManifestFiles={string.Join("%3B", o.Arguments)}")),
-                Create.Option(
-                    "--self-contained",
-                    LocalizableStrings.SelfContainedOptionDescription,
-                    Accept.ZeroOrOneArgument()
-                        .WithSuggestionsFrom("true", "false")
-                        .ForwardAsSingle(o =>
-                        {
-                            string value = o.Arguments.Any() ? o.Arguments.Single() : "true";
-                            return $"/p:SelfContained={value}";
-                        })),
-                CommonOptions.NoRestoreOption(),
-                CommonOptions.VerbosityOption());
+                FullPublishOptions);
+
+        private static Option[] FullPublishOptions
+        {
+            get
+            {
+                var fullPublishOptions = new List<Option>
+                {
+                    CommonOptions.HelpOption(),
+                    Create.Option(
+                        "-o|--output",
+                        LocalizableStrings.OutputOptionDescription,
+                        Accept.ExactlyOneArgument()
+                            .With(name: LocalizableStrings.OutputOption)
+                            .ForwardAsSingle(o => $"/p:PublishDir={o.Arguments.Single()}")),
+                    CommonOptions.FrameworkOption(),
+                    CommonOptions.RuntimeOption(),
+                    CommonOptions.ConfigurationOption(),
+                    CommonOptions.VersionSuffixOption(),
+                    Create.Option(
+                        "--manifest",
+                        LocalizableStrings.ManifestOptionDescription,
+                        Accept.OneOrMoreArguments()
+                            .With(name: LocalizableStrings.ManifestOption)
+                            .ForwardAsSingle(o => $"/p:TargetManifestFiles={string.Join("%3B", o.Arguments)}")),
+                    Create.Option(
+                        "--self-contained",
+                        LocalizableStrings.SelfContainedOptionDescription,
+                        Accept.ZeroOrOneArgument()
+                            .WithSuggestionsFrom("true", "false")
+                            .ForwardAsSingle(o =>
+                            {
+                                string value = o.Arguments.Any() ? o.Arguments.Single() : "true";
+                                return $"/p:SelfContained={value}";
+                            })),
+                    CommonOptions.NoRestoreOption(),
+                    CommonOptions.VerbosityOption()
+                };
+
+                RestoreCommandParser.AddImplicitRestoreOptions(fullPublishOptions);
+
+                return fullPublishOptions.ToArray();
+            }
+        }
     }
 }

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -41,6 +41,7 @@ namespace Microsoft.DotNet.Cli
                             string value = o.Arguments.Any() ? o.Arguments.Single() : "true";
                             return $"/p:SelfContained={value}";
                         })),
+                CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());
     }
 }

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Tools;
 using LocalizableStrings = Microsoft.DotNet.Tools.Publish.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli
@@ -11,53 +12,38 @@ namespace Microsoft.DotNet.Cli
     internal static class PublishCommandParser
     {
         public static Command Publish() =>
-            Create.Command(
+            CreateWithRestoreOptions.Command(
                 "publish",
                 LocalizableStrings.AppDescription,
                 Accept.ZeroOrMoreArguments(),
-                FullPublishOptions);
-
-        private static Option[] FullPublishOptions
-        {
-            get
-            {
-                var fullPublishOptions = new List<Option>
-                {
-                    CommonOptions.HelpOption(),
-                    Create.Option(
-                        "-o|--output",
-                        LocalizableStrings.OutputOptionDescription,
-                        Accept.ExactlyOneArgument()
-                            .With(name: LocalizableStrings.OutputOption)
-                            .ForwardAsSingle(o => $"/p:PublishDir={o.Arguments.Single()}")),
-                    CommonOptions.FrameworkOption(),
-                    CommonOptions.RuntimeOption(),
-                    CommonOptions.ConfigurationOption(),
-                    CommonOptions.VersionSuffixOption(),
-                    Create.Option(
-                        "--manifest",
-                        LocalizableStrings.ManifestOptionDescription,
-                        Accept.OneOrMoreArguments()
-                            .With(name: LocalizableStrings.ManifestOption)
-                            .ForwardAsSingle(o => $"/p:TargetManifestFiles={string.Join("%3B", o.Arguments)}")),
-                    Create.Option(
-                        "--self-contained",
-                        LocalizableStrings.SelfContainedOptionDescription,
-                        Accept.ZeroOrOneArgument()
-                            .WithSuggestionsFrom("true", "false")
-                            .ForwardAsSingle(o =>
-                            {
-                                string value = o.Arguments.Any() ? o.Arguments.Single() : "true";
-                                return $"/p:SelfContained={value}";
-                            })),
-                    CommonOptions.NoRestoreOption(),
-                    CommonOptions.VerbosityOption()
-                };
-
-                RestoreCommandParser.AddImplicitRestoreOptions(fullPublishOptions);
-
-                return fullPublishOptions.ToArray();
-            }
-        }
+                CommonOptions.HelpOption(),
+                Create.Option(
+                    "-o|--output",
+                    LocalizableStrings.OutputOptionDescription,
+                    Accept.ExactlyOneArgument()
+                        .With(name: LocalizableStrings.OutputOption)
+                        .ForwardAsSingle(o => $"/p:PublishDir={o.Arguments.Single()}")),
+                CommonOptions.FrameworkOption(),
+                CommonOptions.RuntimeOption(),
+                CommonOptions.ConfigurationOption(),
+                CommonOptions.VersionSuffixOption(),
+                Create.Option(
+                    "--manifest",
+                    LocalizableStrings.ManifestOptionDescription,
+                    Accept.OneOrMoreArguments()
+                        .With(name: LocalizableStrings.ManifestOption)
+                        .ForwardAsSingle(o => $"/p:TargetManifestFiles={string.Join("%3B", o.Arguments)}")),
+                Create.Option(
+                    "--self-contained",
+                    LocalizableStrings.SelfContainedOptionDescription,
+                    Accept.ZeroOrOneArgument()
+                        .WithSuggestionsFrom("true", "false")
+                        .ForwardAsSingle(o =>
+                        {
+                            string value = o.Arguments.Any() ? o.Arguments.Single() : "true";
+                            return $"/p:SelfContained={value}";
+                        })),
+                CommonOptions.NoRestoreOption(),
+                CommonOptions.VerbosityOption());
     }
 }

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Restore
                 "/t:Restore"
             };
 
-            if (!parsedRestore.HasOption("verbosity"))
+            if (!HasVerbosityOption(parsedRestore))
             {
                 msbuildArgs.Add("/ConsoleLoggerParameters:Verbosity=Minimal");
             }
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Tools.Restore
             msbuildArgs.AddRange(parsedRestore.OptionValuesToBeForwarded());
 
             msbuildArgs.AddRange(parsedRestore.Arguments);
-            
+
             return new RestoreCommand(msbuildArgs, msbuildPath);
         }
 
@@ -64,6 +64,13 @@ namespace Microsoft.DotNet.Tools.Restore
             }
             
             return cmd.Execute();
+        }
+
+        private static bool HasVerbosityOption(AppliedOption parsedRestore)
+        {
+            return parsedRestore.HasOption("verbosity") ||
+                   parsedRestore.Arguments.Any(a => a.Contains("/v:")) ||
+                   parsedRestore.Arguments.Any(a => a.Contains("/verbosity:"));
         }
     }
 }

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -15,28 +15,27 @@ namespace Microsoft.DotNet.Cli
                 "restore",
                 LocalizableStrings.AppFullName,
                 Accept.ZeroOrMoreArguments(),
-                FullRestoreOptions);
+                FullRestoreOptions());
 
-        private static Option[] FullRestoreOptions
+        private static Option[] FullRestoreOptions()
         {
-            get
-            {
-                var fullRestoreOptions = new List<Option>();
+            var fullRestoreOptions = AddImplicitRestoreOptions(new Option[] { CommonOptions.HelpOption() }, true, true);
 
-                fullRestoreOptions.Add(CommonOptions.HelpOption());
-                AddImplicitRestoreOptions(fullRestoreOptions, true, true);
-                fullRestoreOptions.Add(CommonOptions.VerbosityOption());
-
-                return fullRestoreOptions.ToArray();
-            }
+            return fullRestoreOptions.Concat(new Option[] { CommonOptions.VerbosityOption() }).ToArray();
         }
 
-        public static void AddImplicitRestoreOptions(
-            List<Option> commandOptions,
-            bool showHelp = false,
-            bool useShortOptions = false)
+        public static Option[] AddImplicitRestoreOptions(
+            IEnumerable<Option> commandOptions)
         {
-            commandOptions.AddRange(ImplicitRestoreOptions(showHelp, useShortOptions)
+            return AddImplicitRestoreOptions(commandOptions, false, false).ToArray();
+        }
+
+        private static IEnumerable<Option> AddImplicitRestoreOptions(
+            IEnumerable<Option> commandOptions,
+            bool showHelp,
+            bool useShortOptions)
+        {
+            return commandOptions.Concat(ImplicitRestoreOptions(showHelp, useShortOptions)
                 .Where(o => !commandOptions.Any(c => c.Name == o.Name)));
         }
 
@@ -89,11 +88,10 @@ namespace Microsoft.DotNet.Cli
                     Accept.NoArguments()
                           .ForwardAs("/p:RestoreRecursive=false")),
                 Create.Option(
-                    "-f|--force",
+                    useShortOptions ? "-f|--force" : "--force",
                     LocalizableStrings.CmdForceRestoreOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("/p:RestoreForce=true")),
-                CommonOptions.VerbosityOption()
+                          .ForwardAs("/p:RestoreForce=true"))
             };
         }
     }

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Tools.Run
         public string Project { get; private set; }
         public IReadOnlyCollection<string> Args { get; private set; }
         public bool NoRestore { get; private set; }
+        public IEnumerable<string> RestoreArgs { get; private set; }
 
         private List<string> _args;
         private bool ShouldBuild => !NoBuild;
@@ -58,6 +59,7 @@ namespace Microsoft.DotNet.Tools.Run
             string launchProfile,
             bool noLaunchProfile,
             bool noRestore,
+            IEnumerable<string> restoreArgs,
             IReadOnlyCollection<string> args)
         {
             Configuration = configuration;
@@ -67,6 +69,7 @@ namespace Microsoft.DotNet.Tools.Run
             LaunchProfile = launchProfile;
             NoLaunchProfile = noLaunchProfile;
             Args = args;
+            RestoreArgs = restoreArgs;
             NoRestore = noRestore;
         }
 
@@ -77,6 +80,7 @@ namespace Microsoft.DotNet.Tools.Run
             string launchProfile = null,
             bool? noLaunchProfile = null,
             bool? noRestore = null,
+            IEnumerable<string> restoreArgs = null,
             IReadOnlyCollection<string> args = null)
         {
             return new RunCommand(
@@ -87,6 +91,7 @@ namespace Microsoft.DotNet.Tools.Run
                 launchProfile ?? this.LaunchProfile,
                 noLaunchProfile ?? this.NoLaunchProfile,
                 noRestore ?? this.NoRestore,
+                restoreArgs ?? this.RestoreArgs,
                 args ?? this.Args
             );
         }
@@ -138,15 +143,7 @@ namespace Microsoft.DotNet.Tools.Run
             buildArgs.Add("/nologo");
             buildArgs.Add("/verbosity:quiet");
 
-            if (!string.IsNullOrWhiteSpace(Configuration))
-            {
-                buildArgs.Add($"/p:Configuration={Configuration}");
-            }
-
-            if (!string.IsNullOrWhiteSpace(Framework))
-            {
-                buildArgs.Add($"/p:TargetFramework={Framework}");
-            }
+            buildArgs.AddRange(RestoreArgs);
 
             var buildResult = new RestoringCommand(buildArgs, NoRestore).Execute();
             if (buildResult != 0)

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.Run;
 using LocalizableStrings = Microsoft.DotNet.Tools.Run.LocalizableStrings;
 
@@ -12,7 +13,7 @@ namespace Microsoft.DotNet.Cli
     internal static class RunCommandParser
     {
         public static Command Run() =>
-            Create.Command(
+            CreateWithRestoreOptions.Command(
                 "run",
                 LocalizableStrings.AppFullName,
                 treatUnmatchedTokensAsErrors: false,
@@ -29,13 +30,7 @@ namespace Microsoft.DotNet.Cli
                         restoreArgs: o.OptionValuesToBeForwarded(),
                         args: o.Arguments
                     )),
-                options: FullRunOptions);
-
-        private static Option[] FullRunOptions
-        {
-            get
-            {
-                var fullRunOptions = new List<Option>
+                options: new[]
                 {
                     CommonOptions.HelpOption(),
                     CommonOptions.ConfigurationOption(),
@@ -57,12 +52,6 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CommandOptionNoBuildDescription,
                         Accept.NoArguments()),
                     CommonOptions.NoRestoreOption()
-                };
-
-                RestoreCommandParser.AddImplicitRestoreOptions(fullRunOptions);
-
-                return fullRunOptions.ToArray();
-            }
-        }
+                });
     }
 }

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools.Run;
 using LocalizableStrings = Microsoft.DotNet.Tools.Run.LocalizableStrings;
@@ -24,9 +26,16 @@ namespace Microsoft.DotNet.Cli
                         launchProfile: o.SingleArgumentOrDefault("--launch-profile"),
                         noLaunchProfile: o.HasOption("--no-launch-profile"),
                         noRestore: o.HasOption("--no-restore"),
+                        restoreArgs: o.OptionValuesToBeForwarded(),
                         args: o.Arguments
                     )),
-                options: new[]
+                options: FullRunOptions);
+
+        private static Option[] FullRunOptions
+        {
+            get
+            {
+                var fullRunOptions = new List<Option>
                 {
                     CommonOptions.HelpOption(),
                     CommonOptions.ConfigurationOption(),
@@ -47,7 +56,13 @@ namespace Microsoft.DotNet.Cli
                         "--no-build",
                         LocalizableStrings.CommandOptionNoBuildDescription,
                         Accept.NoArguments()),
-                    CommonOptions.NoRestoreOption(),
-                });
+                    CommonOptions.NoRestoreOption()
+                };
+
+                RestoreCommandParser.AddImplicitRestoreOptions(fullRunOptions);
+
+                return fullRunOptions.ToArray();
+            }
+        }
     }
 }

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Cli
                         project: o.SingleArgumentOrDefault("--project"),
                         launchProfile: o.SingleArgumentOrDefault("--launch-profile"),
                         noLaunchProfile: o.HasOption("--no-launch-profile"),
+                        noRestore: o.HasOption("--no-restore"),
                         args: o.Arguments
                     )),
                 options: new[]
@@ -45,7 +46,8 @@ namespace Microsoft.DotNet.Cli
                     Create.Option(
                         "--no-build",
                         LocalizableStrings.CommandOptionNoBuildDescription,
-                        Accept.NoArguments())
+                        Accept.NoArguments()),
+                    CommonOptions.NoRestoreOption(),
                 });
     }
 }

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -14,10 +14,10 @@ using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tools.Test
 {
-    public class TestCommand : MSBuildForwardingApp
+    public class TestCommand : RestoringCommand
     {
-        public TestCommand(IEnumerable<string> msbuildArgs, string msbuildPath = null)
-            : base(msbuildArgs, msbuildPath)
+        public TestCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
+            : base(msbuildArgs, noRestore, msbuildPath)
         {
         }
 
@@ -65,7 +65,9 @@ namespace Microsoft.DotNet.Tools.Test
                 }
             }
 
-            return new TestCommand(msbuildArgs, msbuildPath);
+            bool noRestore = parsedTest.HasOption("--no-restore");
+
+            return new TestCommand(msbuildArgs, noRestore, msbuildPath);
         }
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -81,6 +81,7 @@ namespace Microsoft.DotNet.Cli
                         Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.cmdCollectFriendlyName)
                               .ForwardAsSingle(o => $"/p:VSTestCollect=\"{string.Join(";", o.Arguments)}\"")),
+                  CommonOptions.NoRestoreOption(),
                   CommonOptions.VerbosityOption());
 
         private static string GetSemiColonEsacpedstring(string arg)

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Tools;
 using LocalizableStrings = Microsoft.DotNet.Tools.Test.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli
@@ -18,89 +19,74 @@ namespace Microsoft.DotNet.Cli
                         .With(name: LocalizableStrings.CmdArgProject,
                               description: LocalizableStrings.CmdArgDescription),
                   false,
-                  FullTestOptions);
+                  CommonOptions.HelpOption(),
+                  Create.Option(
+                        "-s|--settings",
+                        LocalizableStrings.CmdSettingsDescription,
+                        Accept.ExactlyOneArgument()
+                              .With(name: LocalizableStrings.CmdSettingsFile)
+                              .ForwardAsSingle(o => $"/p:VSTestSetting={o.Arguments.Single()}")),
+                  Create.Option(
+                        "-t|--list-tests",
+                        LocalizableStrings.CmdListTestsDescription,
+                        Accept.NoArguments()
+                              .ForwardAsSingle(o => "/p:VSTestListTests=true")),
+                  Create.Option(
+                        "--filter",
+                        LocalizableStrings.CmdTestCaseFilterDescription,
+                        Accept.ExactlyOneArgument()
+                              .With(name: LocalizableStrings.CmdTestCaseFilterExpression)
+                              .ForwardAsSingle(o => $"/p:VSTestTestCaseFilter={o.Arguments.Single()}")),
+                  Create.Option(
+                        "-a|--test-adapter-path",
+                        LocalizableStrings.CmdTestAdapterPathDescription,
+                        Accept.ExactlyOneArgument()
+                              .With(name: LocalizableStrings.CmdTestAdapterPath)
+                              .ForwardAsSingle(o => $"/p:VSTestTestAdapterPath={o.Arguments.Single()}")),
+                  Create.Option(
+                        "-l|--logger",
+                        LocalizableStrings.CmdLoggerDescription,
+                        Accept.ExactlyOneArgument()
+                              .With(name: LocalizableStrings.CmdLoggerOption)
+                              .ForwardAsSingle(o =>
+                                    {
+                                          var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
 
-        private static Option[] FullTestOptions
-        {
-            get
-            {
-                var fullTestOptions = new List<Option>
-                {
-                    CommonOptions.HelpOption(),
-                      Create.Option(
-                            "-s|--settings",
-                            LocalizableStrings.CmdSettingsDescription,
-                            Accept.ExactlyOneArgument()
-                                  .With(name: LocalizableStrings.CmdSettingsFile)
-                                  .ForwardAsSingle(o => $"/p:VSTestSetting={o.Arguments.Single()}")),
-                      Create.Option(
-                            "-t|--list-tests",
-                            LocalizableStrings.CmdListTestsDescription,
-                            Accept.NoArguments()
-                                  .ForwardAsSingle(o => "/p:VSTestListTests=true")),
-                      Create.Option(
-                            "--filter",
-                            LocalizableStrings.CmdTestCaseFilterDescription,
-                            Accept.ExactlyOneArgument()
-                                  .With(name: LocalizableStrings.CmdTestCaseFilterExpression)
-                                  .ForwardAsSingle(o => $"/p:VSTestTestCaseFilter={o.Arguments.Single()}")),
-                      Create.Option(
-                            "-a|--test-adapter-path",
-                            LocalizableStrings.CmdTestAdapterPathDescription,
-                            Accept.ExactlyOneArgument()
-                                  .With(name: LocalizableStrings.CmdTestAdapterPath)
-                                  .ForwardAsSingle(o => $"/p:VSTestTestAdapterPath={o.Arguments.Single()}")),
-                      Create.Option(
-                            "-l|--logger",
-                            LocalizableStrings.CmdLoggerDescription,
-                            Accept.ExactlyOneArgument()
-                                  .With(name: LocalizableStrings.CmdLoggerOption)
-                                  .ForwardAsSingle(o =>
-                                        {
-                                              var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
-
-                                              return $"/p:VSTestLogger={loggersString}";
-                                        })),
-                      CommonOptions.ConfigurationOption(),
-                      CommonOptions.FrameworkOption(),
-                      Create.Option(
-                            "-o|--output",
-                            LocalizableStrings.CmdOutputDescription,
-                            Accept.ExactlyOneArgument()
-                                  .With(name: LocalizableStrings.CmdOutputDir)
-                                  .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
-                      Create.Option(
-                            "-d|--diag",
-                            LocalizableStrings.CmdPathTologFileDescription,
-                            Accept.ExactlyOneArgument()
-                                  .With(name: LocalizableStrings.CmdPathToLogFile)
-                                  .ForwardAsSingle(o => $"/p:VSTestDiag={o.Arguments.Single()}")),
-                      Create.Option(
-                            "--no-build",
-                            LocalizableStrings.CmdNoBuildDescription,
-                            Accept.NoArguments()
-                                  .ForwardAsSingle(o => "/p:VSTestNoBuild=true")),
-                      Create.Option(
-                            "-r|--results-directory",
-                            LocalizableStrings.CmdResultsDirectoryDescription,
-                            Accept.ExactlyOneArgument()
-                                  .With(name: LocalizableStrings.CmdPathToResultsDirectory)
-                                  .ForwardAsSingle(o => $"/p:VSTestResultsDirectory={o.Arguments.Single()}")),
-                      Create.Option(
-                            "--collect",
-                            LocalizableStrings.cmdCollectDescription,
-                            Accept.OneOrMoreArguments()
-                                  .With(name: LocalizableStrings.cmdCollectFriendlyName)
-                                  .ForwardAsSingle(o => $"/p:VSTestCollect=\"{string.Join(";", o.Arguments)}\"")),
-                      CommonOptions.NoRestoreOption(),
-                      CommonOptions.VerbosityOption()
-                };
-
-                RestoreCommandParser.AddImplicitRestoreOptions(fullTestOptions);
-
-                return fullTestOptions.ToArray();
-            }
-        }
+                                          return $"/p:VSTestLogger={loggersString}";
+                                    })),
+                  CommonOptions.ConfigurationOption(),
+                  CommonOptions.FrameworkOption(),
+                  Create.Option(
+                        "-o|--output",
+                        LocalizableStrings.CmdOutputDescription,
+                        Accept.ExactlyOneArgument()
+                              .With(name: LocalizableStrings.CmdOutputDir)
+                              .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
+                  Create.Option(
+                        "-d|--diag",
+                        LocalizableStrings.CmdPathTologFileDescription,
+                        Accept.ExactlyOneArgument()
+                              .With(name: LocalizableStrings.CmdPathToLogFile)
+                              .ForwardAsSingle(o => $"/p:VSTestDiag={o.Arguments.Single()}")),
+                  Create.Option(
+                        "--no-build",
+                        LocalizableStrings.CmdNoBuildDescription,
+                        Accept.NoArguments()
+                              .ForwardAsSingle(o => "/p:VSTestNoBuild=true")),
+                  Create.Option(
+                        "-r|--results-directory",
+                        LocalizableStrings.CmdResultsDirectoryDescription,
+                        Accept.ExactlyOneArgument()
+                              .With(name: LocalizableStrings.CmdPathToResultsDirectory)
+                              .ForwardAsSingle(o => $"/p:VSTestResultsDirectory={o.Arguments.Single()}")),
+                  Create.Option(
+                        "--collect",
+                        LocalizableStrings.cmdCollectDescription,
+                        Accept.OneOrMoreArguments()
+                              .With(name: LocalizableStrings.cmdCollectFriendlyName)
+                              .ForwardAsSingle(o => $"/p:VSTestCollect=\"{string.Join(";", o.Arguments)}\"")),
+                  CommonOptions.NoRestoreOption(),
+                  CommonOptions.VerbosityOption());
 
         private static string GetSemiColonEsacpedstring(string arg)
         {

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
@@ -15,74 +18,89 @@ namespace Microsoft.DotNet.Cli
                         .With(name: LocalizableStrings.CmdArgProject,
                               description: LocalizableStrings.CmdArgDescription),
                   false,
-                  CommonOptions.HelpOption(),
-                  Create.Option(
-                        "-s|--settings",
-                        LocalizableStrings.CmdSettingsDescription,
-                        Accept.ExactlyOneArgument()
-                              .With(name: LocalizableStrings.CmdSettingsFile)
-                              .ForwardAsSingle(o => $"/p:VSTestSetting={o.Arguments.Single()}")),
-                  Create.Option(
-                        "-t|--list-tests",
-                        LocalizableStrings.CmdListTestsDescription,
-                        Accept.NoArguments()
-                              .ForwardAsSingle(o => "/p:VSTestListTests=true")),
-                  Create.Option(
-                        "--filter",
-                        LocalizableStrings.CmdTestCaseFilterDescription,
-                        Accept.ExactlyOneArgument()
-                              .With(name: LocalizableStrings.CmdTestCaseFilterExpression)
-                              .ForwardAsSingle(o => $"/p:VSTestTestCaseFilter={o.Arguments.Single()}")),
-                  Create.Option(
-                        "-a|--test-adapter-path",
-                        LocalizableStrings.CmdTestAdapterPathDescription,
-                        Accept.ExactlyOneArgument()
-                              .With(name: LocalizableStrings.CmdTestAdapterPath)
-                              .ForwardAsSingle(o => $"/p:VSTestTestAdapterPath={o.Arguments.Single()}")),
-                  Create.Option(
-                        "-l|--logger",
-                        LocalizableStrings.CmdLoggerDescription,
-                        Accept.ExactlyOneArgument()
-                              .With(name: LocalizableStrings.CmdLoggerOption)
-                              .ForwardAsSingle(o => 
-                                    {
-                                          var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments)); 
-                                          
-                                          return $"/p:VSTestLogger={loggersString}";
-                                    })),
-                  CommonOptions.ConfigurationOption(),
-                  CommonOptions.FrameworkOption(),
-                  Create.Option(
-                        "-o|--output",
-                        LocalizableStrings.CmdOutputDescription,
-                        Accept.ExactlyOneArgument()
-                              .With(name: LocalizableStrings.CmdOutputDir)
-                              .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
-                  Create.Option(
-                        "-d|--diag",
-                        LocalizableStrings.CmdPathTologFileDescription,
-                        Accept.ExactlyOneArgument()
-                              .With(name: LocalizableStrings.CmdPathToLogFile)
-                              .ForwardAsSingle(o => $"/p:VSTestDiag={o.Arguments.Single()}")),
-                  Create.Option(
-                        "--no-build",
-                        LocalizableStrings.CmdNoBuildDescription,
-                        Accept.NoArguments()
-                              .ForwardAsSingle(o => "/p:VSTestNoBuild=true")),
-                  Create.Option(
-                        "-r|--results-directory",
-                        LocalizableStrings.CmdResultsDirectoryDescription,
-                        Accept.ExactlyOneArgument()
-                              .With(name: LocalizableStrings.CmdPathToResultsDirectory)
-                              .ForwardAsSingle(o => $"/p:VSTestResultsDirectory={o.Arguments.Single()}")),
-                  Create.Option(
-                        "--collect",
-                        LocalizableStrings.cmdCollectDescription,
-                        Accept.OneOrMoreArguments()
-                              .With(name: LocalizableStrings.cmdCollectFriendlyName)
-                              .ForwardAsSingle(o => $"/p:VSTestCollect=\"{string.Join(";", o.Arguments)}\"")),
-                  CommonOptions.NoRestoreOption(),
-                  CommonOptions.VerbosityOption());
+                  FullTestOptions);
+
+        private static Option[] FullTestOptions
+        {
+            get
+            {
+                var fullTestOptions = new List<Option>
+                {
+                    CommonOptions.HelpOption(),
+                      Create.Option(
+                            "-s|--settings",
+                            LocalizableStrings.CmdSettingsDescription,
+                            Accept.ExactlyOneArgument()
+                                  .With(name: LocalizableStrings.CmdSettingsFile)
+                                  .ForwardAsSingle(o => $"/p:VSTestSetting={o.Arguments.Single()}")),
+                      Create.Option(
+                            "-t|--list-tests",
+                            LocalizableStrings.CmdListTestsDescription,
+                            Accept.NoArguments()
+                                  .ForwardAsSingle(o => "/p:VSTestListTests=true")),
+                      Create.Option(
+                            "--filter",
+                            LocalizableStrings.CmdTestCaseFilterDescription,
+                            Accept.ExactlyOneArgument()
+                                  .With(name: LocalizableStrings.CmdTestCaseFilterExpression)
+                                  .ForwardAsSingle(o => $"/p:VSTestTestCaseFilter={o.Arguments.Single()}")),
+                      Create.Option(
+                            "-a|--test-adapter-path",
+                            LocalizableStrings.CmdTestAdapterPathDescription,
+                            Accept.ExactlyOneArgument()
+                                  .With(name: LocalizableStrings.CmdTestAdapterPath)
+                                  .ForwardAsSingle(o => $"/p:VSTestTestAdapterPath={o.Arguments.Single()}")),
+                      Create.Option(
+                            "-l|--logger",
+                            LocalizableStrings.CmdLoggerDescription,
+                            Accept.ExactlyOneArgument()
+                                  .With(name: LocalizableStrings.CmdLoggerOption)
+                                  .ForwardAsSingle(o =>
+                                        {
+                                              var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
+
+                                              return $"/p:VSTestLogger={loggersString}";
+                                        })),
+                      CommonOptions.ConfigurationOption(),
+                      CommonOptions.FrameworkOption(),
+                      Create.Option(
+                            "-o|--output",
+                            LocalizableStrings.CmdOutputDescription,
+                            Accept.ExactlyOneArgument()
+                                  .With(name: LocalizableStrings.CmdOutputDir)
+                                  .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
+                      Create.Option(
+                            "-d|--diag",
+                            LocalizableStrings.CmdPathTologFileDescription,
+                            Accept.ExactlyOneArgument()
+                                  .With(name: LocalizableStrings.CmdPathToLogFile)
+                                  .ForwardAsSingle(o => $"/p:VSTestDiag={o.Arguments.Single()}")),
+                      Create.Option(
+                            "--no-build",
+                            LocalizableStrings.CmdNoBuildDescription,
+                            Accept.NoArguments()
+                                  .ForwardAsSingle(o => "/p:VSTestNoBuild=true")),
+                      Create.Option(
+                            "-r|--results-directory",
+                            LocalizableStrings.CmdResultsDirectoryDescription,
+                            Accept.ExactlyOneArgument()
+                                  .With(name: LocalizableStrings.CmdPathToResultsDirectory)
+                                  .ForwardAsSingle(o => $"/p:VSTestResultsDirectory={o.Arguments.Single()}")),
+                      Create.Option(
+                            "--collect",
+                            LocalizableStrings.cmdCollectDescription,
+                            Accept.OneOrMoreArguments()
+                                  .With(name: LocalizableStrings.cmdCollectFriendlyName)
+                                  .ForwardAsSingle(o => $"/p:VSTestCollect=\"{string.Join(";", o.Arguments)}\"")),
+                      CommonOptions.NoRestoreOption(),
+                      CommonOptions.VerbosityOption()
+                };
+
+                RestoreCommandParser.AddImplicitRestoreOptions(fullTestOptions);
+
+                return fullTestOptions.ToArray();
+            }
+        }
 
         private static string GetSemiColonEsacpedstring(string arg)
         {

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -39,6 +39,35 @@ namespace Microsoft.DotNet.Cli.Build.Tests
         }
 
         [Fact]
+        public void ItImplicitlyRestoresAProjectWhenBuilding()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance(testAppName)
+                .WithSourceFiles();
+
+            new BuildCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .Execute()
+                .Should().Pass();
+        }
+
+        [Fact]
+        public void ItDoesNotImplicitlyRestoreAProjectWhenBuildingWithTheNoRestoreOption()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance(testAppName)
+                .WithSourceFiles();
+
+            new BuildCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .ExecuteWithCapturedOutput("--no-restore")
+                .Should().Fail()
+                .And.HaveStdOutContaining("project.assets.json' not found.");;
+        }
+
+        [Fact]
         public void ItRunsWhenRestoringToSpecificPackageDir()
         {
             var rootPath = TestAssets.CreateTestDirectory().FullName;
@@ -62,7 +91,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
 
             new BuildCommand()
                 .WithWorkingDirectory(rootPath)
-                .Execute()
+                .Execute("--no-restore")
                 .Should().Pass();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";

--- a/test/dotnet-pack.Tests/PackTests.cs
+++ b/test/dotnet-pack.Tests/PackTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.DotNet.Tools.Pack.Tests
         }
 
         [Fact]
-        public void PackWorksWithLocalProjectJson()
+        public void PackWorksWithLocalProject()
         {
             var testInstance = TestAssets.Get("TestAppSimple")
                 .CreateInstance()
@@ -169,6 +169,33 @@ namespace Microsoft.DotNet.Tools.Pack.Tests
                 .WithWorkingDirectory(testInstance.Root)
                 .Execute()
                 .Should().Pass();
+        }
+
+        [Fact]
+        public void ItImplicitlyRestoresAProjectWhenPackaging()
+        {
+            var testInstance = TestAssets.Get("TestAppSimple")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            new PackCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .Execute()
+                .Should().Pass();
+        }
+
+        [Fact]
+        public void ItDoesNotImplicitlyRestoreAProjectWhenPackagingWithTheNoRestoreOption()
+        {
+            var testInstance = TestAssets.Get("TestAppSimple")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            new PackCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .ExecuteWithCapturedOutput("--no-restore")
+                .Should().Fail()
+                .And.HaveStdOutContaining("project.assets.json' not found.");;
         }
 
         [Fact]
@@ -231,7 +258,7 @@ namespace Microsoft.DotNet.Tools.Pack.Tests
 
             new PackCommand()
                 .WithWorkingDirectory(rootPath)
-                .ExecuteWithCapturedOutput()
+                .ExecuteWithCapturedOutput("--no-restore")
                 .Should()
                 .Pass();
 

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -45,6 +45,39 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
         }
 
         [Fact]
+        public void ItImplicitlyRestoresAProjectWhenPublishing()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                            .CreateInstance()
+                            .WithSourceFiles();
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            new PublishCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("--framework netcoreapp2.0")
+                .Should().Pass();
+        }
+
+        [Fact]
+        public void ItDoesNotImplicitlyRestoreAProjectWhenPublishingWithTheNoRestoreOption()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                            .CreateInstance()
+                            .WithSourceFiles();
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            new PublishCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("--framework netcoreapp2.0 --no-restore")
+                .Should().Fail()
+                .And.HaveStdOutContaining("project.assets.json' not found.");;
+        }
+
+        [Fact]
         public void ItPublishesARunnableSelfContainedApp()
         {
             var testAppName = "MSBuildTestApp";
@@ -170,7 +203,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             new PublishCommand()
                 .WithWorkingDirectory(rootPath)
-                .ExecuteWithCapturedOutput()
+                .ExecuteWithCapturedOutput("--no-restore")
                 .Should().Pass();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -38,6 +38,40 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
+        public void ItImplicitlyRestoresAProjectWhenRunning()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                            .CreateInstance()
+                            .WithSourceFiles();
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            new RunCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput()
+                .Should().Pass()
+                         .And.HaveStdOutContaining("Hello World!");
+        }
+
+        [Fact]
+        public void ItDoesNotImplicitlyRestoreAProjectWhenRunningWithTheNoRestoreOption()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                            .CreateInstance()
+                            .WithSourceFiles();
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            new RunCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("--no-restore")
+                .Should().Fail()
+                .And.HaveStdOutContaining("project.assets.json' not found.");;
+        }
+
+        [Fact]
         public void ItBuildsTheProjectBeforeRunning()
         {
             var testAppName = "MSBuildTestApp";
@@ -160,7 +194,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 
             new RunCommand()
                 .WithWorkingDirectory(rootPath)
-                .ExecuteWithCapturedOutput()
+                .ExecuteWithCapturedOutput("--no-restore")
                 .Should().Pass()
                          .And.HaveStdOutContaining("Hello World");
         }


### PR DESCRIPTION
The missing piece here is adding restore options to the commands that support implicit restore, so that you can do things like dotnet build --configfile <path_to_config_file> instead of dotnet build /p:RestoreConfigFile=<path_to_config_file>. Also note that all build arguments will be passed down to restore.

For this, I debated not passing them along, but discussed with @emgarten and he confirmed that only restore relevant arguments will be used to decide on noop, also, there may be properties that would change the restore (like a conditional packagereference) and in this case, we do want to pass that and force a new restore. So, I believe this is the right decision here.

Also, currently, the restore verbosity is the default, even in the implicit case, which means, when doing build, you will see the restore output followed by the build output. I think I may end-up making the implicit restore output "quiet", but I am waiting to see what the output for noop restore looks like to decide.

@dotnet/dotnet-cli 