### PR TITLE
Update SDK to 1.1.0-alpha-20170726-4 in rel/1.1.0

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -5,7 +5,7 @@
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>
-    <CLI_NETSDK_Version>1.1.0-alpha-20170721-6</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.1.0-alpha-20170726-4</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-rtm-4324</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz Flow of dependencies into the CLI. This will require a VS insertion. This version of the SDK matches the NuGet version in the CLI.