### PR TITLE
Installation block does not work

### DIFF
--- a/packaging/osx/clisdk/Distribution-Template
+++ b/packaging/osx/clisdk/Distribution-Template
@@ -6,9 +6,9 @@
     <welcome file="welcome.html" mime-type="text/html" />
     <conclusion file="conclusion.html" mime-type="text/html" />
     <volume-check>
-        <allowed-os-version>
+        <allowed-os-versions>
             <os-version min="10.12" />
-        </allowed-os-version>
+        </allowed-os-versions>
     </volume-check>
     <choices-outline>
         <line choice="{SharedFxComponentId}.pkg" />


### PR DESCRIPTION
The product should block installing below 10.12 but does not. Fixing
typo.

Fixes #6592 
