### PR TITLE
Update SPA templates version to 1.0.0-preview-000321

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -28,7 +28,7 @@
     <CliCommandLineParserVersion>0.1.0-alpha-142</CliCommandLineParserVersion>
     <CliMigrateVersion>1.2.1-alpha-002133</CliMigrateVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
-    <SpaTemplateVersion>1.0.0-preview-000312</SpaTemplateVersion>
+    <SpaTemplateVersion>1.0.0-preview-000321</SpaTemplateVersion>
 
     <!-- This should either be timestamped or notimestamp as appropriate -->
     <AspNetCoreRuntimePackageFlavor>notimestamp</AspNetCoreRuntimePackageFlavor>


### PR DESCRIPTION
Removes the `NETStandard.Library.NETFramework` references from the templates as requested.

The actual template code change is here: https://github.com/aspnet/JavaScriptServices/commit/328eb0451b92d1fa7fea3d0109997d63705b02d4 in case you want to see it is the change you expected.