### PR TITLE
Turn off UpdateVersionsRepo task in the build

### DIFF
--- a/build/publish/FinishBuild.targets
+++ b/build/publish/FinishBuild.targets
@@ -30,8 +30,9 @@
                        Channel="$(Channel)"
                        CommitHash="$(CommitHash)" />
 
-    <UpdateVersionsRepo BranchName="$(BranchName)"
+    <!-- Uncomment the line below when https://github.com/dotnet/buildtools/issues/1547 gets fixed. -->
+    <!-- <UpdateVersionsRepo BranchName="$(BranchName)"
                         PackagesDirectory="$(PackagesDirectory)"
-                        GitHubPassword="$(GITHUB_PASSWORD)" />
+                        GitHubPassword="$(GITHUB_PASSWORD)" /> -->
   </Target>
 </Project>


### PR DESCRIPTION
Turn off UpdateVersionsRepo task in the build until the buildtools gets updated to a new NuGet compatible with the CLI.

@dotnet/dotnet-cli 

@MattGertz Infra-structure only change.
