### PR TITLE
Update test platform to 15.3.0-preview-20170703-02

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -18,7 +18,7 @@
     <CLI_NuGet_Version>4.3.0-preview4-4258</CLI_NuGet_Version>
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.0-preview2-25331-02</CLI_NETStandardLibraryNETFrameworkVersion>
     <CLI_WEBSDK_Version>2.0.0-rel-20170629-588</CLI_WEBSDK_Version>
-    <CLI_TestPlatform_Version>15.3.0-preview-20170628-02</CLI_TestPlatform_Version>
+    <CLI_TestPlatform_Version>15.3.0-preview-20170703-02</CLI_TestPlatform_Version>
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>


### PR DESCRIPTION
* Adds support for running net46 tests on non windows machines if mono is installed

(Adding this for 15.3+ builds currently since it is not yet closed if we should port it for 15.3)