### PR TITLE
Update spa templates to 1.0.417

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -30,7 +30,7 @@
     <CliCommandLineParserVersion>0.1.1-alpha-167</CliCommandLineParserVersion>
     <CliMigrateVersion>1.2.1-alpha-002133</CliMigrateVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
-    <SpaTemplateVersion>1.0.0-preview-000409</SpaTemplateVersion>
+    <SpaTemplateVersion>1.0.417</SpaTemplateVersion>
     <XliffTasksVersion>0.2.0-beta-000042</XliffTasksVersion>
 
     <!-- This should either be timestamped or notimestamp as appropriate -->

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -42,8 +42,7 @@ namespace Microsoft.DotNet.New.Tests
             bool skipSpaWebpackSteps)
         {
             string rootPath = TestAssets.CreateTestDirectory(identifier: $"{language}_{projectType}").FullName;
-            //This works around the SPA templates not currently supporting the "--no-restore" switch
-            string noRestoreDirective = skipSpaWebpackSteps ? "" : "--no-restore";
+            string noRestoreDirective = "--no-restore";
 
             new TestCommand("dotnet") { WorkingDirectory = rootPath }
                 .Execute($"new {projectType} -lang {language} -o {rootPath} --debug:ephemeral-hive {noRestoreDirective}")


### PR DESCRIPTION
* Changes the SPA templates to depend on ASP.NET Core final 2.0.0 packages
* Adds the dotnet restore postaction for consistency with other templates, and hence also removes the test workaround that's no longer needed.

This is then all fully ready to ship for RTM.