### PR TITLE
MSBuild 15.3.407

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>2.0.0-preview3-25516-01</CLI_SharedFrameworkVersion>
-    <CLI_MSBuild_Version>15.3.406</CLI_MSBuild_Version>
+    <CLI_MSBuild_Version>15.3.407</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.0-beta4-61830-03</CLI_Roslyn_Version>
     <CLI_Roslyn_Satellites_Version>2.3.0-pre-20170624-6</CLI_Roslyn_Satellites_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>


### PR DESCRIPTION
Delivers a fix for dotnet/sdk#1393.

This change has not yet been approved by shiproom. Please don't merge until and unless https://devdiv.visualstudio.com/DevDiv/_workitems/edit/463935 gets approved.