### PR TITLE
Fix dotnet-install.ps1 script when latest version file for channel is returned as application/octet-stream

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -232,7 +232,7 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel, [bool]$Co
     $StringContent = $Response.Content.ReadAsStringAsync().Result
 
     switch ($Response.Content.Headers.ContentType) {
-        { ($_ -eq "application/octet-stream") } { $VersionText = [Text.Encoding]::UTF8.GetString($StringContent) }
+        { ($_ -eq "application/octet-stream") } { $VersionText = $StringContent }
         { ($_ -eq "text/plain") } { $VersionText = $StringContent }
         { ($_ -eq "text/plain; charset=UTF-8") } { $VersionText = $StringContent }
         default { throw "``$Response.Content.Headers.ContentType`` is an unknown .version file content type." }


### PR DESCRIPTION
When finding the version information for a channel, the dotnet-intsall.ps1 script would look at the response content type, and if the response was `application/octet-stream`, it was trying to decode it as a UTF8 string.  However, the value returned from `HttpReponse.Content.ReadAsStringAsync()` had already decoded the string, so the script would fail with the following error:

```
C:\git\dotnet-cli\scripts\obtain\dotnet-install.ps1 : Cannot convert argument "bytes", with value:
"cdcd1928c9729f495c23e2caf881d800c4989c89
2.0.0", for "GetString" to type "System.Byte[]": "Cannot convert value "cdcd1928c9729f495c23e2caf881d800c4989c89
2.0.0" to type "System.Byte[]". Error: "Cannot convert value "cdcd1928c9729f495c23e2caf881d800c4989c89
2.0.0" to type "System.Byte". Error: "Input string was not in a correct format."""
At line:1 char:1
+ C:\git\dotnet-cli\scripts\obtain\dotnet-install.ps1 -Channel 2.0 -Ins ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [dotnet-install.ps1], MethodException
    + FullyQualifiedErrorId : MethodArgumentConversionInvalidCastArgument,dotnet-install.ps1
```

This PR fixes the script by just using the content value that is already decoded.