### PR TITLE
Localize first-run "Expanding" and "Decompressing"

### DIFF
--- a/src/Microsoft.DotNet.Archive/CompressionUtility.cs
+++ b/src/Microsoft.DotNet.Archive/CompressionUtility.cs
@@ -98,7 +98,7 @@ namespace Microsoft.DotNet.Archive
             }
 
             long compressedSize = inStream.Length - inStream.Position;
-            var lzmaProgress = new LzmaProgress(progress, "Decompressing", outSize, MeasureBy.Output);
+            var lzmaProgress = new LzmaProgress(progress, LocalizableStrings.Decompressing, outSize, MeasureBy.Output);
             lzmaProgress.SetProgress(0, 0);
             decoder.Code(inStream, outStream, compressedSize, outSize, lzmaProgress);
             lzmaProgress.SetProgress(inStream.Length, outSize);

--- a/src/Microsoft.DotNet.Archive/IndexedArchive.cs
+++ b/src/Microsoft.DotNet.Archive/IndexedArchive.cs
@@ -380,7 +380,7 @@ namespace Microsoft.DotNet.Archive
                     extractOperations.AsParallel().ForAll(extractOperation =>
                     {
                         extractOperation.DoOperation();
-                        progress.Report("Expanding", Interlocked.Increment(ref opsExecuted), extractOperations.Count);
+                        progress.Report(LocalizableStrings.Expanding, Interlocked.Increment(ref opsExecuted), extractOperations.Count);
                     });
                 }
             }

--- a/src/Microsoft.DotNet.Archive/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Archive/LocalizableStrings.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Expanding" xml:space="preserve">
+    <value>Expanding</value>
+  </data>
+  <data name="Decompressing" xml:space="preserve">
+    <value>Decompressing</value>
+  </data>
+</root>

--- a/src/Microsoft.DotNet.Archive/Microsoft.DotNet.Archive.csproj
+++ b/src/Microsoft.DotNet.Archive/Microsoft.DotNet.Archive.csproj
@@ -11,7 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="**\*.resx" GenerateSource="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="NETStandard.Library" Version="1.6.0" />
     <PackageReference Include="System.Linq.Parallel" Version="4.0.1" />
+    <PackageReference Include="XliffTasks" Version="$(XliffTasksVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.cs.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.de.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.es.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.fr.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.it.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.ja.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.ko.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.pl.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.pt-BR.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.ru.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.tr.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.zh-Hans.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Archive/xlf/LocalizableStrings.zh-Hant.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="Expanding">
+        <source>Expanding</source>
+        <target state="new">Expanding</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Decompressing">
+        <source>Decompressing</source>
+        <target state="new">Decompressing</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
**Customer scenario**

First run progress reporting of decompressing and expanding archive is not translated

**Bugs this fixes:** 

#7197 

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

Minimal, standard cost of retrieving from resource vs. hard-coded string literal

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Missed during first pass of localization. Now that we actually have everything localized, it was easier to spot the outliers.

**How was the bug found?**

Ad-hoc testing on localized setup