### PR TITLE
Update .NET Core runtime to 2.1

### DIFF
--- a/TestAssets/DesktopTestProjects/AppWithProjTool2Fx/App.csproj
+++ b/TestAssets/DesktopTestProjects/AppWithProjTool2Fx/App.csproj
@@ -2,9 +2,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net451</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <AssetTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(AssetTargetFallback);portable-net45+win8;dnxcore50</AssetTargetFallback>
+    <AssetTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(AssetTargetFallback);portable-net45+win8;dnxcore50</AssetTargetFallback>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/TestAssets/DesktopTestProjects/LibWithProjTool2Fx/Lib.csproj
+++ b/TestAssets/DesktopTestProjects/LibWithProjTool2Fx/Lib.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AssetTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(AssetTargetFallback);portable-net45+win8;dnxcore50;netcoreapp2.0</AssetTargetFallback>
+    <AssetTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(AssetTargetFallback);portable-net45+win8;dnxcore50;netcoreapp2.1</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/DesktopTestProjects/MultiTFMXunitProject/XUnitProject/XUnitProject.csproj
+++ b/TestAssets/DesktopTestProjects/MultiTFMXunitProject/XUnitProject/XUnitProject.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/DesktopTestProjects/NETFrameworkReferenceNETStandard20/MultiTFMTestApp/MultiTFMTestApp.csproj
+++ b/TestAssets/DesktopTestProjects/NETFrameworkReferenceNETStandard20/MultiTFMTestApp/MultiTFMTestApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
   </PropertyGroup>
 
     <ItemGroup>

--- a/TestAssets/NonRestoredTestProjects/AppThrowingException/AppDependingOnOtherAsTool/AppDependingOnOtherAsTool.csproj
+++ b/TestAssets/NonRestoredTestProjects/AppThrowingException/AppDependingOnOtherAsTool/AppDependingOnOtherAsTool.csproj
@@ -3,7 +3,7 @@
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/NonRestoredTestProjects/AppWithNonExistingToolDependency/AppWithNonExistingToolDependency.csproj
+++ b/TestAssets/NonRestoredTestProjects/AppWithNonExistingToolDependency/AppWithNonExistingToolDependency.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/Broken/Broken.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/Broken/Broken.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/EmptyItemGroup/EmptyItemGroup.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/EmptyItemGroup/EmptyItemGroup.csproj
@@ -3,10 +3,10 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/Lib/Lib.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/Lib/Lib.csproj
@@ -3,10 +3,10 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net451;netcoreapp2.0;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.1;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 </Project>

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/MoreThanOne/a.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/MoreThanOne/a.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/MoreThanOne/b.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/MoreThanOne/b.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/Net452AndNetCoreApp10Lib/Net452AndNetCoreApp10Lib.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/Net452AndNetCoreApp10Lib/Net452AndNetCoreApp10Lib.csproj
@@ -3,9 +3,9 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 </Project>

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/ValidRef/ValidRef.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/ValidRef/ValidRef.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net451;netcoreapp1.0;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 </Project>

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/WithDoubledRef/WithDoubledRef.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/WithDoubledRef/WithDoubledRef.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/WithExistingRefCondOnItem/WithExistingRefCondOnItem.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/WithExistingRefCondOnItem/WithExistingRefCondOnItem.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/WithExistingRefCondWhitespaces/WithExistingRefCondWhitespaces.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/WithExistingRefCondWhitespaces/WithExistingRefCondWhitespaces.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
   <ItemGroup Condition="       '$(TargetFramework)' == 'net451'" >

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/WithRefNoCondNonUniform/WithRefNoCondNonUniform.csproj
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/WithRefNoCondNonUniform/WithRefNoCondNonUniform.csproj
@@ -5,7 +5,7 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>net451;netcoreapp1.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 

--- a/TestAssets/NonRestoredTestProjects/PJHalfMigrated/src/ProjectA/ProjectA.csproj
+++ b/TestAssets/NonRestoredTestProjects/PJHalfMigrated/src/ProjectA/ProjectA.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>ProjectA</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/TestProjectWithUnresolvedPlatformDependency.csproj
+++ b/TestAssets/NonRestoredTestProjects/TestProjectWithUnresolvedPlatformDependency/TestProjectWithUnresolvedPlatformDependency.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <AssetTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
+    <AssetTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/NonRestoredTestProjects/ToolWithRandomPackageName/AppWithDepOnTool/AppWithDepOnTool.csproj
+++ b/TestAssets/NonRestoredTestProjects/ToolWithRandomPackageName/AppWithDepOnTool/AppWithDepOnTool.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <GeneratedPackageId>random-name</GeneratedPackageId>
   </PropertyGroup>
 

--- a/TestAssets/NonRestoredTestProjects/ToolWithRandomPackageName/ToolWithRandomPackageName/ToolWithRandomPackageName.csproj
+++ b/TestAssets/NonRestoredTestProjects/ToolWithRandomPackageName/ToolWithRandomPackageName/ToolWithRandomPackageName.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <GeneratedPackageId>random-name</GeneratedPackageId>
     <PackageId>$(GeneratedPackageId)</PackageId>
     <AssemblyName>dotnet-randompackage</AssemblyName>

--- a/TestAssets/TestPackages/ToolWithOutputName/ToolWithOutputName.csproj
+++ b/TestAssets/TestPackages/ToolWithOutputName/ToolWithOutputName.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>dotnet-tool-with-output-name</AssemblyName>
     <PackageId>ToolWithOutputName</PackageId>
     <OutputType>Exe</OutputType>

--- a/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.0-rc</VersionPrefix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.0-rc</VersionPrefix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <VersionSuffix></VersionSuffix>
     <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>

--- a/TestAssets/TestPackages/dotnet-fallbackfoldertool/dotnet-fallbackfoldertool.csproj
+++ b/TestAssets/TestPackages/dotnet-fallbackfoldertool/dotnet-fallbackfoldertool.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>dotnet-fallbackfoldertool</AssemblyName>
     <OutputType>Exe</OutputType>
     <VersionSuffix></VersionSuffix>

--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/dotnet-hello.csproj
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/dotnet-hello.csproj
@@ -5,7 +5,7 @@
     <Version>1.0.0</Version>
     <!--Workaround for https://github.com/NuGet/Home/issues/4583-->
     <VersionSuffix></VersionSuffix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>dotnet-hello</AssemblyName>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/dotnet-hello.csproj
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/dotnet-hello.csproj
@@ -5,7 +5,7 @@
     <Version>2.0.0</Version>
     <!--Workaround for https://github.com/NuGet/Home/issues/4583-->
     <VersionSuffix></VersionSuffix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>dotnet-hello</AssemblyName>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>

--- a/TestAssets/TestPackages/dotnet-portable/dotnet-portable.csproj
+++ b/TestAssets/TestPackages/dotnet-portable/dotnet-portable.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/TestAssets/TestPackages/dotnet-prefercliruntime/dotnet-prefercliruntime.csproj
+++ b/TestAssets/TestPackages/dotnet-prefercliruntime/dotnet-prefercliruntime.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>

--- a/TestAssets/TestProjects/AppWithCorruptedLaunchSettings/AppWithCorruptedLaunchSettings.csproj
+++ b/TestAssets/TestProjects/AppWithCorruptedLaunchSettings/AppWithCorruptedLaunchSettings.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithDepOnToolWithOutputName/AppWithDepOnToolWithOutputName.csproj
+++ b/TestAssets/TestProjects/AppWithDepOnToolWithOutputName/AppWithDepOnToolWithOutputName.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/TestAssets/TestProjects/AppWithDirectAndToolDep/AppWithDirectAndToolDep.csproj
+++ b/TestAssets/TestProjects/AppWithDirectAndToolDep/AppWithDirectAndToolDep.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/TestAssets/TestProjects/AppWithDirectDep/AppWithDirectDep.csproj
+++ b/TestAssets/TestProjects/AppWithDirectDep/AppWithDirectDep.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <AssemblyName>AppWithDirectDep</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/TestAssets/TestProjects/AppWithDirectDepWithOutputName/AppWithDirectDepWithOutputName.csproj
+++ b/TestAssets/TestProjects/AppWithDirectDepWithOutputName/AppWithDirectDepWithOutputName.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/TestAssets/TestProjects/AppWithFallbackFolderToolDependency/AppWithFallbackFolderToolDependency.csproj
+++ b/TestAssets/TestProjects/AppWithFallbackFolderToolDependency/AppWithFallbackFolderToolDependency.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/TestAssets/TestProjects/AppWithLaunchSettings/AppWithLaunchSettings.csproj
+++ b/TestAssets/TestProjects/AppWithLaunchSettings/AppWithLaunchSettings.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithLaunchSettingsNoDefault/AppWithLaunchSettingsNoDefault.csproj
+++ b/TestAssets/TestProjects/AppWithLaunchSettingsNoDefault/AppWithLaunchSettingsNoDefault.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithMultipleFxAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
+++ b/TestAssets/TestProjects/AppWithMultipleFxAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
@@ -3,13 +3,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="dotnet-desktop-and-portable" Version="1.0.0-*" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 

--- a/TestAssets/TestProjects/AppWithToolDependency/AppWithToolDependency.csproj
+++ b/TestAssets/TestProjects/AppWithToolDependency/AppWithToolDependency.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/TestAssets/TestProjects/DependencyContextFromTool/DependencyContextFromTool.csproj
+++ b/TestAssets/TestProjects/DependencyContextFromTool/DependencyContextFromTool.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <AssemblyName>DependencyContextFromTool</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/TestAssets/TestProjects/FSharpTestAppSimple/TestAppSimple.fsproj
+++ b/TestAssets/TestProjects/FSharpTestAppSimple/TestAppSimple.fsproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <!-- Issue: https://github.com/dotnet/sdk/issues/1150 -->
     <DisableImplicitAssetTargetFallback>true</DisableImplicitAssetTargetFallback>

--- a/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworks/MSBuildAppWithMultipleFrameworks.csproj
+++ b/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworks/MSBuildAppWithMultipleFrameworks.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
+++ b/TestAssets/TestProjects/MSBuildAppWithMultipleFrameworksAndTools/MSBuildAppWithMultipleFrameworksAndTools.csproj
@@ -3,13 +3,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="dotnet-desktop-and-portable" Version="1.0.0-*" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 

--- a/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
+++ b/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/TestAssets/TestProjects/MultiDependentProject/MultiDependentProject.csproj
+++ b/TestAssets/TestProjects/MultiDependentProject/MultiDependentProject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/NewtonSoftDependentProject/NewtonSoftDependentProject.csproj
+++ b/TestAssets/TestProjects/NewtonSoftDependentProject/NewtonSoftDependentProject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/NuGetConfigDependentProject/NuGetConfigDependentProject.csproj
+++ b/TestAssets/TestProjects/NuGetConfigDependentProject/NuGetConfigDependentProject.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppSimple/TestAppSimple.csproj
+++ b/TestAssets/TestProjects/TestAppSimple/TestAppSimple.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <!-- Issue: https://github.com/dotnet/sdk/issues/1150 -->
     <DisableImplicitAssetTargetFallback>true</DisableImplicitAssetTargetFallback>

--- a/TestAssets/TestProjects/TestAppWithEmptySln/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithEmptySln/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithMultipleSlnFiles/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithMultipleSlnFiles/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithProjDepTool/TestAppWithProjDepTool.csproj
+++ b/TestAssets/TestProjects/TestAppWithProjDepTool/TestAppWithProjDepTool.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCaseSensitiveSolutionFolders/src/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojFiles/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojFiles/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDir/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDir/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirToRemove/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojInSubDirToRemove/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojProjectGuidFiles/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojProjectGuidFiles/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojToRemove/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojToRemove/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndDuplicateProjectReferences/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndDuplicateProjectReferences/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferences/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferences/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndExistingCsprojReferencesWithEscapedDirSep/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndLastCsprojInSubDirToRemove/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndLastCsprojInSubDirToRemove/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/TestAppWithSlnAndSolutionFolders/src/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndSolutionFolders/src/App/App.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/VBTestApp/VBTestApp.vbproj
+++ b/TestAssets/TestProjects/VBTestApp/VBTestApp.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/TestAssets/TestProjects/VSTestCore/VSTestCore.csproj
+++ b/TestAssets/TestProjects/VSTestCore/VSTestCore.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/VSTestMulti/VSTestDesktopAndNetCore.csproj
+++ b/TestAssets/TestProjects/VSTestMulti/VSTestDesktopAndNetCore.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">

--- a/TestAssets/TestProjects/XunitCore/XunitCore.csproj
+++ b/TestAssets/TestProjects/XunitCore/XunitCore.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestProjects/XunitMulti/VSTestXunitDesktopAndNetCore.csproj
+++ b/TestAssets/TestProjects/XunitMulti/VSTestXunitDesktopAndNetCore.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
     <RuntimeIdentifiers>win7-x86</RuntimeIdentifiers>
     <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
   </PropertyGroup>
@@ -11,7 +11,7 @@
     <DefineConstants>DESKTOP;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.NETCore.App" Version="$(CLI_SharedFrameworkVersion)" />
   </ItemGroup>
 

--- a/build.proj
+++ b/build.proj
@@ -20,7 +20,7 @@
           DependsOnTargets="MSBuildWorkaroundTarget;
                             RestoreDotnetCliBuildFramework">
 
-    <Exec Command="$(DotnetStage0) publish --no-restore -o $(DotnetCliBuildDirectory)/bin --framework netcoreapp2.0 /p:GeneratePropsFile=$(GeneratePropsFile)" 
+    <Exec Command="$(DotnetStage0) publish --no-restore -o $(DotnetCliBuildDirectory)/bin --framework $(CliTargetFramework) /p:GeneratePropsFile=$(GeneratePropsFile)" 
           WorkingDirectory="$(DotnetCliBuildDirectory)"/>
   </Target>
   

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>2.0.0</CLI_SharedFrameworkVersion>
+    <CLI_SharedFrameworkVersion>2.1.0-preview2-25615-02</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_Roslyn_Satellites_Version>2.3.0-pre-20170727-1</CLI_Roslyn_Satellites_Version>

--- a/dir.props
+++ b/dir.props
@@ -11,7 +11,7 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <DisableImplicitPackageTargetFallback>true</DisableImplicitPackageTargetFallback>
 
-    <CliTargetFramework>netcoreapp2.0</CliTargetFramework>
+    <CliTargetFramework>netcoreapp2.1</CliTargetFramework>
   </PropertyGroup>
 
   <Import Project="build/InitRepo.props" />

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <VersionPrefix>$(CliVersionPrefix)</VersionPrefix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>$(CliTargetFramework)</TargetFramework>
     <RuntimeFrameworkVersion>$(CLI_SharedFrameworkVersion)</RuntimeFrameworkVersion>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests.cs
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests.cs
@@ -42,7 +42,8 @@ namespace Microsoft.DotNet.Tests.ArgumentForwarding
         /// This is a critical scenario for the driver.
         /// </summary>
         /// <param name="testUserArgument"></param>
-        [Theory]
+        //  This test is "Windows only" for now due to https://github.com/dotnet/corefx/issues/23496
+        [WindowsOnlyTheory]
         [InlineData(@"""abc"" d e")]
         [InlineData(@"""ábc"" d é")]
         [InlineData(@"""abc""      d e")]

--- a/test/ArgumentForwardingTests/ArgumentForwardingTests.csproj
+++ b/test/ArgumentForwardingTests/ArgumentForwardingTests.csproj
@@ -21,9 +21,10 @@
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)"/>
   </ItemGroup>
 
+  <!-- Disabled on non-Windows due to https://github.com/dotnet/corefx/issues/23496 -->
   <Target Name="PrecompileScript" 
           BeforeTargets="Build" 
-          Condition=" '$(IsCrossTargetingBuild)' != 'true' ">
+          Condition=" '$(IsCrossTargetingBuild)' != 'true' And '$(OS)' == 'Windows_NT'">
     <Exec Command="$(DotnetInOutputDirectory) publish ../ArgumentsReflector/ArgumentsReflector.csproj --output $(MSBuildThisFileDirectory)/$(OutputPath)" />
   </Target>
 

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
 {
     public class GivenDotNetUsesMSBuild : TestBase
     {
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/cli/issues/7476")]
         public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
             using (DisposableDirectory directory = Temp.CreateDirectory())

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             {
                 string projectDirectory = directory.Path;
 
-                string newArgs = "console -f netcoreapp2.0 --debug:ephemeral-hive --no-restore";
+                string newArgs = "console -f netcoreapp2.1 --debug:ephemeral-hive --no-restore";
                 new NewCommandShim()
                     .WithWorkingDirectory(projectDirectory)
                     .Execute(newArgs)
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
             new DotnetCommand(DotnetUnderTest.WithBackwardsCompatibleRuntimes)
                 .WithWorkingDirectory(testProjectDirectory)
                 .ExecuteWithCapturedOutput(
-                    $"-d dependency-tool-invoker -c {configuration} -f netcoreapp2.0 portable")
+                    $"-d dependency-tool-invoker -c {configuration} -f netcoreapp2.1 portable")
                 .Should().Pass()
                      .And.HaveStdOutContaining("Hello Portable World!");;
         }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using NuGet.Frameworks;
 using Xunit;
+using Microsoft.DotNet.Tools.Tests.Utilities;
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
@@ -189,7 +190,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 .Should().Pass();
 
             var factory = new ProjectDependenciesCommandFactory(
-                FrameworkConstants.CommonFrameworks.NetCoreApp20,
+                NuGetFrameworks.NetCoreApp21,
                 configuration,
                 null,
                 null,

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependenciesCommandFactory.cs
@@ -198,7 +198,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
             var command = factory.Create("dotnet-tool-with-output-name", null);
 
             command.CommandArgs.Should().Contain(
-                Path.Combine("toolwithoutputname", "1.0.0", "lib", "netcoreapp2.0", "dotnet-tool-with-output-name.dll"));
+                Path.Combine("toolwithoutputname", "1.0.0", "lib", "netcoreapp2.1", "dotnet-tool-with-output-name.dll"));
         }
     }
 }

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependencyCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectDependencyCommandResolver.cs
@@ -11,6 +11,7 @@ using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using NuGet.Frameworks;
 using Xunit;
+using Microsoft.DotNet.Tools.Tests.Utilities;
 
 namespace Microsoft.DotNet.Cli.Utils.Tests
 {
@@ -47,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandName = "dotnet-portable",
                 Configuration = "Debug",
                 ProjectDirectory = MSBuildTestProjectInstance.Root.FullName,
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp20
+                Framework = NuGetFrameworks.NetCoreApp21
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -83,7 +84,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandName = "dotnet-portable",
                 Configuration = "Debug",
                 ProjectDirectory = MSBuildTestProjectInstance.Root.FullName,
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp20
+                Framework = NuGetFrameworks.NetCoreApp21
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -109,7 +110,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandName = "nonexistent-command",
                 CommandArguments = null,
                 ProjectDirectory = MSBuildTestProjectInstance.Root.FullName,
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp20
+                Framework = NuGetFrameworks.NetCoreApp21
             };
 
             var result = projectDependenciesCommandResolver.Resolve(commandResolverArguments);
@@ -135,7 +136,7 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
                 CommandName = "dotnet-portable",
                 Configuration = "Debug",
                 ProjectDirectory = testInstance.Root.FullName,
-                Framework = FrameworkConstants.CommonFrameworks.NetCoreApp20,
+                Framework = NuGetFrameworks.NetCoreApp21,
                 OutputPath = outputDir.FullName
             };
 

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -375,7 +375,7 @@ namespace Microsoft.DotNet.Tests
                 "dotnet-fallbackfoldertool",
                 "1.0.0",
                 "lib",
-                "netcoreapp2.0",
+                "netcoreapp2.1",
                 "dotnet-fallbackfoldertool.dll"));
         }
 

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -12,13 +12,14 @@ using NuGet.Frameworks;
 using NuGet.ProjectModel;
 using NuGet.Versioning;
 using Xunit;
+using Microsoft.DotNet.Tools.Tests.Utilities;
 
 namespace Microsoft.DotNet.Tests
 {
     public class GivenAProjectToolsCommandResolver : TestBase
     {
         private static readonly NuGetFramework s_toolPackageFramework =
-            FrameworkConstants.CommonFrameworks.NetCoreApp20;
+            NuGetFrameworks.NetCoreApp21;
 
         private const string TestProjectName = "AppWithToolDependency";
 
@@ -309,7 +310,7 @@ namespace Microsoft.DotNet.Tests
 
             result.Should().NotBeNull();
 
-            result.Args.Should().Contain("--fx-version 2.0.0");
+            result.Args.Should().Contain("--fx-version 2.1.0");
         }
 
         [Fact]

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/NuGetFrameworks.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/NuGetFrameworks.cs
@@ -1,0 +1,14 @@
+﻿using NuGet.Frameworks;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.DotNet.Tools.Tests.Utilities
+{
+    //  This class is for frameworks that aren't yet in NuGet's FrameworkConstants.CommonFrameworks class
+    public static class NuGetFrameworks
+    {
+        public static readonly NuGetFramework NetCoreApp21
+                = new NuGetFramework(FrameworkConstants.FrameworkIdentifiers.NetCoreApp, new Version(2, 1, 0, 0));
+    }
+}

--- a/test/dotnet-add-package.Tests/GivenDotnetPackageAdd.cs
+++ b/test/dotnet-add-package.Tests/GivenDotnetPackageAdd.cs
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.Cli.Package.Add.Tests
 
             var packageName = "Newtonsoft.Json";
             var packageVersion = "9.0.1";
-            var framework = "netcoreapp2.0";
+            var framework = "netcoreapp2.1";
             var cmd = new DotnetCommand()
                 .WithWorkingDirectory(projectDirectory)
                 .ExecuteWithCapturedOutput($"add package {packageName} --version {packageVersion} --framework {framework}");

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
 
-            var outputDll = testInstance.Root.GetDirectory("bin", configuration, "netcoreapp2.0")
+            var outputDll = testInstance.Root.GetDirectory("bin", configuration, "netcoreapp2.1")
                 .GetFile($"{testAppName}.dll");
 
             var outputRunCommand = new DotnetCommand();
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
 
             new BuildCommand()
                 .WithWorkingDirectory(projectDirectory)
-                .Execute("--framework netcoreapp2.0")
+                .Execute("--framework netcoreapp2.1")
                 .Should().Pass();
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
             string dir = "pkgs";
             string args = $"--packages {dir}";
 
-            string newArgs = $"console -f netcoreapp2.0 -o \"{rootPath}\" --debug:ephemeral-hive --no-restore";
+            string newArgs = $"console -f netcoreapp2.1 -o \"{rootPath}\" --debug:ephemeral-hive --no-restore";
             new NewCommandShim()
                 .WithWorkingDirectory(rootPath)
                 .Execute(newArgs)
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
 
             var outputDll = Directory.EnumerateFiles(
-                Path.Combine(rootPath, "bin", configuration, "netcoreapp2.0"), "*.dll", 
+                Path.Combine(rootPath, "bin", configuration, "netcoreapp2.1"), "*.dll", 
                 SearchOption.TopDirectoryOnly)
                 .Single();
 

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
                 .And.HaveStdOutContaining("project.assets.json");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/cli/issues/7476")]
         public void ItRunsWhenRestoringToSpecificPackageDir()
         {
             var rootPath = TestAssets.CreateTestDirectory().FullName;

--- a/test/dotnet-clean.Tests/GivenDotnetCleanCleansBuildArtifacts.cs
+++ b/test/dotnet-clean.Tests/GivenDotnetCleanCleansBuildArtifacts.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli.Clean.Tests
                 .Should().Pass();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
-            var outputFolder = testInstance.Root.GetDirectory("bin", configuration, "netcoreapp2.0", "win7-x64");
+            var outputFolder = testInstance.Root.GetDirectory("bin", configuration, "netcoreapp2.1", "win7-x64");
 
             outputFolder.Should().NotBeEmpty();
 

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.New.Tests
                 var sharedFxDir = dotnetDir
                     .GetDirectory("shared", "Microsoft.NETCore.App")
                     .EnumerateDirectories()
-                    .Single(d => d.Name.StartsWith("2.0.0"));
+                    .Single(d => d.Name.StartsWith("2.1.0"));
 
                 if (packageName == "microsoft.netcore.app")
                 {

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.New.Tests
                 .Should().Pass();
         }
 
-        [Theory]
+        [Theory(Skip = "https://github.com/dotnet/cli/issues/7476")]
         [InlineData("console", "RuntimeFrameworkVersion", "microsoft.netcore.app")]
         [InlineData("classlib", "NetStandardImplicitPackageVersion", "netstandard.library")]
         public void NewProjectRestoresCorrectPackageVersion(string type, string propertyName, string packageName)

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -27,7 +27,8 @@ namespace Microsoft.DotNet.New.Tests
         [InlineData("C#", "react", false, true)]
         [InlineData("C#", "reactredux", false, true)]
         [InlineData("F#", "console", false, false)]
-        [InlineData("F#", "classlib", false, false)]
+        //  https://github.com/dotnet/cli/issues/7476
+        //[InlineData("F#", "classlib", false, false)]
         [InlineData("F#", "mstest", false, false)]
         [InlineData("F#", "xunit", false, false)]
         [InlineData("F#", "mvc", true, false)]

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -33,11 +33,11 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             new PublishCommand()
                 .WithWorkingDirectory(testProjectDirectory)
-                .Execute("--framework netcoreapp2.0")
+                .Execute("--framework netcoreapp2.1")
                 .Should().Pass();
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
-            var outputDll = Path.Combine(testProjectDirectory, "bin", configuration, "netcoreapp2.0", "publish", $"{testAppName}.dll");
+            var outputDll = Path.Combine(testProjectDirectory, "bin", configuration, "netcoreapp2.1", "publish", $"{testAppName}.dll");
 
             new DotnetCommand()
                 .ExecuteWithCapturedOutput(outputDll)
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             new PublishCommand()
                 .WithWorkingDirectory(testProjectDirectory)
-                .Execute("--framework netcoreapp2.0")
+                .Execute("--framework netcoreapp2.1")
                 .Should().Pass();
         }
 
@@ -74,7 +74,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             new PublishCommand()
                 .WithWorkingDirectory(projectDirectory)
-                .Execute("--framework netcoreapp2.0")
+                .Execute("--framework netcoreapp2.1")
                 .Should().Pass();
         }
 
@@ -90,7 +90,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             new PublishCommand()
                 .WithWorkingDirectory(testProjectDirectory)
-                .ExecuteWithCapturedOutput("--framework netcoreapp2.0 --no-restore")
+                .ExecuteWithCapturedOutput("--framework netcoreapp2.1 --no-restore")
                 .Should().Fail()
                 .And.HaveStdOutContaining("project.assets.json");
         }
@@ -110,7 +110,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             var rid = DotnetLegacyRuntimeIdentifiers.InferLegacyRestoreRuntimeIdentifier();
 
             new PublishCommand()
-                .WithFramework("netcoreapp2.0")
+                .WithFramework("netcoreapp2.1")
                 .WithRuntime(rid)
                 .WithWorkingDirectory(testProjectDirectory)
                 .Execute()
@@ -119,7 +119,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
 
             var outputProgram = testProjectDirectory
-                .GetDirectory("bin", configuration, "netcoreapp2.0", rid, "publish", $"{testAppName}{Constants.ExeSuffix}")
+                .GetDirectory("bin", configuration, "netcoreapp2.1", rid, "publish", $"{testAppName}{Constants.ExeSuffix}")
                 .FullName;
 
             EnsureProgramIsRunnable(outputProgram);
@@ -185,7 +185,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
             return testProjectDirectory
-                    .GetDirectory("bin", configuration, "netcoreapp2.0", rid, "publish");
+                    .GetDirectory("bin", configuration, "netcoreapp2.1", rid, "publish");
         }
 
         private static void EnsureProgramIsRunnable(string path)
@@ -227,7 +227,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             var configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
 
             var outputProgram = rootDir
-                .GetDirectory("bin", configuration, "netcoreapp2.0", "publish", $"{rootDir.Name}.dll")
+                .GetDirectory("bin", configuration, "netcoreapp2.1", "publish", $"{rootDir.Name}.dll")
                 .FullName;
 
             new TestCommand(outputProgram)

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/cli/issues/7476")]
         public void ItPublishesAppWhenRestoringToSpecificPackageDirectory()
         {
             var rootPath = TestAssets.CreateTestDirectory().FullName;

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 
             new RunCommand()
                 .WithWorkingDirectory(projectDirectory)
-                .ExecuteWithCapturedOutput("--framework netcoreapp2.0")
+                .ExecuteWithCapturedOutput("--framework netcoreapp2.1")
                 .Should().Pass()
                          .And.HaveStdOutContaining("This string came from the test library!");
         }
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 
             new RunCommand()
                 .WithWorkingDirectory(testProjectDirectory)
-                .ExecuteWithCapturedOutput("--framework netcoreapp2.0")
+                .ExecuteWithCapturedOutput("--framework netcoreapp2.1")
                 .Should().Pass()
                          .And.HaveStdOutContaining("Hello World!");
         }

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -192,7 +192,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                          .And.HaveStdOutContaining("Hello World!");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/cli/issues/7476")]
         public void ItRunsAppWhenRestoringToSpecificPackageDirectory()
         {
             var rootPath = TestAssets.CreateTestDirectory().FullName;

--- a/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
+++ b/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
 {
     public class GivenDotnetStoresAndPublishesProjects : TestBase
     {
-        private static string _tfm = "netcoreapp2.0";
+        private static string _tfm = "netcoreapp2.1";
         private static string _frameworkVersion = TestAssetInstance.CurrentRuntimeFrameworkVersion;
         private static string _arch = RuntimeEnvironment.RuntimeArchitecture.ToLowerInvariant();
 

--- a/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
+++ b/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
@@ -108,7 +108,8 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
                     "    path: 'lib/netstandard1.3/NuGet.Configuration.dll'");
         }
 
-        [Fact]
+        //  Windows only for now due to https://github.com/dotnet/cli/issues/7501
+        [WindowsOnlyFact]
         public void ItPublishesAnAppWithMultipleProfiles()
         {
             var testAppName = "MultiDependentProject";

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestFromCsprojForMultipleTFM.cs
@@ -40,8 +40,8 @@ namespace Microsoft.DotNet.Cli.Test.Tests
                 result.StdOut
                     .Should().Contain("Total tests: 3. Passed: 2. Failed: 1. Skipped: 0.", "because .NET 4.6 tests will pass")
                          .And.Contain("Passed   TestNamespace.VSTestTests.VSTestPassTestDesktop", "because .NET 4.6 tests will pass")
-                         .And.Contain("Total tests: 3. Passed: 1. Failed: 2. Skipped: 0.", "because netcoreapp2.0 tests will fail")
-                         .And.Contain("Failed   TestNamespace.VSTestTests.VSTestFailTestNetCoreApp", "because netcoreapp2.0 tests will fail");
+                         .And.Contain("Total tests: 3. Passed: 1. Failed: 2. Skipped: 0.", "because netcoreapp2.1 tests will fail")
+                         .And.Contain("Failed   TestNamespace.VSTestTests.VSTestFailTestNetCoreApp", "because netcoreapp2.1 tests will fail");
             }
             result.ExitCode.Should().Be(1);
         }
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             new DotnetTestCommand()
                .WithWorkingDirectory(projectDirectory)
-               .ExecuteWithCapturedOutput($"{TestBase.ConsoleLoggerOutputNormal} --framework netcoreapp2.0")
+               .ExecuteWithCapturedOutput($"{TestBase.ConsoleLoggerOutputNormal} --framework netcoreapp2.1")
                .Should().Pass();
         }
     }

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("5");
             string configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
             string expectedError = Path.Combine(testProjectDirectory, "bin",
-                                   configuration, "netcoreapp2.0", "VSTestCore.dll");
+                                   configuration, "netcoreapp2.1", "VSTestCore.dll");
             expectedError = "The test source file " + "\"" + expectedError + "\"" + " provided was not found.";
 
             // Call test

--- a/test/dotnet-vstest.Tests/VSTestTests.cs
+++ b/test/dotnet-vstest.Tests/VSTestTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli.VSTest.Tests
                 .Should().Pass();
 
             var outputDll = testRoot
-                .GetDirectory("bin", configuration, "netcoreapp2.0")
+                .GetDirectory("bin", configuration, "netcoreapp2.1")
                 .GetFile($"{testAppName}.dll");
 
             var argsForVstest = $"\"{outputDll.FullName}\" --logger:console;verbosity=normal";

--- a/test/dotnet.Tests/GivenThatICareAboutVBApps.cs
+++ b/test/dotnet.Tests/GivenThatICareAboutVBApps.cs
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Tests
                 _testInstance.Root.FullName,
                 "bin",
                 configuration,
-                "netcoreapp2.0",
+                "netcoreapp2.1",
                 "publish",
                 "VBTestApp.dll");
 

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.DotNet.Tests
                                           ".tools",
                                           toolName);
 
-            //  Other tests may have restored the tool for netcoreapp2.0, so delete its tools folder
+            //  Other tests may have restored the tool for netcoreapp2.1, so delete its tools folder
             if (Directory.Exists(toolFolder))
             {
                 Directory.Delete(toolFolder, true);
@@ -423,7 +423,7 @@ namespace Microsoft.DotNet.Tests
                 .WithRestoreFiles();
 
             var assetsFile = new DirectoryInfo(new RepoDirectoriesProvider().NugetPackages)
-                .GetDirectory(".tools", "dotnet-portable", "1.0.0", "netcoreapp2.0")
+                .GetDirectory(".tools", "dotnet-portable", "1.0.0", "netcoreapp2.1")
                 .GetFile("project.assets.json");
 
             var stopWatch = Stopwatch.StartNew();

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -246,8 +246,8 @@ namespace Microsoft.DotNet.Tests
                 .CreateInstance()
                 .WithSourceFiles()
                 .WithRestoreFiles();
-            
-            const string framework = ".NETCoreApp,Version=v2.0";
+
+            string framework = Tools.Tests.Utilities.NuGetFrameworks.NetCoreApp21.DotNetFrameworkName;
 
             new BuildCommand()
                 .WithProjectDirectory(testInstance.Root)


### PR DESCRIPTION
- Update to .NET Core 2.1 runtime
- Update tests to target .NET Core 2.1
- Disable tests which require .NET Core 2.1 templates, as we currently don't have any.  Filed #7476 to re-enable when there are templates