### PR TITLE
Fix console unbolding on error Issue #4850

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/AnsiConsole.cs
@@ -8,11 +8,14 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class AnsiConsole
     {
+        private const int Light = 0x08;
+
         private AnsiConsole(TextWriter writer)
         {
             Writer = writer;
     
             OriginalForegroundColor = Console.ForegroundColor;
+            _boldRecursion = ((int)OriginalForegroundColor & Light) != 0 ? 1 : 0;
         }
     
         private int _boldRecursion;
@@ -33,7 +36,6 @@ namespace Microsoft.DotNet.Cli.Utils
     
         private void SetColor(ConsoleColor color)
         {
-            const int Light = 0x08;
             int c = (int)color;
 
             Console.ForegroundColor = 


### PR DESCRIPTION
Fixes the issue where if the console color is bold before the CLI is launched & the CLI exits with an error (no command found for example), the original bolding state of the console session is lost, switching back to non-bolded colors until the user resets their console colors.
