### PR TITLE
Updating Roslyn to 2.3.0-beta3-61816-04 in 1.1.0

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -11,5 +11,6 @@
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="AspNetCurrent" value="https://dotnet.myget.org/F/aspnet-feb2017-patch/api/v3/index.json" /> 
     <add key="web-api" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
+    <add key="symreader-native" value="https://dotnet.myget.org/F/symreader-native/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>1.1.2</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000388-01</CLI_MSBuild_Version>
-    <CLI_Roslyn_Version>2.0.0-rc5-61427-04</CLI_Roslyn_Version>
+    <CLI_Roslyn_Version>2.3.0-beta3-61816-04</CLI_Roslyn_Version>
     <CLI_NETSDK_Version>1.1.0-alpha-20170615-3</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview3-4168</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>

--- a/src/tool_roslyn/tool_roslyn.csproj
+++ b/src/tool_roslyn/tool_roslyn.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="$(CLI_Roslyn_Version)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.4.1" />
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.6.0-beta2-25304" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tool_roslyn/tool_roslyn.csproj
+++ b/src/tool_roslyn/tool_roslyn.csproj
@@ -37,9 +37,9 @@
           AfterTargets="Publish"
           BeforeTargets="RemoveFilesAfterPublish">
     <ItemGroup>
-      <AssetsToRemoveFromDeps Include="runtimes/any/native/csc.exe" 
+      <AssetsToRemoveFromDeps Include="runtimes/any/native/csc.dll" 
                               SectionName="runtimeTargets" />
-      <AssetsToRemoveFromDeps Include="runtimes/any/native/vbc.exe" 
+      <AssetsToRemoveFromDeps Include="runtimes/any/native/vbc.dll" 
                               SectionName="runtimeTargets" />
       <AssetsToRemoveFromDeps Include="tool_roslyn.dll" 
                               SectionName="runtime"/>
@@ -49,7 +49,7 @@
                                  SectionName="%(AssetsToRemoveFromDeps.SectionName)"
                                  AssetPath="%(AssetsToRemoveFromDeps.Identity)" />
    
-    <Copy SourceFiles="$(PublishDir)/runtimes/any/native/csc.exe;
+    <Copy SourceFiles="$(PublishDir)/runtimes/any/native/csc.dll;
                        $(PublishDir)/$(TargetName).runtimeconfig.json;
                        $(PublishDir)/$(TargetName).deps.json;"
           DestinationFiles="$(PublishDir)/csc.exe;


### PR DESCRIPTION
@dotnet/dotnet-cli

@MattGertz Flow of dependencies into the CLI.

Updated version of #6884, as that one never merged.