### PR TITLE
Update to SetupCrossgen 277 - Coherence 26182

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -22,9 +22,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta2-20170707-280</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170707-280</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170707-280</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20170710-283</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170710-283</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170710-283</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.0.0-preview3-25510-01</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0-preview3-25510-01</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.1-alpha-167</CliCommandLineParserVersion>
@@ -35,9 +35,9 @@
 
     <!-- This should either be timestamped or notimestamp as appropriate -->
     <AspNetCoreRuntimePackageFlavor>timestamped</AspNetCoreRuntimePackageFlavor>
-    <AspNetCoreRuntimeVersion>dev-270</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>dev-277</AspNetCoreRuntimeVersion>
     <AspNetCoherenceLabel>rtm</AspNetCoherenceLabel>
-    <AspNetCoreCoherenceTimestamp>26151</AspNetCoreCoherenceTimestamp>
+    <AspNetCoreCoherenceTimestamp>26182</AspNetCoreCoherenceTimestamp>
 
   </PropertyGroup>
 

--- a/build_projects/dotnet-cli-build/GenerateNuGetPackagesArchiveVersion.cs
+++ b/build_projects/dotnet-cli-build/GenerateNuGetPackagesArchiveVersion.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Cli.Build
                 {
                     ToolPath = ToolPath,
                     TemplateType = newArgs[0],
-                    TemplateArgs = newArgs[1] + $" --debug:ephemeral-hive -n TempProject -o \"{outputDir}\"",
+                    TemplateArgs = newArgs[1] + $" --debug:ephemeral-hive -n TempProject -o \"{outputDir}\" --no-restore",
                     HostObject = HostObject,
                     BuildEngine = BuildEngine
                 };

--- a/src/dotnet/commands/dotnet-migrate/DotnetNewRedirector.cs
+++ b/src/dotnet/commands/dotnet-migrate/DotnetNewRedirector.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Tools.Migrate
             string outputDirectory,
             string workingDirectory)
         {
-            RunCommand("new", new string[] { "console", "-o", workingDirectory, "--debug:ephemeral-hive" }, workingDirectory);
+            RunCommand("new", new string[] { "console", "-o", workingDirectory, "--debug:ephemeral-hive", "--no-restore" }, workingDirectory);
         }
         private void RunCommand(string commandToExecute, IEnumerable<string> args, string workingDirectory)
         {

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -65,6 +65,7 @@
     <PackageReference Include="Microsoft.DotNet.ProjectJsonMigration" Version="$(CliMigrateVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="$(TemplateEngineVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Cli" Version="$(TemplateEngineVersion)" />
+    <PackageReference Include="Microsoft.TemplateEngine.Cli.Localization" Version="$(TemplateEngineVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="$(TemplateEngineVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Utils" Version="$(TemplateEngineVersion)" />
     <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="All" />

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             {
                 string projectDirectory = directory.Path;
 
-                string newArgs = "console -f netcoreapp2.0 --debug:ephemeral-hive";
+                string newArgs = "console -f netcoreapp2.0 --debug:ephemeral-hive --no-restore";
                 new NewCommandShim()
                     .WithWorkingDirectory(projectDirectory)
                     .Execute(newArgs)

--- a/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
+++ b/test/dotnet-add-reference.Tests/GivenDotnetAddReference.cs
@@ -68,7 +68,7 @@ Commands:
 
             try
             {
-                string args = $"classlib -o \"{projDir.Path}\" --debug:ephemeral-hive";
+                string args = $"classlib -o \"{projDir.Path}\" --debug:ephemeral-hive --no-restore";
                 new NewCommandShim()
                     .WithWorkingDirectory(projDir.Path)
                     .ExecuteWithCapturedOutput(args)

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
             string dir = "pkgs";
             string args = $"--packages {dir}";
 
-            string newArgs = $"console -f netcoreapp2.0 -o \"{rootPath}\" --debug:ephemeral-hive";
+            string newArgs = $"console -f netcoreapp2.0 -o \"{rootPath}\" --debug:ephemeral-hive --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)

--- a/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
+++ b/test/dotnet-list-reference.Tests/GivenDotnetListReference.cs
@@ -209,7 +209,7 @@ Commands:
 
             try
             {
-                string newArgs = $"classlib -o \"{dir.Path}\" --debug:ephemeral-hive";
+                string newArgs = $"classlib -o \"{dir.Path}\" --debug:ephemeral-hive --no-restore";
                 new NewCommandShim()
                     .WithWorkingDirectory(dir.Path)
                     .ExecuteWithCapturedOutput(newArgs)

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -21,13 +21,13 @@ namespace Microsoft.DotNet.New.Tests
 
             new NewCommand()
                 .WithWorkingDirectory(rootPath)
-                .Execute($"console --debug:ephemeral-hive");
+                .Execute($"console --debug:ephemeral-hive --no-restore");
 
             DateTime expectedState = Directory.GetLastWriteTime(rootPath);
 
             var result = new NewCommand()
                 .WithWorkingDirectory(rootPath)
-                .ExecuteWithCapturedOutput($"console --debug:ephemeral-hive");
+                .ExecuteWithCapturedOutput($"console --debug:ephemeral-hive --no-restore");
 
             DateTime actualState = Directory.GetLastWriteTime(rootPath);
 
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.New.Tests
 
             new NewCommand()
                 .WithWorkingDirectory(projectFolder)
-                .Execute($"{projectType} --debug:ephemeral-hive")
+                .Execute($"{projectType} --debug:ephemeral-hive --no-restore")
                 .Should().Pass();
 
             // https://github.com/dotnet/templating/issues/946 - remove DisableImplicitAssetTargetFallback once this is fixed.
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.New.Tests
 
             new NewCommand()
                 .WithWorkingDirectory(rootPath)
-                .Execute($"{type} --name {projectName} -o . --debug:ephemeral-hive")
+                .Execute($"{type} --name {projectName} -o . --debug:ephemeral-hive --no-restore")
                 .Should().Pass();
 
             new RestoreCommand()

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -42,9 +42,11 @@ namespace Microsoft.DotNet.New.Tests
             bool skipSpaWebpackSteps)
         {
             string rootPath = TestAssets.CreateTestDirectory(identifier: $"{language}_{projectType}").FullName;
+            //This works around the SPA templates not currently supporting the "--no-restore" switch
+            string noRestoreDirective = skipSpaWebpackSteps ? "" : "--no-restore";
 
             new TestCommand("dotnet") { WorkingDirectory = rootPath }
-                .Execute($"new {projectType} -lang {language} -o {rootPath} --debug:ephemeral-hive")
+                .Execute($"new {projectType} -lang {language} -o {rootPath} --debug:ephemeral-hive {noRestoreDirective}")
                 .Should().Pass();
 
             if (useNuGetConfigForAspNet)

--- a/test/dotnet-pack.Tests/PackTests.cs
+++ b/test/dotnet-pack.Tests/PackTests.cs
@@ -245,7 +245,7 @@ namespace Microsoft.DotNet.Tools.Pack.Tests
             string dir = "pkgs";
             string args = $"--packages {dir}";
 
-            string newArgs = $"console -o \"{rootPath}\"";
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             string dir = "pkgs";
             string args = $"--packages {dir}";
 
-            string newArgs = $"console -o \"{rootPath}\"";
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)

--- a/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
+++ b/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
@@ -65,7 +65,7 @@ Commands:
 
             try
             {
-                string newArgs = $"classlib -o \"{projDir.Path}\"";
+                string newArgs = $"classlib -o \"{projDir.Path}\" --no-restore";
                 new NewCommandShim()
                     .WithWorkingDirectory(projDir.Path)
                     .ExecuteWithCapturedOutput(newArgs)

--- a/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Restore.Tests
             string dir = "pkgs";
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
-            string newArgs = $"console -o \"{rootPath}\"";
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Restore.Tests
             string dir = "pkgs";
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
-            string newArgs = $"classlib -o \"{rootPath}\"";
+            string newArgs = $"classlib -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Restore.Tests
             string dir = "pkgs";
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
-            string newArgs = $"console -o \"{rootPath}\"";
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             string dir = "pkgs";
             string args = $"--packages {dir}";
 
-            string newArgs = $"console -o \"{rootPath}\"";
+            string newArgs = $"console -o \"{rootPath}\" --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)


### PR DESCRIPTION
CLI impacting changes:
- Enable loc for dotnet new
- Re-enables auto-restore

Non-impacting changes:
- Adds chmod post-action (not used by default) to unblock Fable templates
- Fixes an issue where URL encoded paths are used in the output names when creating templates from ZIPs (default templates don't hit this)
- Adds a post-action for calling chmod (not used by any of the built in templates)
- Fixes an issue where a directory that gets renamed will prevent files from being renamed in the output