### PR TITLE
Update to SDK build which includes NuGet 4.4.0-preview1-4365

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,7 +12,7 @@
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
          cases, so use separate properties but derive one from the other unless we want to
          explicitly use different versions. -->
-    <CLI_NETSDK_Version>2.0.0-preview3-20170804-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.2-vspre-20170817-4</CLI_NETSDK_Version>
     <CLI_MSBuildExtensions_Version>$(CLI_NETSDK_Version)</CLI_MSBuildExtensions_Version>
 
     <CLI_NuGet_Version>4.4.0-preview1-4365</CLI_NuGet_Version>


### PR DESCRIPTION
Third leg of the round trip for NuGet 4.4.0-preview1-4365 into release/2.0-vs

First leg: https://github.com/dotnet/cli/pull/7459
Second leg: https://github.com/dotnet/sdk/pull/1506