### PR TITLE
Do no pass down to implicit restore the framework option.

### DIFF
--- a/TestAssets/DesktopTestProjects/MultiTFMXunitProject/TestLibrary/Helper.cs
+++ b/TestAssets/DesktopTestProjects/MultiTFMXunitProject/TestLibrary/Helper.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace TestLibrary
+{
+    public static class Helper
+    {
+        /// <summary>
+        /// Gets the message from the helper. This comment is here to help test XML documentation file generation, please do not remove it.
+        /// </summary>
+        /// <returns>A message</returns>
+        public static string GetMessage()
+        {
+            return "This string came from the test library!";
+        }
+
+        public static void SayHi()
+        {
+            Console.WriteLine("Hello there!");
+        }
+    }
+}

--- a/TestAssets/DesktopTestProjects/MultiTFMXunitProject/TestLibrary/TestLibrary.csproj
+++ b/TestAssets/DesktopTestProjects/MultiTFMXunitProject/TestLibrary/TestLibrary.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/DesktopTestProjects/MultiTFMXunitProject/XUnitProject/UnitTest1.cs
+++ b/TestAssets/DesktopTestProjects/MultiTFMXunitProject/XUnitProject/UnitTest1.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using TestLibrary;
+using Xunit;
+
+namespace TestNamespace
+{
+    public class VSTestXunitTests
+    {
+        [Fact]
+        public void VSTestXunitPassTest()
+        {
+            Assert.Equal("This string came from the test library!", Helper.GetMessage());
+        }
+
+        [Fact]
+        public void VSTestXunitFailTest()
+        {
+            Assert.Equal(2, 2);
+        }
+    }
+}

--- a/TestAssets/DesktopTestProjects/MultiTFMXunitProject/XUnitProject/XUnitProject.csproj
+++ b/TestAssets/DesktopTestProjects/MultiTFMXunitProject/XUnitProject/XUnitProject.csproj
@@ -1,0 +1,17 @@
+<Project  Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../TestLibrary/TestLibrary.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(CLI_TestPlatform_Version)" />
+    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+  </ItemGroup>
+</Project>

--- a/TestAssets/DesktopTestProjects/NETFrameworkReferenceNETStandard20/MultiTFMTestApp/MultiTFMTestApp.csproj
+++ b/TestAssets/DesktopTestProjects/NETFrameworkReferenceNETStandard20/MultiTFMTestApp/MultiTFMTestApp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+  </PropertyGroup>
+
+    <ItemGroup>
+    <ProjectReference Include="..\TestLibrary\TestLibrary.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/DesktopTestProjects/NETFrameworkReferenceNETStandard20/MultiTFMTestApp/Program.cs
+++ b/TestAssets/DesktopTestProjects/NETFrameworkReferenceNETStandard20/MultiTFMTestApp/Program.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace TestApp
+{
+    class Program
+    {
+        public static void Main(string[] args)
+         {
+             Console.WriteLine(TestLibrary.Helper.GetMessage());
+         }
+    }
+}

--- a/src/dotnet/commands/RestoringCommand.cs
+++ b/src/dotnet/commands/RestoringCommand.cs
@@ -12,31 +12,36 @@ namespace Microsoft.DotNet.Tools
     {
         private bool NoRestore { get; }
 
-        private IEnumerable<string> ArgsToForward { get; }
+        private IEnumerable<string> ParsedArguments { get; }
+
+        private IEnumerable<string> TrailingArguments { get; }
 
         private IEnumerable<string> ArgsToForwardToRestore()
         {
-            var restoreArguments = ArgsToForward.Where(a =>
-                !a.StartsWith("/t:") &&
-                !a.StartsWith("/target:") &&
-                !a.StartsWith("/ConsoleLoggerParameters:") &&
-                !a.StartsWith("/clp:"));
+            var restoreArguments = ParsedArguments.Where(a =>
+                !a.StartsWith("/p:TargetFramework"));
 
-            if (!restoreArguments.Any(a => a.StartsWith("/v:") || a.StartsWith("/verbosity:")))
+            if (!restoreArguments.Any(a => a.StartsWith("/verbosity:")))
             {
-                restoreArguments = restoreArguments.Concat(new string[] { "/v:q" });
+                restoreArguments = restoreArguments.Concat(new string[] { "/verbosity:q" });
             }
 
-            return restoreArguments;
+            return restoreArguments.Concat(TrailingArguments);
         }
 
         private bool ShouldRunImplicitRestore => !NoRestore;
 
-        public RestoringCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
+        public RestoringCommand(
+            IEnumerable<string> msbuildArgs,
+            IEnumerable<string> parsedArguments,
+            IEnumerable<string> trailingArguments,
+            bool noRestore,
+            string msbuildPath = null)
             : base(msbuildArgs, msbuildPath)
         {
             NoRestore = noRestore;
-            ArgsToForward = msbuildArgs;
+            ParsedArguments = parsedArguments;
+            TrailingArguments = trailingArguments;
         }
 
         public override int Execute()

--- a/src/dotnet/commands/dotnet-build/BuildCommand.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommand.cs
@@ -15,8 +15,13 @@ namespace Microsoft.DotNet.Tools.Build
 {
     public class BuildCommand : RestoringCommand
     {
-        public BuildCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
-            : base(msbuildArgs, noRestore, msbuildPath)
+        public BuildCommand(
+            IEnumerable<string> msbuildArgs,
+            IEnumerable<string> userDefinedArguments,
+            IEnumerable<string> trailingArguments,
+            bool noRestore,
+            string msbuildPath = null)
+            : base(msbuildArgs, userDefinedArguments, trailingArguments, noRestore, msbuildPath)
         {
         }
 
@@ -49,7 +54,12 @@ namespace Microsoft.DotNet.Tools.Build
 
             bool noRestore = appliedBuildOptions.HasOption("--no-restore");
 
-            return new BuildCommand(msbuildArgs, noRestore, msbuildPath);
+            return new BuildCommand(
+                msbuildArgs,
+                appliedBuildOptions.OptionValuesToBeForwarded(),
+                appliedBuildOptions.Arguments,
+                noRestore,
+                msbuildPath);
         }
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -14,8 +14,13 @@ namespace Microsoft.DotNet.Tools.Pack
 {
     public class PackCommand : RestoringCommand
     {
-        public PackCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
-            : base(msbuildArgs, noRestore, msbuildPath)
+        public PackCommand(
+            IEnumerable<string> msbuildArgs,
+            IEnumerable<string> userDefinedArguments,
+            IEnumerable<string> trailingArguments,
+            bool noRestore,
+            string msbuildPath = null)
+            : base(msbuildArgs, userDefinedArguments, trailingArguments, noRestore, msbuildPath)
         {
         }
 
@@ -40,7 +45,12 @@ namespace Microsoft.DotNet.Tools.Pack
 
             bool noRestore = parsedPack.HasOption("--no-restore");
 
-            return new PackCommand(msbuildArgs, noRestore, msbuildPath);
+            return new PackCommand(
+                msbuildArgs,
+                parsedPack.OptionValuesToBeForwarded(),
+                parsedPack.Arguments,
+                noRestore,
+                msbuildPath);
         }
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -13,8 +13,13 @@ namespace Microsoft.DotNet.Tools.Publish
 {
     public class PublishCommand : RestoringCommand
     {
-        private PublishCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
-            : base(msbuildArgs, noRestore, msbuildPath)
+        private PublishCommand(
+            IEnumerable<string> msbuildArgs,
+            IEnumerable<string> userDefinedArguments,
+            IEnumerable<string> trailingArguments,
+            bool noRestore,
+            string msbuildPath = null)
+            : base(msbuildArgs, userDefinedArguments, trailingArguments, noRestore, msbuildPath)
         {
         }
 
@@ -40,7 +45,12 @@ namespace Microsoft.DotNet.Tools.Publish
 
             bool noRestore = appliedPublishOption.HasOption("--no-restore");
 
-            return new PublishCommand(msbuildArgs, noRestore, msbuildPath);
+            return new PublishCommand(
+                msbuildArgs,
+                appliedPublishOption.OptionValuesToBeForwarded(),
+                appliedPublishOption.Arguments,
+                noRestore,
+                msbuildPath);
         }
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -145,7 +145,8 @@ namespace Microsoft.DotNet.Tools.Run
 
             buildArgs.AddRange(RestoreArgs);
 
-            var buildResult = new RestoringCommand(buildArgs, NoRestore).Execute();
+            var buildResult =
+                new RestoringCommand(buildArgs, RestoreArgs, new [] { Project }, NoRestore).Execute();
             if (buildResult != 0)
             {
                 Reporter.Error.WriteLine();

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -16,8 +16,13 @@ namespace Microsoft.DotNet.Tools.Test
 {
     public class TestCommand : RestoringCommand
     {
-        public TestCommand(IEnumerable<string> msbuildArgs, bool noRestore, string msbuildPath = null)
-            : base(msbuildArgs, noRestore, msbuildPath)
+        public TestCommand(
+            IEnumerable<string> msbuildArgs,
+            IEnumerable<string> userDefinedArguments,
+            IEnumerable<string> trailingArguments,
+            bool noRestore,
+            string msbuildPath = null)
+            : base(msbuildArgs, userDefinedArguments, trailingArguments, noRestore, msbuildPath)
         {
         }
 
@@ -67,7 +72,12 @@ namespace Microsoft.DotNet.Tools.Test
 
             bool noRestore = parsedTest.HasOption("--no-restore");
 
-            return new TestCommand(msbuildArgs, noRestore, msbuildPath);
+            return new TestCommand(
+                msbuildArgs,
+                parsedTest.OptionValuesToBeForwarded(),
+                parsedTest.Arguments,
+                noRestore,
+                msbuildPath);
         }
 
         public static int Run(string[] args)

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using FluentAssertions;
+using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 using System.Linq;
@@ -49,6 +50,23 @@ namespace Microsoft.DotNet.Cli.Build.Tests
             new BuildCommand()
                 .WithWorkingDirectory(testInstance.Root)
                 .Execute()
+                .Should().Pass();
+        }
+
+        [Fact]
+        public void ItCanBuildAMultiTFMProjectWithImplicitRestore()
+        {
+            var testInstance = TestAssets.Get(
+                    TestAssetKinds.DesktopTestProjects,
+                    "NETFrameworkReferenceNETStandard20")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            string projectDirectory = Path.Combine(testInstance.Root.FullName, "MultiTFMTestApp");
+
+            new BuildCommand()
+                .WithWorkingDirectory(projectDirectory)
+                .Execute("--framework netcoreapp2.0")
                 .Should().Pass();
         }
 

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.PlatformAbstractions;
+using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 
@@ -56,6 +57,23 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             new PublishCommand()
                 .WithWorkingDirectory(testProjectDirectory)
+                .Execute("--framework netcoreapp2.0")
+                .Should().Pass();
+        }
+
+        [Fact]
+        public void ItCanPublishAMultiTFMProjectWithImplicitRestore()
+        {
+            var testInstance = TestAssets.Get(
+                    TestAssetKinds.DesktopTestProjects,
+                    "NETFrameworkReferenceNETStandard20")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            string projectDirectory = Path.Combine(testInstance.Root.FullName, "MultiTFMTestApp");
+
+            new PublishCommand()
+                .WithWorkingDirectory(projectDirectory)
                 .Execute("--framework netcoreapp2.0")
                 .Should().Pass();
         }

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using FluentAssertions;
+using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 
@@ -52,6 +53,24 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .ExecuteWithCapturedOutput()
                 .Should().Pass()
                          .And.HaveStdOutContaining("Hello World!");
+        }
+
+        [Fact]
+        public void ItCanRunAMultiTFMProjectWithImplicitRestore()
+        {
+            var testInstance = TestAssets.Get(
+                    TestAssetKinds.DesktopTestProjects,
+                    "NETFrameworkReferenceNETStandard20")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            string projectDirectory = Path.Combine(testInstance.Root.FullName, "MultiTFMTestApp");
+
+            new RunCommand()
+                .WithWorkingDirectory(projectDirectory)
+                .ExecuteWithCapturedOutput("--framework netcoreapp2.0")
+                .Should().Pass()
+                         .And.HaveStdOutContaining("This string came from the test library!");
         }
 
         [Fact]

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Cli.Utils;
 using System.IO;
 using System;
+using Xunit;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -74,6 +75,23 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.StdOut.Should().Contain("Total tests: 3. Passed: 1. Failed: 2. Skipped: 0.");
             result.StdOut.Should().Contain("Failed   TestNamespace.VSTestXunitTests.VSTestXunitFailTestNetCoreApp");
             result.ExitCode.Should().Be(1);
+        }
+
+        [Fact]
+        public void ItCanTestAMultiTFMProjectWithImplicitRestore()
+        {
+            var testInstance = TestAssets.Get(
+                    TestAssetKinds.DesktopTestProjects,
+                    "MultiTFMXunitProject")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            string projectDirectory = Path.Combine(testInstance.Root.FullName, "XUnitProject");
+
+            new DotnetTestCommand()
+               .WithWorkingDirectory(projectDirectory)
+               .ExecuteWithCapturedOutput($"{TestBase.ConsoleLoggerOutputNormal} --framework netcoreapp2.0")
+               .Should().Pass();
         }
     }
 }


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz for approval.

**Customer scenario**

User tries to publish a multi-tfm project selecting one specific TFM to publish to. And this project has a dependency on a netstandard project. This publish will fail because the TFM will be passed to restore, say, as netcoreapp2.0, and the library will be restored as netcoreapp2.0, which is not compatible with net461 (one of the TFMs of the app). This happens because when the TFM is explicitly set for restore, it overwrites the TFM set in the library.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/cli/issues/6843

**Workarounds, if any**

Pass --no-restore to the publish command.

**Risk**

Low. We are removing a property from being passed down to implicit restore. A property that restore does not explicitly support today.

**Performance impact**

N/A

**Is this a regression from a previous update?**

Yes. Publishing of multi-tfm projects is broken unless we take this fix or tell customer to pass --no-restore when publishing.

**Root cause analysis:**

This was something that had never been tried before and I didn't realize it would be a problem.

**How was the bug found?**

Reported by partner team.
