### PR TITLE
dotnet-install.sh: fall back to portable linux

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -143,6 +143,9 @@ get_distro_specific_os_name() {
             if [ -n "$os" ]; then
                 echo "$os"
                 return 0
+            elif [ "$uname" = "Linux" ]; then
+                echo "linux"
+                return 0
             fi
         fi
     fi


### PR DESCRIPTION
For linux flavors with an unknown rid, fall back to the portable linux rid.