### PR TITLE
Update SDK to 2.0.0-preview3-20170728-1

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,7 +12,7 @@
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
          cases, so use separate properties but derive one from the other unless we want to
          explicitly use different versions. -->
-    <CLI_NETSDK_Version>2.0.0-preview3-20170727-2</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.0-preview3-20170728-1</CLI_NETSDK_Version>
     <CLI_MSBuildExtensions_Version>$(CLI_NETSDK_Version)</CLI_MSBuildExtensions_Version>
 
     <CLI_NuGet_Version>4.3.0-rtm-4324</CLI_NuGet_Version>


### PR DESCRIPTION
Contains the new error message for .NET Framework referencing NetStandard 1.5 and 1.6 without the 2.0 SDK.

@dotnet/dotnet-cli 

@MattGertz Flow of dependency into the CLI. Already approved insertion into VS.
