### PR TITLE
Update templates to add missing BrowserLink package

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -21,8 +21,8 @@
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
     <TemplateEngineVersion>1.0.0-beta2-20170614-260</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170619-264</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170619-264</TemplateEngineTemplate2_0Version>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170620-265</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170620-265</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.0.0-preview2-25407-01</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0-preview2-25407-01</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -21,8 +21,8 @@
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
     <TemplateEngineVersion>1.0.0-beta2-20170614-260</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170620-265</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170620-265</TemplateEngineTemplate2_0Version>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170620-266</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170620-266</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.0.0-preview2-25407-01</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0-preview2-25407-01</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>


### PR DESCRIPTION
We should hold off on merging this one until we get an understanding of why the previous fix for the warnings for Microsoft.Composition didn't work.