### PR TITLE
Remove --targets from usage.

### DIFF
--- a/run-build.sh
+++ b/run-build.sh
@@ -108,7 +108,7 @@ while [[ $# > 0 ]]; do
             args=( "${args[@]/$1}" )
             ;;
         --help)
-            echo "Usage: $0 [--configuration <CONFIGURATION>] [--targets <TARGETS...>] [--skip-prereqs] [--nopackage] [--docker <IMAGENAME>] [--help]"
+            echo "Usage: $0 [--configuration <CONFIGURATION>] [--skip-prereqs] [--nopackage] [--docker <IMAGENAME>] [--help]"
             echo ""
             echo "Options:"
             echo "  --configuration <CONFIGURATION>     Build the specified Configuration (Debug or Release, default: Debug)"


### PR DESCRIPTION
This removes `--targets` from the example usage of `run-build.sh`, which seems to imply that this argument does not do anything on line 100, but has some handling for CI purposes that are not applicable in an example usage.

The Windows PowerShell script does not show this argument in the example usage.

skip ci please