### PR TITLE
Only open help page for commands with DocLink

### DIFF
--- a/src/dotnet/commands/dotnet-help/HelpCommand.cs
+++ b/src/dotnet/commands/dotnet-help/HelpCommand.cs
@@ -102,7 +102,8 @@ namespace Microsoft.DotNet.Tools.Help
         {
             if (BuiltInCommandsCatalog.Commands.TryGetValue(
                 _appliedOption.Arguments.Single(),
-                out BuiltInCommandMetadata builtIn))
+                out BuiltInCommandMetadata builtIn) &&
+                !string.IsNullOrEmpty(builtIn.DocLink))
             {
                 var process = ConfigureProcess(builtIn.DocLink);
                 process.Start();

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -89,6 +89,19 @@ runtime-options:
           cmd.StdOut.Should().ContainVisuallySameFragmentIfNotLocalized(HelpText);
         }
 
+        [Theory]
+        [InlineData("complete")]
+        [InlineData("parse")]
+        public void WhenCommandWithoutDocLinkIsPassedToDotnetHelpItPrintsError(string command)
+        {
+          var cmd = new DotnetCommand()
+                .ExecuteWithCapturedOutput($"help {command}");
+
+          cmd.Should().Fail();
+          cmd.StdErr.Should().Contain(string.Format(Tools.Help.LocalizableStrings.CommandDoesNotExist, command));
+          cmd.StdOut.Should().ContainVisuallySameFragmentIfNotLocalized(HelpText);
+        }
+
         [WindowsOnlyFact]
         public void WhenRunOnWindowsDotnetHelpCommandShouldContainProperProcessInformation()
         {


### PR DESCRIPTION
The help-command now handles commands without a DocLink
in the same manner as unknown commands.

Fixes #7065 