### PR TITLE
Add F# and Roslyn satellites

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,8 +4,10 @@
     <CLI_SharedFrameworkVersion>2.0.0-preview3-25419-01</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000400-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.0-beta3-61816-04</CLI_Roslyn_Version>
+    <CLI_Roslyn_Satellites_Version>2.3.0-pre-20170624-6</CLI_Roslyn_Satellites_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>
     <CLI_FSharp_Version>4.2.0-rc-170602-0</CLI_FSharp_Version>
+    <CLI_FSharp_Satellites_Version>4.4.1-pre-20170624-6</CLI_FSharp_Satellites_Version>
 
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
          cases, so use separate properties but derive one from the other unless we want to

--- a/src/tool_fsharp/tool_fsc.csproj
+++ b/src/tool_fsharp/tool_fsc.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NetCore.App" Version="$(CLI_SharedFrameworkVersion)" />
     <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(CLI_FSharp_Version)" />
+    <PackageReference Include="CliDeps.Satellites.FSharp" Version="$(CLI_FSharp_Satellites_Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tool_roslyn/tool_roslyn.csproj
+++ b/src/tool_roslyn/tool_roslyn.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(CLI_DiaSymNative_Version)" />
+    <PackageReference Include="CliDeps.Satellites.Roslyn" Version="$(CLI_Roslyn_Satellites_Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
                 .WithWorkingDirectory(testInstance.Root)
                 .ExecuteWithCapturedOutput("--no-restore")
                 .Should().Fail()
-                .And.HaveStdOutContaining("project.assets.json' not found.");;
+                .And.HaveStdOutContaining("project.assets.json");
         }
 
         [Fact]

--- a/test/dotnet-pack.Tests/PackTests.cs
+++ b/test/dotnet-pack.Tests/PackTests.cs
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Tools.Pack.Tests
                 .WithWorkingDirectory(testInstance.Root)
                 .ExecuteWithCapturedOutput("--no-restore")
                 .Should().Fail()
-                .And.HaveStdOutContaining("project.assets.json' not found.");;
+                .And.HaveStdOutContaining("project.assets.json");
         }
 
         [Fact]

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
                 .WithWorkingDirectory(testProjectDirectory)
                 .ExecuteWithCapturedOutput("--framework netcoreapp2.0 --no-restore")
                 .Should().Fail()
-                .And.HaveStdOutContaining("project.assets.json' not found.");;
+                .And.HaveStdOutContaining("project.assets.json");
         }
 
         [Fact]

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .WithWorkingDirectory(testProjectDirectory)
                 .ExecuteWithCapturedOutput("--no-restore")
                 .Should().Fail()
-                .And.HaveStdOutContaining("project.assets.json' not found.");;
+                .And.HaveStdOutContaining("project.assets.json");
         }
 
         [Fact]

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 .WithWorkingDirectory(testProjectDirectory)
                 .ExecuteWithCapturedOutput($"{TestBase.ConsoleLoggerOutputNormal} --no-restore")
                 .Should().Fail()
-                .And.HaveStdOutContaining("project.assets.json' not found.");;
+                .And.HaveStdOutContaining("project.assets.json");
         }
 
         [Fact]


### PR DESCRIPTION
Localize compiler output by adding their satellite assemblies to the CLI.

For now, while F# and Roslyn do not yet have an OSS-based localization these are built from decompiled resx source at https://github.com/dotnet/cli-deps-satellites. This will allow building the full CLI stack from source including satellites without blocking on the localization process change. (cc @ellismg)

Also fixing some tests that were hard-coding an expectation of English messages from dotnet/sdk. The recent msbuild upgrade fixed the bug where task satellites were not being loaded and unmasked a few more failures.

@livarcocc @dotnet/dotnet-cli 