### PR TITLE
Adding a installer for Downlevel (Dev14) to install .NET Framework pr…

### DIFF
--- a/build/Branding.props
+++ b/build/Branding.props
@@ -1,6 +1,7 @@
 <Project ToolsVersion="14.0">
   <PropertyGroup>
     <SdkBrandName>Microsoft .NET Core SDK - 2.0.0 Preview 2</SdkBrandName>
+    <MSBuildExtensionsBrandName>Microsoft .NET Core MSBuild Extensions - 2.0.0 Preview 2</MSBuildExtensionsBrandName>
     <SharedFrameworkBrandName>Microsoft .NET Core Runtime - 2.0.0</SharedFrameworkBrandName>
     <SharedHostBrandName>Microsoft .NET Core Host - 2.0.0</SharedHostBrandName>
     <HostFxrBrandName>Microsoft .NET Core Host FX Resolver - 2.0.0</HostFxrBrandName>
@@ -24,7 +25,7 @@
     <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk</ArtifactNameCombinedHostHostFxrFrameworkSdk>
 
     <ArtifactNameWithVersionSdk>$(ArtifactNameSdk)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionSdk>
-
+    <ArtifactNameWithVersionMSBuildExtensions>dotnet-msbuild-extensions-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionMSBuildExtensions>
 
     <ArtifactNameWithVersionSdkDebug>$(ArtifactNameSdkDebug)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionSdkDebug>
     <ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>

--- a/build/InstallerInfo.props
+++ b/build/InstallerInfo.props
@@ -2,11 +2,13 @@
   <PropertyGroup>
     <InstallerOutputDirectory>$(PackagesDirectory)</InstallerOutputDirectory>
     <SdkInstallerFile>$(InstallerOutputDirectory)/$(ArtifactNameWithVersionSdk)$(InstallerExtension)</SdkInstallerFile>
+    <MSBuildExtensionsInstallerFile>$(InstallerOutputDirectory)/$(ArtifactNameWithVersionMSBuildExtensions)$(InstallerExtension)</MSBuildExtensionsInstallerFile>
     <CombinedFrameworkSdkHostInstallerFile>$(InstallerOutputDirectory)/$(ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(BundleExtension)</CombinedFrameworkSdkHostInstallerFile>
 
     <SdkDebianIntermediateDirectory>$(IntermediateDirectory)/debian/sdk</SdkDebianIntermediateDirectory>
     <LayoutDirectory Condition=" '$(OSName)' == 'ubuntu' OR '$(OSName)' == 'debian' ">$(SdkDebianIntermediateDirectory)/debianLayoutDirectory</LayoutDirectory>
     <LayoutDirectory Condition=" '$(OSName)' != 'ubuntu' AND '$(OSName)' != 'debian' ">$(IntermediateDirectory)/layouts</LayoutDirectory>
     <SdkLayoutOutputDirectory>$(LayoutDirectory)/$(ArtifactNameSdk)</SdkLayoutOutputDirectory>
+    <MSBuildExtensionsOutputDirectory>$(LayoutDirectory)/MSBuildExtensions</MSBuildExtensionsOutputDirectory>
   </PropertyGroup>
 </Project>

--- a/build/package/Archive.targets
+++ b/build/package/Archive.targets
@@ -37,7 +37,7 @@
   <Target Name="SetupGenerateArchivesInputsOutputs"
           DependsOnTargets="Init">
     <ItemGroup>
-      <GenerateArchivesInputsOutputs Include="%(LayoutDefinition.Name)">
+      <GenerateArchivesInputsOutputs Condition=" '%(LayoutDefinition.Name)' != '' " Include="%(LayoutDefinition.Name)">
         <Inputs>%(LayoutDefinition.OutputFiles)</Inputs>
         <Outputs>$(ArchiveOutputDirectory)/%(LayoutDefinition.NameWithVersion)$(ArchiveExtension)</Outputs>
         <InputDirectory>$(LayoutDirectory)/%(LayoutDefinition.Name)</InputDirectory>

--- a/build/package/Installer.MSI.targets
+++ b/build/package/Installer.MSI.targets
@@ -17,6 +17,8 @@
       <SdkGenerateBundlePowershellScript>$(RepoRoot)/packaging/windows/clisdk/generatebundle.ps1</SdkGenerateBundlePowershellScript>
       <SdkGenerateNupkgPowershellScript>$(RepoRoot)/packaging/windows/clisdk/generatenupkg.ps1</SdkGenerateNupkgPowershellScript>
 
+      <MSBuildExtensionsGenerateMsiPowershellScript>$(RepoRoot)/packaging/windows/msbuildextensions/generatemsi.ps1</MSBuildExtensionsGenerateMsiPowershellScript>
+
       <SdkInstallerNuspecFile>$(RepoRoot)/packaging/windows/clisdk/VS.Redist.Common.Net.Core.SDK.$(Architecture).nuspec</SdkInstallerNuspecFile>
       <SdkInstallerNupkgFile>$(InstallerOutputDirectory)/VS.Redist.Common.Net.Core.SDK.$(Architecture).$(FullNugetVersion).nupkg</SdkInstallerNupkgFile>
 
@@ -36,11 +38,14 @@
       <ItemGroup>
         <GenerateSdkMsiInputs Include="$(SdkLayoutOutputDirectory)/**/*;
                                        $(SdkGenerateMsiPowershellScript)" />
+        <GenerateMSBuildExtensionsMsiInputs Include="$(MSBuildExtensionsOutputDirectory)/**/*;
+                                                     $(MSBuildExtensionsGenerateMsiPowershellScript)" />
       </ItemGroup>
       
       <!-- Consumed By Publish -->
       <ItemGroup>
         <GeneratedInstallers Include="$(SdkInstallerFile);$(CombinedFrameworkSdkHostInstallerFile)" />
+        <GeneratedInstallers Condition=" '$(Architecture)' == 'x86' " Include="$(MSBuildExtensionsInstallerFile)" />
       </ItemGroup>
 
       <GenerateMsiVersion CommitCount="$(CommitCount)"
@@ -53,6 +58,11 @@
       <GenerateGuidFromName Name="$(SdkInstallerFile)">
         <Output TaskParameter="OutputGuid"
             PropertyName="SdkInstallerUpgradeCode" />
+      </GenerateGuidFromName>
+
+      <GenerateGuidFromName Name="$(MSBuildExtensionsInstallerFile)">
+        <Output TaskParameter="OutputGuid"
+            PropertyName="MSBuildExtensionsInstallerUpgradeCode" />
       </GenerateGuidFromName>
 
       <GenerateGuidFromName Name="$(CombinedFrameworkSdkHostInstallerFile)">
@@ -100,6 +110,24 @@
                       '$(SimpleVersion)'
                       '$(NugetVersion)'
                       '$(SdkInstallerUpgradeCode)'
+                      '$(Architecture)'" />
+    </Target>
+
+    <Target Name="GenerateMSBuildExtensionsMsi"
+            DependsOnTargets="Init;Layout;AcquireWix;MsiTargetsSetupInputOutputs"
+            Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x86' "
+            Inputs="@(GenerateMSBuildExtensionsMsiInputs)"
+            Outputs="$(MSBuildExtensionsInstallerFile)">
+
+      <Exec Command="powershell -NoProfile -NoLogo $(MSBuildExtensionsGenerateMsiPowershellScript)
+                      '$(MSBuildExtensionsOutputDirectory)'
+                      '$(MSBuildExtensionsInstallerFile)'
+                      '$(WixRoot)'
+                      '$(MSBuildExtensionsBrandName)'
+                      '$(SimpleVersion)'
+                      '$(SimpleVersion)'
+                      '$(NugetVersion)'
+                      '$(MSBuildExtensionsInstallerUpgradeCode)'
                       '$(Architecture)'" />
     </Target>
 
@@ -186,6 +214,7 @@
                             MsiTargetsSetupInputOutputs;
                             AcquireWix;
                             GenerateSdkMsi;
+                            GenerateMSBuildExtensionsMsi;
                             GenerateSdkBundle;
                             GenerateSdkNupkg;
                             GenerateSdkMSBuildExtensionsNupkg;

--- a/build/package/Layout.targets
+++ b/build/package/Layout.targets
@@ -13,6 +13,11 @@
       <CombinedHostHostFxrFrameworkSdkInput Include="$(OutputDirectory)/**/*" />
 
       <AspNetRuntimeFilesInput Include="$(AspNetRuntimePackageStorePublishDirectory)/**/*" />
+
+      <MSBuildExtensionsInput Include="$(MSBuildExtensionsLayoutDirectory)/msbuildExtensions/**/*" />
+      <MSBuildExtensionsVerInput Include="$(MSBuildExtensionsLayoutDirectory)/msbuildExtensions-ver/**/*" />
+      <CombinedMSBuildExtensionsInput Include="@(MSBuildExtensionsInput)" />
+      <CombinedMSBuildExtensionsInput Include="@(MSBuildExtensionsVerInput)" />
     </ItemGroup>
 
     <MakeRelative
@@ -30,6 +35,22 @@
       Path2="%(CombinedHostHostFxrFrameworkSdkInput.Identity)" >
       <Output TaskParameter="RelativePath" ItemName="CombinedHostHostFxrFrameworkSdkRelativeOutputFiles" />
     </MakeRelative>
+
+    <MakeRelative
+      Path1="$(MSBuildExtensionsLayoutDirectory)/msbuildExtensions/"
+      Path2="%(MSBuildExtensionsInput.Identity)" >
+      <Output TaskParameter="RelativePath" ItemName="MSBuildExtensionsRelativeOutputFiles" />
+    </MakeRelative>
+    <MakeRelative
+      Path1="$(MSBuildExtensionsLayoutDirectory)/msbuildExtensions-ver/"
+      Path2="%(MSBuildExtensionsVerInput.Identity)" >
+      <Output TaskParameter="RelativePath" ItemName="MSBuildExtensionsVerRelativeOutputFiles" />
+    </MakeRelative>
+
+    <ItemGroup>
+      <CombinedMSBuildExtensionsRelativeOutputFiles Include="@(MSBuildExtensionsRelativeOutputFiles)" />
+      <CombinedMSBuildExtensionsRelativeOutputFiles Include="@(MSBuildExtensionsVerRelativeOutputFiles -> '14.0/%(Identity)')" />
+    </ItemGroup>
 
     <!-- Set up Items Defining Layouts for easy change -->
     <ItemGroup>
@@ -53,7 +74,13 @@
         <NameWithVersion>$(ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)</NameWithVersion>
         <Name>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)</Name>
       </LayoutDefinition>
+    </ItemGroup>
 
+    <ItemGroup Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x86' ">
+      <LayoutDefinition Include="MSBuildExtensions">
+        <InputFiles>@(CombinedMSBuildExtensionsInput)</InputFiles>
+        <OutputFiles>@(CombinedMSBuildExtensionsRelativeOutputFiles -> '$(MSBuildExtensionsOutputDirectory)/%(Identity)')</OutputFiles>
+      </LayoutDefinition>
     </ItemGroup>
   </Target>
 

--- a/packaging/windows/msbuildextensions/generatemsi.ps1
+++ b/packaging/windows/msbuildextensions/generatemsi.ps1
@@ -1,0 +1,140 @@
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+param(
+    [Parameter(Mandatory=$true)][string]$inputDir,
+    [Parameter(Mandatory=$true)][string]$MSBuildExtensionsMSIOutput,
+    [Parameter(Mandatory=$true)][string]$WixRoot,
+    [Parameter(Mandatory=$true)][string]$ProductMoniker,
+    [Parameter(Mandatory=$true)][string]$DotnetMSIVersion,
+    [Parameter(Mandatory=$true)][string]$DotnetCLIDisplayVersion,
+    [Parameter(Mandatory=$true)][string]$DotnetCLINugetVersion,
+    [Parameter(Mandatory=$true)][string]$UpgradeCode,
+    [Parameter(Mandatory=$true)][string]$Architecture
+)
+
+. "$PSScriptRoot\..\..\..\scripts\common\_common.ps1"
+$RepoRoot = Convert-Path "$PSScriptRoot\..\..\.."
+
+$InstallFileswsx = "install-files.wxs"
+$InstallFilesWixobj = "install-files.wixobj"
+
+function RunHeat
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Output Running heat..
+
+    .\heat.exe dir `"$inputDir`" -template fragment -sreg -gg -var var.DotnetSrc -cg InstallFiles -srd -dr MSBUILDEXTENSIONSHOME -out $InstallFileswsx | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Output "Heat failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+function RunCandle
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Output Running candle..
+    $AuthWsxRoot =  Join-Path $RepoRoot "packaging\windows\msbuildextensions"
+
+    .\candle.exe -nologo `
+        -dDotnetSrc="$inputDir" `
+        -dMicrosoftEula="$RepoRoot\packaging\windows\clisdk\dummyeula.rtf" `
+        -dProductMoniker="$ProductMoniker" `
+        -dBuildVersion="$DotnetMSIVersion" `
+        -dDisplayVersion="$DotnetCLIDisplayVersion" `
+        -dNugetVersion="$DotnetCLINugetVersion" `
+        -dUpgradeCode="$UpgradeCode" `
+        -arch "$Architecture" `
+        -ext WixDependencyExtension.dll `
+        "$AuthWsxRoot\msbuildextensions.wxs" `
+        "$AuthWsxRoot\provider.wxs" `
+        "$AuthWsxRoot\registrykeys.wxs" `
+        $InstallFileswsx | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Output "Candle failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+function RunLight
+{
+    $result = $true
+    pushd "$WixRoot"
+
+    Write-Output Running light..
+    $CabCache = Join-Path $WixRoot "cabcache"
+    $AuthWsxRoot =  Join-Path $RepoRoot "packaging\windows\msbuildextensions"
+
+    .\light.exe -nologo -ext WixUIExtension -ext WixDependencyExtension -ext WixUtilExtension `
+        -cultures:en-us `
+        msbuildextensions.wixobj `
+        provider.wixobj `
+        registrykeys.wixobj `
+        $InstallFilesWixobj `
+        -b "$inputDir" `
+        -b "$AuthWsxRoot" `
+        -reusecab `
+        -cc "$CabCache" `
+        -out $MSBuildExtensionsMSIOutput | Out-Host
+
+    if($LastExitCode -ne 0)
+    {
+        $result = $false
+        Write-Output "Light failed with exit code $LastExitCode."
+    }
+
+    popd
+    return $result
+}
+
+if(!(Test-Path $inputDir))
+{
+    throw "$inputDir not found"
+}
+
+Write-Output "Creating MSBuild Extensions MSI at $MSBuildExtensionsMSIOutput"
+
+if([string]::IsNullOrEmpty($WixRoot))
+{
+    Exit -1
+}
+
+if(-Not (RunHeat))
+{
+    Exit -1
+}
+
+if(-Not (RunCandle))
+{
+    Exit -1
+}
+
+if(-Not (RunLight))
+{
+    Exit -1
+}
+
+if(!(Test-Path $MSBuildExtensionsMSIOutput))
+{
+    throw "Unable to create the MSBuild Extensions msi."
+    Exit -1
+}
+
+Write-Output -ForegroundColor Green "Successfully created MSBuild Extensions MSI - $MSBuildExtensionsMSIOutput"
+
+exit $LastExitCode

--- a/packaging/windows/msbuildextensions/msbuildextensions.wxs
+++ b/packaging/windows/msbuildextensions/msbuildextensions.wxs
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?include "Variables.wxi" ?>
+  <Product Id="*" Name="$(var.ProductName)" Language="$(var.ProductLanguage)" Version="$(var.ProductVersion)" Manufacturer="$(var.Manufacturer)" UpgradeCode="$(var.UpgradeCode)">
+    <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
+
+    <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
+
+    <MediaTemplate CabinetTemplate="dnet-{0}.cab" CompressionLevel="high" />
+
+    <Feature Id="MainFeature" Title="Main Feature" Level="1">
+      <ComponentGroupRef Id="InstallFiles" />
+      <ComponentGroupRef Id="AuthoredRegistryKeys"/>
+    </Feature>
+    <Feature Id="Provider" Absent="disallow" AllowAdvertise="no" Description="Used for Ref Counting" Display="hidden" Level="1" InstallDefault="local" Title="RefCounting" TypicalDefault="install">
+      <ComponentRef Id="$(var.DependencyKeyId)" />
+    </Feature>
+    <Property Id="ProductFamily" Value="$(var.ProductFamily)" />
+    <Property Id="ProductEdition" Value="$(var.ProductEdition)" />
+    <Property Id="ProductCPU" Value="$(var.Platform)" />
+    <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />
+    <Property Id="MSIFASTINSTALL" Value="7" />
+    <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
+
+    <CustomActionRef Id="WixBroadcastEnvironmentChange" />
+  </Product>
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="$(var.Program_Files)">
+        <Directory Id="MSBUILDEXTENSIONSHOME" Name="MSBuild"/>
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>

--- a/packaging/windows/msbuildextensions/provider.wxs
+++ b/packaging/windows/msbuildextensions/provider.wxs
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:dep="http://schemas.microsoft.com/wix/DependencyExtension">
+  <?include "Variables.wxi" ?>
+  <Fragment>
+    <Component Id="$(var.DependencyKeyId)" Directory="TARGETDIR" Win64="no" Guid="*">
+      <dep:Provides Key="$(var.DependencyKey)" />
+    </Component>
+  </Fragment>
+</Wix>

--- a/packaging/windows/msbuildextensions/registrykeys.wxs
+++ b/packaging/windows/msbuildextensions/registrykeys.wxs
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?include "Variables.wxi" ?>
+  <Fragment>
+    <ComponentGroup Id="AuthoredRegistryKeys">
+      <Component Id="SetupRegistry_x86" Directory="TARGETDIR" Win64="no">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\dotnet\Setup\InstalledVersions\$(var.Platform)\MSBuildExtensions">
+          <RegistryValue Action="write" Name="$(var.NugetVersion)" Type="integer" Value="1" KeyPath="yes"/>
+        </RegistryKey>
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/packaging/windows/msbuildextensions/variables.wxi
+++ b/packaging/windows/msbuildextensions/variables.wxi
@@ -15,6 +15,7 @@
   <?define LCID  = "$(var.ProductLanguage)"?>
   <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
 
+  <?define Platform   =   "$(sys.BUILDARCH)" ?>
   <?define Program_Files="ProgramFilesFolder"?>
   <?define Win64AttributeValue=no?>
 

--- a/packaging/windows/msbuildextensions/variables.wxi
+++ b/packaging/windows/msbuildextensions/variables.wxi
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<Include xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?define Servicing_Key_SP   =   "0" ?>
+  <?define Servicing_Key_SPIndex   =   "0" ?>
+  <?define Servicing_Key_SPName   =   "Beta" ?>
+  <?define Dotnet_ProductVersion   =   "$(var.BuildVersion)" ?>
+  <?define Dotnet_DisplayVersion   =   "$(var.DisplayVersion)" ?>
+  <?define Dotnet_BuildVersion   =   "$(var.BuildVersion)" ?>
+  <?define Manufacturer     =   "Microsoft Corporation" ?>
+  <?define ProductName      =   "$(var.ProductMoniker) ($(sys.BUILDARCH))" ?>
+  <?define ProductLanguage  =   "1033" ?>
+  <?define ProductVersion   =   "$(var.Dotnet_ProductVersion)" ?>
+  <?define ProductFamily    =   "dotnet" ?>
+  <?define ProductEdition   =   "001dotnet" ?>
+  <?define LCID  = "$(var.ProductLanguage)"?>
+  <?define DowngradeErrorMessage  = "A newer version is already installed; please uninstall it and re-run setup."?>
+
+  <?define Program_Files="ProgramFilesFolder"?>
+  <?define Win64AttributeValue=no?>
+
+  <?define DependencyKey   = "Dotnet_MSBUILD_EXTENSIONS_$(var.Dotnet_DisplayVersion)_$(var.Platform)"?>
+  <?define DependencyKeyId = "$(var.DependencyKey)" ?>
+</Include>


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz for approval.

**Customer scenario**

Enable users in downlevel VS to be able to work with full framework projects targeting net4.6.1 and referencing netstandard 2.0 packages. This is key to the netstandard2.0 adoption plan. We do this by adding a installer for Downlevel (Dev14) to install .NET Framework props and targets to enable it to reference netstandard 2.0.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/cli/issues/6739

**Workarounds, if any**

I believe user could manually add NetStandard.Library.Framework (or something like that) explicitly to the full framework project to enable compatibility with NetStandard2.0, but I don't really think we will actually publish this package in nuget.org, since it is not really needed.

**Risk**

Low

**Performance impact**

None.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

N/A

**How was the bug found?**

Planned work.
