### PR TITLE
[New] Security build for CLI

### DIFF
--- a/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
+++ b/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
@@ -1,0 +1,719 @@
+{
+  "build": [
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Workaround for BuildTools - Clone Core-Setup",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(PB_Git)",
+        "arguments": "clone $(CoreSetupUrl) core-setup",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Workaround for BuildTools - Checkout Core-Setup master",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "$(PB_Git)",
+        "arguments": "checkout master",
+        "workingFolder": "$(build.SourcesDirectory)\\core-setup",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Workaround for BuildTools - Run init-tools.cmd",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "init-tools.cmd",
+        "arguments": "",
+        "workingFolder": "$(Build.SourcesDirectory)\\core-setup",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Workaround for BuildTools - Delete CLI dir.props",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-path \"$(Build.SourcesDirectory)\"",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "param ($path)\ngci \"$path\\dir.props\" | Remove-Item -Force",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Download blobs from container $(PB_CloudDropAccountName)",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "c6c4c611-aa2e-4a33-b606-5eaba2196824",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "solution": "$(Build.SourcesDirectory)\\build\\buildpipeline\\security\\syncAzure.proj",
+        "msbuildLocationMethod": "version",
+        "msbuildVersion": "latest",
+        "msbuildArchitecture": "x64",
+        "msbuildLocation": "",
+        "platform": "x64",
+        "configuration": "$(BuildConfiguration)",
+        "msbuildArguments": "/p:AzureAccount=\"$(PB_CloudDropAccountName)\" /p:AzureToken=\"$(PB_CloudDropAccessToken)\" /p:BlobName=\"$(PB_BlobNameFilter)\" /verbosity:diag",
+        "clean": "false",
+        "maximumCpuCount": "false",
+        "restoreNugetPackages": "false",
+        "logProjectEvents": "false",
+        "createLogFile": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Copy downloaded packages to security folder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "refName": "PowerShell_23",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-SrcDir \"$(Build.SourcesDirectory)\"",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "param($SrcDir)\n$secDir = Join-Path \"$SrcDir\" \"security\"\n$pkgDir = \"$SrcDir\\core-setup\\packages\\AzureTransfer\"\nCopy-Item \"$pkgDir \" \"$secDir\" -Force -Recurse\n",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Extract downloaded packages",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-SrcDir \"$(Build.SourcesDirectory)\"",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "param($SrcDir)\n$secDir = Join-Path \"$SrcDir\" \"security\"\ngci \"$secDir\\*.zip\" | % {\n$dstDir = Join-Path \"$secDir\" $($_.BaseName)\nExpand-Archive -Path $($_.FullName) -DestinationPath \"$dstDir\" -Force\nWrite-Host \"Expanded: $($_.FullName)\"\nRemove-Item $_.FullName -Force\n}\n",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "List all files",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(Build.SourcesDirectory)",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "param($SrcDir)\n$fileCount = 0\ngci $SrcDir -recurse | % {\nWrite-Host $($_.FullName)\n$fileCount += 1\n}\nWrite-Host \"File Count: $fileCount\"\n",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Remove non-CLI folders",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "refName": "PowerShell_22",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-SrcDir \"$(Build.SourcesDirectory)\"",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "param($SrcDir)\n$secDir = Join-Path \"$SrcDir\" \"security\"\n\ngci \"$secDir\" | where {$_.PSIsContainer} | % {\n    gci $_.FullName | where {$_.PSIsContainer} | % {\n        if ($_.BaseName -ine \"sdk\" -and $_.BaseName -notmatch \"symbols\")\n        {\n            Remove-Item $_.FullName -Recurse -Force -ErrorAction Continue\n            Write-Host \"Removed $($_.FullName)\"\n        }\n    }\n}",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Workaround for long path - DELETE files with path length greater than or equal to 240 characters",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "refName": "Task_10",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-SrcDir \"$(Build.SourcesDirectory)\"",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "param($SrcDir)\n$longPath = New-Object System.Collections.ArrayList\ngci \"$SrcDir\\*\" -recurse | where {!$_.PSIsContainer}  | % {\nif ($($_.FullName.Length) -ge 240)\n{\n$longPath.Add($($_.Directory.FullName)) | Out-Null\n}\n}\n$longPath | % {\nStart-Process \"cmd\" -ArgumentList \"/c rd /S /Q $_\" -Wait\nWrite-Host \"DELETED $_\"\n}\n",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "List all files - post delete",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "refName": "Task_11",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(Build.SourcesDirectory)",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "param($SrcDir)\n$fileCount = 0\ngci $SrcDir -recurse | % {\nWrite-Host $($_.FullName)\n$fileCount += 1\n}\nWrite-Host \"File Count: $fileCount\"\n",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Run BinSkim ",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "3056813a-40e9-4b2f-8f6b-612d1bc4e045",
+        "versionSpec": "3.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "InputType": "CommandLine",
+        "arguments": "analyze $(Build.SourcesDirectory)\\security\\*.dll $(Build.SourcesDirectory)\\security\\*.exe --recurse --sympath $(Build.SourcesDirectory)\\security\\*.pdb --verbose --statistics",
+        "Function": "analyze",
+        "AnalyzeTarget": "$(Build.ArtifactStagingDirectory)",
+        "AnalyzeSymPath": "",
+        "AnalyzeConfigPath": "default",
+        "AnalyzePluginPath": "",
+        "AnalyzeRecurse": "true",
+        "AnalyzeVerbose": "true",
+        "AnalyzeHashes": "true",
+        "AnalyzeStatistics": "false",
+        "AnalyzeEnvironment": "false",
+        "ExportRulesOutputType": "SARIF",
+        "DumpTarget": "$(Build.ArtifactStagingDirectory)",
+        "DumpRecurse": "true",
+        "DumpVerbose": "true",
+        "toolVersion": "Latest"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Run APIScan",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "9adea2b1-3752-438c-80c6-a6f0a812abdd",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "targetMode": "binarysym",
+        "softwareFolder": "$(Build.SourcesDirectory)\\security",
+        "mpdFolder": "",
+        "softwareName": "CLI",
+        "softwareVersionNum": "$(PB_BuildNumber)",
+        "softwareBuildNum": "$(PB_BuildNumber)",
+        "modeType": "prerelease",
+        "noCopySymbols": "false",
+        "noCopyBinaries": "false",
+        "noDecompress": "true",
+        "exclusionList": "",
+        "email": "",
+        "symbolsFolder": "$(Build.SourcesDirectory)\\security",
+        "preBbtBinariesFolder": "",
+        "preBbtSymbolsFolder": "",
+        "isLargeApp": "false",
+        "analyzerTimeout": "00:00:00",
+        "preserveTempFiles": "false",
+        "toolVersion": "Latest"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Checkout CLI at SHA listed in latest.version",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-SrcDir \"$(Build.SourcesDirectory)\" -git \"$(PB_Git)\"",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "param($SrcDir, $git)\n$secDir = Join-Path \"$SrcDir\" \"security\"\n$shaFile= Join-Path \"$secDir\" \"latest.version\"\n$sha = gc \"$shaFile\" -first 1\n\nif ([string]::IsNullOrWhiteSpace($sha))\n{ Write-Error \"Unable to determine latest commit SHA.\" }\n\nStart-Process \"$git\" -ArgumentList \"clean -df\" -Wait -Verbose -ErrorAction Stop\nStart-Process \"$git\" -ArgumentList \"checkout $sha\" -Wait -Verbose -ErrorAction Stop\nWrite-Host \"Checked out at $sha\"\n",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Run Core-Setup clean.cmd",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d9bafed4-0b18-4f58-968d-86655b4d2ce9",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "filename": "clean.cmd",
+        "arguments": "-all",
+        "workingFolder": "$(Build.SourcesDirectory)\\core-setup",
+        "failOnStandardError": "false"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Delete Core-Setup folder",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-path \"$(Build.SourcesDirectory)\\core-setup\"",
+        "workingFolder": "",
+        "inlineScript": "param ($path)\nRemove-Item \"$path\" -Force -Recurse -ErrorAction Continue\n",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "List all files - post checkout",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "$(Build.SourcesDirectory)",
+        "workingFolder": "$(Build.SourcesDirectory)",
+        "inlineScript": "param($SrcDir)\n$fileCount = 0\ngci $SrcDir -recurse | % {\nWrite-Host $($_.FullName)\n$fileCount += 1\n}\nWrite-Host \"File Count: $fileCount\"\n",
+        "failOnStandardError": "true"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Run CredScan",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "ea576cd4-c61f-48f8-97e7-a3cb07b90a6f",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "outputFormat": "pre",
+        "toolVersion": "Latest",
+        "scanFolder": "$(Build.SourcesDirectory)",
+        "searchersFileType": "Default",
+        "searchersFile": "",
+        "suppressionsFile": "",
+        "suppressAsError": "false",
+        "batchSize": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Run PoliCheck",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "d785890c-0d0d-46bd-8167-8fa9d49990c7",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "inputType": "Basic",
+        "cmdLineArgs": "/F:$(Build.SourcesDirectory) /T:9 /O:PoliCheck.xml",
+        "targetType": "F",
+        "targetArgument": "$(Build.SourcesDirectory)",
+        "importEx": "0",
+        "termTypeT": "0029a9",
+        "termTypeTCustom": "9",
+        "termTypeK": "",
+        "termTypeL": "",
+        "EXGT": "false",
+        "result": "PoliCheck.xml",
+        "optionsFC": "1",
+        "optionsXS": "1",
+        "optionsCTGLEN": "",
+        "optionsSEV": "",
+        "optionsPE": "",
+        "optionsHMENABLE": "",
+        "optionsHPATH": "",
+        "optionsHVER": "",
+        "optionsRulesDBPath": "",
+        "optionsRule": "",
+        "optionsXCLASS": "",
+        "optionsTASKNAME": "",
+        "optionsWORKINGDIRECTORY": "",
+        "optionsFTPATH": "",
+        "optionsD": "",
+        "optionsB1": "",
+        "optionsB2": "",
+        "optionsB3": "",
+        "optionsOCDB": "",
+        "toolVersion": "Latest"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Post Analysis",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "f5679091-e6da-4974-a8dc-0eec03a8ea63",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "APIScan": "true",
+        "BinScope": "false",
+        "BinSkim": "true",
+        "BinSkimBreakOn": "Error",
+        "CredScan": "true",
+        "FortifySCA": "false",
+        "FxCop": "false",
+        "FxCopBreakOn": "ErrorAbove",
+        "ModernCop": "false",
+        "ModernCopBreakOn": "Error",
+        "PoliCheck": "true",
+        "PoliCheckBreakOn": "Severity1",
+        "SDLNativeRules": "false",
+        "TSLint": "false",
+        "TSLintBreakOn": "Error"
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "Publish Security Analysis Logs",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "4096c760-3a8a-435d-9689-88c0311bbc0e",
+        "versionSpec": "2.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "ArtifactName": "CodeAnalysisLogs",
+        "ArtifactType": "Container",
+        "TargetPath": "\\\\my\\share\\$(Build.DefinitionName)\\$(Build.BuildNumber)",
+        "RvName": "",
+        "ProductComponentName": "",
+        "ProductVersionNumber": "",
+        "PlatformName": "",
+        "SDLToolName": "",
+        "SDLToolResultFile": ""
+      }
+    },
+    {
+      "enabled": true,
+      "continueOnError": true,
+      "alwaysRun": false,
+      "displayName": "TSA upload to Codebase: DotNet-CLI-Trusted_$(CodeBase) Stamp: Azure",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "task": {
+        "id": "3da26988-bb64-4a23-8f06-45531d297dae",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "codebase": "NewOrUpdate",
+        "tsaStamp": "Azure",
+        "tsaWebApiUrl": "$(TSAStamp)",
+        "codeBaseName": "DotNet-CLI-Trusted_$(CodeBase)",
+        "notificationAlias": "$(NotificationAlias)",
+        "codeBaseAdmins": "NORTHAMERICA\\raeda",
+        "instanceUrlAzure": "MSAZURE",
+        "instanceUrlBing": "",
+        "instanceUrlCarbon": "",
+        "instanceUrlDevDiv": "DEVDIV",
+        "instanceUrlSkype": "",
+        "instanceUrlTsa": "",
+        "instanceUrlPpe": "",
+        "projectNameDAIPVSTF": "",
+        "projectNameDYNAMICSCRM": "",
+        "projectNameMSAZURE": "One",
+        "projectNameMSDYENG": "",
+        "projectNameMSECG": "",
+        "projectNameIDENTITYDIVISION": "Code Scan - TSA",
+        "projectNameVSTFRD": "",
+        "projectNameMSASG": "",
+        "projectNameMICROSOFTVSTS": "",
+        "projectNameMSDATA": "",
+        "projectNameMSENG": "",
+        "projectNameDEVDIV": "DevDiv",
+        "projectNameSKYPETEST2": "",
+        "projectNameONEDRIVE": "",
+        "projectNameSQLBUVSTS": "",
+        "projectNamePOWERBI": "",
+        "projectNameAZUREVSTFPPE": "",
+        "projectNameSKYPE": "",
+        "projectNameDOMOREEXP": "",
+        "projectNameSQLBUVSTSTEST": "",
+        "areaPath": "One\\DevDiv\\DotNetCore",
+        "iterationPath": "One",
+        "uploadAPIScan": "true",
+        "uploadBinScope": "false",
+        "uploadBinSkim": "true",
+        "uploadCredScan": "true",
+        "uploadFortifySCA": "false",
+        "uploadFxCop": "false",
+        "uploadModernCop": "false",
+        "uploadPoliCheck": "true",
+        "uploadPREfast": "false",
+        "validateToolOutput": "Warning",
+        "validateCompatibility": "Error",
+        "uploadAsync": "true"
+      }
+    }
+  ],
+  "options": [
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5bc3cfb7-6b54-4a4b-b5d2-a3905949f8a6"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "7c555368-ca64-4199-add6-9ebaf0b0137d"
+      },
+      "inputs": {
+        "multipliers": "[]",
+        "parallel": "false",
+        "continueOnError": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "a9db38f9-9fdc-478c-b0f9-464221e58316"
+      },
+      "inputs": {
+        "workItemType": "234347",
+        "assignToRequestor": "true",
+        "additionalFields": "{}"
+      }
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "57578776-4c22-4526-aeb0-86b6da17ee9c"
+      },
+      "inputs": {}
+    },
+    {
+      "enabled": false,
+      "definition": {
+        "id": "5d58cc01-7c75-450c-be18-a388ddb129ec"
+      },
+      "inputs": {
+        "branchFilters": "[\"+refs/heads/*\"]",
+        "additionalFields": "{}"
+      }
+    }
+  ],
+  "variables": {
+    "system.debug": {
+      "value": "false"
+    }
+  },
+  "demands": [
+    "Agent.OS -equals windows_nt",
+    "msbuild"
+  ],
+  "retentionRules": [
+    {
+      "branches": [
+        "+refs/heads/*"
+      ],
+      "artifacts": [
+        "build.SourceLabel"
+      ],
+      "artifactTypesToDelete": [],
+      "daysToKeep": 10,
+      "minimumToKeep": 1,
+      "deleteBuildRecord": true,
+      "deleteTestResults": true
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6661"
+    },
+    "web": {
+      "href": "https://devdiv.visualstudio.com/_permalink/_build/index?collectionId=011b8bdf-6d56-4f87-be0d-0092136884d9&projectId=0bdbc590-a062-4c3f-b0f6-9383f67865ee&definitionId=6661"
+    },
+    "editor": {
+      "href": "https://devdiv.visualstudio.com/_permalink/_build/definitionEditor?collectionId=011b8bdf-6d56-4f87-be0d-0092136884d9&projectId=0bdbc590-a062-4c3f-b0f6-9383f67865ee&definitionId=6661"
+    },
+    "badge": {
+      "href": "https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/6661/badge"
+    }
+  },
+  "buildNumberFormat": "$(date:yyyyMMdd)$(rev:-rr)",
+  "jobAuthorizationScope": 1,
+  "jobTimeoutInMinutes": 600,
+  "jobCancelTimeoutInMinutes": 5,
+  "badgeEnabled": true,
+  "repository": {
+    "properties": {
+      "cleanOptions": "3",
+      "labelSources": "0",
+      "labelSourcesFormat": "$(build.buildNumber)",
+      "reportBuildStatus": "true",
+      "gitLfsSupport": "false",
+      "skipSyncSource": "false",
+      "checkoutNestedSubmodules": "false",
+      "fetchDepth": "0"
+    },
+    "id": "ceac4423-53f8-4c97-bc62-173630412581",
+    "type": "TfsGit",
+    "name": "DotNet-Cli-Trusted",
+    "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Cli-Trusted",
+    "defaultBranch": "refs/heads/master",
+    "clean": "true",
+    "checkoutSubmodules": false
+  },
+  "processParameters": {},
+  "quality": "definition",
+  "authoredBy": {
+    "id": "9d5fdf9f-36b6-4d0c-a12e-2737a673af94",
+    "displayName": "Ravi Eda",
+    "uniqueName": "raeda@microsoft.com",
+    "url": "https://app.vssps.visualstudio.com/Aa44b2c06-f247-425c-8464-4a0676af910a/_apis/Identities/9d5fdf9f-36b6-4d0c-a12e-2737a673af94",
+    "imageUrl": "https://devdiv.visualstudio.com/_api/_common/identityImage?id=9d5fdf9f-36b6-4d0c-a12e-2737a673af94"
+  },
+  "queue": {
+    "id": 36,
+    "name": "DotNet-Build",
+    "pool": {
+      "id": 39,
+      "name": "DotNet-Build"
+    }
+  },
+  "id": 6733,
+  "name": "DotNet-CLI-Security-Windows",
+  "url": "https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_apis/build/Definitions/6661",
+  "uri": "vstfs:///Build/Definition/6733",
+  "path": "\\",
+  "type": 2,
+  "revision": 6,
+  "createdDate": "2017-06-21T21:58:12.397Z",
+  "project": {
+    "id": "0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "name": "DevDiv",
+    "description": "Visual Studio and DevDiv team project for git source code repositories.  Work items will be added for Adams, Dev14 work items are tracked in vstfdevdiv.  ",
+    "url": "https://devdiv.visualstudio.com/_apis/projects/0bdbc590-a062-4c3f-b0f6-9383f67865ee",
+    "state": "wellFormed",
+    "revision": 418097676,
+    "visibility": 0
+  }
+}

--- a/build/buildpipeline/security/dir.props
+++ b/build/buildpipeline/security/dir.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\core-setup\dir.props" />
+</Project>

--- a/build/buildpipeline/security/pipeline.json
+++ b/build/buildpipeline/security/pipeline.json
@@ -1,0 +1,22 @@
+{
+    "Repository": "cli",
+    "Definitions": {
+        "Path": ".",
+        "Type": "VSTS",
+        "BaseUrl": "https://devdiv.visualstudio.com/DefaultCollection",
+        "SkipBranchAndVersionOverrides": "false"
+    },
+    "Pipelines": [
+        {
+            "Name": "Security Build for Windows",
+            "Parameters": {
+                "TreatWarningsAsErrors": "false"
+            },
+            "Definitions": [
+                {
+                    "Name": "DotNet-CLI-Security-Windows"
+                }
+            ]
+        }
+    ]
+}

--- a/build/buildpipeline/security/syncAzure.proj
+++ b/build/buildpipeline/security/syncAzure.proj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <CloudTestTasksPath>$(BuildToolsTaskDesktopDir)Microsoft.DotNet.Build.CloudTestTasks.dll</CloudTestTasksPath>
+    <ContainerName Condition="'$(ContainerName)' == ''">dotnet</ContainerName>
+    <DownloadDirectory>$(PackagesDir)AzureTransfer</DownloadDirectory>
+  </PropertyGroup>
+
+  <Import Project="syncAzure.targets" />
+
+  <Target Name="ValidateRequiredProperties">
+    <Error Condition="'$(AzureAccount)' == ''" Text="Missing property AzureAccount." />
+    <Error Condition="'$(AzureToken)' == ''" Text="Missing property AzureToken." />
+    <Error Condition="'$(ContainerName)' == ''" Text="Missing required property 'ContainerName'" />
+    <Error Condition="'$(BlobName)' == ''" Text="Missing required property 'BlobName'" />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="ValidateRequiredProperties;DownloadBlobsFromAzureTargets" />
+</Project>

--- a/build/buildpipeline/security/syncAzure.targets
+++ b/build/buildpipeline/security/syncAzure.targets
@@ -1,0 +1,31 @@
+<Project ToolsVersion="12.0" DefaultTargets="DownloadBlobsFromAzureTargets" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="DownloadFromAzure" AssemblyFile="$(CloudTestTasksPath)"/>
+  <UsingTask TaskName="ListAzureBlobs" AssemblyFile="$(CloudTestTasksPath)" />
+  <UsingTask TaskName="ListAzureContainers" AssemblyFile="$(CloudTestTasksPath)"/>
+
+  <PropertyGroup>
+    <DownloadDirectory Condition="'$(DownloadDirectory)' == ''">$(PackagesDir)/AzureTransfer</DownloadDirectory>
+  </PropertyGroup>
+
+  <Target Name="DownloadBlobsFromAzureTargets" Condition="'$(ContainerName)' != ''">
+    <ListAzureBlobs AccountName="$(AzureAccount)"
+                    AccountKey="$(AzureToken)"
+                    ContainerName="$(ContainerName)"
+                    FilterBlobNames="$(BlobName)">
+      <Output TaskParameter="BlobNames" ItemName="_BlobList" />
+    </ListAzureBlobs>
+
+    <ItemGroup>
+      <_OSFilteredBlobNames Include="@(_BlobList)" 
+                        Condition="'$(OSGroup)' == 'Windows_NT' AND 
+                        ('%(_BlobList.Extension)' == '.zip' OR '%(_BlobList.Extension)' == '.exe' OR '%(_BlobList.Extension)' == '.version')" />
+    </ItemGroup>
+
+    <DownloadFromAzure AccountName="$(AzureAccount)"
+                        AccountKey="$(AzureToken)"
+                        ContainerName="$(ContainerName)"
+                        BlobNames="@(_OSFilteredBlobNames)"
+                        BlobNamePrefix="$(BlobName)"
+                        DownloadDirectory="$(DownloadDirectory)" />
+  </Target>
+</Project>


### PR DESCRIPTION
Starting a fresh PR since the earlier one (https://github.com/dotnet/cli/pull/7076) has run into rebase-merge conflicts leading to lot of noise. All comments from that PR have been addressed.

Approach for CLI security build is:
1. Download official build packages (*.zip) from `dotnetcli/Sdk/<branch>` 
2. Extract the packages
3. Run BinSkim and APIScan on all assemblies and executables in `sdk` folder
4. Checkout the sources at the SHA listed in `latest.version` file
5. Run CredScan and PoliCheck on the sources

VSTS build definition is at https://devdiv.visualstudio.com/DevDiv/_build/index?context=allDefinitions&path=%5CDotNet%5CSecurity&definitionId=6698&_a=completed

This invokes the build whose JSON is shown in this PR.

How to launch a security build is described at https://github.com/dotnet/core-eng/blob/master/Documentation/Project-Docs/security-builds.md

Running this build produced the following report - http://aztsa/api/Result/CodeBase/DotNet-CLI-Trusted_master/Summary

There are around 180 issues to triage -
https://msazure.visualstudio.com/DefaultCollection/One/_workitems?tempQueryId=740da6e8-15ce-4912-b983-2cf87ed6a530

@livarcocc please review.

Post merge I will log an issue to read latest build from https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/latest.version
