### PR TITLE
Fix dotnet-install script when latest version file for channel is returned as application/octet-stream

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -232,7 +232,7 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel, [bool]$Co
     $StringContent = $Response.Content.ReadAsStringAsync().Result
 
     switch ($Response.Content.Headers.ContentType) {
-        { ($_ -eq "application/octet-stream") } { $VersionText = [Text.Encoding]::UTF8.GetString($StringContent) }
+        { ($_ -eq "application/octet-stream") } { $VersionText = $StringContent }
         { ($_ -eq "text/plain") } { $VersionText = $StringContent }
         { ($_ -eq "text/plain; charset=UTF-8") } { $VersionText = $StringContent }
         default { throw "``$Response.Content.Headers.ContentType`` is an unknown .version file content type." }


### PR DESCRIPTION
Same fix to install script as #7439, applied to the release/2.0.0 branch in this PR.  There are scripts which download the install script from the branch for a given release, which is why we need to apply the fix to each release branch.

@MattGertz FYI for this change, which isn't shipped with the product.