### PR TITLE
2.0: MSBuildSdkResolver: resolve symlink for 'dotnet' binary

### DIFF
--- a/src/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/MSBuildSdkResolver.cs
@@ -174,8 +174,18 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
             }
 
             var environmentProvider = new EnvironmentProvider(_getEnvironmentVariable);
+            var dotnetExe = environmentProvider.GetCommandPath("dotnet");
 
-            return Path.GetDirectoryName(environmentProvider.GetCommandPath("dotnet"));
+#if NETSTANDARD1_5
+            if (dotnetExe != null && !Interop.RunningOnWindows)
+            {
+                // e.g. on Linux the 'dotnet' command from PATH is a symlink so we need to
+                // resolve it to get the actual path to the binary
+                dotnetExe = Interop.realpath(dotnetExe) ?? dotnetExe;
+            }
+#endif
+
+            return Path.GetDirectoryName(dotnetExe);
         }
     }
 }


### PR DESCRIPTION
Backport of #7126 to release/2.0.0.

ASK MODE template:

**Customer scenario**

msbuild shipped with Mono 5.2 won't pick up msbuild sdks from .NET Core on Linux before this fix since the sdkresolver doesn't correctly find the .NET Core installation directory.

**Bugs this fixes**

#7125

**Workarounds, if any**

Set DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR env var to `/usr/share/dotnet`

**Risk**

Zero, since you're not using the netstandard binary of the sdkresolver in Windows/msbuild but the NET46 version.

**Performance impact**

Low

**Root cause analysis**

We removed "run as user" during install process. However, native installer other than Windows are using the old prime cache command which will create templatecache folder as super user and caused the permission denied

**How was the bug found?**

Xamarin testing

