### PR TITLE
Pass Deb repo secret to the repoapi script

### DIFF
--- a/build/publish/PublishDebian.targets
+++ b/build/publish/PublishDebian.targets
@@ -28,6 +28,6 @@
     <Delete Files="$(DebianUploadJsonFile)" />
     <WriteLinesToFile File="$(DebianUploadJsonFile)" Lines="$(DebianUploadJsonContent)" />
 
-    <Exec Command="$(RepoRoot)/scripts/publish/repoapi_client.sh -addpkg $(DebianUploadJsonFile)" />
+    <Exec Command="REPO_PASS=$(REPO_PASS) sh -c '$(RepoRoot)/scripts/publish/repoapi_client.sh -addpkg $(DebianUploadJsonFile)'" />
   </Target>
 </Project>


### PR DESCRIPTION
The secret is not passing by env now. However repoapi still assumes the
secret will be passed by env. Pass through the secret via command line