### PR TITLE
Skip versions repo publish if auth not defined

### DIFF
--- a/build/publish/FinishBuild.targets
+++ b/build/publish/FinishBuild.targets
@@ -34,6 +34,7 @@
 
     <UpdateVersionsRepo BranchName="$(BranchName)"
                         PackagesDirectory="$(PackagesDirectory)"
-                        GitHubPassword="$(GITHUB_PASSWORD)" />
+                        GitHubPassword="$(GITHUB_PASSWORD)"
+                        Condition=" '$(GITHUB_PASSWORD)' != '' " />
   </Target>
 </Project>


### PR DESCRIPTION
See https://github.com/dotnet/cli/pull/6302 (same change on rel/1.0.1):

> We need to disable `UpdateVersionsRepo` when publishing to only blob storage. This adds a condition so that when `GITHUB_PASSWORD` isn't set, versions repo update is skipped.

I'm submitting this to `master` for the future, but what's important now is the port to `release/2.0.0` for servicing.

@nguerrera @Chrisboh 