### PR TITLE
Improving UX for dotnet add package when Path.GetTempPath throws

### DIFF
--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
@@ -163,6 +163,6 @@
     <value>PACKAGE_DIRECTORY</value>
   </data>
   <data name="CmdDGFileIOException" xml:space="preserve">
-    <value>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</value>
+    <value>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
@@ -162,4 +162,7 @@
   <data name="CmdPackageDirectory" xml:space="preserve">
     <value>PACKAGE_DIRECTORY</value>
   </data>
+  <data name="CmdDGFileIOException" xml:space="preserve">
+    <value>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
@@ -71,12 +71,14 @@ namespace Microsoft.DotNet.Tools.Add.PackageReference
                 {
                     // Create a Dependency Graph file for the project
                     tempDgFilePath = Path.GetTempFileName();
-                    GetProjectDependencyGraph(projectFilePath, tempDgFilePath);
                 }
                 catch (IOException ioex)
                 {
-                     throw new GracefulException(string.Format(LocalizableStrings.CmdDGFileIOException, projectFilePath));
+                    // Catch IOException from Path.GetTempFileName() and throw a graceful exception to the user.
+                    throw new GracefulException(string.Format(LocalizableStrings.CmdDGFileIOException, projectFilePath));
                 }
+                
+                GetProjectDependencyGraph(projectFilePath, tempDgFilePath);
             }
 
             var result = NuGetCommand.Run(

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
@@ -66,9 +66,10 @@ namespace Microsoft.DotNet.Tools.Add.PackageReference
 
             if (!_appliedCommand.HasOption("no-restore"))
             {
-                // Create a Dependency Graph file for the project
+                
                 try
                 {
+                    // Create a Dependency Graph file for the project
                     tempDgFilePath = Path.GetTempFileName();
                     GetProjectDependencyGraph(projectFilePath, tempDgFilePath);
                 }

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
@@ -67,8 +67,15 @@ namespace Microsoft.DotNet.Tools.Add.PackageReference
             if (!_appliedCommand.HasOption("no-restore"))
             {
                 // Create a Dependency Graph file for the project
-                tempDgFilePath = Path.GetTempFileName();
-                GetProjectDependencyGraph(projectFilePath, tempDgFilePath);
+                try
+                {
+                    tempDgFilePath = Path.GetTempFileName();
+                    GetProjectDependencyGraph(projectFilePath, tempDgFilePath);
+                }
+                catch (IOException ioex)
+                {
+                     throw new GracefulException(string.Format(LocalizableStrings.CmdDGFileIOException, projectFilePath));
+                }
             }
 
             var result = NuGetCommand.Run(

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
@@ -77,6 +77,11 @@
         <target state="translated">NOME_PACCHETTO</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
@@ -77,6 +77,11 @@
         <target state="translated">NAZWA_PAKIETU</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -77,6 +77,11 @@
         <target state="translated">PACKAGE_NAME</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDGFileIOException">
+        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
+        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -78,8 +78,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdDGFileIOException">
-        <source>Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</source>
-        <target state="new">Unable to get a temp path for a dependency graph file for project '{0}'. Cannot add package reference.</target>
+        <source>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</source>
+        <target state="new">Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fixes the UX  in https://github.com/dotnet/cli/issues/7331

I have added a try/catch around the call to `Path.GetTempPath()`. In the rare case it does throw an `IOException`. dotnet will throw a `GracefulException`.