### PR TITLE
Make deb package has linux-x64 content

### DIFF
--- a/build/BackwardsCompatibilityRuntimes.props
+++ b/build/BackwardsCompatibilityRuntimes.props
@@ -5,13 +5,13 @@
     <BackwardsCompatibility110SharedHostVersion>1.1.0</BackwardsCompatibility110SharedHostVersion>
     <BackwardsCompatibility110HostFxrVersion>1.1.0</BackwardsCompatibility110HostFxrVersion>
 
-    <BackwardsCompatibility110DownloadedSharedHostInstallerFileName Condition=" '$(OSName)' != 'linux' ">dotnet-host-$(HostMonikerRid).$(BackwardsCompatibility110SharedHostVersion)$(OSName)</BackwardsCompatibility110DownloadedSharedHostInstallerFileName>
+    <BackwardsCompatibility110DownloadedSharedHostInstallerFileName Condition=" '$(OSName)' != 'linux' ">dotnet-host-$(HostMonikerRid).$(BackwardsCompatibility110SharedHostVersion)$(InstallerExtension)</BackwardsCompatibility110DownloadedSharedHostInstallerFileName>
     <BackwardsCompatibility110DownloadedSharedHostInstallerFile Condition=" '$(OSName)' != 'linux' ">$(PackagesDirectory)/$(BackwardsCompatibility110DownloadedSharedHostInstallerFileName)</BackwardsCompatibility110DownloadedSharedHostInstallerFile>
 
-    <BackwardsCompatibility110DownloadedHostFxrInstallerFileName Condition=" '$(OSName)' != 'linux' ">dotnet-hostfxr-$(HostMonikerRid).$(BackwardsCompatibility110HostFxrVersion)$(OSName)</BackwardsCompatibility110DownloadedHostFxrInstallerFileName>
+    <BackwardsCompatibility110DownloadedHostFxrInstallerFileName Condition=" '$(OSName)' != 'linux' ">dotnet-hostfxr-$(HostMonikerRid).$(BackwardsCompatibility110HostFxrVersion)$(InstallerExtension)</BackwardsCompatibility110DownloadedHostFxrInstallerFileName>
     <BackwardsCompatibility110DownloadedHostFxrInstallerFile Condition=" '$(OSName)' != 'linux' ">$(PackagesDirectory)/$(BackwardsCompatibility110DownloadedHostFxrInstallerFileName)</BackwardsCompatibility110DownloadedHostFxrInstallerFile>
 
-    <BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName Condition=" '$(OSName)' != 'linux' ">dotnet-sharedframework-$(HostMonikerRid).$(BackwardsCompatibility110SharedFrameworkVersion)$(OSName)</BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName>
+    <BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName Condition=" '$(OSName)' != 'linux' ">dotnet-sharedframework-$(HostMonikerRid).$(BackwardsCompatibility110SharedFrameworkVersion)$(InstallerExtension)</BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName>
     <BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile Condition=" '$(OSName)' != 'linux' ">$(PackagesDirectory)/$(BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName)</BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile>
 
     <BackwardsCompatibility110CombinedFrameworkHostCompressedFileName>dotnet-$(HostMonikerRid).$(BackwardsCompatibility110SharedFrameworkVersion)$(ArchiveExtension)</BackwardsCompatibility110CombinedFrameworkHostCompressedFileName>

--- a/build/BackwardsCompatibilityRuntimes.props
+++ b/build/BackwardsCompatibilityRuntimes.props
@@ -5,16 +5,16 @@
     <BackwardsCompatibility110SharedHostVersion>1.1.0</BackwardsCompatibility110SharedHostVersion>
     <BackwardsCompatibility110HostFxrVersion>1.1.0</BackwardsCompatibility110HostFxrVersion>
 
-    <BackwardsCompatibility110DownloadedSharedHostInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-host-$(ProductMonikerRid).$(BackwardsCompatibility110SharedHostVersion)$(InstallerExtension)</BackwardsCompatibility110DownloadedSharedHostInstallerFileName>
-    <BackwardsCompatibility110DownloadedSharedHostInstallerFile Condition=" '$(InstallerExtension)' != '' ">$(PackagesDirectory)/$(BackwardsCompatibility110DownloadedSharedHostInstallerFileName)</BackwardsCompatibility110DownloadedSharedHostInstallerFile>
+    <BackwardsCompatibility110DownloadedSharedHostInstallerFileName Condition=" '$(OSName)' != 'linux' ">dotnet-host-$(HostMonikerRid).$(BackwardsCompatibility110SharedHostVersion)$(OSName)</BackwardsCompatibility110DownloadedSharedHostInstallerFileName>
+    <BackwardsCompatibility110DownloadedSharedHostInstallerFile Condition=" '$(OSName)' != 'linux' ">$(PackagesDirectory)/$(BackwardsCompatibility110DownloadedSharedHostInstallerFileName)</BackwardsCompatibility110DownloadedSharedHostInstallerFile>
 
-    <BackwardsCompatibility110DownloadedHostFxrInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-hostfxr-$(ProductMonikerRid).$(BackwardsCompatibility110HostFxrVersion)$(InstallerExtension)</BackwardsCompatibility110DownloadedHostFxrInstallerFileName>
-    <BackwardsCompatibility110DownloadedHostFxrInstallerFile Condition=" '$(InstallerExtension)' != '' ">$(PackagesDirectory)/$(BackwardsCompatibility110DownloadedHostFxrInstallerFileName)</BackwardsCompatibility110DownloadedHostFxrInstallerFile>
+    <BackwardsCompatibility110DownloadedHostFxrInstallerFileName Condition=" '$(OSName)' != 'linux' ">dotnet-hostfxr-$(HostMonikerRid).$(BackwardsCompatibility110HostFxrVersion)$(OSName)</BackwardsCompatibility110DownloadedHostFxrInstallerFileName>
+    <BackwardsCompatibility110DownloadedHostFxrInstallerFile Condition=" '$(OSName)' != 'linux' ">$(PackagesDirectory)/$(BackwardsCompatibility110DownloadedHostFxrInstallerFileName)</BackwardsCompatibility110DownloadedHostFxrInstallerFile>
 
-    <BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-sharedframework-$(ProductMonikerRid).$(BackwardsCompatibility110SharedFrameworkVersion)$(InstallerExtension)</BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName>
-    <BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile Condition=" '$(InstallerExtension)' != '' ">$(PackagesDirectory)/$(BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName)</BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile>
+    <BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName Condition=" '$(OSName)' != 'linux' ">dotnet-sharedframework-$(HostMonikerRid).$(BackwardsCompatibility110SharedFrameworkVersion)$(OSName)</BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName>
+    <BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile Condition=" '$(OSName)' != 'linux' ">$(PackagesDirectory)/$(BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName)</BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile>
 
-    <BackwardsCompatibility110CombinedFrameworkHostCompressedFileName>dotnet-$(ProductMonikerRid).$(BackwardsCompatibility110SharedFrameworkVersion)$(ArchiveExtension)</BackwardsCompatibility110CombinedFrameworkHostCompressedFileName>
+    <BackwardsCompatibility110CombinedFrameworkHostCompressedFileName>dotnet-$(HostMonikerRid).$(BackwardsCompatibility110SharedFrameworkVersion)$(ArchiveExtension)</BackwardsCompatibility110CombinedFrameworkHostCompressedFileName>
 
     <BackwardsCompatibility110CoreSetupBlobRootUrlWithChannel>$(CoreSetupBlobRootUrl)$(BackwardsCompatibility110CoreSetupChannel)</BackwardsCompatibility110CoreSetupBlobRootUrlWithChannel>
     <BackwardsCompatibility110SharedFrameworkArchiveBlobRootUrl>$(BackwardsCompatibility110CoreSetupBlobRootUrlWithChannel)/Binaries/$(BackwardsCompatibility110SharedFrameworkVersion)</BackwardsCompatibility110SharedFrameworkArchiveBlobRootUrl>
@@ -34,21 +34,21 @@
     </_DownloadAndExtractItem>
 
     <_DownloadAndExtractItem Include="BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile"
-                             Condition="!Exists('$(BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile)') And '$(InstallerExtension)' != ''">
+                             Condition="!Exists('$(BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile)') And '$(OSName)' != 'linux'">
       <Url>$(BackwardsCompatibility110CoreSetupInstallerBlobRootUrl)/$(BackwardsCompatibility110SharedFrameworkVersion)/$(BackwardsCompatibility110DownloadedSharedFrameworkInstallerFileName)</Url>
       <DownloadFileName>$(BackwardsCompatibility110DownloadedSharedFrameworkInstallerFile)</DownloadFileName>
       <ExtractDestination></ExtractDestination>
     </_DownloadAndExtractItem>
 
     <_DownloadAndExtractItem Include="BackwardsCompatibility110DownloadedSharedHostInstallerFile"
-                             Condition="!Exists('$(BackwardsCompatibility110DownloadedSharedHostInstallerFile)') And '$(InstallerExtension)' != ''">
+                             Condition="!Exists('$(BackwardsCompatibility110DownloadedSharedHostInstallerFile)') And '$(OSName)' != 'linux'">
       <Url>$(BackwardsCompatibility110CoreSetupInstallerBlobRootUrl)/$(BackwardsCompatibility110SharedHostVersion)/$(BackwardsCompatibility110DownloadedSharedHostInstallerFileName)</Url>
       <DownloadFileName>$(BackwardsCompatibility110DownloadedSharedHostInstallerFile)</DownloadFileName>
       <ExtractDestintation></ExtractDestintation>
     </_DownloadAndExtractItem>
 
     <_DownloadAndExtractItem Include="BackwardsCompatibility110DownloadedHostFxrInstallerFile"
-                             Condition="!Exists('$(BackwardsCompatibility110DownloadedHostFxrInstallerFile)') And '$(InstallerExtension)' != ''">
+                             Condition="!Exists('$(BackwardsCompatibility110DownloadedHostFxrInstallerFile)') And '$(OSName)' != 'linux'">
       <Url>$(BackwardsCompatibility110CoreSetupInstallerBlobRootUrl)/$(BackwardsCompatibility110HostFxrVersion)/$(BackwardsCompatibility110DownloadedHostFxrInstallerFileName)</Url>
       <DownloadFileName>$(BackwardsCompatibility110DownloadedHostFxrInstallerFile)</DownloadFileName>
       <ExtractDestintation></ExtractDestintation>

--- a/build/Branding.props
+++ b/build/Branding.props
@@ -13,14 +13,21 @@
                                    '$(Rid)' == 'fedora.24-x64' OR
                                    '$(Rid)' == 'opensuse.42.1-x64' ">$(Rid)</ProductMonikerRid>
     <ProductMonikerRid Condition=" '$(ProductMonikerRid)' == '' ">$(OSName)-$(Architecture)</ProductMonikerRid>
+    <HostMonikerRid Condition=" '$(HostRid)' == 'ubuntu.16.04-x64' OR
+        '$(HostRid)' == 'ubuntu.16.10-x64' OR
+        '$(HostRid)' == 'fedora.24-x64' OR
+        '$(HostRid)' == 'opensuse.42.1-x64' ">$(HostRid)</HostMonikerRid>
+    <HostMonikerRid Condition=" '$(HostMonikerRid)' == '' ">$(HostOSName)-$(Architecture)</HostMonikerRid>
 
     <ArtifactNameSdk>dotnet-sdk-internal</ArtifactNameSdk>
     <ArtifactNameSdkDebug>dotnet-sdk-debug</ArtifactNameSdkDebug>
     <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk</ArtifactNameCombinedHostHostFxrFrameworkSdk>
 
     <ArtifactNameWithVersionSdk>$(ArtifactNameSdk)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionSdk>
+
+
     <ArtifactNameWithVersionSdkDebug>$(ArtifactNameSdkDebug)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionSdkDebug>
     <ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
-
+    <DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkVersion)-$(HostMonikerRid)</DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
   </PropertyGroup>
 </Project>

--- a/build/BuildInfo.targets
+++ b/build/BuildInfo.targets
@@ -1,23 +1,4 @@
 <Project ToolsVersion="15.0">
-    <Choose>
-        <When Condition=" '$(Rid)' == '' AND '$(OS)'=='Unix' ">
-            <PropertyGroup>
-            <Rid>linux-x64</Rid>
-            <Architecture>x64</Architecture>
-            <OSName>linux</OSName>
-            <OSPlatform>linux</OSPlatform>
-             </PropertyGroup>
-         </When>
-        <When Condition=" '$(Rid)' == '' AND '$(OS)'!='Unix' ">
-            <PropertyGroup>
-                <Rid>$(HostRid)</Rid>
-                <Architecture>x64</Architecture>
-                <OSName>$(HostOSName)</OSName>
-                <OSPlatform>$(HostOSPlatform)</OSPlatform>
-              </PropertyGroup>
-         </When>
-    </Choose>
-
   <Target Name="WriteBuildInfoProps"
           DependsOnTargets="BuildDotnetCliBuildFramework">
 
@@ -26,8 +7,20 @@
       <Output TaskParameter="OSName" PropertyName="HostOSName" />
       <Output TaskParameter="OSPlatform" PropertyName="HostOSPlatform" />
     </GetCurrentRuntimeInformation>
-   <PropertyGroup>
-   <BuildInfoPropsContent>
+
+    <PropertyGroup>
+      <IsLinux Condition = " '$(HostOSName)' != 'win' AND '$(HostOSName)' != 'osx' ">True</IsLinux>
+      <Rid Condition=" '$(Rid)' == '' AND '$(IsLinux)' != 'True' ">$(HostRid)</Rid>
+      <Architecture Condition=" '$(Architecture)' == '' AND '$(IsLinux)' != 'True' ">x64</Architecture>
+      <OSName Condition=" '$(OSName)' == '' AND '$(IsLinux)' != 'True' ">$(HostOSName)</OSName>
+      <OSPlatform Condition=" '$(OSPlatform)' == '' AND '$(IsLinux)' != 'True' ">$(HostOSPlatform)</OSPlatform>
+
+      <Rid Condition=" '$(Rid)' == '' AND '$(IsLinux)' == 'True' ">linux-x64</Rid>
+      <Architecture Condition=" '$(Architecture)' == '' AND '$(IsLinux)' == 'True' ">x64</Architecture>
+      <OSName Condition=" '$(OSName)' == '' AND '$(IsLinux)' == 'True' ">linux</OSName>
+      <OSPlatform Condition=" '$(OSPlatform)' == '' AND '$(IsLinux)' == 'True' ">linux</OSPlatform>
+
+      <BuildInfoPropsContent>
 &lt;Project ToolsVersion=&quot;14.0&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
     &lt;PropertyGroup&gt;
         &lt;Rid&gt;$(Rid)&lt;/Rid&gt;

--- a/build/BuildInfo.targets
+++ b/build/BuildInfo.targets
@@ -1,4 +1,23 @@
 <Project ToolsVersion="15.0">
+    <Choose>
+        <When Condition=" '$(Rid)' == '' AND '$(OS)'=='Unix' ">
+            <PropertyGroup>
+            <Rid>linux-x64</Rid>
+            <Architecture>x64</Architecture>
+            <OSName>linux</OSName>
+            <OSPlatform>linux</OSPlatform>
+             </PropertyGroup>
+         </When>
+        <When Condition=" '$(Rid)' == '' AND '$(OS)'!='Unix' ">
+            <PropertyGroup>
+                <Rid>$(HostRid)</Rid>
+                <Architecture>x64</Architecture>
+                <OSName>$(HostOSName)</OSName>
+                <OSPlatform>$(HostOSPlatform)</OSPlatform>
+              </PropertyGroup>
+         </When>
+    </Choose>
+
   <Target Name="WriteBuildInfoProps"
           DependsOnTargets="BuildDotnetCliBuildFramework">
 
@@ -7,14 +26,8 @@
       <Output TaskParameter="OSName" PropertyName="HostOSName" />
       <Output TaskParameter="OSPlatform" PropertyName="HostOSPlatform" />
     </GetCurrentRuntimeInformation>
-
-    <PropertyGroup>
-      <Rid Condition=" '$(Rid)' == '' ">$(HostRid)</Rid>
-      <Architecture Condition=" '$(Architecture)' == '' ">x64</Architecture>
-      <OSName Condition=" '$(OSName)' == '' ">$(HostOSName)</OSName>
-      <OSPlatform Condition=" '$(OSPlatform)' == '' ">$(HostOSPlatform)</OSPlatform>
-
-      <BuildInfoPropsContent>
+   <PropertyGroup>
+   <BuildInfoPropsContent>
 &lt;Project ToolsVersion=&quot;14.0&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
     &lt;PropertyGroup&gt;
         &lt;Rid&gt;$(Rid)&lt;/Rid&gt;

--- a/build/BundledRuntimes.props
+++ b/build/BundledRuntimes.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <CoreSetupRid>$(Rid)</CoreSetupRid>
-    <CoreSetupRid Condition=" '$(OSName)' == 'win' or '$(OSName)' == 'osx' ">$(ProductMonikerRid)</CoreSetupRid>
+    <CoreSetupRid>$(HostRid)</CoreSetupRid>
+    <CoreSetupRid Condition=" '$(HostOSName)' == 'win' or '$(HostOSName)' == 'osx' ">$(HostMonikerRid)</CoreSetupRid>
 
     <!-- only the runtime OSX .pkgs have a `-internal` suffix -->
     <InstallerStartSuffix Condition="'$(OSName)' == 'osx'">-internal</InstallerStartSuffix>

--- a/build/BundledRuntimes.props
+++ b/build/BundledRuntimes.props
@@ -4,7 +4,7 @@
     <CoreSetupRid Condition=" '$(HostOSName)' == 'win' or '$(HostOSName)' == 'osx' ">$(HostMonikerRid)</CoreSetupRid>
 
     <!-- only the runtime OSX .pkgs have a `-internal` suffix -->
-    <InstallerStartSuffix Condition="'$(OSName)' == 'osx'">-internal</InstallerStartSuffix>
+    <InstallerStartSuffix Condition="'$(HostOSName)' == 'osx'">-internal</InstallerStartSuffix>
     
     <!-- Downloaded Installers + Archives -->
     <DownloadedSharedHostInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-host$(InstallerStartSuffix)-$(SharedHostVersion)-$(CoreSetupRid)$(InstallerExtension)</DownloadedSharedHostInstallerFileName>
@@ -34,8 +34,8 @@
     <AspNetCoreRuntimeInstallerBlobRootUrl>$(CoreSetupBlobRootUrl)aspnetcore/store/$(AspNetCoreRuntimeVersion)</AspNetCoreRuntimeInstallerBlobRootUrl>
 
     <!-- Examples:    Build.RS.linux.zip    Build.RS.winx86.zip    AspNetCorePackageStoreLibx64.wixlib   -->
-    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(OSName)' == 'win' ">$(OSName)$(Architecture)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
-    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(OSName)' == 'osx' ">$(OSName)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
+    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(HostOSName)' == 'win' ">$(HostOSName)$(Architecture)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
+    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(HostOSName)' == 'osx' ">$(HostOSName)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
     <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(AspNetCoreRuntimeInstallerArchiveFileNameOSToken)' == '' ">linux</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
 
     <AspNetCoreRuntimeStoreSuffix Condition="'$(AspNetCoreRuntimePackageFlavor)' != 'notimestamp'">-$(AspNetCoreCoherenceTimestamp)</AspNetCoreRuntimeStoreSuffix>
@@ -43,7 +43,7 @@
     <AspNetCoreRuntimeInstallerArchiveFileName>Build.RS.$(AspNetCoreRuntimeInstallerArchiveFileNameOSToken)$(AspNetCoreRuntimeInstallerArchiveSuffix)$(ArchiveExtension)</AspNetCoreRuntimeInstallerArchiveFileName>
     <AspNetCoreRuntimeInstallerArchiveFile>$(PackagesDirectory)/$(AspNetCoreRuntimeInstallerArchiveFileName)</AspNetCoreRuntimeInstallerArchiveFile>
 
-    <AspNetCoreRuntimeInstallerWixLibFileName Condition=" '$(OSName)' == 'win' ">AspNetCorePackageStoreLib$(Architecture)$(AspNetCoreRuntimeStoreSuffix).wixlib</AspNetCoreRuntimeInstallerWixLibFileName>
+    <AspNetCoreRuntimeInstallerWixLibFileName Condition=" '$(HostOSName)' == 'win' ">AspNetCorePackageStoreLib$(Architecture)$(AspNetCoreRuntimeStoreSuffix).wixlib</AspNetCoreRuntimeInstallerWixLibFileName>
     <AspNetCoreRuntimeInstallerWixLibFile Condition=" '$(AspNetCoreRuntimeInstallerWixLibFileName)' != '' ">$(PackagesDirectory)/$(AspNetCoreRuntimeInstallerWixLibFileName)</AspNetCoreRuntimeInstallerWixLibFile>
   </PropertyGroup>
 

--- a/build/FileExtensions.props
+++ b/build/FileExtensions.props
@@ -1,23 +1,23 @@
 <Project>
     <PropertyGroup>
 
-      <ArchiveExtension Condition=" '$(OSName)' == 'win' ">.zip</ArchiveExtension>
-      <ArchiveExtension Condition=" '$(OSName)' != 'win' ">.tar.gz</ArchiveExtension>
+      <ArchiveExtension Condition=" '$(HostOSName)' == 'win' ">.zip</ArchiveExtension>
+      <ArchiveExtension Condition=" '$(HostOSName)' != 'win' ">.tar.gz</ArchiveExtension>
 
-      <InstallerExtension Condition=" '$(OSName)' == 'win' ">.msi</InstallerExtension>
-      <InstallerExtension Condition=" '$(OSName)' == 'osx' ">.pkg</InstallerExtension>
-      <InstallerExtension Condition=" '$(OSName)' == 'ubuntu' OR '$(OSName)' == 'debian' ">.deb</InstallerExtension>
+      <InstallerExtension Condition=" '$(HostOSName)' == 'win' ">.msi</InstallerExtension>
+      <InstallerExtension Condition=" '$(HostOSName)' == 'osx' ">.pkg</InstallerExtension>
+      <InstallerExtension Condition=" '$(HostOSName)' == 'ubuntu' OR '$(OSName)' == 'debian' ">.deb</InstallerExtension>
 
-      <BundleExtension Condition=" '$(OSName)' == 'win' ">.exe</BundleExtension>
-      <BundleExtension Condition=" '$(OSName)' == 'osx' ">$(InstallerExtension)</BundleExtension>
-      <BundleExtension Condition=" '$(OSName)' == 'ubuntu' OR '$(OSName)' == 'debian' ">$(InstallerExtension)</BundleExtension>
+      <BundleExtension Condition=" '$(HostOSName)' == 'win' ">.exe</BundleExtension>
+      <BundleExtension Condition=" '$(HostOSName)' == 'osx' ">$(InstallerExtension)</BundleExtension>
+      <BundleExtension Condition=" '$(HostOSName)' == 'ubuntu' OR '$(OSName)' == 'debian' ">$(InstallerExtension)</BundleExtension>
 
       <DynamicLibPrefix>lib</DynamicLibPrefix>
-      <DynamicLibPrefix Condition=" '$(OSName)' == 'win' "></DynamicLibPrefix>
+      <DynamicLibPrefix Condition=" '$(HostOSName)' == 'win' "></DynamicLibPrefix>
 
       <DynamicLibExtension>.so</DynamicLibExtension>
-      <DynamicLibExtension Condition=" '$(OSName)' == 'win' ">.dll</DynamicLibExtension>
-      <DynamicLibExtension Condition=" '$(OSName)' == 'osx' ">.dylib</DynamicLibExtension>
+      <DynamicLibExtension Condition=" '$(HostOSName)' == 'win' ">.dll</DynamicLibExtension>
+      <DynamicLibExtension Condition=" '$(HostOSName)' == 'osx' ">.dylib</DynamicLibExtension>
 
       <ExeExtension>.exe</ExeExtension>
       <ExeExtension Condition=" '$(OS)' != 'Windows_NT' "></ExeExtension>

--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -10,11 +10,11 @@
                             TestDebuild;
                             BuildSdkDeb;
                             TestSdkDeb;"
-          Condition=" '$(OSName)' == 'ubuntu' OR '$(OSName)' == 'debian' "
+          Condition=" '$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian' "
           Outputs="@(GeneratedInstallers)"/>
 
   <Target Name="BuildSdkDeb"
-      Condition=" ('$(OSName)' == 'ubuntu' OR '$(OSName)' == 'debian') AND '$(DebuildPresent)'  == 'true' "
+      Condition=" ('$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian') AND '$(DebuildPresent)'  == 'true' "
       DependsOnTargets="PrepareDotnetDebDirectories;
                         PrepareDotnetDebTool;"
       Inputs="@(CLISdkFiles)"
@@ -98,7 +98,7 @@
   </Target>
 
   <Target Name="TestSdkDeb"
-      Condition=" ('$(OSName)' == 'ubuntu' OR '$(OSName)' == 'debian') and '$(DebuildPresent)'  == 'true' "
+      Condition=" ('$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian') and '$(DebuildPresent)'  == 'true' "
       Inputs="$(DownloadedSharedHostInstallerFile);
               $(DownloadedHostFxrInstallerFile);
               $(DownloadedSharedFrameworkInstallerFile);

--- a/build/package/Installer.DEB.targets
+++ b/build/package/Installer.DEB.targets
@@ -52,8 +52,7 @@
     <!-- Output Directories -->
     <PropertyGroup>
       <InstallerOutputDirectory>$(PackagesDirectory)</InstallerOutputDirectory>
-      <SdkInstallerFile>$(InstallerOutputDirectory)/$(ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkInstallerFile>
-
+      <SdkInstallerFile>$(InstallerOutputDirectory)/$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkInstallerFile>
       <SdkDebianIntermediateDirectory>$(IntermediateDirectory)/debian/sdk</SdkDebianIntermediateDirectory>
       <DotNetDebToolOutputDirectory>$(SdkDebianIntermediateDirectory)/deb-tool-output</DotNetDebToolOutputDirectory>
       <DebianTestResultsXmlFile>$(SdkDebianIntermediateDirectory)/debian-testResults.xml</DebianTestResultsXmlFile>

--- a/build/publish/PublishDebian.targets
+++ b/build/publish/PublishDebian.targets
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SdkDebianUploadUrl>$(DotnetBlobRootUrl)/$(Product)/$(FullNugetVersion)/$(ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkDebianUploadUrl>
+    <SdkDebianUploadUrl>$(DotnetBlobRootUrl)/$(Product)/$(FullNugetVersion)/$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkDebianUploadUrl>
     <DebianUploadJsonFile>$(SdkDebianIntermediateDirectory)/package_upload.json</DebianUploadJsonFile>
     <DebianRevisionNumber>1</DebianRevisionNumber>
 
@@ -19,7 +19,7 @@
     </DebianUploadJsonContent>
   </PropertyGroup>
 
-  <Target Name="PublishDebFilesToDebianRepo" Condition=" ('$(OSName)' == 'ubuntu' OR '$(OSName)' == 'debian') AND '$(SkipPublishToDebianRepo)' != 'true' ">
+  <Target Name="PublishDebFilesToDebianRepo" Condition=" ('$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian') AND '$(SkipPublishToDebianRepo)' != 'true' ">
     <Error Condition="'$(REPO_ID)' == ''" Text="REPO_ID must be set as an environment variable for debian publishing." />
     <Error Condition="'$(REPO_USER)' == ''" Text="REPO_USER must be set as an environment variable for debian publishing." />
     <Error Condition="'$(REPO_PASS)' == ''" Text="REPO_PASS must be set as an environment variable for debian publishing." />


### PR DESCRIPTION
By build using RID -- linux-x64 and
package publish use HostRID ubuntu etc

**Customer scenario**

Ubuntu/Debian user install CLI/SDK via apt-get

```
sudo apt-get install dotnet-sdk-2.0.0-preview2-0060XX
```

The binary file installed on user machine are not Linux generic but specific to RID

**Bugs this fixes**

https://github.com/dotnet/cli/issues/6809

**Workarounds, if any**

Install CLI/SDK via install script

**Risk**

The Ubuntu/Debian users will get different binary file when install via apt-get and it will potentially out of support

**Performance impact**

no

**Root cause analysis**

N/A

**How was the bug found?**

N/A
