### PR TITLE
Update the SDK to 1.1.0-alpha-20170713-1

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -5,7 +5,7 @@
     <CLI_MSBuild_Version>15.3.0-preview-000402-01</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.0-beta4-61830-03</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>
-    <CLI_NETSDK_Version>1.1.0-alpha-20170630-2</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.1.0-alpha-20170713-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-preview4-4258</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>


### PR DESCRIPTION
This carries the version cap for the 1.1 SDK.

It has already been approved for insertion into VS.

@dotnet/dotnet-cli @MattGertz @srivatsn 
