### PR TITLE
Finalize v2.0.1

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,7 +12,7 @@
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
          cases, so use separate properties but derive one from the other unless we want to
          explicitly use different versions. -->
-    <CLI_NETSDK_Version>2.0.0-preview3-20170804-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.1-servicing-20170821-1</CLI_NETSDK_Version>
     <CLI_MSBuildExtensions_Version>$(CLI_NETSDK_Version)</CLI_MSBuildExtensions_Version>
 
     <CLI_NuGet_Version>4.3.0-rtm-4382</CLI_NuGet_Version>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>2.0.1-servicing-25630-01</CLI_SharedFrameworkVersion>
+    <CLI_SharedFrameworkVersion>2.0.1</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_Roslyn_Satellites_Version>2.3.0-pre-20170727-1</CLI_Roslyn_Satellites_Version>

--- a/build/Signing.proj
+++ b/build/Signing.proj
@@ -38,14 +38,23 @@
       <!-- Built binaries -->
       <FilesToSign Include="$(OutputDirectory)/sdk/**/csc.exe;
                             $(OutputDirectory)/sdk/**/csc.dll;
+                            $(OutputDirectory)/sdk/**/vbc.exe;
+                            $(OutputDirectory)/sdk/**/vbc.dll;
+                            $(OutputDirectory)/sdk/**/fsc.exe;
+                            $(OutputDirectory)/sdk/**/fsi.exe;
+                            $(OutputDirectory)/sdk/**/FSharp.*.dll;
                             $(OutputDirectory)/sdk/**/dotnet.dll;
                             $(OutputDirectory)/sdk/**/dotnet.resources.dll;
                             $(OutputDirectory)/sdk/**/System.*.dll;
                             $(OutputDirectory)/sdk/**/Microsoft.*.dll;
                             $(OutputDirectory)/sdk/**/NuGet*.dll;
                             $(OutputDirectory)/sdk/**/datacollector.dll;
+                            $(OutputDirectory)/sdk/**/datacollector.exe;
                             $(OutputDirectory)/sdk/**/MSBuild.dll;
+                            $(OutputDirectory)/sdk/**/MSBuild.resources.dll;
                             $(OutputDirectory)/sdk/**/testhost.dll;
+                            $(OutputDirectory)/sdk/**/testhost.exe;
+                            $(OutputDirectory)/sdk/**/testhost.x86.exe;
                             $(OutputDirectory)/sdk/**/vstest.console.dll;
                             $(OutputDirectory)/sdk/**/vstest.console.resources.dll">
         <Authenticode>$(InternalCertificateId)</Authenticode>

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -105,7 +105,7 @@ namespace Microsoft.DotNet.New.Tests
                 var sharedFxDir = dotnetDir
                     .GetDirectory("shared", "Microsoft.NETCore.App")
                     .EnumerateDirectories()
-                    .Single(d => d.Name.StartsWith("2.0.1")); // NOTE: implicit package version will be 2.0.0 again when https://github.com/dotnet/cli/pull/7489 can be merged.
+                    .Single(d => d.Name.StartsWith("2.0.0"));
 
                 if (packageName == "microsoft.netcore.app")
                 {

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -75,14 +75,14 @@ namespace Microsoft.DotNet.New.Tests
         }
 
         [Theory]
-        [InlineData("console", "RuntimeFrameworkVersion", "microsoft.netcore.app")]
-        [InlineData("classlib", "NetStandardImplicitPackageVersion", "netstandard.library")]
-        public void NewProjectRestoresCorrectPackageVersion(string type, string propertyName, string packageName)
+        [InlineData("console", "microsoft.netcore.app")]
+        [InlineData("classlib", "netstandard.library")]
+        public void NewProjectRestoresCorrectPackageVersion(string type, string packageName)
         {
             var rootPath = TestAssets.CreateTestDirectory(identifier: $"_{type}").FullName;
             var packagesDirectory = Path.Combine(rootPath, "packages");
             var projectName = "Project";
-            var expectedVersion = GetFrameworkPackageVersion();
+            var expectedVersion = "2.0.0";
             var repoRootNuGetConfig = Path.Combine(RepoDirectoriesProvider.RepoRoot, "NuGet.Config");
 
             new NewCommand()
@@ -98,32 +98,6 @@ namespace Microsoft.DotNet.New.Tests
             new DirectoryInfo(Path.Combine(packagesDirectory, packageName))
                 .Should().Exist()
                 .And.HaveDirectory(expectedVersion);
-
-            string GetFrameworkPackageVersion()
-            {
-                var dotnetDir = new FileInfo(DotnetUnderTest.FullName).Directory;
-                var sharedFxDir = dotnetDir
-                    .GetDirectory("shared", "Microsoft.NETCore.App")
-                    .EnumerateDirectories()
-                    .Single(d => d.Name.StartsWith("2.0.0"));
-
-                if (packageName == "microsoft.netcore.app")
-                {
-                    return sharedFxDir.Name;
-                }
-
-                var depsFile = Path.Combine(sharedFxDir.FullName, "Microsoft.NETCore.App.deps.json");
-                using (var stream = File.OpenRead(depsFile))
-                using (var reader = new DependencyContextJsonReader())
-                {
-                    var context = reader.Read(stream);
-                    var dependency = context
-                        .RuntimeLibraries
-                        .Single(library => string.Equals(library.Name, packageName, StringComparison.OrdinalIgnoreCase));
-
-                    return dependency.Version;
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
* Ingest 2.0.1 SDK that bumps standalone versions appropriately
* Bump to stable runtime/framework/host packages
* Cherry pick signing fix from release/2.0-vs
