### PR TITLE
Remove unneeded char[] allocations

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
@@ -11,6 +11,8 @@ namespace Microsoft.DotNet.Cli.Utils
 {
     public class EnvironmentProvider : IEnvironmentProvider
     {
+        private static char[] s_pathSeparator = new char[] { Path.PathSeparator };
+        private static char[] s_quote = new char[] { '"' };
         private IEnumerable<string> _searchPaths;
         private IEnumerable<string> _executableExtensions;
 
@@ -42,8 +44,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
                     searchPaths.AddRange(Environment
                         .GetEnvironmentVariable("PATH")
-                        .Split(Path.PathSeparator)
-                        .Select(p => p.Trim('"')));
+                        .Split(s_pathSeparator)
+                        .Select(p => p.Trim(s_quote)));
 
                     _searchPaths = searchPaths;
                 }


### PR DESCRIPTION
This was causing 0.2% of allocations in a design-time build trace from a customer.

![image](https://user-images.githubusercontent.com/1103906/28865968-e7113594-77b4-11e7-9a46-8396c48d34ba.png)


