### PR TITLE
Changing to use FileStream constructor with FileAccess.Read.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/RuntimeConfig.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/RuntimeConfig.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Cli.Utils
         public RuntimeConfig(string runtimeConfigPath) 
         {
             JObject runtimeConfigJson;
-            using (var streamReader = new StreamReader(new FileStream(runtimeConfigPath, FileMode.Open)))
+            using (var streamReader = new StreamReader(File.OpenRead(runtimeConfigPath)))
             {
                 runtimeConfigJson = OpenRuntimeConfig(streamReader);
             }


### PR DESCRIPTION
**Customer scenario**

Changing to use FileStream constructor with FileAccess.Read. This is …required because when access readonly files, you must pass FileAccess.Read, otherwise, we get a UnauthorizedFileAccess exception. Without this, customers won't be able to execute tools that are present in the offline cache when the CLI gets installed in a protected location.


**Bugs this fixes:** 

Fixes https://github.com/dotnet/cli/issues/7034

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

Happened due to our change of moving the fallback folder into the dotnet hive and the cases where that hive exists in a protected location. The API we were using was wrong for when we tried to access a readonly file.

**How was the bug found?**

Reported by our test team.

@livarcocc @dotnet/dotnet-cli for review

@MattGertz for approval