### PR TITLE
Update Roslyn to 2.3.0-beta4-61830-03 in 1.1.0

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>1.1.2</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.0-preview-000402-01</CLI_MSBuild_Version>
-    <CLI_Roslyn_Version>2.3.0-beta3-61816-04</CLI_Roslyn_Version>
+    <CLI_Roslyn_Version>2.3.0-beta4-61830-03</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>
     <CLI_NETSDK_Version>1.1.0-alpha-20170630-2</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview3-4168</CLI_NuGet_Version>


### PR DESCRIPTION
@dotnet/dotnet-cli

@MattGertz Flow of dependencies into the CLI.