### PR TITLE
Add store and help to SDK commands

### DIFF
--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -27,6 +27,8 @@ path-to-application:
   nuget            {LocalizableStrings.NugetDefinition}
   msbuild          {LocalizableStrings.MsBuildDefinition}
   vstest           {LocalizableStrings.VsTestDefinition}
+  store            {LocalizableStrings.StoreDefinition}
+  help             {LocalizableStrings.HelpDefinition}
 
 {LocalizableStrings.CommonOptions}:
   -v|--verbosity        {CommonLocalizableStrings.VerbosityOptionDescription}

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -180,6 +180,9 @@
   <data name="MigrateDefinition" xml:space="preserve">
     <value>Migrates a project.json based project to a msbuild based project.</value>
   </data>
+  <data name="StoreDefinition" xml:space="preserve">
+    <value>Stores the specified assemblies in the runtime package store.</value>
+  </data>
   <data name="ProjectModificationCommands" xml:space="preserve">
     <value>Project modification commands</value>
   </data>

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -181,7 +181,7 @@
     <value>Migrates a project.json based project to a msbuild based project.</value>
   </data>
   <data name="StoreDefinition" xml:space="preserve">
-    <value>Stores the specified assemblies in the runtime package store.</value>
+    <value>Stores the specified assemblies in the runtime store.</value>
   </data>
   <data name="ProjectModificationCommands" xml:space="preserve">
     <value>Project modification commands</value>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">Cesta k dodatečnému souboru deps.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">Pfad zur zusätzlichen "deps.json"-Datei.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">Ruta de acceso al archivo deps.json adicional.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">Chemin du fichier deps.json supplémentaire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">Percorso del file deps.json aggiuntivo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">追加 deps.json ファイルへのパス。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">추가 deps.json 파일의 경로입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">Ścieżka do dodatkowego pliku deps.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">Caminho para o arquivo deps.json adicional.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">Путь к дополнительному файлу deps.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">Ek deps.json dosyasının yolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">其他 deps.json 文件的路径。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -237,6 +237,11 @@
         <target state="needs-review-translation">其他 deps.json 檔案的路徑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StoreDefinition">
+        <source>Stores the specified assemblies in the runtime package store.</source>
+        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -238,8 +238,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StoreDefinition">
-        <source>Stores the specified assemblies in the runtime package store.</source>
-        <target state="new">Stores the specified assemblies in the runtime package store.</target>
+        <source>Stores the specified assemblies in the runtime store.</source>
+        <target state="new">Stores the specified assemblies in the runtime store.</target>
         <note />
       </trans-unit>
     </body>

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -38,7 +38,7 @@ SDK commands:
   nuget            Provides additional NuGet commands.
   msbuild          Runs Microsoft Build Engine (MSBuild).
   vstest           Runs Microsoft Test Execution Command Line Tool.
-  store            Stores the specified assemblies in the runtime package store.
+  store            Stores the specified assemblies in the runtime store.
   help             Show help.
 
 Common options:

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -38,6 +38,8 @@ SDK commands:
   nuget            Provides additional NuGet commands.
   msbuild          Runs Microsoft Build Engine (MSBuild).
   vstest           Runs Microsoft Test Execution Command Line Tool.
+  store            Stores the specified assemblies in the runtime package store.
+  help             Show help.
 
 Common options:
   -v|--verbosity        Set the verbosity level of the command. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].


### PR DESCRIPTION
I've added the store command as a localizable string (the
help command was already one), but I've not supplied any
translations.

Fixes #7432 