### PR TITLE
Update SpaTemplateVersion to 1.0.0-preview-000312

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -28,7 +28,7 @@
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
     <CliMigrateVersion>1.2.1-alpha-002133</CliMigrateVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
-    <SpaTemplateVersion>1.0.0-preview-000297</SpaTemplateVersion>
+    <SpaTemplateVersion>1.0.0-preview-000312</SpaTemplateVersion>
 
     <!-- This should either be timestamped or notimestamp as appropriate -->
     <AspNetCoreRuntimePackageFlavor>notimestamp</AspNetCoreRuntimePackageFlavor>


### PR DESCRIPTION
I'm hoping that this PR is against the correct branch (`release/2.0.0-preview2`). That seems to be a new branch since I submitted my last PR.

The changes in this template package are to account for tooling updates (e.g., changing `PackageTargetFallback` to `AssetTargetFallback`).