### PR TITLE
Fix ubuntu and mac no permission error

### DIFF
--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -19,4 +19,10 @@ Installation Note
 --------------
 A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete."
 
-/usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "debianpackage" > /dev/null 2>&1 || true
+first_run() {
+    /usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "debianpackage" > /dev/null 2>&1 || true
+}
+
+INSTALL_TEMP_HOME=/tmp/dotnet-installer
+[ -d $INSTALL_TEMP_HOME ] || mkdir $INSTALL_TEMP_HOME
+HOME=$INSTALL_TEMP_HOME first_run

--- a/packaging/osx/clisdk/scripts/postinstall
+++ b/packaging/osx/clisdk/scripts/postinstall
@@ -6,11 +6,16 @@
 
 PACKAGE=$1
 INSTALL_DESTINATION=$2
-
+INSTALL_TEMP_HOME=/tmp/dotnet-installer
 
 # A temporary fix for the permissions issue(s)
 chmod -R 755 $INSTALL_DESTINATION
 
-$INSTALL_DESTINATION/dotnet exec $INSTALL_DESTINATION/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "$1" > /dev/null 2>&1 || true
+first_run() {
+    $INSTALL_DESTINATION/dotnet exec $INSTALL_DESTINATION/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "$1" > /dev/null 2>&1 || true
+}
+
+[ -d $INSTALL_TEMP_HOME ] || mkdir $INSTALL_TEMP_HOME
+HOME=$INSTALL_TEMP_HOME first_run
 
 exit 0

--- a/packaging/rpm/scripts/after_install_host.sh
+++ b/packaging/rpm/scripts/after_install_host.sh
@@ -23,4 +23,10 @@ Installation Note
 --------------
 A command will be run during the install process that will improve project restore speed and enable offline access. It will take up to a minute to complete."
 
-/usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "rpmpackage" > /dev/null 2>&1 || true
+first_run() {
+    /usr/share/dotnet/dotnet exec /usr/share/dotnet/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "rpmpackage" > /dev/null 2>&1 || true
+}
+
+INSTALL_TEMP_HOME=/tmp/dotnet-installer
+[ -d $INSTALL_TEMP_HOME ] || mkdir $INSTALL_TEMP_HOME
+HOME=$INSTALL_TEMP_HOME first_run


### PR DESCRIPTION
**Customer scenario**

SDK native installer user using deb on Ubuntu and pkg on macOS. After install, the user cannot run dotnet command due to Permission Denied error

**Bugs this fixes**

N/A

**Workarounds, if any**

- Pass -H to sudo when launching the installer (Ubuntu only)
- Delete ~/.dotnet after installation
- Change owner of ~/.dotnet after installation

**Risk**

low, the fix is in install process

**Performance impact**

no

**Root cause analysis**

There is no good abstraction of cross session state management in CLI, especially add the complexity of user level and machine level

**How was the bug found?**

Manual testing
