### PR TITLE
Producing a nupkg for Microsoft.NET.MSBuildResolver.

### DIFF
--- a/build/package/Nupkg.targets
+++ b/build/package/Nupkg.targets
@@ -11,6 +11,10 @@
         <ProjectName>Microsoft.DotNet.Cli.Utils</ProjectName>
         <Version>$(SdkNugetVersion)</Version>
       </ProjectsToPack>
+      <ProjectsToPack Include="$(SrcDirectory)/Microsoft.DotNet.MSBuildSdkResolver" >
+        <ProjectName>Microsoft.DotNet.MSBuildSdkResolver</ProjectName>
+        <Version>$(SdkNugetVersion)</Version>
+      </ProjectsToPack>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Producing a nupkg for Microsoft.NET.MSBuildResolver. Note that this package contains only the Resolver dll. The hostfxr dll will still have to be acquired separately.

Fixes https://github.com/dotnet/cli/issues/7151

@dotnet/dotnet-cli @nguerrera 

@srivatsn Infra-structure change only. We are producing one extra package.