### PR TITLE
MIT License *NIX Builds.

### DIFF
--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -142,6 +142,14 @@
                                    AssetPath="%(NuPkgContentForMSBuildExtensionsRelativePaths.Identity)" />
   </Target>
 
+  <!-- The msdia140typelib_clr0200.dll file is not MIT licensed (and it only used on Windows). Remove it, so
+       we can MIT license the published dotnet -->
+  <Target Name="RemoveMSDiaTypeLib"
+          AfterTargets="Publish"
+          Condition="'$(OSName)' != 'win'">
+    <Delete Files="$(PublishDir)/TestHost/msdia140typelib_clr0200.dll" />
+  </Target>
+
   <Target Name="PublishSdks"
           AfterTargets="Publish">
     <ItemGroup>

--- a/src/tool_roslyn/tool_roslyn.csproj
+++ b/src/tool_roslyn/tool_roslyn.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Build.Tasks" Version="$(CLI_Roslyn_Version)" />
     <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="$(CLI_Roslyn_Version)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(CLI_DiaSymNative_Version)" />
+    <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(CLI_DiaSymNative_Version)" Condition="'$(OSName)' == 'win'" />
     <PackageReference Include="CliDeps.Satellites.Roslyn" Version="$(CLI_Roslyn_Satellites_Version)" />
   </ItemGroup>
 


### PR DESCRIPTION
Remove non MIT licensed components from the CLI when building on non
windows platforms. The shared framework provides the LICENSE file that is
included with the tarballs, so we just need to ensure we don't pull any
windows specific stuff that is not MIT licensed.

Fixes: dotnet/core-setup#676