### PR TITLE
Update SDK to 1.1.0-alpha-20170721-6

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -5,7 +5,7 @@
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.0-beta4-61830-03</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>
-    <CLI_NETSDK_Version>1.1.0-alpha-20170719-3</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.1.0-alpha-20170721-6</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-rtm-4315</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>


### PR DESCRIPTION
@dotnet/dotnet-cli 

@srivatsn Flow of dependencies into the CLI. Will be inserted into VS. But only carries dependencies updates.