### PR TITLE
Use docker image for opensuse 13.2 from runtime

### DIFF
--- a/scripts/docker/opensuse.13.2/Dockerfile
+++ b/scripts/docker/opensuse.13.2/Dockerfile
@@ -3,37 +3,11 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-FROM opensuse:13.2
+FROM microsoft/dotnet-buildtools-prereqs:opensuse132_prereqs_v4
 
-# Install the base toolchain we need to build anything (clang, cmake, make and the like)
-# this does not include libraries that we need to compile different projects, we'd like
-# them in a different layer.
-RUN zypper -n install binutils \
-              cmake \
-              which \
-              gcc \
-              llvm-clang \
-              tar \
-              ncurses-utils \
-              curl \
-              git \
-              sudo && \
-    ln -s /usr/bin/clang++ /usr/bin/clang++-3.5 && \
+RUN zypper -n install sudo \
+    ncurses-utils && \
     zypper clean -a
-
-# Dependencies of CoreCLR and CoreFX.  We need to add an additional repository to get lttng.
-RUN zypper addrepo -G http://download.opensuse.org/repositories/devel:/tools:/lttng/openSUSE_13.2/devel:tools:lttng.repo && \
-    zypper refresh && \
-    zypper -n remove krb5-mini && \
-    zypper -n install libunwind \
-                      libicu \
-                      lttng-ust \
-                      libuuid1 \
-                      libopenssl1_0_0 \
-                      libcurl4 \
-                      krb5 && \
-    zypper clean -a
-
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0
 RUN useradd -m code_executor -u ${USER_ID} -g wheel


### PR DESCRIPTION
Use docker image for opensuse 13.2 from runtime
from https://github.com/dotnet/cli/pull/7186

@srivatsn FYI this is infrastructure change