### PR TITLE
Updating the vstest.console to use the same runtime that is shipping with the CLI.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -20,7 +20,7 @@
           DependsOnTargets="MSBuildWorkaroundTarget;
                             RestoreDotnetCliBuildFramework">
 
-    <Exec Command="$(DotnetStage0) publish -o $(DotnetCliBuildDirectory)/bin --framework netcoreapp2.0 /p:GeneratePropsFile=$(GeneratePropsFile)" 
+    <Exec Command="$(DotnetStage0) publish --no-restore -o $(DotnetCliBuildDirectory)/bin --framework netcoreapp2.0 /p:GeneratePropsFile=$(GeneratePropsFile)" 
           WorkingDirectory="$(DotnetCliBuildDirectory)"/>
   </Target>
   

--- a/build_projects/dotnet-cli-build/ReplaceFileContents.cs
+++ b/build_projects/dotnet-cli-build/ReplaceFileContents.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Framework;
 
@@ -84,7 +85,8 @@ namespace Microsoft.DotNet.Cli.Build
                 var replacementPattern = ReplacementPatterns[i].ItemSpec;
                 var replacementString = ReplacementStrings[i].ItemSpec;
 
-                outText = outText.Replace(replacementPattern, replacementString);
+                var regex = new Regex(replacementPattern);
+                outText = regex.Replace(outText, replacementString);
             }
 
             return outText;

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -264,4 +264,18 @@
     <Copy SourceFiles="@(Stage2Cli)"
           DestinationFiles="@(Stage2Cli->'$(Stage2WithBackwardsCompatibleRuntimesOutputDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
+
+  <Target Name="RetargetVSTestConsole"
+          AfterTargets="Publish">
+    <PropertyGroup>
+      <VSTestRuntimeConfigPath>$(PublishDir)/vstest.console.runtimeconfig.json</VSTestRuntimeConfigPath>
+      <ReplacementPattern>"version": ".*"</ReplacementPattern>
+      <ReplacementString>"version": "$(CLI_SharedFrameworkVersion)"</ReplacementString>
+    </PropertyGroup>
+    <ReplaceFileContents
+      InputFile="$(VSTestRuntimeConfigPath)"
+      DestinationFile="$(VSTestRuntimeConfigPath)"
+      ReplacementPatterns="$(ReplacementPattern)"
+      ReplacementStrings="$(ReplacementString)" />
+  </Target>
 </Project>


### PR DESCRIPTION
Updating the vstest.console to use the same runtime that is shipping with the CLI.

Fixes https://github.com/dotnet/cli/issues/6806

@dotnet/dotnet-cli @eerhardt 

@MattGertz this is an infra change.
