### PR TITLE
Sync windows installer change

### DIFF
--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -19,4 +19,4 @@ Installation Note
 --------------
 A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete."
 
-dotnet new > /dev/null 2>&1 || true
+dotnet internal-reportinstallsuccess "debianpackage" > /dev/null 2>&1 || true

--- a/packaging/osx/clisdk/scripts/postinstall
+++ b/packaging/osx/clisdk/scripts/postinstall
@@ -11,7 +11,6 @@ INSTALL_DESTINATION=$2
 # A temporary fix for the permissions issue(s)
 chmod -R 755 $INSTALL_DESTINATION
 
-# Run 'dotnet new' to trigger the first time experience to initialize the cache
-$INSTALL_DESTINATION/dotnet new > /dev/null 2>&1 || true
+$INSTALL_DESTINATION/dotnet internal-reportinstallsuccess "$1" > /dev/null 2>&1 || true
 
 exit 0

--- a/packaging/rpm/scripts/after_install_host.sh
+++ b/packaging/rpm/scripts/after_install_host.sh
@@ -23,4 +23,4 @@ Installation Note
 --------------
 A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete."
 
-dotnet new > /dev/null 2>&1 || true
+dotnet internal-reportinstallsuccess "rpmpackage" > /dev/null 2>&1 || true


### PR DESCRIPTION
**Customer scenario**

User invoke dotnet new after install from pkg for macOS, the user get Permission denied message.

**Bugs this fixes**

https://github.com/dotnet/cli/issues/7119

**Workarounds, if any**

Install via tar.gz

**Risk**

Low, since this issue is blocking dotnet new scenario

**Performance impact**

Low

**Root cause analysis**

We removed "run as user" during install process. However, native installer other than Windows are using the old prime cache command which will create templatecache folder as super user and caused the permission denied

**How was the bug found?**

GitHub issue

@MattGertz could you review this change?