### PR TITLE
Update Roslyn to 2.3.0-beta3-61814-09 in 1.1.0

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -7,7 +7,7 @@
     <CLI_NETSDK_Version>1.1.0-alpha-20170615-3</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview3-4168</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>
-    <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>
+    <CLI_TestPlatform_Version>15.3.0-preview-20170609-02</CLI_TestPlatform_Version>
     <TemplateEngineVersion>1.0.0-beta1-20170202-111</TemplateEngineVersion>
     <TemplateEngineTemplateVersion>1.0.0-beta1-20170427-174</TemplateEngineTemplateVersion>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>1.1.2</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000388-01</CLI_MSBuild_Version>
-    <CLI_Roslyn_Version>2.0.0-rc5-61427-04</CLI_Roslyn_Version>
+    <CLI_Roslyn_Version>2.3.0-beta3-61814-09</CLI_Roslyn_Version>
     <CLI_NETSDK_Version>1.1.0-alpha-20170607-4</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview3-4168</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>

--- a/src/tool_roslyn/tool_roslyn.csproj
+++ b/src/tool_roslyn/tool_roslyn.csproj
@@ -37,9 +37,9 @@
           AfterTargets="Publish"
           BeforeTargets="RemoveFilesAfterPublish">
     <ItemGroup>
-      <AssetsToRemoveFromDeps Include="runtimes/any/native/csc.exe" 
+      <AssetsToRemoveFromDeps Include="runtimes/any/native/csc.dll" 
                               SectionName="runtimeTargets" />
-      <AssetsToRemoveFromDeps Include="runtimes/any/native/vbc.exe" 
+      <AssetsToRemoveFromDeps Include="runtimes/any/native/vbc.dll" 
                               SectionName="runtimeTargets" />
       <AssetsToRemoveFromDeps Include="tool_roslyn.dll" 
                               SectionName="runtime"/>
@@ -49,7 +49,7 @@
                                  SectionName="%(AssetsToRemoveFromDeps.SectionName)"
                                  AssetPath="%(AssetsToRemoveFromDeps.Identity)" />
    
-    <Copy SourceFiles="$(PublishDir)/runtimes/any/native/csc.exe;
+    <Copy SourceFiles="$(PublishDir)/runtimes/any/native/csc.dll;
                        $(PublishDir)/$(TargetName).runtimeconfig.json;
                        $(PublishDir)/$(TargetName).deps.json;"
           DestinationFiles="$(PublishDir)/csc.exe;


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz Flow of dependencies into the CLI.
