### PR TITLE
Update SDK to 2.0.0-preview3-20170727-2

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,7 +12,7 @@
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
          cases, so use separate properties but derive one from the other unless we want to
          explicitly use different versions. -->
-    <CLI_NETSDK_Version>2.0.0-preview3-20170727-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-preview3-20170727-2</CLI_NETSDK_Version>
     <CLI_MSBuildExtensions_Version>$(CLI_NETSDK_Version)</CLI_MSBuildExtensions_Version>
 
     <CLI_NuGet_Version>4.3.0-rtm-4324</CLI_NuGet_Version>


### PR DESCRIPTION
@dotnet/dotnet-cli 

@MattGertz Flow of dependencies into the CLI. This carries the resource assemblies fix.