### PR TITLE
Ingest new version Aspnet store

### DIFF
--- a/build/BundledRuntimes.props
+++ b/build/BundledRuntimes.props
@@ -31,21 +31,17 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AspNetCoreRuntimeInstallerBlobRootUrl>$(CoreSetupBlobRootUrl)aspnetcore/store/$(AspNetCoreRuntimeAzureblobStoresSubfolderName)</AspNetCoreRuntimeInstallerBlobRootUrl>
+    <AspNetCoreRuntimeInstallerBlobRootUrl>$(CoreSetupBlobRootUrl)aspnetcore/store/$(AspNetCoreRuntimePackageFolderName)</AspNetCoreRuntimeInstallerBlobRootUrl>
     <AspNetCoreSharedRuntimeVersionFileName>runtime.version</AspNetCoreSharedRuntimeVersionFileName>
     <AspNetCoreSharedRuntimeVersionFile Condition=" '$(AspNetCoreSharedRuntimeVersionFileName)' != '' ">$(PackagesDirectory)/$(AspNetCoreSharedRuntimeVersionFileName)</AspNetCoreSharedRuntimeVersionFile>
     
-    <!-- Examples:    Build.RS.linux.zip    Build.RS.winx86.zip    AspNetCorePackageStoreLibx64.wixlib   -->
-    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(HostOSName)' == 'win' ">$(HostOSName)$(Architecture)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
-    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(HostOSName)' == 'osx' ">$(HostOSName)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
-    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(AspNetCoreRuntimeInstallerArchiveFileNameOSToken)' == '' ">linux</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
-
-    <AspNetCoreRuntimeStoreSuffix Condition="'$(AspNetCoreRuntimePackageFlavor)' != 'notimestamp'">-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimeStoreSuffix>
-    <AspNetCoreRuntimeInstallerArchiveSuffix Condition="'$(AspNetCoreRuntimeStoreSuffix)' != ''">-$(AspNetCoreRelease)$(AspNetCoreRuntimeStoreSuffix)</AspNetCoreRuntimeInstallerArchiveSuffix>
-    <AspNetCoreRuntimeInstallerArchiveFileName>Build.RS.$(AspNetCoreRuntimeInstallerArchiveFileNameOSToken)$(AspNetCoreRuntimeInstallerArchiveSuffix)$(ArchiveExtension)</AspNetCoreRuntimeInstallerArchiveFileName>
+    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(HostOSName)' == 'win' ">win7-$(Architecture)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
+    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(HostOSName)' == 'osx' ">$(HostOSName)-$(Architecture)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
+    <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(AspNetCoreRuntimeInstallerArchiveFileNameOSToken)' == '' ">linux-$(Architecture)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
+    <AspNetCoreRuntimeInstallerArchiveFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)-$(AspNetCoreRuntimeInstallerArchiveFileNameOSToken)$(ArchiveExtension)</AspNetCoreRuntimeInstallerArchiveFileName>
     <AspNetCoreRuntimeInstallerArchiveFile>$(PackagesDirectory)/$(AspNetCoreRuntimeInstallerArchiveFileName)</AspNetCoreRuntimeInstallerArchiveFile>
 
-    <AspNetCoreRuntimeInstallerWixLibFileName Condition=" '$(HostOSName)' == 'win' ">AspNetCorePackageStoreLib$(Architecture)$(AspNetCoreRuntimeStoreSuffix).wixlib</AspNetCoreRuntimeInstallerWixLibFileName>
+    <AspNetCoreRuntimeInstallerWixLibFileName Condition=" '$(HostOSName)' == 'win' ">AspNetCorePackageStoreLib_$(Architecture)-$(AspNetCoreRuntimePackageVersion).wixlib</AspNetCoreRuntimeInstallerWixLibFileName>
     <AspNetCoreRuntimeInstallerWixLibFile Condition=" '$(AspNetCoreRuntimeInstallerWixLibFileName)' != '' ">$(PackagesDirectory)/$(AspNetCoreRuntimeInstallerWixLibFileName)</AspNetCoreRuntimeInstallerWixLibFile>
   </PropertyGroup>
 

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -32,18 +32,9 @@
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
     <SpaTemplateVersion>1.0.417</SpaTemplateVersion>
     <XliffTasksVersion>0.2.0-beta-000042</XliffTasksVersion>
-
-    <!-- This should either be timestamped or notimestamp as appropriate -->
-    <AspNetCoreRuntimePackageFlavor>notimestamp</AspNetCoreRuntimePackageFlavor>
-    <!--BranchName and AspNetCoreVersion will not always be the same-->
-    <AspNetCoreBranchName>2.0.0</AspNetCoreBranchName>
-    <AspNetCoreRelease>rtm</AspNetCoreRelease>
-    <AspNetCoreVersion>2.0.0</AspNetCoreVersion>
-    <AspNetCoreRuntimePackageTimestamp>26452</AspNetCoreRuntimePackageTimestamp>
-
     <AspNetCoreRuntimePackageBrandName>aspnetcore-store</AspNetCoreRuntimePackageBrandName>
-    <AspNetCoreVersionAndRelease>$(AspNetCoreVersion)-$(AspNetCoreRelease)</AspNetCoreVersionAndRelease>
-    <AspNetCoreRuntimeAzureblobStoresSubfolderName>$(AspNetCoreBranchName)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimeAzureblobStoresSubfolderName>
+    <AspNetCoreRuntimePackageFolderName>dev-26623</AspNetCoreRuntimePackageFolderName>
+    <AspNetCoreRuntimePackageVersion>2.1.0-preview1-26623</AspNetCoreRuntimePackageVersion>
   </PropertyGroup>
 
   <!-- infrastructure and test only dependencies -->

--- a/build/Test.targets
+++ b/build/Test.targets
@@ -22,7 +22,7 @@
 
   <Target Name="Test"
           Condition=" '$(CLIBUILD_SKIP_TESTS)' != 'true' "
-          DependsOnTargets="BuildTests;">
+          DependsOnTargets="TestsForBuildItself;BuildTests;">
 
     <ItemGroup>
       <ProjectsToTest Include="build/test/RunTest.proj">
@@ -83,6 +83,11 @@
                 VersionSuffix="%(TestPackageProject.VersionSuffix)"
                 MsbuildArgs="%(TestPackageProject.MsbuildArgs) /p:SdkNuGetVersion=$(SdkNugetVersion)" />
 
+  </Target>
+
+  <Target Name="TestsForBuildItself">
+    <DotNetMSBuild Arguments="/v:diag $(RepoRoot)/test/MsBuildScript.Tests/runtests.target"
+                   ToolPath="$(Stage0Directory)" />
   </Target>
 
   <Target Name="EnsureStageSeparation">

--- a/build/compile/LzmaArchive.targets
+++ b/build/compile/LzmaArchive.targets
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
       <FinalArchive>$(SdkOutputDirectory)/nuGetPackagesArchive.lzma</FinalArchive>
-      <NugetPackagesArchiveName>nuGetPackagesArchive.$(AspNetCoreRuntimePackageFlavor).lzma</NugetPackagesArchiveName>
+      <NugetPackagesArchiveName>nuGetPackagesArchive-$(AspNetCoreRuntimePackageVersion).lzma</NugetPackagesArchiveName>
       <IntermediateArchive>$(IntermediateDirectory)/$(NugetPackagesArchiveName)</IntermediateArchive>
       <NugetPackagesArchiveBlobUrl>$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(NugetPackagesArchiveName)</NugetPackagesArchiveBlobUrl>
     </PropertyGroup>

--- a/build/package/Installer.DEB.targets
+++ b/build/package/Installer.DEB.targets
@@ -35,11 +35,8 @@
       <HostFxrDebianPackageName>dotnet-hostfxr-$(HostFxrDebianPackageVersion)</HostFxrDebianPackageName>
       <HostFxrDebianPackageName>$(HostFxrDebianPackageName.ToLower())</HostFxrDebianPackageName>
       <HostDebianPackageName>dotnet-host</HostDebianPackageName>
-      <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageName>
-      <AspNetCoreRuntimePackageName Condition=" '$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp' ">$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersion)</AspNetCoreRuntimePackageName>
-      <HostRidInAspNetCoreRuntimeDebInstallerFileName>$(HostRid)</HostRidInAspNetCoreRuntimeDebInstallerFileName>
-      <AspNetCoreRuntimeDebInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)-$(HostRidInAspNetCoreRuntimeDebInstallerFileName).deb</AspNetCoreRuntimeDebInstallerFileName>
-      <AspNetCoreRuntimeDebInstallerFileName Condition=" '$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp' ">$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersion)-$(HostRidInAspNetCoreRuntimeDebInstallerFileName).deb</AspNetCoreRuntimeDebInstallerFileName>
+      <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)</AspNetCoreRuntimePackageName>
+      <AspNetCoreRuntimeDebInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)-$(HostRid)-$(Architecture).deb</AspNetCoreRuntimeDebInstallerFileName>
     </PropertyGroup>
 
     <!-- Inputs -->

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -170,10 +170,9 @@
       <HostFxrRpmPackageName>dotnet-hostfxr-$(HostFxrRpmPackageVersion)</HostFxrRpmPackageName>
       <HostFxrRpmPackageName>$(HostFxrRpmPackageName.ToLower())</HostFxrRpmPackageName>
       <HostRpmPackageName>dotnet-host</HostRpmPackageName>
-      <HostRidInAspNetCoreRuntimeRpmInstallerFileName>$(HostRid)</HostRidInAspNetCoreRuntimeRpmInstallerFileName>
       <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)</AspNetCoreRuntimePackageName>
       <AspNetCoreRuntimePackageVersion>$(AspNetCoreRuntimePackageVersion)</AspNetCoreRuntimePackageVersion>
-      <AspNetCoreRuntimeDebInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)-$(HostRid)-$(Architecture).rpm</AspNetCoreRuntimeDebInstallerFileName>
+      <AspNetCoreRuntimeRpmInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)-$(HostRid)-$(Architecture).rpm</AspNetCoreRuntimeRpmInstallerFileName>
       <AfterInstallHostScriptTemplateFile>$(ScriptsDir)/$(AfterInstallHostScriptName)</AfterInstallHostScriptTemplateFile>
       <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)/$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
     </PropertyGroup>

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -18,8 +18,48 @@
           DependsOnTargets="GenerateSdkRpm"
           Condition=" '$(BuildRpmPackage)' == 'True' and '$(FPMPresent)' == 'True' "/>
 
-  <Target Name="GenerateSdkRpm"
-          DependsOnTargets="SetupRpmProps">
+  <Target Name="GenerateSdkRpm">
+    <PropertyGroup>
+      <RpmPackageVersion>$(SdkVersion)</RpmPackageVersion>
+      <InputRoot>$(OutputDirectory)/sdk</InputRoot>
+      <SdkInstallerFile>$(InstallerOutputDirectory)/$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkInstallerFile>
+      <RpmFile>$(SdkInstallerFile)</RpmFile>
+      <ManPagesDir>$(RepoRoot)/Documentation/manpages</ManPagesDir>
+      <ConfigJsonFile>$(RepoRoot)/packaging/rpm/dotnet-config.json</ConfigJsonFile>
+      <RpmIntermediatesDir>$(IntermediateDirectory)/$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
+      <RpmTestResultsXmlFile>$(RpmIntermediatesDir)/debian-testResults.xml</RpmTestResultsXmlFile>
+      <RpmInstalledDirectory>/usr/share/dotnet</RpmInstalledDirectory>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <RpmLayoutDirectory>$(RpmIntermediatesDir)/RpmLayoutDirectory/</RpmLayoutDirectory>
+      <RpmLayoutPackageRoot>$(RpmLayoutDirectory)package_root</RpmLayoutPackageRoot>
+      <RpmLayoutSDK>$(RpmLayoutPackageRoot)/sdk</RpmLayoutSDK>
+      <RpmLayoutDocs>$(RpmLayoutDirectory)docs</RpmLayoutDocs>                <!-- Man Pages -->
+      <RpmLayoutTemplates>$(RpmLayoutDirectory)templates</RpmLayoutTemplates> <!-- Copyright, Changelog -->
+      <RpmLayoutScripts>$(RpmLayoutDirectory)scripts</RpmLayoutScripts>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <SdkRpmPackageVersion>$(SdkVersion)</SdkRpmPackageVersion>
+      <SdkRpmPackageName>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkRpmPackageVersion)</SdkRpmPackageName>
+      <SharedFxRpmPackageVersion>$(SharedFrameworkVersion)</SharedFxRpmPackageVersion>
+      <SharedFxRpmPackageName>dotnet-runtime-$(SharedFxRpmPackageVersion)</SharedFxRpmPackageName>
+      <SharedFxRpmPackageName>$(SharedFxRpmPackageName.ToLower())</SharedFxRpmPackageName>
+      <HostFxrRpmPackageVersion>$(HostFxrVersion)</HostFxrRpmPackageVersion>
+      <HostFxrRpmPackageName>dotnet-hostfxr-$(HostFxrRpmPackageVersion)</HostFxrRpmPackageName>
+      <HostFxrRpmPackageName>$(HostFxrRpmPackageName.ToLower())</HostFxrRpmPackageName>
+      <HostRpmPackageName>dotnet-host</HostRpmPackageName>
+      <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)</AspNetCoreRuntimePackageName>
+      <AspNetCoreRuntimePackageVersion>$(AspNetCoreRuntimePackageVersion)</AspNetCoreRuntimePackageVersion>
+      <AspNetCoreRuntimeRpmInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)-$(HostRid)-$(Architecture).rpm</AspNetCoreRuntimeRpmInstallerFileName>
+      <AfterInstallHostScriptTemplateFile>$(ScriptsDir)/$(AfterInstallHostScriptName)</AfterInstallHostScriptTemplateFile>
+      <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)/$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <EndToEndTestProject>$(RepoRoot)/test/EndToEnd/EndToEnd.csproj</EndToEndTestProject>
+    </PropertyGroup>
 
     <RemoveDir Condition="Exists('$(RpmIntermediatesDir)')" Directories="$(RpmIntermediatesDir)"/>
     <MakeDir Directories="$(RpmIntermediatesDir)"/>
@@ -139,47 +179,7 @@
   </Target>
 
   <Target Name="SetupRpmProps">
-    <PropertyGroup>
-      <RpmPackageVersion>$(SdkVersion)</RpmPackageVersion>
-      <InputRoot>$(OutputDirectory)/sdk</InputRoot>
-      <SdkInstallerFile>$(InstallerOutputDirectory)/$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkInstallerFile>
-      <RpmFile>$(SdkInstallerFile)</RpmFile>
-      <ManPagesDir>$(RepoRoot)/Documentation/manpages</ManPagesDir>
-      <ConfigJsonFile>$(RepoRoot)/packaging/rpm/dotnet-config.json</ConfigJsonFile>
-      <RpmIntermediatesDir>$(IntermediateDirectory)/$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
-      <RpmTestResultsXmlFile>$(RpmIntermediatesDir)/debian-testResults.xml</RpmTestResultsXmlFile>
-      <RpmInstalledDirectory>/usr/share/dotnet</RpmInstalledDirectory>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <RpmLayoutDirectory>$(RpmIntermediatesDir)/RpmLayoutDirectory/</RpmLayoutDirectory>
-      <RpmLayoutPackageRoot>$(RpmLayoutDirectory)package_root</RpmLayoutPackageRoot>
-      <RpmLayoutSDK>$(RpmLayoutPackageRoot)/sdk</RpmLayoutSDK>
-      <RpmLayoutDocs>$(RpmLayoutDirectory)docs</RpmLayoutDocs>                <!-- Man Pages -->
-      <RpmLayoutTemplates>$(RpmLayoutDirectory)templates</RpmLayoutTemplates> <!-- Copyright, Changelog -->
-      <RpmLayoutScripts>$(RpmLayoutDirectory)scripts</RpmLayoutScripts>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <SdkRpmPackageVersion>$(SdkVersion)</SdkRpmPackageVersion>
-      <SdkRpmPackageName>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkRpmPackageVersion)</SdkRpmPackageName>
-      <SharedFxRpmPackageVersion>$(SharedFrameworkVersion)</SharedFxRpmPackageVersion>
-      <SharedFxRpmPackageName>dotnet-runtime-$(SharedFxRpmPackageVersion)</SharedFxRpmPackageName>
-      <SharedFxRpmPackageName>$(SharedFxRpmPackageName.ToLower())</SharedFxRpmPackageName>
-      <HostFxrRpmPackageVersion>$(HostFxrVersion)</HostFxrRpmPackageVersion>
-      <HostFxrRpmPackageName>dotnet-hostfxr-$(HostFxrRpmPackageVersion)</HostFxrRpmPackageName>
-      <HostFxrRpmPackageName>$(HostFxrRpmPackageName.ToLower())</HostFxrRpmPackageName>
-      <HostRpmPackageName>dotnet-host</HostRpmPackageName>
-      <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)</AspNetCoreRuntimePackageName>
-      <AspNetCoreRuntimePackageVersion>$(AspNetCoreRuntimePackageVersion)</AspNetCoreRuntimePackageVersion>
-      <AspNetCoreRuntimeRpmInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)-$(HostRid)-$(Architecture).rpm</AspNetCoreRuntimeRpmInstallerFileName>
-      <AfterInstallHostScriptTemplateFile>$(ScriptsDir)/$(AfterInstallHostScriptName)</AfterInstallHostScriptTemplateFile>
-      <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)/$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <EndToEndTestProject>$(RepoRoot)/test/EndToEnd/EndToEnd.csproj</EndToEndTestProject>
-    </PropertyGroup>
+    
   </Target>
 
   <Target Name="DownloadAspNetCoreRuntimeRpmInstaller"

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -18,52 +18,8 @@
           DependsOnTargets="GenerateSdkRpm"
           Condition=" '$(BuildRpmPackage)' == 'True' and '$(FPMPresent)' == 'True' "/>
 
-  <Target Name="GenerateSdkRpm">
-    <PropertyGroup>
-      <RpmPackageVersion>$(SdkVersion)</RpmPackageVersion>
-      <InputRoot>$(OutputDirectory)/sdk</InputRoot>
-      <SdkInstallerFile>$(InstallerOutputDirectory)/$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkInstallerFile>
-      <RpmFile>$(SdkInstallerFile)</RpmFile>
-      <ManPagesDir>$(RepoRoot)/Documentation/manpages</ManPagesDir>
-      <ConfigJsonFile>$(RepoRoot)/packaging/rpm/dotnet-config.json</ConfigJsonFile>
-      <RpmIntermediatesDir>$(IntermediateDirectory)/$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
-      <RpmTestResultsXmlFile>$(RpmIntermediatesDir)/debian-testResults.xml</RpmTestResultsXmlFile>
-      <RpmInstalledDirectory>/usr/share/dotnet</RpmInstalledDirectory>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <RpmLayoutDirectory>$(RpmIntermediatesDir)/RpmLayoutDirectory/</RpmLayoutDirectory>
-      <RpmLayoutPackageRoot>$(RpmLayoutDirectory)package_root</RpmLayoutPackageRoot>
-      <RpmLayoutSDK>$(RpmLayoutPackageRoot)/sdk</RpmLayoutSDK>
-      <RpmLayoutDocs>$(RpmLayoutDirectory)docs</RpmLayoutDocs>                <!-- Man Pages -->
-      <RpmLayoutTemplates>$(RpmLayoutDirectory)templates</RpmLayoutTemplates> <!-- Copyright, Changelog -->
-      <RpmLayoutScripts>$(RpmLayoutDirectory)scripts</RpmLayoutScripts>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <SdkRpmPackageVersion>$(SdkVersion)</SdkRpmPackageVersion>
-      <SdkRpmPackageName>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkRpmPackageVersion)</SdkRpmPackageName>
-      <SharedFxRpmPackageVersion>$(SharedFrameworkVersion)</SharedFxRpmPackageVersion>
-      <SharedFxRpmPackageName>dotnet-runtime-$(SharedFxRpmPackageVersion)</SharedFxRpmPackageName>
-      <SharedFxRpmPackageName>$(SharedFxRpmPackageName.ToLower())</SharedFxRpmPackageName>
-      <HostFxrRpmPackageVersion>$(HostFxrVersion)</HostFxrRpmPackageVersion>
-      <HostFxrRpmPackageName>dotnet-hostfxr-$(HostFxrRpmPackageVersion)</HostFxrRpmPackageName>
-      <HostFxrRpmPackageName>$(HostFxrRpmPackageName.ToLower())</HostFxrRpmPackageName>
-      <HostRpmPackageName>dotnet-host</HostRpmPackageName>
-      <HostRidInAspNetCoreRuntimeRpmInstallerFileName>$(HostRid)</HostRidInAspNetCoreRuntimeRpmInstallerFileName>
-      <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageName>
-      <AspNetCoreRuntimePackageName Condition="'$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp'">$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersion)</AspNetCoreRuntimePackageName>
-      <AspNetCoreRuntimePackageVersion>$(AspNetCoreVersion)-$(AspNetCoreRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageVersion>
-      <AspNetCoreRuntimePackageVersion Condition="'$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp'">$(AspNetCoreVersion)</AspNetCoreRuntimePackageVersion>
-      <AspNetCoreRuntimeRpmInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)-$(HostRidInAspNetCoreRuntimeRpmInstallerFileName).rpm</AspNetCoreRuntimeRpmInstallerFileName>
-      <AspNetCoreRuntimeRpmInstallerFileName Condition="'$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp'">$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersion)-$(HostRidInAspNetCoreRuntimeRpmInstallerFileName).rpm</AspNetCoreRuntimeRpmInstallerFileName>
-      <AfterInstallHostScriptTemplateFile>$(ScriptsDir)/$(AfterInstallHostScriptName)</AfterInstallHostScriptTemplateFile>
-      <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)/$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <EndToEndTestProject>$(RepoRoot)/test/EndToEnd/EndToEnd.csproj</EndToEndTestProject>
-    </PropertyGroup>
+  <Target Name="GenerateSdkRpm"
+          DependsOnTargets="SetupRpmProps">
 
     <RemoveDir Condition="Exists('$(RpmIntermediatesDir)')" Directories="$(RpmIntermediatesDir)"/>
     <MakeDir Directories="$(RpmIntermediatesDir)"/>
@@ -180,6 +136,51 @@
           SkipUnchangedFiles="False"
           UseHardlinksIfPossible="False"/>
 
+  </Target>
+
+  <Target Name="SetupRpmProps">
+    <PropertyGroup>
+      <RpmPackageVersion>$(SdkVersion)</RpmPackageVersion>
+      <InputRoot>$(OutputDirectory)/sdk</InputRoot>
+      <SdkInstallerFile>$(InstallerOutputDirectory)/$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkInstallerFile>
+      <RpmFile>$(SdkInstallerFile)</RpmFile>
+      <ManPagesDir>$(RepoRoot)/Documentation/manpages</ManPagesDir>
+      <ConfigJsonFile>$(RepoRoot)/packaging/rpm/dotnet-config.json</ConfigJsonFile>
+      <RpmIntermediatesDir>$(IntermediateDirectory)/$(RpmPackageName)/$(RpmPackageVersion)</RpmIntermediatesDir>
+      <RpmTestResultsXmlFile>$(RpmIntermediatesDir)/debian-testResults.xml</RpmTestResultsXmlFile>
+      <RpmInstalledDirectory>/usr/share/dotnet</RpmInstalledDirectory>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <RpmLayoutDirectory>$(RpmIntermediatesDir)/RpmLayoutDirectory/</RpmLayoutDirectory>
+      <RpmLayoutPackageRoot>$(RpmLayoutDirectory)package_root</RpmLayoutPackageRoot>
+      <RpmLayoutSDK>$(RpmLayoutPackageRoot)/sdk</RpmLayoutSDK>
+      <RpmLayoutDocs>$(RpmLayoutDirectory)docs</RpmLayoutDocs>                <!-- Man Pages -->
+      <RpmLayoutTemplates>$(RpmLayoutDirectory)templates</RpmLayoutTemplates> <!-- Copyright, Changelog -->
+      <RpmLayoutScripts>$(RpmLayoutDirectory)scripts</RpmLayoutScripts>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <SdkRpmPackageVersion>$(SdkVersion)</SdkRpmPackageVersion>
+      <SdkRpmPackageName>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkRpmPackageVersion)</SdkRpmPackageName>
+      <SharedFxRpmPackageVersion>$(SharedFrameworkVersion)</SharedFxRpmPackageVersion>
+      <SharedFxRpmPackageName>dotnet-runtime-$(SharedFxRpmPackageVersion)</SharedFxRpmPackageName>
+      <SharedFxRpmPackageName>$(SharedFxRpmPackageName.ToLower())</SharedFxRpmPackageName>
+      <HostFxrRpmPackageVersion>$(HostFxrVersion)</HostFxrRpmPackageVersion>
+      <HostFxrRpmPackageName>dotnet-hostfxr-$(HostFxrRpmPackageVersion)</HostFxrRpmPackageName>
+      <HostFxrRpmPackageName>$(HostFxrRpmPackageName.ToLower())</HostFxrRpmPackageName>
+      <HostRpmPackageName>dotnet-host</HostRpmPackageName>
+      <HostRidInAspNetCoreRuntimeRpmInstallerFileName>$(HostRid)</HostRidInAspNetCoreRuntimeRpmInstallerFileName>
+      <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)</AspNetCoreRuntimePackageName>
+      <AspNetCoreRuntimePackageVersion>$(AspNetCoreRuntimePackageVersion)</AspNetCoreRuntimePackageVersion>
+      <AspNetCoreRuntimeDebInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreRuntimePackageVersion)-$(HostRid)-$(Architecture).rpm</AspNetCoreRuntimeDebInstallerFileName>
+      <AfterInstallHostScriptTemplateFile>$(ScriptsDir)/$(AfterInstallHostScriptName)</AfterInstallHostScriptTemplateFile>
+      <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)/$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <EndToEndTestProject>$(RepoRoot)/test/EndToEnd/EndToEnd.csproj</EndToEndTestProject>
+    </PropertyGroup>
   </Target>
 
   <Target Name="DownloadAspNetCoreRuntimeRpmInstaller"

--- a/build/publish/PublishDebian.targets
+++ b/build/publish/PublishDebian.targets
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SdkDebianUploadUrl>$(DotnetBlobRootUrl)/$(Product)/$(FullNugetVersion)/$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)$(InstallerExtension)</SdkDebianUploadUrl>
+    <SdkDebianUploadUrl>$(DotnetBlobRootUrl)/$(Product)/$(FullNugetVersion)/$(DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk)-$(Architecture)$(InstallerExtension)</SdkDebianUploadUrl>
     <DebianUploadJsonFile>$(SdkDebianIntermediateDirectory)/package_upload.json</DebianUploadJsonFile>
     <DebianRevisionNumber>1</DebianRevisionNumber>
 

--- a/build_projects/dotnet-cli-build/EnsureFileExistsOnAzureBlobStorage.cs
+++ b/build_projects/dotnet-cli-build/EnsureFileExistsOnAzureBlobStorage.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.Build.Framework;
+using Microsoft.WindowsAzure.Storage.Blob;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.Build.CloudTestTasks
+{
+    public class EnsureFileExistsOnAzureBlobStorage : Microsoft.Build.Utilities.Task
+    {
+        [Required]
+        public string FileUrl{ get; set; }
+
+        public override bool Execute()
+        {
+            if (!ExecuteAsync().GetAwaiter().GetResult())
+            {
+                throw new FileDoesNotExistOnAzureBlobStorageException(FileUrl);
+
+            }
+            return true;
+        }
+
+        private Task<bool> ExecuteAsync()
+        {
+            var blobClient = new CloudBlockBlob(new Uri(FileUrl));
+            return blobClient.ExistsAsync();
+        }
+
+        public class FileDoesNotExistOnAzureBlobStorageException : Exception
+        {
+            public FileDoesNotExistOnAzureBlobStorageException(string message) : base(message + " cannot be found on Azure Blob Storage")
+            {
+            }
+        }
+    }
+}

--- a/test/MsBuildScript.Tests/runtests.target
+++ b/test/MsBuildScript.Tests/runtests.target
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="RunMsBuildScriptTests" 
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="../../dir.props" />
+  <Import Project="$(RepoRoot)/build/compile/LzmaArchive.targets" />
+  <Import Project="$(RepoRoot)/build/package/Installer.DEB.targets" />
+  <Import Project="$(RepoRoot)/build/package/Installer.RPM.targets" />
+
+  <Target Name="Init"></Target>
+
+  <UsingTask TaskName="DownloadFile" AssemblyFile="$(CLIBuildDll)" />
+  <UsingTask TaskName="EnsureFileExistsOnAzureBlobStorage" AssemblyFile="$(CLIBuildDll)" />
+
+  <Target Name="RunMsBuildScriptTests" DependsOnTargets="SetupDebProps;EnsureAllDependencyFilesExist"></Target>
+
+  <Target Name="EnsureAllDependencyFilesExist" DependsOnTargets="SetupDebProps;">
+    <EnsureFileExistsOnAzureBlobStorage FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeInstallerWixLibFileName)" />
+    <EnsureFileExistsOnAzureBlobStorage FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeInstallerArchiveFileName)" />
+    <EnsureFileExistsOnAzureBlobStorage FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreSharedRuntimeVersionFileName)" />
+    <EnsureFileExistsOnAzureBlobStorage FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(NugetPackagesArchiveName)" />
+    <EnsureFileExistsOnAzureBlobStorage Condition=" $(IsDebianBaseDistro) == 'true' " FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeDebInstallerFileName)" />
+  </Target>
+</Project>

--- a/test/MsBuildScript.Tests/runtests.target
+++ b/test/MsBuildScript.Tests/runtests.target
@@ -3,21 +3,16 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="../../dir.props" />
   <Import Project="$(RepoRoot)/build/compile/LzmaArchive.targets" />
-  <Import Project="$(RepoRoot)/build/package/Installer.DEB.targets" />
-  <Import Project="$(RepoRoot)/build/package/Installer.RPM.targets" />
-
-  <Target Name="Init"></Target>
 
   <UsingTask TaskName="DownloadFile" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="EnsureFileExistsOnAzureBlobStorage" AssemblyFile="$(CLIBuildDll)" />
 
-  <Target Name="RunMsBuildScriptTests" DependsOnTargets="SetupDebProps;EnsureAllDependencyFilesExist"></Target>
+  <Target Name="RunMsBuildScriptTests" DependsOnTargets="EnsureAllDependencyFilesExist"></Target>
 
-  <Target Name="EnsureAllDependencyFilesExist" DependsOnTargets="SetupDebProps;">
+  <Target Name="EnsureAllDependencyFilesExist">
     <EnsureFileExistsOnAzureBlobStorage FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeInstallerWixLibFileName)" />
     <EnsureFileExistsOnAzureBlobStorage FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeInstallerArchiveFileName)" />
     <EnsureFileExistsOnAzureBlobStorage FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreSharedRuntimeVersionFileName)" />
     <EnsureFileExistsOnAzureBlobStorage FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(NugetPackagesArchiveName)" />
-    <EnsureFileExistsOnAzureBlobStorage Condition=" $(IsDebianBaseDistro) == 'true' " FileUrl="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeDebInstallerFileName)" />
   </Target>
 </Project>


### PR DESCRIPTION
Change the url and name accordingly for the name naming convention

In new protocol, to insert new store to CLI, only 2 properties are required to change.
 
```
AspNetCoreRuntimePackageFolderName
AspNetCoreRuntimePackageVersion
```
And CLI will construct artifact URL completely rely on these 2 properties, in straight forward
https://dotnetcli.azureedge.net/dotnet/aspnetcore/store/$(AspNetCoreRuntimePackageFolderName)/FILE-$(AspNetCoreRuntimePackageFolderName).zip
And no more timestamp/no timestamp

There are also rename for the achieve to ex:

```
AspNetCorePackageStoreLib_x64-2.1.0-preview1-26609.wixlib
AspNetCorePackageStoreLib_x64-2.1.0-preview1-final.wixlib
AspNetCorePackageStoreLib_x86-2.1.0-preview1-26609.wixlib
AspNetCorePackageStoreLib_x86-2.1.0-preview1-final.wixlib
AspNetCoreRuntimePackageStore_x64-2.1.0-preview1-26609.exe
AspNetCoreRuntimePackageStore_x64-2.1.0-preview1-26609.msi
AspNetCoreRuntimePackageStore_x64-2.1.0-preview1-final.exe
AspNetCoreRuntimePackageStore_x64-2.1.0-preview1-final.msi
AspNetCoreRuntimePackageStore_x86-2.1.0-preview1-26609.exe
AspNetCoreRuntimePackageStore_x86-2.1.0-preview1-26609.msi
AspNetCoreRuntimePackageStore_x86-2.1.0-preview1-final.exe
AspNetCoreRuntimePackageStore_x86-2.1.0-preview1-final.msi
```