### PR TITLE
Revert "Updating SDK to 2.0.0-preview3-20170721-1"

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,7 +12,7 @@
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
          cases, so use separate properties but derive one from the other unless we want to
          explicitly use different versions. -->
-    <CLI_NETSDK_Version>2.0.0-preview3-20170721-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-preview3-20170717-1</CLI_NETSDK_Version>
     <CLI_MSBuildExtensions_Version>$(CLI_NETSDK_Version)</CLI_MSBuildExtensions_Version>
 
     <CLI_NuGet_Version>4.3.0-rtm-4315</CLI_NuGet_Version>


### PR DESCRIPTION
This reverts commit c45fca648c8e379c2f29c8e05dc963b79b62243d.

Will bring the SDK back once we fix the test issues with it.

@dotnet/dotnet-cli 

@srivatsn Reverting a dependency.
