### PR TITLE
Localize parser validation messages

### DIFF
--- a/src/dotnet/CommandLine/CommandLineValidationMessages.cs
+++ b/src/dotnet/CommandLine/CommandLineValidationMessages.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+
+namespace Microsoft.DotNet.Cli.CommandLine
+{
+    internal sealed class CommandLineValidationMessages : IValidationMessages
+    {
+        public string CommandAcceptsOnlyOneArgument(string command, int argumentCount) =>
+            string.Format(LocalizableStrings.CommandAcceptsOnlyOneArgument, command, argumentCount);
+
+        public string CommandAcceptsOnlyOneSubcommand(string command, string subcommandsSpecified) =>
+            string.Format(LocalizableStrings.CommandAcceptsOnlyOneSubcommand, command, subcommandsSpecified);
+
+        public string FileDoesNotExist(string filePath) =>
+            string.Format(LocalizableStrings.FileDoesNotExist, filePath);
+
+        public string NoArgumentsAllowed(string option) =>
+            string.Format(LocalizableStrings.NoArgumentsAllowed, option);
+
+        public string OptionAcceptsOnlyOneArgument(string option, int argumentCount) =>
+            string.Format(LocalizableStrings.OptionAcceptsOnlyOneArgument, option, argumentCount);
+
+        public string RequiredArgumentMissingForCommand(string command) =>
+            string.Format(LocalizableStrings.RequiredArgumentMissingForCommand, command);
+
+        public string RequiredArgumentMissingForOption(string option) =>
+            string.Format(LocalizableStrings.RequiredArgumentMissingForOption, option);
+
+        public string RequiredCommandWasNotProvided() =>
+            string.Format(LocalizableStrings.RequiredCommandWasNotProvided);
+
+        public string UnrecognizedArgument(string unrecognizedArg, string[] allowedValues) =>
+            string.Format(LocalizableStrings.UnrecognizedArgument, unrecognizedArg, $"\n\t{string.Join("\n\t", allowedValues.Select(v => $"'{v}'"))}");
+
+        public string UnrecognizedCommandOrArgument(string arg) =>
+            string.Format(LocalizableStrings.UnrecognizedCommandOrArgument, arg);
+
+        public string UnrecognizedOption(string unrecognizedOption, string[] allowedValues) =>
+            string.Format(LocalizableStrings.UnrecognizedOption, unrecognizedOption, $"\n\t{string.Join("\n\t", allowedValues.Select(v => $"'{v}'"))}");
+    }
+}

--- a/src/dotnet/CommandLine/LocalizableStrings.resx
+++ b/src/dotnet/CommandLine/LocalizableStrings.resx
@@ -180,4 +180,37 @@
   <data name="MSBuildAdditionalArgsHelpText" xml:space="preserve">
     <value>Any extra options that should be passed to MSBuild. See 'dotnet msbuild -h' for available options.</value>
   </data>
+  <data name="CommandAcceptsOnlyOneArgument" xml:space="preserve">
+    <value>Command '{0}' only accepts a single argument but {1} were provided.</value>
+  </data>
+  <data name="CommandAcceptsOnlyOneSubcommand" xml:space="preserve">
+    <value>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</value>
+  </data>
+  <data name="FileDoesNotExist" xml:space="preserve">
+    <value>File does not exist: {0}</value>
+  </data>
+  <data name="NoArgumentsAllowed" xml:space="preserve">
+    <value>Arguments not allowed for option: {0}</value>
+  </data>
+  <data name="OptionAcceptsOnlyOneArgument" xml:space="preserve">
+    <value>Option '{0}' only accepts a single argument but {1} were provided.</value>
+  </data>
+  <data name="RequiredArgumentMissingForCommand" xml:space="preserve">
+    <value>Required argument missing for command: {0}</value>
+  </data>
+  <data name="RequiredArgumentMissingForOption" xml:space="preserve">
+    <value>Required argument missing for option: {0}</value>
+  </data>
+  <data name="RequiredCommandWasNotProvided" xml:space="preserve">
+    <value>Required command was not provided.</value>
+  </data>
+  <data name="UnrecognizedArgument" xml:space="preserve">
+    <value>Argument '{0}' not recognized. Must be one of: {1}</value>
+  </data>
+  <data name="UnrecognizedCommandOrArgument" xml:space="preserve">
+    <value>Unrecognized command or argument '{0}'</value>
+  </data>
+  <data name="UnrecognizedOption" xml:space="preserve">
+    <value>Option '{0}' not recognized. Must be one of: {1}</value>
+  </data>
 </root>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.cs.xlf
@@ -107,6 +107,61 @@
         <target state="translated">Nebyla zadána povinná hodnota parametru {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.de.xlf
@@ -107,6 +107,61 @@
         <target state="translated">Der erforderliche Wert für die Option "{0}" wurde nicht angegeben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.es.xlf
@@ -107,6 +107,61 @@
         <target state="translated">No se ha proporcionado el valor requerido para la opción "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.fr.xlf
@@ -107,6 +107,61 @@
         <target state="translated">La valeur nécessaire pour l'option '{0}' n'a pas été fournie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.it.xlf
@@ -107,6 +107,61 @@
         <target state="translated">Il valore obbligatorio per l'opzione '{0}' non è stato specificato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.ja.xlf
@@ -107,6 +107,61 @@
         <target state="translated">オプション '{0}' に必要な値が指定されませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.ko.xlf
@@ -107,6 +107,61 @@
         <target state="translated">옵션 '{0}'에 대해 필요한 값이 제공되지 않았습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.pl.xlf
@@ -107,6 +107,61 @@
         <target state="translated">Nie podano wymaganej wartości dla opcji „{0}”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.pt-BR.xlf
@@ -107,6 +107,61 @@
         <target state="translated">Um valor obrigatório para a opção '{0}' não foi fornecido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.ru.xlf
@@ -107,6 +107,61 @@
         <target state="translated">Не указано обязательное значение параметра "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.tr.xlf
@@ -107,6 +107,61 @@
         <target state="translated">'{0}' seçeneği için gerekli değer sağlanmadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.zh-Hans.xlf
@@ -107,6 +107,61 @@
         <target state="translated">未提供选项“{0}”必需的值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/CommandLine/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/CommandLine/xlf/LocalizableStrings.zh-Hant.xlf
@@ -107,6 +107,61 @@
         <target state="translated">未對選項 '{0}' 提供必要的值。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneArgument">
+        <source>Command '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Command '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandAcceptsOnlyOneSubcommand">
+        <source>Command '{0}' only accepts a single subcommand but multiple were provided: {1}</source>
+        <target state="new">Command '{0}' only accepts a single subcommand but multiple were provided: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDoesNotExist">
+        <source>File does not exist: {0}</source>
+        <target state="new">File does not exist: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoArgumentsAllowed">
+        <source>Arguments not allowed for option: {0}</source>
+        <target state="new">Arguments not allowed for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OptionAcceptsOnlyOneArgument">
+        <source>Option '{0}' only accepts a single argument but {1} were provided.</source>
+        <target state="new">Option '{0}' only accepts a single argument but {1} were provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForCommand">
+        <source>Required argument missing for command: {0}</source>
+        <target state="new">Required argument missing for command: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredArgumentMissingForOption">
+        <source>Required argument missing for option: {0}</source>
+        <target state="new">Required argument missing for option: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredCommandWasNotProvided">
+        <source>Required command was not provided.</source>
+        <target state="new">Required command was not provided.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedArgument">
+        <source>Argument '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Argument '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedCommandOrArgument">
+        <source>Unrecognized command or argument '{0}'</source>
+        <target state="new">Unrecognized command or argument '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnrecognizedOption">
+        <source>Option '{0}' not recognized. Must be one of: {1}</source>
+        <target state="new">Option '{0}' not recognized. Must be one of: {1}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/Parser.cs
+++ b/src/dotnet/Parser.cs
@@ -27,6 +27,8 @@ namespace Microsoft.DotNet.Cli
             DefaultHelpViewText.Synopsis.Command = UsageCommandToken;
             DefaultHelpViewText.Synopsis.Options = UsageOptionsToken;
             DefaultHelpViewText.Synopsis.Title = UsageHeader;
+
+            ValidationMessages.Current = new CommandLineValidationMessages();
         }
 
         public static CommandLine.Parser Instance { get; } = new CommandLine.Parser(

--- a/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
+++ b/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
@@ -125,8 +125,8 @@ Commands:
                     .WithProject("one two three")
                     .Execute("proj.csproj");
             cmd.ExitCode.Should().NotBe(0);
-            cmd.StdErr.Should().BeVisuallyEquivalentTo(
-                "Unrecognized command or argument 'two'\r\nUnrecognized command or argument 'three'");
+            cmd.StdErr.Should().BeVisuallyEquivalentTo($@"{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "two")}
+{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "three")}");
         }
 
         [Theory]

--- a/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
+++ b/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
@@ -69,8 +69,8 @@ Commands:
                     .WithProject("one two three")
                     .Execute("proj.csproj");
             cmd.ExitCode.Should().NotBe(0);
-            cmd.StdErr.Should().BeVisuallyEquivalentTo(
-                "Unrecognized command or argument 'two'\r\nUnrecognized command or argument 'three'");
+            cmd.StdErr.Should().BeVisuallyEquivalentTo($@"{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "two")}
+{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "three")}");
         }
 
         [Theory]

--- a/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
+++ b/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
@@ -151,7 +151,8 @@ Commands:
                     .WithProject("one two three")
                     .Execute("proj.csproj");
             cmd.ExitCode.Should().NotBe(0);
-            cmd.StdErr.Should().BeVisuallyEquivalentTo("Unrecognized command or argument 'two'\r\nUnrecognized command or argument 'three'");
+            cmd.StdErr.Should().BeVisuallyEquivalentTo($@"{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "two")}
+{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "three")}");
         }
 
         [Theory]

--- a/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
+++ b/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
@@ -216,7 +216,9 @@ EndGlobal
             var cmd = new DotnetCommand()
                 .ExecuteWithCapturedOutput("sln one.sln two.sln three.sln add");
             cmd.Should().Fail();
-            cmd.StdErr.Should().BeVisuallyEquivalentTo($"Unrecognized command or argument 'two.sln'\r\nUnrecognized command or argument 'three.sln'\r\n{CommonLocalizableStrings.SpecifyAtLeastOneProjectToAdd}");
+            cmd.StdErr.Should().BeVisuallyEquivalentTo($@"{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "two.sln")}
+{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "three.sln")}
+{CommonLocalizableStrings.SpecifyAtLeastOneProjectToAdd}");
         }
 
         [Theory]

--- a/test/dotnet-sln-list.Tests/GivenDotnetSlnList.cs
+++ b/test/dotnet-sln-list.Tests/GivenDotnetSlnList.cs
@@ -66,7 +66,8 @@ Commands:
             var cmd = new DotnetCommand()
                 .ExecuteWithCapturedOutput("sln one.sln two.sln three.sln list");
             cmd.Should().Fail();
-            cmd.StdErr.Should().BeVisuallyEquivalentTo("Unrecognized command or argument 'two.sln'\r\nUnrecognized command or argument 'three.sln'");
+            cmd.StdErr.Should().BeVisuallyEquivalentTo($@"{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "two.sln")}
+{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "three.sln")}");
         }
 
         [Theory]

--- a/test/dotnet-sln-remove.Tests/GivenDotnetSlnRemove.cs
+++ b/test/dotnet-sln-remove.Tests/GivenDotnetSlnRemove.cs
@@ -188,7 +188,9 @@ EndGlobal
             var cmd = new DotnetCommand()
                 .ExecuteWithCapturedOutput("sln one.sln two.sln three.sln remove");
             cmd.Should().Fail();
-            cmd.StdErr.Should().BeVisuallyEquivalentTo($"Unrecognized command or argument 'two.sln'\r\nUnrecognized command or argument 'three.sln'\r\n{CommonLocalizableStrings.SpecifyAtLeastOneProjectToRemove}");
+            cmd.StdErr.Should().BeVisuallyEquivalentTo($@"{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "two.sln")}
+{string.Format(CommandLine.LocalizableStrings.UnrecognizedCommandOrArgument, "three.sln")}
+{CommonLocalizableStrings.SpecifyAtLeastOneProjectToRemove}");
         }
 
         [Theory]

--- a/test/dotnet.Tests/ParserTests/AddReferenceParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/AddReferenceParserTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
                 .Errors
                 .Select(e => e.Message)
                 .Should()
-                .BeEquivalentTo("Required argument missing for command: reference");
+                .BeEquivalentTo(string.Format(LocalizableStrings.RequiredArgumentMissingForCommand, "reference"));
         }
     }
 }

--- a/test/dotnet.Tests/ParserTests/ValdidationMessageTests.cs
+++ b/test/dotnet.Tests/ParserTests/ValdidationMessageTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    public class ValidationMessageTests
+    {
+        private readonly ITestOutputHelper output;
+
+        [Fact]
+        public void ValidationMessagesFormatCorrectly()
+        {
+            // Since not all validation messages that we provided to the command-line parser are triggered by our
+            // tests (and some may not be possible to trigger with our current usage), unit test  that we can 
+            // obtain validation messages through the same interface as the command-line parser.
+            //
+            // In English configuration, we check that the messages are exactly what we expect and otherwise we at
+            // lest ensure that we don't get a FormatException.
+
+            IValidationMessages m = new CommandLineValidationMessages();
+
+            m.CommandAcceptsOnlyOneArgument("xyz", 3)
+             .Should().BeVisuallyEquivalentToIfNotLocalized(
+                 "Command 'xyz' only accepts a single argument but 3 were provided.");
+
+            m.CommandAcceptsOnlyOneSubcommand("zyx", "a;b;c")
+             .Should().BeVisuallyEquivalentToIfNotLocalized(
+                "Command 'zyx' only accepts a single subcommand but multiple were provided: a;b;c");
+
+            m.FileDoesNotExist("abc.def")
+              .Should().BeVisuallyEquivalentToIfNotLocalized(
+                "File does not exist: abc.def");
+
+            m.NoArgumentsAllowed("zzz")
+            .Should().BeVisuallyEquivalentToIfNotLocalized(
+                "Arguments not allowed for option: zzz");
+
+            m.OptionAcceptsOnlyOneArgument("qqq", 4)
+             .Should().BeVisuallyEquivalentToIfNotLocalized(
+                "Option 'qqq' only accepts a single argument but 4 were provided.");
+
+            m.RequiredArgumentMissingForCommand("www")
+             .Should().BeVisuallyEquivalentToIfNotLocalized(
+                "Required argument missing for command: www");
+
+            m.RequiredArgumentMissingForOption("rrr")
+             .Should().BeVisuallyEquivalentToIfNotLocalized(
+                 "Required argument missing for option: rrr");
+
+            m.RequiredCommandWasNotProvided()
+             .Should().BeVisuallyEquivalentToIfNotLocalized(
+                 "Required command was not provided.");
+
+            m.UnrecognizedArgument("apple", new[] { "banana", "orange" })
+              .Should().BeVisuallyEquivalentToIfNotLocalized(
+                 "Argument 'apple' not recognized. Must be one of: \n\t'banana'\n\t\'orange'");
+
+            m.UnrecognizedCommandOrArgument("ppp")
+              .Should().BeVisuallyEquivalentToIfNotLocalized(
+                 "Unrecognized command or argument 'ppp'");
+
+            m.UnrecognizedOption("apple", new[] { "banana", "orange" })
+              .Should().BeVisuallyEquivalentToIfNotLocalized(
+                 "Option 'apple' not recognized. Must be one of: \n\t'banana'\n\t\'orange'");
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**

Certain validation messages from the command line parser are not localized

**Bugs this fixes:** 

https://github.com/dotnet/CliCommandLineParser/issues/75

The command line parser library we use was fixed to allow the caller to supply localized overrides for its common validation messages. This change follows up on that by overriding the messages appropriately.

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

None.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Strings were hard-coded during the development of the new parser and we're only now localized and seeing the messages that were missed.

**How was the bug found?**

Ad-hoc testing on localized setup
