### PR TITLE
Change usages of Write-Output to Write-Host

### DIFF
--- a/scripts/dev-dotnet.ps1
+++ b/scripts/dev-dotnet.ps1
@@ -10,12 +10,12 @@ try {
         throw "You need to have a version of 'dotnet' on your path so we can determine the RID"
     }
 
-    $rid = dotnet --version | where { $_ -match "^ Runtime Id:\s*(.*)$" } | foreach { $matches[1] } 
+    $rid = dotnet --version | where { $_ -match "^ Runtime Id:\s*(.*)$" } | foreach { $matches[1] }
     $stage2 = "$PSScriptRoot\..\artifacts\$rid\stage2\bin"
     if (Test-Path $stage2) {
         $env:PATH="$stage2;$env:PATH"
     } else {
-        Write-Output "You don't have a dev build in the 'artifacts\$rid\stage2' folder!"
+        Write-Host "You don't have a dev build in the 'artifacts\$rid\stage2' folder!"
     }
 
     dotnet @args

--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -470,7 +470,6 @@ if ($IsSdkInstalled) {
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 
 $installDrive = $((Get-Item $InstallRoot).PSDrive.Name);
-Write-Host "${installDrive}:";
 $free = Get-CimInstance -Class win32_logicaldisk | where Deviceid -eq "${installDrive}:"
 if ($free.Freespace / 1MB -le 100 ) {
     Say "There is not enough disk space on drive ${installDrive}:"

--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -85,7 +85,7 @@ $VersionRegEx="/\d+\.\d+[^/]+/"
 $OverrideNonVersionedFiles=$true
 
 function Say($str) {
-    Write-Output "dotnet-install: $str"
+    Write-Host "dotnet-install: $str"
 }
 
 function Say-Verbose($str) {
@@ -182,7 +182,7 @@ function GetHTTPResponse([Uri] $Uri)
                 $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
                 $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{Address=$ProxyAddress;UseDefaultCredentials=$ProxyUseDefaultCredentials}
                 $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
-            } 
+            }
             else {
                 $HttpClient = New-Object System.Net.Http.HttpClient
             }
@@ -208,7 +208,7 @@ function GetHTTPResponse([Uri] $Uri)
                 $HttpClient.Dispose()
             }
         }
-    })  
+    })
 }
 
 
@@ -227,7 +227,7 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel, [bool]$Co
             $VersionFileUrl = "$UncachedFeed/Sdk/$Channel/latest.version"
         }
     }
-    
+
     $Response = GetHTTPResponse -Uri $VersionFileUrl
     $StringContent = $Response.Content.ReadAsStringAsync().Result
 
@@ -262,7 +262,7 @@ function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$Channel,
 
 function Get-Download-Link([string]$AzureFeed, [string]$Channel, [string]$SpecificVersion, [string]$CLIArchitecture) {
     Say-Invocation $MyInvocation
-    
+
     if ($SharedRuntime) {
         $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-runtime-$SpecificVersion-win-$CLIArchitecture.zip"
     }
@@ -277,7 +277,7 @@ function Get-Download-Link([string]$AzureFeed, [string]$Channel, [string]$Specif
 
 function Get-LegacyDownload-Link([string]$AzureFeed, [string]$Channel, [string]$SpecificVersion, [string]$CLIArchitecture) {
     Say-Invocation $MyInvocation
-    
+
     if ($SharedRuntime) {
         $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-win-$CLIArchitecture.$SpecificVersion.zip"
     }
@@ -314,7 +314,7 @@ function Get-Version-Info-From-Version-File([string]$InstallRoot, [string]$Relat
 
     $VersionFile = Join-Path -Path $InstallRoot -ChildPath $RelativePathToVersionFile
     Say-Verbose "Local version file: $VersionFile"
-    
+
     if (Test-Path $VersionFile) {
         $VersionText = cat $VersionFile
         Say-Verbose "Local version file text: $VersionText"
@@ -328,7 +328,7 @@ function Get-Version-Info-From-Version-File([string]$InstallRoot, [string]$Relat
 
 function Is-Dotnet-Package-Installed([string]$InstallRoot, [string]$RelativePathToPackage, [string]$SpecificVersion) {
     Say-Invocation $MyInvocation
-    
+
     $DotnetPackagePath = Join-Path -Path $InstallRoot -ChildPath $RelativePathToPackage | Join-Path -ChildPath $SpecificVersion
     Say-Verbose "Is-Dotnet-Package-Installed: Path to a package: $DotnetPackagePath"
     return Test-Path $DotnetPackagePath -PathType Container
@@ -346,13 +346,13 @@ function Get-Path-Prefix-With-Version($path) {
     if ($match.Success) {
         return $entry.FullName.Substring(0, $match.Index + $match.Length)
     }
-    
+
     return $null
 }
 
 function Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package([System.IO.Compression.ZipArchive]$Zip, [string]$OutPath) {
     Say-Invocation $MyInvocation
-    
+
     $ret = @()
     foreach ($entry in $Zip.Entries) {
         $dir = Get-Path-Prefix-With-Version $entry.FullName
@@ -363,12 +363,12 @@ function Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package([Sys
             }
         }
     }
-    
+
     $ret = $ret | Sort-Object | Get-Unique
-    
+
     $values = ($ret | foreach { "$_" }) -join ";"
     Say-Verbose "Directories to unpack: $values"
-    
+
     return $ret
 }
 
@@ -392,9 +392,9 @@ function Extract-Dotnet-Package([string]$ZipPath, [string]$OutPath) {
     Set-Variable -Name Zip
     try {
         $Zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
-        
+
         $DirectoriesToUnpack = Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package -Zip $Zip -OutPath $OutPath
-        
+
         foreach ($entry in $Zip.Entries) {
             $PathWithVersion = Get-Path-Prefix-With-Version $entry.FullName
             if (($PathWithVersion -eq $null) -Or ($DirectoriesToUnpack -contains $PathWithVersion)) {
@@ -470,7 +470,7 @@ if ($IsSdkInstalled) {
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 
 $installDrive = $((Get-Item $InstallRoot).PSDrive.Name);
-Write-Output "${installDrive}:";
+Write-Host "${installDrive}:";
 $free = Get-CimInstance -Class win32_logicaldisk | where Deviceid -eq "${installDrive}:"
 if ($free.Freespace / 1MB -le 100 ) {
     Say "There is not enough disk space on drive ${installDrive}:"

--- a/scripts/use-dev.ps1
+++ b/scripts/use-dev.ps1
@@ -12,5 +12,5 @@ if (Test-Path $stage2) {
         $env:PATH="$stage2;$env:PATH"
     }
 } else {
-    Write-Output "You don't have a dev build in the 'artifacts\win10-x64\stage2' folder!"
+    Write-Host "You don't have a dev build in the 'artifacts\win10-x64\stage2' folder!"
 }


### PR DESCRIPTION
A few scripts are using `Write-Output` to display console messages, but the more appropriate call is `Write-Host`. This can cause issues when dotnet-install.ps1 is invoked from a PowerShell function because `Write-Output` pushes data to the cmdlet pipeline.

Simple example:
```ps1
function Get-DotNet {
  & dotnet-install.ps1 -InstallDir "$PSScriptRoot/.dotnet"
  return "$PSScriptRoot/.dotnet/dotnet.exe"
}
$dotnet = Get-DotNet
& $dotnet build
```

In this example, console output is not displayed, and `$dotnet` is actually an array of strings that includes all the console output produced by dotnet-install.ps1, when you would actually expect this to only include the value returned from `Get-DotNet`. This sample script would fail with

> The term 'dotnet-install: .NET SDK version 2.0.0-preview2-006494 is already installed. .....' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that
the path is correct and try again.

Using `Write-Host` fixes this. Console output is produced and `$dotnet` only contains `"$PSScriptRoot/.dotnet/dotnet.exe"`