### PR TITLE
Fix Linux build. cli package for testing is based on 1.x which does not work.

### DIFF
--- a/run-build.sh
+++ b/run-build.sh
@@ -164,7 +164,7 @@ if [ $EXIT_CODE != 0 ]; then
 fi
 
 # Install a project.json based CLI for use by tests
-(set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --channel "master" --install-dir "$DOTNET_INSTALL_DIR_PJ" --architecture "$ARCHITECTURE" --version "1.0.0-preview2-1-003177")
+(set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --channel "master" --install-dir "$DOTNET_INSTALL_DIR_PJ" --architecture "$ARCHITECTURE" --version "2.1.0-preview1-007012")
 EXIT_CODE=$?
 if [ $EXIT_CODE != 0 ]; then
     echo "run-build: Error: installing project-json based cli failed with exit code $EXIT_CODE." >&2


### PR DESCRIPTION
...unless you are using Ubuntu 14.04 or 16.04.
Note that it is not just a test blocker, it is a build blocker.