### PR TITLE
Add explicit dependency for pakcage smoke test

### DIFF
--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -99,6 +99,7 @@
 
   <Target Name="TestSdkDeb"
       Condition=" '$(IsDebianBaseDistro)' == 'True' and '$(DebuildPresent)'  == 'true' "
+      DependsOnTargets="RestoreTests"
       Inputs="$(DownloadedSharedHostInstallerFile);
               $(DownloadedHostFxrInstallerFile);
               $(DownloadedSharedFrameworkInstallerFile);

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -182,6 +182,7 @@
   </Target>
 
   <Target Name="TestSdkRpm"
+          DependsOnTargets="RestoreTests"
           Condition=" '$(IsRPMBasedDistro)' == 'True' and '$(FPMPresent)' == 'True' "
           Inputs="$(DownloadedSharedHostInstallerFile);
               $(DownloadedHostFxrInstallerFile);


### PR DESCRIPTION
Cherry-pick for 2.0.0-preview2 & 2.0.0 can be build faster with CLIBUILD_SKIP_TESTS on VSTS