### PR TITLE
MSBuild 15.3.407

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>1.1.2</CLI_SharedFrameworkVersion>
-    <CLI_MSBuild_Version>15.3.406</CLI_MSBuild_Version>
+    <CLI_MSBuild_Version>15.3.407</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.0-beta4-61830-03</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>
     <CLI_NETSDK_Version>1.1.0-alpha-20170713-1</CLI_NETSDK_Version>


### PR DESCRIPTION
Delivers a fix for dotnet/sdk#1393.

This change has not yet been approved by shiproom. Please don't merge until and unless https://devdiv.visualstudio.com/DevDiv/_workitems/edit/463935 gets approved.

1.1 branch version of #7175.