### PR TITLE
Add Microsoft.NET.Build.Extensions files to package for VS insertion

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -6,9 +6,14 @@
     <CLI_Roslyn_Version>2.3.0-beta2-61716-09</CLI_Roslyn_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>
     <CLI_FSharp_Version>4.2.0-rc-170602-0</CLI_FSharp_Version>
-    <CLI_NETSDK_Version>2.0.0-preview2-20170608-2</CLI_NETSDK_Version>
+    
+    <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
+         cases, so use separate properties but derive one from the other unless we want to
+         explicitly use different versions. -->
+    <CLI_NETSDK_Version>2.0.0-preview2-20170610-3</CLI_NETSDK_Version>
+    <CLI_MSBuildExtensions_Version>$(CLI_NETSDK_Version)</CLI_MSBuildExtensions_Version>
+    
     <CLI_NuGet_Version>4.3.0-preview3-4146</CLI_NuGet_Version>
-    <CLI_MSBuildExtensions_Version>2.0.0-preview2-20170608-2</CLI_MSBuildExtensions_Version>
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.0-preview2-25331-02</CLI_NETStandardLibraryNETFrameworkVersion>
     <CLI_WEBSDK_Version>2.0.0-rel-20170518-512</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.3.0-preview-20170609-02</CLI_TestPlatform_Version>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -3,6 +3,8 @@
           DependsOnTargets="GenerateBundledVersionsProps;RestoreMSBuildExtensionsPackages">
 
     <ItemGroup>
+      
+      <!-- The MSBuildExtensionsContent item is for the files that will be laid out in the CLI install -->
       <MSBuildExtensionsContent Include="$(GeneratedMSBuildExtensionsDirectory)/**/*" />
 
       <!-- We want to include the tasks and targets from the Microsoft.NET.Build.Extensions package, but we don't want to include the DLLs
@@ -22,7 +24,25 @@
       <MSBuildExtensionsContent Include="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.*"
                                 Exclude="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.props;$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.targets"
                                 DeploymentSubpath="Microsoft.NET.Build.Extensions/" />
+
+
+      <!-- The VSMSBuildExtensionsContent item is for the files that will be included in the VS.Redist.Common.Net.Core.SDK.MSBuildExtensions
+           package and inserted into Visual Studio -->
+      <VSMSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\**\*.*"
+                                  Exclude="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft.NET.Build.Extensions\net*\**"
+                                  DeploymentSubpath="msbuildExtensions/"/>
+      <VSMSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions-ver\**\*.*"
+                                  DeploymentSubpath="msbuildExtensions-ver/"/>
+      <VSMSBuildExtensionsContent Include="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.*"
+                                  Exclude="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.props;$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.targets"
+                                  DeploymentSubpath="msbuildExtensions/Microsoft.NET.Build.Extensions/" />
+
+      <VSMSBuildExtensionsContent Update="@(VSMSBuildExtensionsContent)">
+        <DestinationPath >$(MSBuildExtensionsLayoutDirectory)/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>
+      </VSMSBuildExtensionsContent>
     </ItemGroup>
+
+    <Copy SourceFiles="@(VSMSBuildExtensionsContent)" DestinationFiles="%(VSMSBuildExtensionsContent.DestinationPath)" />
   </Target>
 
   <Target Name="PrepareMSBuildExtensionsProps">

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -16,26 +16,26 @@
            we generate it.
            -->
       <MSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\**\*.*"
-                                Exclude="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft.NET.Build.Extensions\net*\**" />
+                                Exclude="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\net*\**" />
 
       <MSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions-ver\**\*.*"
                                 DeploymentSubpath="$(MSBuildExtensionsVersionSubfolder)/" />
       
       <MSBuildExtensionsContent Include="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.*"
                                 Exclude="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.props;$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.targets"
-                                DeploymentSubpath="Microsoft.NET.Build.Extensions/" />
+                                DeploymentSubpath="Microsoft/Microsoft.NET.Build.Extensions/" />
 
 
       <!-- The VSMSBuildExtensionsContent item is for the files that will be included in the VS.Redist.Common.Net.Core.SDK.MSBuildExtensions
            package and inserted into Visual Studio -->
       <VSMSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\**\*.*"
-                                  Exclude="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft.NET.Build.Extensions\net*\**"
+                                  Exclude="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\net*\**"
                                   DeploymentSubpath="msbuildExtensions/"/>
       <VSMSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions-ver\**\*.*"
                                   DeploymentSubpath="msbuildExtensions-ver/"/>
       <VSMSBuildExtensionsContent Include="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.*"
                                   Exclude="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.props;$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.targets"
-                                  DeploymentSubpath="msbuildExtensions/Microsoft.NET.Build.Extensions/" />
+                                  DeploymentSubpath="msbuildExtensions/Microsoft/Microsoft.NET.Build.Extensions/" />
 
       <VSMSBuildExtensionsContent Update="@(VSMSBuildExtensionsContent)">
         <DestinationPath >$(MSBuildExtensionsLayoutDirectory)/%(VSMSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -17,6 +17,9 @@
            -->
       <MSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\**\*.*"
                                 Exclude="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\net*\**" />
+      
+      <!-- Don't include .NET Framework MS.NET.Build.Extensions tasks in CLI layout -->
+      <MSBuildExtensionsContent Remove="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\tools\net46\**" />
 
       <MSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions-ver\**\*.*"
                                 DeploymentSubpath="$(MSBuildExtensionsVersionSubfolder)/" />
@@ -31,6 +34,10 @@
       <VSMSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\**\*.*"
                                   Exclude="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\net*\**"
                                   DeploymentSubpath="msbuildExtensions/"/>
+
+      <!-- Don't include .NET Core MS.NET.Build.Extensions tasks in Full Framework MSBuild layout -->
+      <VSMSBuildExtensionsContent Remove="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions\Microsoft\Microsoft.NET.Build.Extensions\tools\netcoreapp*\**" />
+
       <VSMSBuildExtensionsContent Include="$(MSBuildExtensionsNuPkgPath)\msbuildExtensions-ver\**\*.*"
                                   DeploymentSubpath="msbuildExtensions-ver/"/>
       <VSMSBuildExtensionsContent Include="$(NETStandardLibraryNETFrameworkNuPkgPath)\build\**\*.*"

--- a/build/Microsoft.DotNet.Cli.tasks
+++ b/build/Microsoft.DotNet.Cli.tasks
@@ -19,6 +19,7 @@
   <UsingTask TaskName="DownloadFile" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="GenerateChecksums" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="GenerateGuidFromName" AssemblyFile="$(CLIBuildDll)" />
+  <UsingTask TaskName="GenerateMSBuildExtensionsSWR" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="GenerateMsiVersion" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="GenerateNuGetPackagesArchiveVersion" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="GetCurrentRuntimeInformation" AssemblyFile="$(CLIBuildDll)" />

--- a/build/OutputDirectories.props
+++ b/build/OutputDirectories.props
@@ -17,6 +17,7 @@
       <TestOutputDir>$(RepoRoot)/artifacts/testpackages/</TestOutputDir>
       <DotnetInOutputDirectory>$(OutputDirectory)/dotnet$(ExeExtension)</DotnetInOutputDirectory>
       <GeneratedMSBuildExtensionsDirectory>$(IntermediateDirectory)/GeneratedMSBuildExtensions</GeneratedMSBuildExtensionsDirectory>
-      <SdkResolverOutputDirectory>$(IntermediateDirectory)/MSBuildSdkResolver</SdkResolverOutputDirectory>
+      <MSBuildExtensionsLayoutDirectory>$(IntermediateDirectory)/MSBuildExtensionsLayout</MSBuildExtensionsLayoutDirectory>
+      <SdkResolverOutputDirectory>$(MSBuildExtensionsLayoutDirectory)/MSBuildSdkResolver</SdkResolverOutputDirectory>
   </PropertyGroup>
 </Project>

--- a/build/package/Installer.MSI.targets
+++ b/build/package/Installer.MSI.targets
@@ -22,6 +22,7 @@
 
       <SdkMSBuildExtensionsNuspecFile>$(RepoRoot)/packaging/windows/clisdk/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.nuspec</SdkMSBuildExtensionsNuspecFile>
       <SdkMSBuildExtensionsNupkgFile>$(InstallerOutputDirectory)/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.$(FullNugetVersion).nupkg</SdkMSBuildExtensionsNupkgFile>
+      <SdkMSBuildExtensionsSwrFile>$(InstallerOutputDirectory)/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.swr</SdkMSBuildExtensionsSwrFile>
     </PropertyGroup>
 
     <!-- Test Sdk MSI Properties -->
@@ -146,16 +147,20 @@
     <Target Name="GenerateSdkMSBuildExtensionsNupkg"
             DependsOnTargets="Init;Layout;MsiTargetsSetupInputOutputs;GenerateSdkBundle"
             Condition=" '$(OS)' == 'Windows_NT'"
-            Inputs="$(SdkResolverOutputDirectory)/**/*;
+            Inputs="$(MSBuildExtensionsLayoutDirectory)/**/*;
                     $(SdkInstallerNuspecFile);
                     $(SdkGenerateNupkgPowershellScript)"
-            Outputs="$(SdkInstallerNupkgFile)">
+            Outputs="$(SdkMSBuildExtensionsNupkgFile);$(SdkMSBuildExtensionsSwrFile)">
 
       <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateNupkgPowershellScript)
-                      '$(SdkResolverOutputDirectory)'
+                      '$(MSBuildExtensionsLayoutDirectory)'
                       '$(FullNugetVersion)'
                       '$(SdkMSBuildExtensionsNuspecFile)'
                       '$(SdkMSBuildExtensionsNupkgFile)'" />
+      
+      <GenerateMSBuildExtensionsSWR MSBuildExtensionsLayoutDirectory="$(MSBuildExtensionsLayoutDirectory)"
+                                    OutputFile="$(SdkMSBuildExtensionsSwrFile)"/>
+      
     </Target>
 
     <Target Name="TestSdkMsi"

--- a/build_projects/dotnet-cli-build/GenerateMSBuildExtensionsSWR.cs
+++ b/build_projects/dotnet-cli-build/GenerateMSBuildExtensionsSWR.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class GenerateMSBuildExtensionsSWR : Task
+    {
+        [Required]
+        public string MSBuildExtensionsLayoutDirectory { get; set; }
+
+        [Required]
+        public string OutputFile { get; set; }
+
+        public override bool Execute()
+        {
+            StringBuilder sb = new StringBuilder(SWR_HEADER);
+
+            AddFolder(sb,
+                      @"MSBuildSdkResolver",
+                      @"MSBuild\15.0\Bin\SdkResolvers\Microsoft.DotNet.MSBuildSdkResolver");
+
+            AddFolder(sb,
+                      @"msbuildExtensions",
+                      @"MSBuild");
+
+            AddFolder(sb,
+                      @"msbuildExtensions-ver",
+                      @"MSBuild\15.0");
+
+            File.WriteAllText(OutputFile, sb.ToString());
+
+            return true;
+        }
+
+        private void AddFolder(StringBuilder sb, string relativeSourcePath, string swrInstallDir)
+        {
+            string sourceFolder = Path.Combine(MSBuildExtensionsLayoutDirectory, relativeSourcePath);
+            var files = Directory.GetFiles(sourceFolder)
+                            .Where(f => !Path.GetExtension(f).Equals(".pdb", StringComparison.OrdinalIgnoreCase))
+                            .ToList();
+            if (files.Any())
+            {
+                sb.Append(@"folder ""InstallDir:\");
+                sb.Append(swrInstallDir);
+                sb.AppendLine(@"\""");
+
+                foreach (var file in files)
+                {
+                    sb.Append(@"  file source=""!(bindpath.sources)\Redist\Common\NetCoreSDK\MSBuildExtensions\");
+                    sb.Append(Path.Combine(relativeSourcePath, Path.GetFileName(file)));
+                    sb.AppendLine("\"");
+                }
+
+                sb.AppendLine();
+            }
+
+            foreach (var subfolder in Directory.GetDirectories(sourceFolder))
+            {
+                string subfolderName = Path.GetFileName(subfolder);
+                string newRelativeSourcePath = Path.Combine(relativeSourcePath, subfolderName);
+                string newSwrInstallDir = Path.Combine(swrInstallDir, subfolderName);
+
+                AddFolder(sb, newRelativeSourcePath, newSwrInstallDir);
+            }
+        }
+
+        readonly string SWR_HEADER = @"use vs
+
+package name=Microsoft.Net.Core.SDK.MSBuildExtensions
+        version=$(Version)
+        vs.package.branch=$(VsSingletonPackageBranch)
+        vs.package.internalRevision=$(PackageInternalRevision)
+
+";
+    }
+}

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -196,10 +196,10 @@
       <SdkFiles Include="$(PublishDir)/**/*" Exclude="$(PublishDir)/TestHost*/**/*;$(PublishDir)/Sdks/**/*" />
 
       <!-- Don't try to CrossGen .NET Framework support assemblies for .NET Standard -->
-      <SdkFiles Remove="$(PublishDir)/Microsoft.NET.Build.Extensions\net*\**\*" />
+      <SdkFiles Remove="$(PublishDir)/Microsoft\Microsoft.NET.Build.Extensions\net*\**\*" />
 
       <!-- Don't try to CrossGen tasks and supporting DLLs compiled for .NET Framework -->
-      <SdkFiles Remove="$(PublishDir)/Microsoft.NET.Build.Extensions\tools\net*\**\*" />
+      <SdkFiles Remove="$(PublishDir)/Microsoft\Microsoft.NET.Build.Extensions\tools\net*\**\*" />
     </ItemGroup>
 
     <AddMetadataIsPE Items="@(SdkFiles)">


### PR DESCRIPTION
- Add Microsoft.NET.Build.Extensions files to `VS.Redist.Common.Net.Core.SDK.MSBuildExtensions` package for insertion into Visual Studio
- Add task to generate .swr file based on contents of package, as there are about 350 total files being added