### PR TITLE
Update test platform to 15.3.0-preview-20170628-02

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -18,7 +18,7 @@
     <CLI_NuGet_Version>4.3.0-preview3-4168</CLI_NuGet_Version>
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.0-preview2-25331-02</CLI_NETStandardLibraryNETFrameworkVersion>
     <CLI_WEBSDK_Version>2.0.0-rel-20170518-512</CLI_WEBSDK_Version>
-    <CLI_TestPlatform_Version>15.3.0-preview-20170618-03</CLI_TestPlatform_Version>
+    <CLI_TestPlatform_Version>15.3.0-preview-20170628-02</CLI_TestPlatform_Version>
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>


### PR DESCRIPTION
Reliability fixes in test platform.
1. Fix an issue where vstest.console will not terminate if VS terminates during discovery
2. Fix reliability in LUT where successive discoveries for .NET core will fail due to test host sticking around

ASK mode bug: [457469](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/457469)
