### PR TITLE
Workaround for APIScan build parameter.

### DIFF
--- a/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
+++ b/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
@@ -260,6 +260,29 @@
       }
     },
     {
+      "environment": {},
+      "enabled": true,
+      "continueOnError": false,
+      "alwaysRun": false,
+      "displayName": "Workaround for long package Id",
+      "timeoutInMinutes": 0,
+      "condition": "succeeded()",
+      "refName": "PowerShell24",
+      "task": {
+        "id": "e213ff0f-5d5c-4791-802d-52ea3e7be1f1",
+        "versionSpec": "1.*",
+        "definitionType": "task"
+      },
+      "inputs": {
+        "scriptType": "inlineScript",
+        "scriptName": "",
+        "arguments": "-packageId $(CliLatestPackageId)",
+        "workingFolder": "",
+        "inlineScript": "param($packageId)\n\nif ($packageId.Length -ge 16)\n{\n    Write-Host \"Build number for security build is the package Id. TSA has a limit of 16 characters for build number. Since package Id is greater than 16 characters, build number will be set to current date time in yyyymmddHHMMss format.\"\n    $CliLatestPackageId = Get-Date -Format yyyymmddHHMMss\n    Write-Host \"##vso[task.setvariable variable=CliLatestPackageId;]$CliLatestPackageId\"\n}",
+        "failOnStandardError": "true"
+      }
+    },
+    {
       "enabled": true,
       "continueOnError": true,
       "alwaysRun": false,
@@ -700,7 +723,7 @@
     "type": "TfsGit",
     "name": "DotNet-Cli-Trusted",
     "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Cli-Trusted",
-    "defaultBranch": "refs/heads/master",
+    "defaultBranch": "refs/heads/sec_ext",
     "clean": "true",
     "checkoutSubmodules": false
   },

--- a/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
+++ b/build/buildpipeline/security/DotNet-CLI-Security-Windows.json
@@ -723,7 +723,7 @@
     "type": "TfsGit",
     "name": "DotNet-Cli-Trusted",
     "url": "https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Cli-Trusted",
-    "defaultBranch": "refs/heads/sec_ext",
+    "defaultBranch": "refs/heads/master",
     "clean": "true",
     "checkoutSubmodules": false
   },


### PR DESCRIPTION
APIScan does not run in security build since one of the input parameters gets assigned an invalid value. Build number parameter has a limitation of 16 characters. Build number was being set as the package Id, which happens to be greater than 16 characters.  For example, the latest package Id, `2.1.0-preview1-007012` is 22 character long.

```
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?_a=summary&buildId=907152
ERROR: Microsoft.Tools.ApiScan.ApiScanLib.Exceptions.BadArgumentException: The build name can not exceed 16 characters
```
These changes add a workaround such that when package Id is greater than 16 characters, current date time in the format `yyyymmddHHMMss` is set as the package Id, which will be the build number. 
Performed a test build to validate the workaround. Link to test build: https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/index?buildId=907723&_a=summary

@nguerrera PTAL
