### PR TITLE
Add prereq check for libcurl

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -194,6 +194,7 @@ check_pre_reqs() {
         [ -z "$($LDCONFIG_COMMAND -p | grep libunwind)" ] && say_err "Unable to locate libunwind. Install libunwind to continue" && failing=true
         [ -z "$($LDCONFIG_COMMAND -p | grep libssl)" ] && say_err "Unable to locate libssl. Install libssl to continue" && failing=true
         [ -z "$($LDCONFIG_COMMAND -p | grep libicu)" ] && say_err "Unable to locate libicu. Install libicu to continue" && failing=true
+        [ -z "$($LDCONFIG_COMMAND -p | grep -F libcurl.so)" ] && say_err "Unable to locate libcurl. Install libcurl to continue" && failing=true
     fi
 
     if [ "$failing" = true ]; then


### PR DESCRIPTION
I think `libcurl` shoudl be added to the prereq checks.  I used the script to install .NET Core on a relatively fresh Ubuntu 16.04 machine, and the install succeeded, but my app failed at runtime with:

```
Unable to load the service index for source https://api.nuget.org/v3/index.json.
  The type initializer for 'System.Net.Http.CurlHandler' threw an exception.
  The type initializer for 'Http' threw an exception.
  The type initializer for 'HttpInitializer' threw an exception.
  Unable to load DLL 'System.Net.Http.Native': The specified module or one of its dependencies could not be found.
   (Exception from HRESULT: 0x8007007E)
```

The issue was that package `libcurl3` was not installed, though `libcurl3-gnutls` was installed.  The prereq check would need to specifically look for `libcurl.so`, to avoid false positives like `libcurl-gnutls`:

```
$ ldconfig -p | grep libcurl
        libcurl.so.4 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcurl.so.4
        libcurl-gnutls.so.4 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4

$ ldconfig -p | grep -F libcurl.so
        libcurl.so.4 (libc6,x86-64) => /usr/lib/x86_64-linux-gnu/libcurl.so.4
```

Note that I have only tested this change on one Ubuntu 16.04 machine, so I don't know if the check is safe on all platforms.