### PR TITLE
MSBuildSdkResolver: resolve symlink for 'dotnet' binary

### DIFF
--- a/src/Microsoft.DotNet.MSBuildSdkResolver/Interop.NETStandard.cs
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/Interop.NETStandard.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// NOTE: Currently, only the NET46 build ships (with Visual Studio/desktop msbuild), 
-// but the netstandard1.5 adaptation here acts a proof-of-concept for cross-platform 
+// NOTE: the NET46 build ships with Visual Studio/desktop msbuild on Windows. 
+// The netstandard1.5 adaptation here acts a proof-of-concept for cross-platform 
 // portability of the underlying hostfxr API and gives us build and test coverage 
-// on non-Windows machines.
+// on non-Windows machines. It also ships with msbuild on Mono.
 #if NETSTANDARD1_5
 
 using System;

--- a/src/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -174,8 +174,18 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             }
 
             var environmentProvider = new EnvironmentProvider(_getEnvironmentVariable);
+            var dotnetExe = environmentProvider.GetCommandPath("dotnet");
 
-            return Path.GetDirectoryName(environmentProvider.GetCommandPath("dotnet"));
+#if NETSTANDARD1_5
+            if (dotnetExe != null && !Interop.RunningOnWindows)
+            {
+                // e.g. on Linux the 'dotnet' command from PATH is a symlink so we need to
+                // resolve it to get the actual path to the binary
+                dotnetExe = Interop.realpath(dotnetExe) ?? dotnetExe;
+            }
+#endif
+
+            return Path.GetDirectoryName(dotnetExe);
         }
     }
 }


### PR DESCRIPTION
On Linux the dotnet installed by the dotnet-sdk packages is a symlink (/usr/bin/dotnet -> ../share/dotnet/dotnet).

We need to resolve the symlink so we're passing the path to the actual .NET Core installation to libhostfxr.

Fixes https://github.com/dotnet/cli/issues/7125

