### PR TITLE
Update FSharp compiler for Preview VS2017.4.2 -- in release/2.0-vs

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -6,7 +6,7 @@
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_Roslyn_Satellites_Version>2.3.0-pre-20170727-1</CLI_Roslyn_Satellites_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>
-    <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>
+    <CLI_FSharp_Version>4.2.0-rc-170818-0</CLI_FSharp_Version>
     <CLI_FSharp_Satellites_Version>4.4.1-pre-20170727-1</CLI_FSharp_Satellites_Version>
 
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some


### PR DESCRIPTION
@nguerrera
Localization resources can be found at: \cpvsbuild\drops\FSharp\Microbuild-Dev15-RTM\20170818.1\Binaries\net40\bin
/cc @dsyme, @brettfo, @Pilchie, @nguerrera
