### PR TITLE
Stop produce duplicated package for VSTS build definition

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -59,6 +59,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{89905EC4
 		build\Test.targets = build\Test.targets
 		build\Version.props = build\Version.props
 		build\VersionBadge.props = build\VersionBadge.props
+		build\DerivedHostMachineInfo.props = build\DerivedHostMachineInfo.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "package", "package", "{FD7D515A-D10F-4F49-B8AE-21CF7ED071AE}"

--- a/build/DerivedHostMachineInfo.props
+++ b/build/DerivedHostMachineInfo.props
@@ -1,0 +1,7 @@
+<Project>
+    <PropertyGroup>
+      <IsDebianBaseDistro Condition=" '$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian' ">true</IsDebianBaseDistro>
+      <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) ">true</IsRPMBasedDistro>
+      <IsLinuxDistroSpecific Condition=" ('$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true') AND '$(IslinuxPortable)' != 'true' ">true</IsLinuxDistroSpecific>
+    </PropertyGroup>
+</Project>

--- a/build/FileExtensions.props
+++ b/build/FileExtensions.props
@@ -1,20 +1,17 @@
 <Project>
     <PropertyGroup>
-      <IsDebianBaseDistro Condition=" '$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian' ">True</IsDebianBaseDistro>
-      <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) ">True</IsRPMBasedDistro>
-
       <ArchiveExtension Condition=" '$(HostOSName)' == 'win' ">.zip</ArchiveExtension>
       <ArchiveExtension Condition=" '$(HostOSName)' != 'win' ">.tar.gz</ArchiveExtension>
 
       <InstallerExtension Condition=" '$(HostOSName)' == 'win' ">.msi</InstallerExtension>
       <InstallerExtension Condition=" '$(HostOSName)' == 'osx' ">.pkg</InstallerExtension>
-      <InstallerExtension Condition=" '$(IsDebianBaseDistro)' == 'True' ">.deb</InstallerExtension>
-      <InstallerExtension Condition=" '$(IsRPMBasedDistro)' == True ">.rpm</InstallerExtension>
+      <InstallerExtension Condition=" '$(IsDebianBaseDistro)' == 'true' ">.deb</InstallerExtension>
+      <InstallerExtension Condition=" '$(IsRPMBasedDistro)' == true ">.rpm</InstallerExtension>
 
       <BundleExtension Condition=" '$(HostOSName)' == 'win' ">.exe</BundleExtension>
       <BundleExtension Condition=" '$(HostOSName)' == 'osx' ">$(InstallerExtension)</BundleExtension>
-      <BundleExtension Condition=" '$(IsDebianBaseDistro)' == 'True' ">$(InstallerExtension)</BundleExtension>
-      <BundleExtension Condition=" '$(IsRPMBasedDistro)' == True ">$(InstallerExtension)</BundleExtension>
+      <BundleExtension Condition=" '$(IsDebianBaseDistro)' == 'true' ">$(InstallerExtension)</BundleExtension>
+      <BundleExtension Condition=" '$(IsRPMBasedDistro)' == true ">$(InstallerExtension)</BundleExtension>
 
       <DynamicLibPrefix>lib</DynamicLibPrefix>
       <DynamicLibPrefix Condition=" '$(HostOSName)' == 'win' "></DynamicLibPrefix>

--- a/build/Publish.targets
+++ b/build/Publish.targets
@@ -26,9 +26,12 @@
 
   <Target Name="GatherItemsForPattern">
     <ItemGroup>
-      <ForPublishing Include="@(GeneratedInstallers)" />
-      <ForPublishing Include="%(GenerateArchivesInputsOutputs.Outputs)" />
-      <ForPublishing Include="$(PackagesDirectory)/Microsoft*.nupkg" Condition=" '$(PUBLISH_NUPKG_TO_AZURE_BLOB)' != '' " />
+      <ForPublishing Include="@(GeneratedInstallers)"
+                     Condition=" '$(IslinuxPortable)' != 'true' "/>
+      <ForPublishing Include="%(GenerateArchivesInputsOutputs.Outputs)"
+                     Condition=" '$(IsLinuxDistroSpecific)' != 'true' "/>
+      <ForPublishing Include="$(PackagesDirectory)/Microsoft*.nupkg"
+                     Condition=" '$(PUBLISH_NUPKG_TO_AZURE_BLOB)' != '' AND '$(IsLinuxDistroSpecific)' != 'true'"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/dir.props
+++ b/dir.props
@@ -28,6 +28,7 @@
   <Import Project="build/Version.props" />
   <Import Project="build/Branding.props" />
 
+  <Import Project="build/DerivedHostMachineInfo.props" />
   <Import Project="build/FileExtensions.props" />
   <Import Project="build/InputDirectories.props" />
   <Import Project="build/MSBuildExtensions.props" />

--- a/run-build.sh
+++ b/run-build.sh
@@ -104,7 +104,7 @@ while [[ $# > 0 ]]; do
             ;;
         --linux-portable)
             LINUX_PORTABLE_INSTALL_ARGS="--runtime-id linux-x64"
-            CUSTOM_BUILD_ARGS="/p:Rid=\"linux-x64\" /p:OSName=\"linux\""
+            CUSTOM_BUILD_ARGS="/p:Rid=\"linux-x64\" /p:OSName=\"linux\" /p:IslinuxPortable=\"true\""
             args=( "${args[@]/$1}" )
             ;;
         --help)


### PR DESCRIPTION
Currently VSTS is producing duplicate package and they are running into
each other will producing

Today:
Linux x64 build definition: both .deb and .tar.gz
Ubuntu 16.04 build definition: both .deb and .tar.gz (ex.
dotnet-sdk-2.0.0-preview3-006477-linux-x64.tar.gz,
dotnet-sdk-debug-2.0.0-preview3-006477-linux-x64.tar.gz,
dotnet-sdk-internal-2.0.0-preview3-006477-linux-x64.tar.gz)

After this change:
Linux x64: .tar.gz
Ubuntu 16.04: .deb

No change for windows and macOS
Tested on Ubuntu with and without --linux-portable and windows
