### PR TITLE
Adding a Minimum VS Defined SDK version to the resolver.

### DIFF
--- a/src/Microsoft.DotNet.MSBuildSdkResolver/Interop.NETStandard.cs
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/Interop.NETStandard.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 // NOTE: Currently, only the NET46 build ships (with Visual Studio/desktop msbuild), 
-// but the netstandard1.3 adaptation here acts a proof-of-concept for cross-platform 
+// but the netstandard1.5 adaptation here acts a proof-of-concept for cross-platform 
 // portability of the underlying hostfxr API and gives us build and test coverage 
 // on non-Windows machines.
-#if NETSTANDARD1_3
+#if NETSTANDARD1_5
 
 using System.Runtime.InteropServices;
 using System.Text;
@@ -34,4 +34,4 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
     }
 }
 
-#endif // NETSTANDARD1_3
+#endif // NETSTANDARD1_5

--- a/src/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -3,8 +3,8 @@
 
   <PropertyGroup>
     <Version>$(SdkVersion)</Version>
-    <TargetFrameworks>netstandard1.3;net46</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;net46</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard1.5</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
     <WarningsAsErrors>true</WarningsAsErrors>
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NETCore.DotNetHostResolver" Version="$(CLI_SharedFrameworkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
     <PackageReference Include="NETStandard.Library" Version="1.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
**Customer scenario**

User tried to open a project in VS while having a global.json pinning the SDK version to a version older than 1.0.4 This version is missing required changes by VS. We are adding a Minimum VS Defined SDK version to the resolver. It is set to 1.0.4 if the minimum SDK version file is not found. this way, VS can indicate the minimum SDK version it requires and give a proper error message telling the user to update the tooling.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/cli/issues/6887

**Workarounds, if any**

None.

**Risk**

Low

**Performance impact**

Low. We will read one more file in the resolver.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

N/A

**How was the bug found?**

Found during testing.

@dotnet/dotnet-cli for review

VS Bug: https://devdiv.visualstudio.com/DevDiv/_workitems?id=460283&_a=edit

@MattGertz for approval
