### PR TITLE
Update Microsoft.Net.SDK version to 2.0.0-preview2-20170608-1.

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -6,7 +6,7 @@
     <CLI_Roslyn_Version>2.3.0-beta2-61716-09</CLI_Roslyn_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>
     <CLI_FSharp_Version>4.2.0-rc-170602-0</CLI_FSharp_Version>
-    <CLI_NETSDK_Version>2.0.0-preview2-20170607-3</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-preview2-20170608-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview3-4146</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>2.0.0-rel-20170518-512</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.3.0-preview-20170601-03</CLI_TestPlatform_Version>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -6,7 +6,7 @@
     <CLI_Roslyn_Version>2.3.0-beta2-61716-09</CLI_Roslyn_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>
     <CLI_FSharp_Version>4.2.0-rc-170602-0</CLI_FSharp_Version>
-    <CLI_NETSDK_Version>2.0.0-preview2-20170602-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-preview2-20170607-3</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview3-4146</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>2.0.0-rel-20170518-512</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.3.0-preview-20170601-03</CLI_TestPlatform_Version>


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz Flow of dependencies into the CLI.