### PR TITLE
Update Roslyn to 2.3.2-beta1-61921-05 in 1.1.0

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>1.1.2</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
-    <CLI_Roslyn_Version>2.3.0-beta4-61830-03</CLI_Roslyn_Version>
+    <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>
     <CLI_NETSDK_Version>1.1.0-alpha-20170721-6</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-rtm-4315</CLI_NuGet_Version>


### PR DESCRIPTION
@dotnet/dotnet-cli Change as per email chain. Not sure what the process for merging this is (VSO bug required?)