### PR TITLE
Updating the native installers to use the SDK just installed for first run

### DIFF
--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -43,13 +43,15 @@
         SkipUnchangedFiles="False"
         UseHardlinksIfPossible="False" />
 
-      <!-- Create layout: postinst -->
-      <Copy
-        DestinationFiles= "$(DebianPostinstFile)"
-        SourceFiles="$(DebianPostinstTemplateFile)"
-        OverwriteReadOnlyFiles="True"
-        SkipUnchangedFiles="False"
-        UseHardlinksIfPossible="False" />
+      <!-- Create layout: Generate and Place postinst -->
+      <ReplaceFileContents
+        InputFile="$(DebianPostinstTemplateFile)"
+        DestinationFile="$(DebianPostinstFile)"
+        ReplacementItems="@(DebianPostInstTokenValues)" />
+
+      <Chmod
+        Glob="$(DebianPostinstFile)"
+        Mode="ugo+x" />
 
       <!-- Create layout: Generate and Place debian_config.json -->
       <ReplaceFileContents

--- a/build/package/Installer.DEB.targets
+++ b/build/package/Installer.DEB.targets
@@ -105,6 +105,10 @@
       <DebianConfigTokenValues Include="%CLI_SDK_BRAND_NAME%">
         <ReplacementString>$(SdkBrandName)</ReplacementString>
       </DebianConfigTokenValues>
+
+      <DebianPostInstTokenValues Include="%SDK_VERSION%">
+        <ReplacementString>$(SdkVersion)</ReplacementString>
+      </DebianPostInstTokenValues>
     </ItemGroup>
 
     <ItemGroup>

--- a/build/package/Installer.PKG.targets
+++ b/build/package/Installer.PKG.targets
@@ -14,6 +14,9 @@
 
     <SdkPkgSourcesRootDirectory>$(RepoRoot)/packaging/osx/clisdk</SdkPkgSourcesRootDirectory>
     <SdkPkgScriptsDirectory>$(SdkPkgSourcesRootDirectory)/scripts</SdkPkgScriptsDirectory>
+    <SdkPkgScriptTemplateFile>$(SdkPkgScriptsDirectory)/postinstall</SdkPkgScriptTemplateFile>
+    <SdkPkgDestinationScriptsDirectory>$(PkgIntermediateDirectory)/scripts</SdkPkgDestinationScriptsDirectory>
+    <SdkPkgScriptFile>$(SdkPkgDestinationScriptsDirectory)/postinstall</SdkPkgScriptFile>
     <SdkProductArchiveResourcesDirectory>$(SdkPkgSourcesRootDirectory)/resources</SdkProductArchiveResourcesDirectory>
 
     <SdkProductArchiveDistributionTemplateFile>$(SdkPkgSourcesRootDirectory)/Distribution-Template</SdkProductArchiveDistributionTemplateFile>
@@ -54,6 +57,10 @@
         <DistributionTemplateReplacement Include="{HostFxrBrandName}">
           <ReplacementString>$(HostFxrBrandName)</ReplacementString>
         </DistributionTemplateReplacement>
+
+        <PostInstallScriptReplacement Include="%SDK_VERSION%">
+          <ReplacementString>$(SdkVersion)</ReplacementString>
+        </PostInstallScriptReplacement>
       </ItemGroup>
       
       <!-- Consumed By Publish -->
@@ -83,12 +90,22 @@
       <Copy SourceFiles="@(AspNetRuntimeFilesInput)"
             DestinationFiles="@(AspNetRuntimeFilesInput->'$(SdkLayoutOutputDirectory)/%(RecursiveDir)%(FileName)%(Extension)')" />
 
+      <ReplaceFileContents
+        InputFile="$(SdkPkgScriptTemplateFile)"
+        DestinationFile="$(SdkPkgScriptFile)"
+        ReplacementPatterns="@(PostInstallScriptReplacement -> '%(Identity)')"
+        ReplacementStrings="@(PostInstallScriptReplacement -> '%(ReplacementString)')" />
+
+      <Chmod
+        Glob="$(SdkPkgScriptFile)"
+        Mode="ugo+x" />
+
       <Exec Command="pkgbuild
                      --root '$(SdkLayoutOutputDirectory)'
                      --identifier '$(SdkComponentId)'
                      --version '$(SdkVersion)'
                      --install-location '$(PkgInstallDirectory)'
-                     --scripts '$(SdkPkgScriptsDirectory)'
+                     --scripts '$(SdkPkgDestinationScriptsDirectory)'
                      '$(SdkInstallerFile)'" />
     </Target>
 

--- a/build/package/Installer.RPM.props
+++ b/build/package/Installer.RPM.props
@@ -4,5 +4,6 @@
     <RpmConfigJsonName>rpm_config.json</RpmConfigJsonName>
     <TemplatesDir>$(RepoRoot)/packaging/rpm/templates</TemplatesDir>
     <ScriptsDir>$(RepoRoot)/packaging/rpm/scripts</ScriptsDir>
+    <AfterInstallHostScriptName>after_install_host.sh</AfterInstallHostScriptName>
   </PropertyGroup>
 </Project>

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -55,6 +55,8 @@
       <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageName>
       <AspNetCoreRuntimePackageVersion>$(AspNetCoreVersion)-$(AspNetCoreRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageVersion>
       <AspNetCoreRuntimeRpmInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)-$(HostRidInAspNetCoreRuntimeRpmInstallerFileName).rpm</AspNetCoreRuntimeRpmInstallerFileName>
+      <AfterInstallHostScriptTemplateFile>$(ScriptsDir)/$(AfterInstallHostScriptName)</AfterInstallHostScriptTemplateFile>
+      <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -78,7 +80,7 @@
       <SDKFiles Include="$(InputRoot)/**/*"/>
       <SDKManpages Include="$(ManPagesDir)/**/*"/>
       <SDKTemplatesFiles Include="$(TemplatesDir)/**/*"/>
-      <SDKScriptsFiles Include="$(ScriptsDir)/**/*"/>
+      <SDKScriptsFiles Include="$(ScriptsDir)/after_remove_host.sh"/>
     </ItemGroup>
 
     <Copy SourceFiles="@(SDKFiles)"
@@ -128,12 +130,24 @@
       <SDKTokenValue Include="%SDK_RPM_PACKAGE_NAME%">
         <ReplacementString>$(SdkRpmPackageName)</ReplacementString>
       </SDKTokenValue>
+
+      <AfterInstallHostTokenValue  Include="%SDK_VERSION%">
+        <ReplacementString>$(SdkVersion)</ReplacementString>
+      </AfterInstallHostTokenValue>
     </ItemGroup>
 
     <ItemGroup>
       <TestSdkRpmTaskEnvironmentVariables Include="PATH=$(RpmInstalledDirectory)$(PathListSeparator)$(PATH)" />
       <GeneratedInstallers Include="$(SdkInstallerFile)" />
     </ItemGroup>
+
+    <ReplaceFileContents InputFile="$(AfterInstallHostScriptTemplateFile)"
+                         DestinationFile="$(AfterInstallHostScriptDestinationFile)"
+                         ReplacementItems="@(AfterInstallHostTokenValue)"/>
+
+    <Chmod
+        Glob="$(AfterInstallHostScriptDestinationFile)"
+        Mode="ugo+x" />
 
     <ReplaceFileContents InputFile="$(ConfigJsonFile)"
                          DestinationFile="$(RpmLayoutDirectory)$(RpmConfigJsonName)"

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -56,7 +56,7 @@
       <AspNetCoreRuntimePackageVersion>$(AspNetCoreVersion)-$(AspNetCoreRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageVersion>
       <AspNetCoreRuntimeRpmInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)-$(HostRidInAspNetCoreRuntimeRpmInstallerFileName).rpm</AspNetCoreRuntimeRpmInstallerFileName>
       <AfterInstallHostScriptTemplateFile>$(ScriptsDir)/$(AfterInstallHostScriptName)</AfterInstallHostScriptTemplateFile>
-      <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
+      <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)/$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -19,4 +19,4 @@ Installation Note
 --------------
 A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete."
 
-dotnet internal-reportinstallsuccess "debianpackage" > /dev/null 2>&1 || true
+/usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "debianpackage" > /dev/null 2>&1 || true

--- a/packaging/osx/clisdk/scripts/postinstall
+++ b/packaging/osx/clisdk/scripts/postinstall
@@ -11,6 +11,6 @@ INSTALL_DESTINATION=$2
 # A temporary fix for the permissions issue(s)
 chmod -R 755 $INSTALL_DESTINATION
 
-$INSTALL_DESTINATION/dotnet internal-reportinstallsuccess "$1" > /dev/null 2>&1 || true
+$INSTALL_DESTINATION/dotnet exec $INSTALL_DESTINATION/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "$1" > /dev/null 2>&1 || true
 
 exit 0

--- a/packaging/rpm/scripts/after_install_host.sh
+++ b/packaging/rpm/scripts/after_install_host.sh
@@ -23,4 +23,4 @@ Installation Note
 --------------
 A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete."
 
-dotnet internal-reportinstallsuccess "rpmpackage" > /dev/null 2>&1 || true
+/usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "rpmpackage" > /dev/null 2>&1 || true

--- a/packaging/windows/clisdk/dotnet.wxs
+++ b/packaging/windows/clisdk/dotnet.wxs
@@ -20,6 +20,7 @@
     <Property Id="ProductCPU" Value="$(var.Platform)" />
     <Property Id="RTM_ProductVersion" Value="$(var.Dotnet_ProductVersion)" />
     <Property Id="MSIFASTINSTALL" Value="7" />
+    <Property Id="NUGETVERSION" Value="$(var.NugetVersion)" />
     <WixVariable Id="WixUILicenseRtf" Value="$(var.MicrosoftEula)" />
 
     <Property Id="DOTNETEXE">
@@ -32,7 +33,7 @@
 
     <CustomAction Id="PropertyAssignPrimeCacheAndTelemetry"
                   Property="QtExecPrimeCacheAndTelemetryTarget"
-                  Value="&quot;[DOTNETHOME]\dotnet.exe&quot; internal-reportinstallsuccess &quot;[EXEFULLPATH]&quot;"
+                  Value="&quot;[DOTNETHOME]\dotnet.exe&quot; exec &quot;[DOTNETHOME]\sdk\[NUGETVERSION]\dotnet.dll&quot; internal-reportinstallsuccess &quot;[EXEFULLPATH]&quot;"
                   Execute="immediate" />
     <CustomAction Id="QtExecPrimeCacheAndTelemetryTarget"
                   BinaryKey="WixCA"


### PR DESCRIPTION
**Customer scenario**

The native installers shell out to dotnet to invoke the command that sends the install telemetry and kicks off the offline cache expansion. The problem starts when you install, say, SDK 2.0.1. Everything is good and works out. Then, you install SDK 2.0.0. Because the installer shells out, the host will follow its policy, find the latest SDK (2.0.1) and execute the command on that SDK instead of the one just installed. This will cause the cache expansion to happen again for 2.0.1 instead of 2.0.0.
 
This has two visible effects from the user POV:
1. The user won’t get the packages for 2.0.0 offline and will hit the web when trying to use them.
2. This is the more serious one, if the user tries to use the 2.0.0 SDK, he will get a first run message every time, because every time we will try to expand the offline cache, but the user won’t have access to the install folder (unless he invokes the command with elevated permissions).

The fix is to update the native installers to use a fully qualified path to dotnet.dll and execute it with dotnet exec, so that the first run experience to populate the offline cache will trigger for the SDK being installed, instead of for the latest one in the box.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/cli/issues/7282

**Workarounds, if any**

Execute a dotnet command under elevated privileges, to trigger first run with the appropriate permissions.

**Risk**

Medium, since it is a change to all native installers.

**Performance impact**

N/A

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

We had never tried this scenario before. Due to the increasing version numbers, we were always installing the highest SDK on the box and therefore never hit this.

**How was the bug found?**

Dev team, while validating a different fix.

@dotnet/dotnet-cli for review

@MattGertz for approval
