### PR TITLE
Show first run notice even when CLI is installed by native installers.

### DIFF
--- a/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -45,10 +45,12 @@ namespace Microsoft.DotNet.Configurer
                 {
                     PrintUnauthorizedAccessMessage();
                 }
+                else
+                {
+                    PrintNugetCachePrimeMessage();
 
-                PrintNugetCachePrimeMessage();
-
-                _nugetCachePrimer.PrimeCache();
+                    _nugetCachePrimer.PrimeCache();
+                }
             }
         }
 
@@ -81,6 +83,8 @@ namespace Microsoft.DotNet.Configurer
         private bool ShouldPrimeNugetCache()
         {
             return ShouldRunFirstRunExperience() &&
+                !_nugetCacheSentinel.Exists() &&
+                !_nugetCacheSentinel.InProgressSentinelAlreadyExists() &&
                 !_nugetCachePrimer.SkipPrimingTheCache();
         }
 
@@ -96,9 +100,7 @@ namespace Microsoft.DotNet.Configurer
             var skipFirstTimeExperience = 
                 _environmentProvider.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false);
 
-            return !skipFirstTimeExperience &&
-                !_nugetCacheSentinel.Exists() &&
-                !_nugetCacheSentinel.InProgressSentinelAlreadyExists();
+            return !skipFirstTimeExperience;
         }
     }
 }

--- a/src/Microsoft.DotNet.Configurer/NoOpFirstTimeUseNoticeSentinel.cs
+++ b/src/Microsoft.DotNet.Configurer/NoOpFirstTimeUseNoticeSentinel.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.Configuration;
+
+namespace Microsoft.DotNet.Configurer
+{
+    public class NoOpFirstTimeUseNoticeSentinel : IFirstTimeUseNoticeSentinel
+    {
+        public bool Exists()
+        {
+            return true;
+        }
+
+        public void CreateIfNotExists()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Configurer/NuGetCacheSentinel.cs
+++ b/src/Microsoft.DotNet.Configurer/NuGetCacheSentinel.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Configurer
 
         public bool InProgressSentinelAlreadyExists()
         {
-            return CouldNotGetAHandleToTheInProgressSentinel();
+            return CouldNotGetAHandleToTheInProgressSentinel() && !UnauthorizedAccess;
         }
 
         public bool Exists()

--- a/src/dotnet/Telemetry.cs
+++ b/src/dotnet/Telemetry.cs
@@ -37,23 +37,7 @@ namespace Microsoft.DotNet.Cli
 
         public Telemetry(IFirstTimeUseNoticeSentinel sentinel) : this(sentinel, null) { }
 
-        public Telemetry(IFirstTimeUseNoticeSentinel sentinel, string sessionId)
-        {
-            Enabled = !Env.GetEnvironmentVariableAsBool(TelemetryOptout) && PermissionExists(sentinel);
-
-            if (!Enabled)
-            {
-                return;
-            }
-
-            // Store the session ID in a static field so that it can be reused
-            CurrentSessionId = sessionId ?? Guid.NewGuid().ToString();
-
-            //initialize in task to offload to parallel thread
-            _trackEventTask = Task.Factory.StartNew(() => InitializeTelemetry());
-        }
-
-        public Telemetry(IFirstTimeUseNoticeSentinel sentinel, string sessionId, bool blockThreadInitialization)
+        public Telemetry(IFirstTimeUseNoticeSentinel sentinel, string sessionId, bool blockThreadInitialization = false)
         {
             Enabled = !Env.GetEnvironmentVariableAsBool(TelemetryOptout) && PermissionExists(sentinel);
 
@@ -71,6 +55,7 @@ namespace Microsoft.DotNet.Cli
             }
             else
             {
+                //initialize in task to offload to parallel thread
                 _trackEventTask = Task.Factory.StartNew(() => InitializeTelemetry());
             }
         }

--- a/src/dotnet/commands/dotnet-internal-reportinstallsuccess/InternalReportinstallsuccessCommand.cs
+++ b/src/dotnet/commands/dotnet-internal-reportinstallsuccess/InternalReportinstallsuccessCommand.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli
             {
                 var sessionId =
                 Environment.GetEnvironmentVariable(TelemetrySessionIdEnvironmentVariableName);
-                telemetry = new Telemetry(new FirstTimeUseNoticeSentinel(new CliFallbackFolderPathCalculator()), sessionId);
+                telemetry = new Telemetry(new NoOpFirstTimeUseNoticeSentinel(), sessionId);
             }
             public bool Enabled => telemetry.Enabled;
 

--- a/src/dotnet/commands/dotnet-internal-reportinstallsuccess/InternalReportinstallsuccessCommand.cs
+++ b/src/dotnet/commands/dotnet-internal-reportinstallsuccess/InternalReportinstallsuccessCommand.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli
             {
                 var sessionId =
                 Environment.GetEnvironmentVariable(TelemetrySessionIdEnvironmentVariableName);
-                telemetry = new Telemetry(new NoOpFirstTimeUseNoticeSentinel(), sessionId);
+                telemetry = new Telemetry(new NoOpFirstTimeUseNoticeSentinel(), sessionId, blockThreadInitialization: true);
             }
             public bool Enabled => telemetry.Enabled;
 

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCacheSentinel.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCacheSentinel.cs
@@ -71,6 +71,18 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Fact]
+        public void It_returns_false_to_the_in_progress_sentinel_already_exists_when_it_fails_to_get_a_handle_to_it_but_it_failed_because_it_was_unauthorized()
+        {
+            var fileMock = new FileMock();
+            var directoryMock = new DirectoryMock();
+            fileMock.InProgressSentinel = null;
+            var nugetCacheSentinel =
+                new NuGetCacheSentinel(NUGET_CACHE_PATH, fileMock, directoryMock);
+
+            nugetCacheSentinel.InProgressSentinelAlreadyExists().Should().BeFalse();
+        }
+
+        [Fact]
         public void It_returns_false_to_the_in_progress_sentinel_already_exists_when_it_succeeds_in_getting_a_handle_to_it()
         {
             var fileSystemMock = _fileSystemMockBuilder.Build();

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -91,21 +91,23 @@ namespace Microsoft.DotNet.Tests
         [Fact]
         public void ItDoesNotCreateAFirstUseSentinelFileUnderTheDotDotNetFolderWhenInternalReportInstallSuccessIsInvoked()
         {
-            var newHome = Path.Combine(_testDirectory, "new_home");
-            var newHomeFolder = new DirectoryInfo(Path.Combine(newHome, ".dotnet"));
+            var emptyHome = Path.Combine(_testDirectory, "empty_home");
 
             var command = new DotnetCommand()
                 .WithWorkingDirectory(_testDirectory);
-            command.Environment["HOME"] = newHome;
-            command.Environment["USERPROFILE"] = newHome;
-            command.Environment["APPDATA"] = newHome;
+            command.Environment["HOME"] = emptyHome;
+            command.Environment["USERPROFILE"] = emptyHome;
+            command.Environment["APPDATA"] = emptyHome;
             command.Environment["DOTNET_CLI_TEST_FALLBACKFOLDER"] = _nugetFallbackFolder.FullName;
             command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
+            // Disable to prevent the creation of the .dotnet folder by optimizationdata.
+            command.Environment["DOTNET_DISABLE_MULTICOREJIT"] = "true";
             command.Environment["SkipInvalidConfigurations"] = "true";
 
             command.ExecuteWithCapturedOutput("internal-reportinstallsuccess test").Should().Pass();
 
-            newHomeFolder.Should().NotHaveFile($"{GetDotnetVersion()}.dotnetFirstUseSentinel");
+            var emptyHomeFolder = new DirectoryInfo(Path.Combine(emptyHome, ".dotnet"));
+            emptyHomeFolder.Should().NotExist();
         }
 
         [Fact]

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -20,15 +20,17 @@ namespace Microsoft.DotNet.Tests
         private static CommandResult _firstDotnetNonVerbUseCommandResult;
         private static CommandResult _firstDotnetVerbUseCommandResult;
         private static DirectoryInfo _nugetFallbackFolder;
+        private static DirectoryInfo _dotDotnetFolder;
+        private static string _testDirectory;
 
         static GivenThatTheUserIsRunningDotNetForTheFirstTime()
         {
-            var testDirectory = TestAssets.CreateTestDirectory("Dotnet_first_time_experience_tests");
-            var testNuGetHome = Path.Combine(testDirectory.FullName, "nuget_home");
+            _testDirectory = TestAssets.CreateTestDirectory("Dotnet_first_time_experience_tests").FullName;
+            var testNuGetHome = Path.Combine(_testDirectory, "nuget_home");
             var cliTestFallbackFolder = Path.Combine(testNuGetHome, ".dotnet", "NuGetFallbackFolder");
 
             var command = new DotnetCommand()
-                .WithWorkingDirectory(testDirectory);
+                .WithWorkingDirectory(_testDirectory);
             command.Environment["HOME"] = testNuGetHome;
             command.Environment["USERPROFILE"] = testNuGetHome;
             command.Environment["APPDATA"] = testNuGetHome;
@@ -40,6 +42,7 @@ namespace Microsoft.DotNet.Tests
             _firstDotnetVerbUseCommandResult = command.ExecuteWithCapturedOutput("new --debug:ephemeral-hive");
 
             _nugetFallbackFolder = new DirectoryInfo(cliTestFallbackFolder);
+            _dotDotnetFolder = new DirectoryInfo(Path.Combine(testNuGetHome, ".dotnet"));
         }
 
         [Fact]
@@ -76,6 +79,58 @@ namespace Microsoft.DotNet.Tests
                 .Should()
                 .HaveFile($"{GetDotnetVersion()}.dotnetSentinel");
     	}
+
+        [Fact]
+        public void ItCreatesAFirstUseSentinelFileUnderTheDotDotNetFolder()
+        {
+            _dotDotnetFolder
+                .Should()
+                .HaveFile($"{GetDotnetVersion()}.dotnetFirstUseSentinel");
+        }
+
+        [Fact]
+        public void ItDoesNotCreateAFirstUseSentinelFileUnderTheDotDotNetFolderWhenInternalReportInstallSuccessIsInvoked()
+        {
+            var newHome = Path.Combine(_testDirectory, "new_home");
+            var newHomeFolder = new DirectoryInfo(Path.Combine(newHome, ".dotnet"));
+
+            var command = new DotnetCommand()
+                .WithWorkingDirectory(_testDirectory);
+            command.Environment["HOME"] = newHome;
+            command.Environment["USERPROFILE"] = newHome;
+            command.Environment["APPDATA"] = newHome;
+            command.Environment["DOTNET_CLI_TEST_FALLBACKFOLDER"] = _nugetFallbackFolder.FullName;
+            command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
+            command.Environment["SkipInvalidConfigurations"] = "true";
+
+            command.ExecuteWithCapturedOutput("internal-reportinstallsuccess test").Should().Pass();
+
+            newHomeFolder.Should().NotHaveFile($"{GetDotnetVersion()}.dotnetFirstUseSentinel");
+        }
+
+        [Fact]
+        public void ItShowsTheTelemetryNoticeWhenInvokingACommandAfterInternalReportInstallSuccessHasBeenInvoked()
+        {
+            var newHome = Path.Combine(_testDirectory, "new_home");
+            var newHomeFolder = new DirectoryInfo(Path.Combine(newHome, ".dotnet"));
+
+            var command = new DotnetCommand()
+                .WithWorkingDirectory(_testDirectory);
+            command.Environment["HOME"] = newHome;
+            command.Environment["USERPROFILE"] = newHome;
+            command.Environment["APPDATA"] = newHome;
+            command.Environment["DOTNET_CLI_TEST_FALLBACKFOLDER"] = _nugetFallbackFolder.FullName;
+            command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
+            command.Environment["SkipInvalidConfigurations"] = "true";
+
+            command.ExecuteWithCapturedOutput("internal-reportinstallsuccess test").Should().Pass();
+
+            var result = command.ExecuteWithCapturedOutput("new --debug:ephemeral-hive");
+
+            result.StdOut
+                .Should()
+                .ContainVisuallySameFragment(Configurer.LocalizableStrings.FirstTimeWelcomeMessage);
+        }
 
         [Fact]
         public void ItRestoresTheNuGetPackagesToTheNuGetCacheFolder()


### PR DESCRIPTION
**Customer scenario**

Making a change that will cause the first run notice to always show up in the first run of the CLI, even when it is installed by native installers.

**Bugs this fixes:** 

No bug filled.

**Workarounds, if any**

Continue with the current implementation when installing the CLI using a native installer won't display the first run notice when you drop to the command line.

**Risk**

Low

**Performance impact**

N/A

**Is this a regression from a previous update?**

N/A

**Root cause analysis:**

N/A

**How was the bug found?**

PM feature request.

@dotnet/dotnet-cli @richlander  for review

@MattGertz for approval
