### PR TITLE
Fix Debian VSTS/packing failure

### DIFF
--- a/build/FileExtensions.props
+++ b/build/FileExtensions.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-
+      <IsDebianBaseDistro Condition=" '$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian' ">True</IsDebianBaseDistro>
       <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) ">True</IsRPMBasedDistro>
 
       <ArchiveExtension Condition=" '$(HostOSName)' == 'win' ">.zip</ArchiveExtension>
@@ -8,13 +8,13 @@
 
       <InstallerExtension Condition=" '$(HostOSName)' == 'win' ">.msi</InstallerExtension>
       <InstallerExtension Condition=" '$(HostOSName)' == 'osx' ">.pkg</InstallerExtension>
-      <InstallerExtension Condition=" '$(HostOSName)' == 'ubuntu' OR '$(OSName)' == 'debian' ">.deb</InstallerExtension>
+      <InstallerExtension Condition=" '$(IsDebianBaseDistro)' == 'True' ">.deb</InstallerExtension>
       <InstallerExtension Condition=" '$(IsRPMBasedDistro)' == True ">.rpm</InstallerExtension>
 
       <BundleExtension Condition=" '$(HostOSName)' == 'win' ">.exe</BundleExtension>
       <BundleExtension Condition=" '$(HostOSName)' == 'osx' ">$(InstallerExtension)</BundleExtension>
-      <BundleExtension Condition=" '$(HostOSName)' == 'ubuntu' OR '$(OSName)' == 'debian' ">$(InstallerExtension)</BundleExtension>
-      <BundleExtension Condition=" '$(IsRPMBasedDistro)' == True ">.rpm</BundleExtension>
+      <BundleExtension Condition=" '$(IsDebianBaseDistro)' == 'True' ">$(InstallerExtension)</BundleExtension>
+      <BundleExtension Condition=" '$(IsRPMBasedDistro)' == True ">$(InstallerExtension)</BundleExtension>
 
       <DynamicLibPrefix>lib</DynamicLibPrefix>
       <DynamicLibPrefix Condition=" '$(HostOSName)' == 'win' "></DynamicLibPrefix>

--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -10,11 +10,11 @@
                             TestDebuild;
                             BuildSdkDeb;
                             TestSdkDeb;"
-          Condition=" '$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian' "
+          Condition=" '$(IsDebianBaseDistro)' == 'True' "
           Outputs="@(GeneratedInstallers)"/>
 
   <Target Name="BuildSdkDeb"
-      Condition=" ('$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian') AND '$(DebuildPresent)'  == 'true' "
+      Condition=" '$(IsDebianBaseDistro)' == 'True' AND '$(DebuildPresent)'  == 'true' "
       DependsOnTargets="PrepareDotnetDebDirectories;
                         PrepareDotnetDebTool;"
       Inputs="@(CLISdkFiles)"
@@ -98,7 +98,7 @@
   </Target>
 
   <Target Name="TestSdkDeb"
-      Condition=" ('$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian') and '$(DebuildPresent)'  == 'true' "
+      Condition=" '$(IsDebianBaseDistro)' == 'True' and '$(DebuildPresent)'  == 'true' "
       Inputs="$(DownloadedSharedHostInstallerFile);
               $(DownloadedHostFxrInstallerFile);
               $(DownloadedSharedFrameworkInstallerFile);

--- a/build/publish/PublishDebian.targets
+++ b/build/publish/PublishDebian.targets
@@ -19,7 +19,7 @@
     </DebianUploadJsonContent>
   </PropertyGroup>
 
-  <Target Name="PublishDebFilesToDebianRepo" Condition=" ('$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian') AND '$(SkipPublishToDebianRepo)' != 'true' ">
+  <Target Name="PublishDebFilesToDebianRepo" Condition=" '$(IsDebianBaseDistro)' == 'True' AND '$(SkipPublishToDebianRepo)' != 'true' ">
     <Error Condition="'$(REPO_ID)' == ''" Text="REPO_ID must be set as an environment variable for debian publishing." />
     <Error Condition="'$(REPO_USER)' == ''" Text="REPO_USER must be set as an environment variable for debian publishing." />
     <Error Condition="'$(REPO_PASS)' == ''" Text="REPO_PASS must be set as an environment variable for debian publishing." />


### PR DESCRIPTION
**Customer scenario**

Debian user install CLI/SDK via deb package, however, they cannot find the latest packages in blob storage

**Bugs this fixes**

https://github.com/dotnet/cli/issues/6854

**Workarounds, if any**

Install generic Linux CLI/SDK via install script

**Risk**

The Debian users cannot get native install experience

**Performance impact**

no

**Root cause analysis**

$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian' is duplicated too much. Extract _IsDebianBaseDistro_ for it

**How was the bug found?**

Build failure in VSTS


One place missing replacement of OsName => HostOsName. But the root cause is 
```$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian'``` duplicated too much.

Extract IsDebianBaseDistro for it