### PR TITLE
Add ubuntu 17.04 to dotnet-install.sh to not prevent any further actions

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -100,6 +100,10 @@ get_os_download_name_from_platform() {
             echo "ubuntu.16.10"
             return 0
             ;;
+        "ubuntu.17.04")
+            echo "ubuntu.17.04"
+            return 0
+            ;;
         "alpine.3.4.3")
             echo "alpine"
             return 0


### PR DESCRIPTION
Without this anyone (like myself) who is on Ubuntu 17.04 cannot run anything that depends on dotnet (which is almost anything, I encountered this when I was trying to build NuGet.Client).