### PR TITLE
Automate triggering of CLI security build.

### DIFF
--- a/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
+++ b/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
@@ -255,7 +255,7 @@
         "scriptType": "filePath",
         "scriptName": "$(Build.SourcesDirectory)\\build\\buildpipeline\\security\\Get-LatestVersion.ps1",
         "arguments": "-Branch \"$(CodeBase)\"",
-        "workingFolder": "$(Build.SourcesDirectory)\\$(PB_Repo)\\build\\buildpipeline\\security\\",
+        "workingFolder": "",
         "failOnStandardError": "true"
       }
     },

--- a/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
+++ b/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
@@ -678,7 +678,7 @@
     "type": "TfsGit",
     "name": "DotNet-Cli-Trusted",
     "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Cli-Trusted",
-    "defaultBranch": "refs/heads/sec_ext",
+    "defaultBranch": "refs/heads/master",
     "clean": "true",
     "checkoutSubmodules": false
   },

--- a/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
+++ b/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
@@ -238,6 +238,28 @@
       }
     },
     {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Get latest version info",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "refName": "PowerShell23",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "filePath",
+        "scriptName": "$(Build.SourcesDirectory)\\build\\buildpipeline\\security\\Get-LatestVersion.ps1",
+        "arguments": "-Branch \"$(CodeBase)\"",
+        "workingFolder": "$(Build.SourcesDirectory)\\$(PB_Repo)\\build\\buildpipeline\\security\\",
+        "failOnStandardError": "true"
+      }
+    },
+    {
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": false,

--- a/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
+++ b/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
@@ -286,8 +286,8 @@
         "softwareFolder": "$(Build.SourcesDirectory)\\security",
         "mpdFolder": "",
         "softwareName": "CLI",
-        "softwareVersionNum": "$(PB_BuildNumber)",
-        "softwareBuildNum": "$(PB_BuildNumber)",
+        "softwareVersionNum": "$(CliLatestPackageId)",
+        "softwareBuildNum": "$(CliLatestPackageId)",
         "modeType": "prerelease",
         "noCopySymbols": "false",
         "noCopyBinaries": "false",
@@ -318,9 +318,9 @@
       "inputs": {
         "scriptType": "inlineScript",
         "scriptName": "",
-        "arguments": "-SrcDir \"$(Build.SourcesDirectory)\" -git \"$(PB_Git)\"",
+        "arguments": "-sha \"$(CliLatestCommitSha)\" -git \"$(PB_Git)\"",
         "workingFolder": "$(Build.SourcesDirectory)",
-        "inlineScript": "param($SrcDir, $git)\n$secDir = Join-Path \"$SrcDir\" \"security\"\n$shaFile= Join-Path \"$secDir\" \"latest.version\"\n$sha = gc \"$shaFile\" -first 1\n\nif ([string]::IsNullOrWhiteSpace($sha))\n{ Write-Error \"Unable to determine latest commit SHA.\" }\n\nStart-Process \"$git\" -ArgumentList \"clean -df\" -Wait -Verbose -ErrorAction Stop\nStart-Process \"$git\" -ArgumentList \"checkout $sha\" -Wait -Verbose -ErrorAction Stop\nWrite-Host \"Checked out at $sha\"\n",
+        "inlineScript": "param($sha, $git)\n\nStart-Process \"$git\" -ArgumentList \"clean -df\" -Wait -Verbose -ErrorAction Stop\nStart-Process \"$git\" -ArgumentList \"checkout $sha\" -Wait -Verbose -ErrorAction Stop\nWrite-Host \"Checked out at $sha\"\n",
         "failOnStandardError": "true"
       }
     },
@@ -678,7 +678,7 @@
     "type": "TfsGit",
     "name": "DotNet-Cli-Trusted",
     "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Cli-Trusted",
-    "defaultBranch": "refs/heads/master",
+    "defaultBranch": "refs/heads/sec_ext",
     "clean": "true",
     "checkoutSubmodules": false
   },

--- a/build/buildpipeline/security/Get-LatestVersion.ps1
+++ b/build/buildpipeline/security/Get-LatestVersion.ps1
@@ -27,13 +27,14 @@ function Get-VersionInfo
     $retryCount = 1
     $oldEap = $ErrorActionPreference
 
-    while ($retryCount -le 3)
+    while ($retryCount -le $retries)
     {
         $ErrorActionPreference = "Stop"
 
         try
         {
-            return (Invoke-WebRequest -Uri "$latestVersionUrl" -UseBasicParsing).Content.Split([Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries)
+            $content = (Invoke-WebRequest -Uri "$latestVersionUrl" -UseBasicParsing).Content
+            return $content.Split([Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries)
         }
         catch
         {
@@ -53,7 +54,7 @@ function Get-VersionInfo
 $latestVersionUrl = "$UrlPrefix/$Branch/$Filename"
 $latestVersionContent = Get-VersionInfo
 
-if (-not [string]::IsNullOrWhiteSpace($latestVersionContent) -and $latestVersionContent.Length -eq 2)
+if ($latestVersionContent -ne $null -and $latestVersionContent.Length -eq 2)
 {
     $CliLatestCommitSha = $latestVersionContent[0]
     $CliLatestPackageId = $latestVersionContent[1]

--- a/build/buildpipeline/security/Get-LatestVersion.ps1
+++ b/build/buildpipeline/security/Get-LatestVersion.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+    Retrieves the latest commit SHA and the corresponding package Id for the specified branch of CLI. 
+    This retrieval is achieved by downloading the latest.version file, which contains the commit SHA and package Id info.
+    If retrieval succeeds, then the commit is set as $env:CliLatestCommitSha, and package Id is set as $env:CliLatestPackageId.
+.PARAMETER $Branch
+    Name of the CLI branch.
+.PARAMETER $Filename
+    Name of the file that contains latest version info i.e. commit SHA and package Id.
+    If not specified, then the default value is latest.version
+.PARAMETER $UrlPrefix
+    URL prefix for $Filename.
+    If not specified, then the default value is https://dotnetcli.blob.core.windows.net/dotnet/Sdk
+#>
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$Branch,
+    [string]$Filename="latest.version",
+    [string]$UrlPrefix="https://dotnetcli.blob.core.windows.net/dotnet/Sdk"
+)
+
+$latestVersionUrl = "$UrlPrefix/$Branch/$Filename"
+$latestVersionFilePath = ".\latest.version"
+$env:CliLatestCommitSha = ""
+$env:CliLatestPackageId = ""
+
+
+function Get-VersionInfo
+{
+    Write-Host "Attempting to retrieve latest version info from $latestVersionUrl"
+    $retries = 3
+    $retryCount = 1
+    $oldEap = $ErrorActionPreference
+
+    while ($retryCount -le 3)
+    {
+        $ErrorActionPreference = "Stop"
+
+        try
+        {
+            if(Test-Path "$latestVersionFilePath")
+            {
+                Remove-Item "$latestVersionFilePath" -Force
+            }
+
+            Invoke-WebRequest -Uri "$latestVersionUrl" -OutFile "$latestVersionFilePath"
+
+            $latestVersionContent = Get-Content "$latestVersionFilePath"
+            $env:CliLatestCommitSha = $latestVersionContent[0]
+            $env:CliLatestPackageId = $latestVersionContent[1]
+
+            break
+        }
+        catch
+        {
+            Sleep -Seconds (Get-Random -minimum 3 -maximum 10)
+            Write-Host "Exception occurred while attempting to get latest version info from $latestVersionUrl. $_"
+            Write-Host "Retry $retryCount of $retries"
+        }
+        finally
+        {
+            $ErrorActionPreference = $oldEap
+        }
+
+        $retryCount++
+    }
+}
+
+Get-VersionInfo
+
+if (-not [string]::IsNullOrWhiteSpace($env:CliLatestCommitSha) -and -not [string]::IsNullOrWhiteSpace($env:CliLatestPackageId))
+{
+    Write-Host "##vso[task.setvariable variable=CliLatestCommitSha;]$env:CliLatestCommitSha"
+    Write-Host "##vso[task.setvariable variable=CliLatestPackageId;]$env:CliLatestPackageId"
+
+    Write-Host "The latest commit SHA in CLI $Branch is $env:CliLatestCommitSha"
+    Write-Host "The latest package Id in CLI $Branch is $env:CliLatestPackageId"
+}
+else
+{
+    Write-Error "Unable to get latest version info from $latestVersionUrl"
+}


### PR DESCRIPTION
These changes allow automatic queuing of security build. 

`build/buildpipeline/security/Get-LatestVersion.ps1` is invoked by the root build (https://devdiv.visualstudio.com/DevDiv/_build/index?context=allDefinitions&path=%5CDotNet%5CSecurity&definitionId=6698&_a=completed) to retrieve commit SHA and package Id from latest.version. This info is passed onto the build leg i.e. `DotNet-CLI-Security-Windows.json`, which perform the scanning of assemblies and sources for security issues.

Refer (https://github.com/dotnet/core-eng/issues/1401). 

Post merge, I will setup a trigger to run security build once per day, and cleanup documentation at https://github.com/dotnet/core-eng/blob/master/Documentation/Project-Docs/security-builds.md

@livarcocc PTAL.

Cc @MichaelSimons 