### PR TITLE
Add force restore option

### DIFF
--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
@@ -165,4 +165,7 @@
   <data name="CmdNoDependenciesOptionDescription" xml:space="preserve">
     <value>Set this flag to ignore project to project references and only restore the root project.</value>
   </data>
+  <data name="CmdForceRestoreOptionDescription" xml:space="preserve">
+    <value>Set this flag to force all dependencies to be resolved even if the last restore was successful. This is equivalent to deleting project.assets.json.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -60,6 +60,11 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.CmdNoDependenciesOptionDescription,
                     Accept.NoArguments()
                           .ForwardAs("/p:RestoreRecursive=false")),
+                Create.Option(
+                    "-f|--force",
+                    LocalizableStrings.CmdForceRestoreOptionDescription,
+                    Accept.NoArguments()
+                          .ForwardAs("/p:RestoreForce=true")),
                 CommonOptions.VerbosityOption());
     }
 }


### PR DESCRIPTION
Adding the force option in the CLI, added in the NuGet as part of the restore no-op work.
More info here:
https://github.com/NuGet/Home/wiki/NuGet-Restore-No-Op
&&
https://github.com/NuGet/Home/wiki/%5BSpec%5D-NuGet-settings-in-MSBuild

This flag will be used by NuGet once 4.3.0.4118 or later is inserted:

Fixes:
NuGet/Home#5080
NuGet/Home#5181

//cc
@emgarten @rrelyea @livarcocc