### PR TITLE
Create the Dotnet User Profile folder when running the first experience

### DIFF
--- a/src/Microsoft.DotNet.Configurer/FirstTimeUseNoticeSentinel.cs
+++ b/src/Microsoft.DotNet.Configurer/FirstTimeUseNoticeSentinel.cs
@@ -13,19 +13,24 @@ namespace Microsoft.DotNet.Configurer
         public static readonly string SENTINEL = $"{Product.Version}.dotnetFirstUseSentinel";
 
         private readonly IFile _file;
+        private readonly IDirectory _directory;
 
         private string _dotnetUserProfileFolderPath;
 
         private string SentinelPath => Path.Combine(_dotnetUserProfileFolderPath, SENTINEL);
 
         public FirstTimeUseNoticeSentinel(CliFallbackFolderPathCalculator cliFallbackFolderPathCalculator) :
-            this(cliFallbackFolderPathCalculator.DotnetUserProfileFolderPath, FileSystemWrapper.Default.File)
+            this(
+                cliFallbackFolderPathCalculator.DotnetUserProfileFolderPath,
+                FileSystemWrapper.Default.File,
+                FileSystemWrapper.Default.Directory)
         {
         }
 
-        internal FirstTimeUseNoticeSentinel(string dotnetUserProfileFolderPath, IFile file)
+        internal FirstTimeUseNoticeSentinel(string dotnetUserProfileFolderPath, IFile file, IDirectory directory)
         {
             _file = file;
+            _directory = directory;
             _dotnetUserProfileFolderPath = dotnetUserProfileFolderPath;
         }
 
@@ -38,6 +43,11 @@ namespace Microsoft.DotNet.Configurer
         {
             if (!Exists())
             {
+                if (!_directory.Exists(_dotnetUserProfileFolderPath))
+                {
+                    _directory.CreateDirectory(_dotnetUserProfileFolderPath);
+                }
+
                 _file.CreateEmptyFile(SentinelPath);
             }
         }

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenAFirstTimeUseNoticeSentinel.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenAFirstTimeUseNoticeSentinel.cs
@@ -1,0 +1,175 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Configurer;
+using Microsoft.Extensions.DependencyModel.Tests;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Configurer.UnitTests
+{
+    public class GivenAFirstTimeUseNoticeSentinel
+    {
+        private const string DOTNET_USER_PROFILE_FOLDER_PATH = "some path";
+
+        private FileSystemMockBuilder _fileSystemMockBuilder;
+
+        public GivenAFirstTimeUseNoticeSentinel()
+        {
+            _fileSystemMockBuilder = FileSystemMockBuilder.Create();
+        }
+
+        [Fact]
+        public void TheSentinelHasTheCurrentVersionInItsName()
+        {
+            FirstTimeUseNoticeSentinel.SENTINEL.Should().Contain($"{Product.Version}");
+        }
+
+        [Fact]
+        public void ItReturnsTrueIfTheSentinelExists()
+        {
+            _fileSystemMockBuilder.AddFiles(DOTNET_USER_PROFILE_FOLDER_PATH, FirstTimeUseNoticeSentinel.SENTINEL);
+
+            var fileSystemMock = _fileSystemMockBuilder.Build();
+
+            var firstTimeUseNoticeSentinel =
+                new FirstTimeUseNoticeSentinel(
+                    DOTNET_USER_PROFILE_FOLDER_PATH,
+                    fileSystemMock.File,
+                    fileSystemMock.Directory);
+
+            firstTimeUseNoticeSentinel.Exists().Should().BeTrue();
+        }
+
+        [Fact]
+        public void ItReturnsFalseIfTheSentinelDoesNotExist()
+        {
+            var fileSystemMock = _fileSystemMockBuilder.Build();
+
+            var firstTimeUseNoticeSentinel =
+                new FirstTimeUseNoticeSentinel(
+                    DOTNET_USER_PROFILE_FOLDER_PATH,
+                    fileSystemMock.File,
+                    fileSystemMock.Directory);
+
+            firstTimeUseNoticeSentinel.Exists().Should().BeFalse();
+        }
+
+        [Fact]
+        public void ItCreatesTheSentinelInTheDotnetUserProfileFolderPathIfItDoesNotExistAlready()
+        {
+            var fileSystemMock = _fileSystemMockBuilder.Build();
+            var firstTimeUseNoticeSentinel =
+                new FirstTimeUseNoticeSentinel(
+                    DOTNET_USER_PROFILE_FOLDER_PATH,
+                    fileSystemMock.File,
+                    fileSystemMock.Directory);
+
+            firstTimeUseNoticeSentinel.Exists().Should().BeFalse();
+
+            firstTimeUseNoticeSentinel.CreateIfNotExists();
+
+            firstTimeUseNoticeSentinel.Exists().Should().BeTrue();
+        }
+
+        [Fact]
+        public void ItDoesNotCreateTheSentinelAgainIfItAlreadyExistsInTheDotnetUserProfileFolderPath()
+        {
+            const string contentToValidateSentinalWasNotReplaced = "some string";
+            var sentinel = Path.Combine(DOTNET_USER_PROFILE_FOLDER_PATH, FirstTimeUseNoticeSentinel.SENTINEL);
+            _fileSystemMockBuilder.AddFile(sentinel, contentToValidateSentinalWasNotReplaced);
+
+            var fileSystemMock = _fileSystemMockBuilder.Build();
+
+            var firstTimeUseNoticeSentinel =
+                new FirstTimeUseNoticeSentinel(
+                    DOTNET_USER_PROFILE_FOLDER_PATH,
+                    fileSystemMock.File,
+                    fileSystemMock.Directory);
+
+            firstTimeUseNoticeSentinel.Exists().Should().BeTrue();
+
+            firstTimeUseNoticeSentinel.CreateIfNotExists();
+
+            fileSystemMock.File.ReadAllText(sentinel).Should().Be(contentToValidateSentinalWasNotReplaced);
+        }
+
+        [Fact]
+        public void ItCreatesTheDotnetUserProfileFolderIfItDoesNotExistAlreadyWhenCreatingTheSentinel()
+        {
+            var fileSystemMock = _fileSystemMockBuilder.Build();
+            var directoryMock = new DirectoryMock();
+            var firstTimeUseNoticeSentinel =
+                new FirstTimeUseNoticeSentinel(
+                    DOTNET_USER_PROFILE_FOLDER_PATH,
+                    fileSystemMock.File,
+                    directoryMock);
+
+            firstTimeUseNoticeSentinel.CreateIfNotExists();
+
+            directoryMock.Exists(DOTNET_USER_PROFILE_FOLDER_PATH).Should().BeTrue();
+            directoryMock.CreateDirectoryInvoked.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ItDoesNotAttemptToCreateTheDotnetUserProfileFolderIfItAlreadyExistsWhenCreatingTheSentinel()
+        {
+            var fileSystemMock = _fileSystemMockBuilder.Build();
+            var directoryMock = new DirectoryMock(new List<string> { DOTNET_USER_PROFILE_FOLDER_PATH });
+            var firstTimeUseNoticeSentinel =
+                new FirstTimeUseNoticeSentinel(
+                    DOTNET_USER_PROFILE_FOLDER_PATH,
+                    fileSystemMock.File,
+                    directoryMock);
+
+            firstTimeUseNoticeSentinel.CreateIfNotExists();
+
+            directoryMock.CreateDirectoryInvoked.Should().BeFalse();
+        }
+
+        private class DirectoryMock : IDirectory
+        {
+            private IList<string> _directories;
+
+            public bool CreateDirectoryInvoked { get; set; }
+
+            public DirectoryMock(IList<string> directories = null)
+            {
+                _directories = directories ?? new List<string>();
+            }
+
+            public bool Exists(string path)
+            {
+                return _directories.Any(d => d == path);
+            }
+
+            public ITemporaryDirectory CreateTemporaryDirectory()
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerable<string> GetFiles(string path, string searchPattern)
+            {
+                throw new NotImplementedException();
+            }
+
+            public string GetDirectoryFullName(string path)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void CreateDirectory(string path)
+            {
+                _directories.Add(path);
+                CreateDirectoryInvoked = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz for approval

**Customer scenario**

When running a 2.0.0-preview3 for the first time in a machine in a machine without any other CLI, the .dotnet folder won't be created. This will cause the first run to fail, because we will try to write a file in a folder that does not exist. The fix is to create the Dotnet User Profile folder when running the first experience, if the folder does not exist.

**Bugs this fixes:** 

https://github.com/dotnet/cli/issues/6989

**Workarounds, if any**

Tell the user to create the folder manually. But I would prefer if our customers did not know our internal folder structures.

**Risk**

Small.

**Performance impact**

None.

**Is this a regression from a previous update?**

N/A

**Root cause analysis:**

On a Mac, where I ran local testing for this, the folder is guaranteed to exist because that's where we write the Multicore JIT data. So, I didn't hit this.

**How was the bug found?**

Reported by team member and customer.
