### PR TITLE
Detect git worktrees correctly

### DIFF
--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
@@ -37,9 +37,14 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 string directory = AppContext.BaseDirectory;
 #endif
 
-                while (!Directory.Exists(Path.Combine(directory, ".git")) && directory != null)
+                while (directory != null)
                 {
-                    directory = Directory.GetParent(directory).FullName;
+                    var gitDirOrFile = Path.Combine(directory, ".git");
+                    if (Directory.Exists(gitDirOrFile) || File.Exists(gitDirOrFile))
+                    {
+                        break;
+                    }
+                    directory = Directory.GetParent(directory)?.FullName;
                 }
 
                 if (directory == null)


### PR DESCRIPTION
[Git worktrees](https://git-scm.com/docs/git-worktree) are represented as a file named `.git` in the root directory, with contents that look like:

    gitdir: E:/cli/.git/worktrees/cli2

When trying to build in a worktree, `RepoRoot` throws a null reference exception when `Directory.GetParent` returns null (when it hits the root of the FS). This PR also changes that line to use `?.`, to throw the exception just below (that was never getting hit before this PR).