### PR TITLE
Make configurer unit tests pass on localized setup

### DIFF
--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
 
             dotnetFirstTimeUseConfigurer.Configure();
 
-            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str.StartsWith("Welcome to .NET Core!"))), Times.Never);
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.FirstTimeWelcomeMessage)), Times.Never);
             _reporterMock.Verify(r => r.Write(It.IsAny<string>()), Times.Never);
         }
 
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
 
             dotnetFirstTimeUseConfigurer.Configure();
 
-            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str.StartsWith("Welcome to .NET Core!"))), Times.Never);
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.FirstTimeWelcomeMessage)), Times.Never);
             _reporterMock.Verify(r => r.Write(It.IsAny<string>()), Times.Never);
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
 
             dotnetFirstTimeUseConfigurer.Configure();
 
-            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str.StartsWith("Welcome to .NET Core!"))), Times.Never);
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.FirstTimeWelcomeMessage)), Times.Never);
             _reporterMock.Verify(r => r.Write(It.IsAny<string>()), Times.Never);
         }
 
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
 
             dotnetFirstTimeUseConfigurer.Configure();
 
-            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str.StartsWith("Welcome to .NET Core!"))));
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.FirstTimeWelcomeMessage)));
             _reporterMock.Verify(r => r.Write(It.IsAny<string>()), Times.Never);
         }
 
@@ -228,8 +228,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
 
             dotnetFirstTimeUseConfigurer.Configure();
 
-            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str.StartsWith("Welcome to .NET Core!"))));
-            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str.StartsWith("Configuring"))));
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.FirstTimeWelcomeMessage)));
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.NugetCachePrimeMessage)));
             _nugetCachePrimerMock.Verify(r => r.PrimeCache(), Times.Once);
             _reporterMock.Verify(r => r.Write(It.IsAny<string>()), Times.Never);
         }


### PR DESCRIPTION
Fixes the last set of failing tests on localized setup. These tests came in very recently and so they weren't caught by my first pass. 

@livarcocc 
