### PR TITLE
Clarified the examples for the `--logger` parameter

### DIFF
--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -162,7 +162,9 @@
   </data>
   <data name="CmdLoggerDescription" xml:space="preserve">
     <value>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</value>
   </data>
   <data name="CmdConfiguration" xml:space="preserve">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">Zadejte protokolovací nástroj pro výsledky testů. 
+        <target state="needs-review-translation">Zadejte protokolovací nástroj pro výsledky testů. 
                                         Příklad: --logger "trx[;LogFileName=&lt;Standardně se nastaví jedinečný název souboru&gt;]"
                                         Další informace o podpoře argumentů protokolovacího nástroje: https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">Geben Sie eine Protokollierung für Testergebnisse an. 
+        <target state="needs-review-translation">Geben Sie eine Protokollierung für Testergebnisse an. 
                                         Beispiel: --logger "trx[;LogFileName=&lt;Standardmäßig der eindeutige Dateiname&gt;]"
                                         Weitere Informationen zur Unterstützung von Protokollierungsargumenten: https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">Especifica un registrador para los resultados de prueba.
+        <target state="needs-review-translation">Especifica un registrador para los resultados de prueba.
                                         Ejemplo: --logger "trx[;LogFileName=&lt;Adopta como valor predeterminado un nombre de archivo único&gt;]"
                                         Más información sobre la compatibilidad con los argumentos de registrador: https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">Spécifiez un enregistreur d'événements pour les résultats des tests.
+        <target state="needs-review-translation">Spécifiez un enregistreur d'événements pour les résultats des tests.
                                         Exemple : --logger "trx[;LogFileName=&lt;Nom de fichier unique par défaut&gt;]"
                                         En savoir plus sur la prise en charge des arguments de l'enregistreur d'événements : https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">Consente di specificare un logger per i risultati dei test.
+        <target state="needs-review-translation">Consente di specificare un logger per i risultati dei test.
                                         Esempio: --logger "trx[;LogFileName=&lt;l'impostazione predefinita è un nome file univoco&gt;]"
                                         Per altre informazioni sul supporto degli argomenti del logger, vedere: https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">テスト結果のロガーを指定します。
+        <target state="needs-review-translation">テスト結果のロガーを指定します。
                                         例: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
                                         ロガー引数サポートの詳細:https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">테스트 결과에 대해 로거를 지정합니다. 
+        <target state="needs-review-translation">테스트 결과에 대해 로거를 지정합니다. 
                                         예: --logger "trx[;LogFileName=&lt;고유한 파일 이름을 기본값으로 설정&gt;]"
                                         로거 인수 지원에 대한 추가 정보: https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">Określ rejestrator wyników testów.
+        <target state="needs-review-translation">Określ rejestrator wyników testów.
                                         Przykład: --logger "trx[;LogFileName=&lt;domyślnie jest to unikatowa nazwa pliku&gt;]"
                                         Więcej informacji o obsłudze argumentów rejestratora: https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">Especifique um agente para os resultados de teste.
+        <target state="needs-review-translation">Especifique um agente para os resultados de teste.
                                         Exemplo: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
                                         Mais informações sobre suporte a argumentos de agente: https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">Укажите средство ведения журнала для результатов теста.
+        <target state="needs-review-translation">Укажите средство ведения журнала для результатов теста.
                                         Пример: --logger "trx[;LogFileName=&lt;по умолчанию используется уникальное имя файла&gt;]"
                                         Дополнительные сведения о поддержке аргументов средства ведения журнала: https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">Test sonuçları için bir günlükçü belirtin. 
+        <target state="needs-review-translation">Test sonuçları için bir günlükçü belirtin. 
                                         Örnek: --logger "trx[;LogFileName=&lt;Varsayılan olarak benzersiz dosya adı kullanılır&gt;]"
                                         Günlükçü bağımsız değişkenleri desteği hakkında daha fazla bilgi: https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">指定测试结果的记录器。
+        <target state="needs-review-translation">指定测试结果的记录器。
                                         示例: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
                                         有关记录器参数的详细信息，请访问 support:https://aka.ms/vstest-report</target>
         <note />

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -73,9 +73,11 @@
       </trans-unit>
       <trans-unit id="CmdLoggerDescription">
         <source>Specify a logger for test results.
-                                        Example: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"
+                                        Examples:
+                                        Log in trx format using a unqiue file name: --logger trx
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
-        <target state="translated">指定測試結果的記錄器。
+        <target state="needs-review-translation">指定測試結果的記錄器。
                                         範例: --logger "trx[;LogFileName=&lt;預設為唯一的檔案名稱&gt;]"
                                         記錄器引數支援的詳細資訊: https://aka.ms/vstest-report</target>
         <note />


### PR DESCRIPTION
Replacement PR for #5972

The command line documentation `dotnet help test` currently reads:
```
 -l|--logger <LoggerUri/FriendlyName>  Specify a logger for test results.
                                        Example: --logger "trx[;LogFileName=<Defaults to unique file name>]"
```

However the example does not work. It should read `--logger "trx;LogFileName=<Defaults to unique file name>"`, ie without the `[]`. This correct usage can be seen in this [test](https://github.com/dotnet/cli/blob/70c65160f6163666dbe5f052b2331ec59582fce5/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs#L180)
