### PR TITLE
Fix test failures in local build due to environment variable filter

### DIFF
--- a/build_projects/dotnet-cli-build/EnvironmentVariableFilter.cs
+++ b/build_projects/dotnet-cli-build/EnvironmentVariableFilter.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet.Cli.Build
         private IEnumerable<string> _environmentVariablesToKeep = new string []
         {
             "DOTNET_CLI_TELEMETRY_SESSIONID",
+            "DOTNET_MULTILEVEL_LOOKUP",
             "DOTNET_RUNTIME_ID",
             "DOTNET_SKIP_FIRST_TIME_EXPERIENCE",
             "NUGET_PACKAGES"

--- a/run-build.sh
+++ b/run-build.sh
@@ -152,7 +152,7 @@ export VSTEST_TRACE_BUILD=1
 
 
 # Don't resolve shared frameworks from user or global locations
-DOTNET_MULTILEVEL_LOOKUP=0
+export DOTNET_MULTILEVEL_LOOKUP=0
 
 # Install a stage 0
 (set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --channel "release/2.0.0" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS)


### PR DESCRIPTION
Finally got to the bottom of two tests that always fail locally for me, as it turned out to have the same root cause as a test issue with the UI language environment variable that I'm working on.

The culprit is af9a85fd3f3b25a0a371527e3fe611fe184c2b75, which tries to make DOTNET_MULTILEVEL_LOOKUP=0 global to the entire build and test process and removes the setting of DOTNET_MULTILEVEL_LOOKUP=0 on individual tests, but:

* It fails to export the environment variable to sub-process on Unix
* Only an explicit list of environment variables prefixed with DOTNET_ are passed down to our DotnetTool build tasks, and DOTNET_MULTILEVEL_LOOKUP was not in the list.

I debated reverting back to how things were (with individual test opt-outs of multilevel lookup), but decided to instead move forward from af9a85fd3f3b25a0a371527e3fe611fe184c2b75 and fix the two issues above. This makes the entire build free of a dependency on which SDKs are installed globally as af9a85fd3f3b25a0a371527e3fe611fe184c2b75 intended.

@dotnet/dotnet-cli @livarcocc 

@MattGertz FYI, infrastructure-only change