### PR TITLE
Fixing help text for version, info and diagnostics and also removing …

### DIFF
--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -5,7 +5,7 @@ internal static class HelpUsageText
 {
     public static readonly string UsageText =
 $@"{LocalizableStrings.Usage}: dotnet [runtime-options] [path-to-application]
-{LocalizableStrings.Usage}: dotnet [command] [arguments] [command-options]
+{LocalizableStrings.Usage}: dotnet [sdk-options] [command] [arguments] [command-options]
 
 path-to-application:
   {LocalizableStrings.PathToApplicationDefinition}
@@ -27,9 +27,6 @@ path-to-application:
   nuget            {LocalizableStrings.NugetDefinition}
   msbuild          {LocalizableStrings.MsBuildDefinition}
   vstest           {LocalizableStrings.VsTestDefinition}
-  -v|--version     {LocalizableStrings.SDKVersionCommandDefinition}
-  -i|--info        {LocalizableStrings.SDKInfoCommandDefinition}
-  -d|--diagnostics {LocalizableStrings.SDKDiagnosticsCommandDefinition}
 
 {LocalizableStrings.CommonOptions}:
   -v|--verbosity        {CommonLocalizableStrings.VerbosityOptionDescription}
@@ -37,10 +34,13 @@ path-to-application:
 
 {LocalizableStrings.RunDotnetCommandHelpForMore}
 
+sdk-options:
+  --version        {LocalizableStrings.SDKVersionCommandDefinition}
+  --info           {LocalizableStrings.SDKInfoCommandDefinition}
+  -d|--diagnostics {LocalizableStrings.SDKDiagnosticsCommandDefinition}
+
 runtime-options:
   --additionalprobingpath <path>    {LocalizableStrings.AdditionalprobingpathDefinition}
-  --depsfile <path>                 {LocalizableStrings.DepsfilDefinition}
-  --runtimeconfig <path>            {LocalizableStrings.RuntimeconfigDefinition}
   --fx-version <version>            {LocalizableStrings.FxVersionDefinition}
   --roll-forward-on-no-candidate-fx {LocalizableStrings.RollForwardOnNoCandidateFxDefinition}
   --additional-deps <path>          {LocalizableStrings.AdditionalDeps}

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Help.Tests
     {
         private const string HelpText =
 @"Usage: dotnet [runtime-options] [path-to-application]
-Usage: dotnet [command] [arguments] [command-options]
+Usage: dotnet [sdk-options] [command] [arguments] [command-options]
 
 path-to-application:
   The path to an application .dll file to execute.
@@ -38,9 +38,6 @@ SDK commands:
   nuget            Provides additional NuGet commands.
   msbuild          Runs Microsoft Build Engine (MSBuild).
   vstest           Runs Microsoft Test Execution Command Line Tool.
-  -v|--version     Display .NET Core SDK version.
-  -i|--info        Display .NET Core information.
-  -d|--diagnostics Enable diagnostic output.
 
 Common options:
   -v|--verbosity        Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].
@@ -48,10 +45,13 @@ Common options:
 
 Run 'dotnet COMMAND --help' for more information on a command.
 
+sdk-options:
+  --version        Display .NET Core SDK version.
+  --info           Display .NET Core information.
+  -d|--diagnostics Enable diagnostic output.
+
 runtime-options:
   --additionalprobingpath <path>    Path containing probing policy and assemblies to probe for.
-  --depsfile <path>                 Path to <application>.deps.json file.
-  --runtimeconfig <path>            Path to <application>.runtimeconfig.json file.
   --fx-version <version>            Version of the installed Shared Framework to use to run the application.
   --roll-forward-on-no-candidate-fx Roll forward on no candidate shared framework is enabled.
   --additional-deps <path>          Path to additonal deps.json file.";


### PR DESCRIPTION
**Customer scenario**

dotnet --help is displaying help wrong. It has options that are not available to the command being run and it has options that are only available in conjunction with other commands. This fix updates the help content.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/cli/issues/7030

**Workarounds, if any**

None.

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

N/A

**How was the bug found?**

Reported by the community.

@dotnet/dotnet-cli for review
cc @richlander @Petermarcu 

@MattGertz for approval