### PR TITLE
[release/2.0.0] Skip versions repo publish if auth not defined

### DIFF
--- a/build/publish/FinishBuild.targets
+++ b/build/publish/FinishBuild.targets
@@ -34,6 +34,7 @@
 
     <UpdateVersionsRepo BranchName="$(BranchName)"
                         PackagesDirectory="$(PackagesDirectory)"
-                        GitHubPassword="$(GITHUB_PASSWORD)" />
+                        GitHubPassword="$(GITHUB_PASSWORD)"
+                        Condition=" '$(GITHUB_PASSWORD)' != '' " />
   </Target>
 </Project>


### PR DESCRIPTION
(cherry picked from commit b4c1a809b883927e6103569feb8c4ac976d6131f)

Ports https://github.com/dotnet/cli/pull/7436 to release/2.0.0.

> We need to disable UpdateVersionsRepo when publishing to only blob storage. This adds a condition so that when GITHUB_PASSWORD isn't set, versions repo update is skipped.

@nguerrera @Chrisboh 