### PR TITLE
Update to 2.1 runtime

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>2.0.0</CLI_SharedFrameworkVersion>
+    <CLI_SharedFrameworkVersion>2.1.0-preview2-25615-02</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_Roslyn_Satellites_Version>2.3.0-pre-20170727-1</CLI_Roslyn_Satellites_Version>


### PR DESCRIPTION
Attempt to unblock https://github.com/dotnet/cli/pull/6942 by updating just the runtime first and then PlatformAbstractions and DependencyModel. 