### PR TITLE
Add indication for first time experience

### DIFF
--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -13,6 +13,10 @@ The .NET Core Tools include a telemetry feature that collects usage information.
 
 The data collected is anonymous and will be published in an aggregated form for use by both Microsoft and community engineers under the Creative Commons Attribution License.
 
-The .NET Core Tools telemetry feature is enabled by default. You can opt-out of the telemetry feature by setting an environment variable DOTNET_CLI_TELEMETRY_OPTOUT (for example, 'export' on macOS/Linux, 'set' on Windows) to true (for example, 'true', 1). You can read more about .NET Core tools telemetry at https://aka.ms/dotnet-cli-telemetry."
+The .NET Core Tools telemetry feature is enabled by default. You can opt-out of the telemetry feature by setting an environment variable DOTNET_CLI_TELEMETRY_OPTOUT (for example, 'export' on macOS/Linux, 'set' on Windows) to true (for example, 'true', 1). You can read more about .NET Core tools telemetry at https://aka.ms/dotnet-cli-telemetry.
+
+Installation Note
+--------------
+A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete."
 
 dotnet new > /dev/null 2>&1 || true

--- a/packaging/rpm/scripts/after_install_host.sh
+++ b/packaging/rpm/scripts/after_install_host.sh
@@ -17,6 +17,10 @@ The .NET Core Tools include a telemetry feature that collects usage information.
 
 The data collected is anonymous and will be published in an aggregated form for use by both Microsoft and community engineers under the Creative Commons Attribution License.
 
-The .NET Core Tools telemetry feature is enabled by default. You can opt-out of the telemetry feature by setting an environment variable DOTNET_CLI_TELEMETRY_OPTOUT (for example, 'export' on macOS/Linux, 'set' on Windows) to true (for example, 'true', 1). You can read more about .NET Core tools telemetry at https://aka.ms/dotnet-cli-telemetry."
+The .NET Core Tools telemetry feature is enabled by default. You can opt-out of the telemetry feature by setting an environment variable DOTNET_CLI_TELEMETRY_OPTOUT (for example, 'export' on macOS/Linux, 'set' on Windows) to true (for example, 'true', 1). You can read more about .NET Core tools telemetry at https://aka.ms/dotnet-cli-telemetry.
+
+Installation Note
+--------------
+A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete."
 
 dotnet new > /dev/null 2>&1 || true


### PR DESCRIPTION
https://github.com/dotnet/cli/issues/7037

**Customer scenario**

Debian/Ubuntu user install CLI/SDK via deb package, the user have to wait for minutes at the end of the installation process without any indication of what is the installer doing. And the user will be confused.

**Bugs this fixes**

https://github.com/dotnet/cli/issues/7037

**Workarounds, if any**

No functional impact.

**Risk**

Low

**Performance impact**

no

**Root cause analysis**

No test on a fresh user experience

**How was the bug found?**

Issue filed from Github
