### PR TITLE
Update spa templates version to preview 297

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -28,7 +28,7 @@
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
     <CliMigrateVersion>1.2.1-alpha-002133</CliMigrateVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
-    <SpaTemplateVersion>1.0.0-preview-000286</SpaTemplateVersion>
+    <SpaTemplateVersion>1.0.0-preview-000297</SpaTemplateVersion>
 
     <!-- This should either be timestamped or notimestamp as appropriate -->
     <AspNetCoreRuntimePackageFlavor>timestamped</AspNetCoreRuntimePackageFlavor>


### PR DESCRIPTION
As discussed, this bumps the CLI up to the latest SPA templates, which includes a few necessary fixes. Having this version in place now lets us proceed with verification.

The version number will need to change again to `-preview2-final` or similar for the final preview 2 release.