### PR TITLE
Fix x86 installer

### DIFF
--- a/packaging/windows/msbuildextensions/generatemsi.ps1
+++ b/packaging/windows/msbuildextensions/generatemsi.ps1
@@ -16,8 +16,8 @@ param(
 . "$PSScriptRoot\..\..\..\scripts\common\_common.ps1"
 $RepoRoot = Convert-Path "$PSScriptRoot\..\..\.."
 
-$InstallFileswsx = "install-files.wxs"
-$InstallFilesWixobj = "install-files.wixobj"
+$InstallFileswsx = "install-msbuild-extensions-files.wxs"
+$InstallFilesWixobj = "install-msbuild-extensions-files.wixobj"
 
 function RunHeat
 {

--- a/packaging/windows/msbuildextensions/msbuildextensions.wxs
+++ b/packaging/windows/msbuildextensions/msbuildextensions.wxs
@@ -6,7 +6,7 @@
 
     <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
 
-    <MediaTemplate CabinetTemplate="dnet-{0}.cab" CompressionLevel="high" />
+    <MediaTemplate CabinetTemplate="dnet-mse-{0}.cab" CompressionLevel="high" />
 
     <Feature Id="MainFeature" Title="Main Feature" Level="1">
       <ComponentGroupRef Id="InstallFiles" />

--- a/packaging/windows/msbuildextensions/msbuildextensions.wxs
+++ b/packaging/windows/msbuildextensions/msbuildextensions.wxs
@@ -6,7 +6,7 @@
 
     <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
 
-    <MediaTemplate CabinetTemplate="dnet-mse-{0}.cab" CompressionLevel="high" />
+    <MediaTemplate CabinetTemplate="dnbe{0}.cab" CompressionLevel="high" EmbedCab="yes" />
 
     <Feature Id="MainFeature" Title="Main Feature" Level="1">
       <ComponentGroupRef Id="InstallFiles" />


### PR DESCRIPTION


**Customer scenario**

The windows x86 installer is broken, because the wrong cab is being embedded in the bundle. This happened because two installers had the same cab name and were stomping on each other. The fix is to change the cab name in the downlevel MSI.

**Bugs this fixes:** 

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/459276

**Workarounds, if any**

Use the zip to install the x86 windows CLI.

**Risk**

Low

**Performance impact**

N/A

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

We have two installers and both had the same cab name. So they were stomping on each other.

**How was the bug found?**

Test team.

@dotnet/dotnet-cli for review

@MattGertz for approval
