### PR TITLE
Fixing an issue in the RepoDirectoriesProvider

### DIFF
--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
@@ -98,7 +98,10 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             _builtDotnet = builtDotnet ?? Path.Combine(_artifacts, "intermediate", "sharedFrameworkPublish");
             _nugetPackages = nugetPackages ?? Path.Combine(RepoRoot, ".nuget", "packages");
             _pjDotnet = pjDotnet ?? GetPjDotnetPath();
-            _stage2Sdk = Directory.EnumerateDirectories(Path.Combine(_artifacts, "stage2", "sdk")).First();
+            _stage2Sdk = Directory
+                .EnumerateDirectories(Path.Combine(_artifacts, "stage2", "sdk"))
+                .First(d => !d.Contains("NuGetFallbackFolder"));
+
             _stage2WithBackwardsCompatibleRuntimesDirectory =
                 Path.Combine(_artifacts, "stage2WithBackwardsCompatibleRuntimes");
             _testPackages = Path.Combine(RepoRoot, "artifacts", "testpackages", "packages");


### PR DESCRIPTION
Fixing an issue in the RepoDirectoriesProvider where it assumed that the only directory under SDK was the SDK directories. This is no longer true now that we moved the NuGet fallback folder there.

@dotnet/dotnet-cli 

@MattGertz test change only.