### PR TITLE
Disable tests that can fail when LZMA is regenerated incorrectly

### DIFF
--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -79,7 +79,7 @@ A command is running to initially populate your local package cache, to improve 
                      .And.NotContain("Restore completed in");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/cli/issues/7508")]
         public void ItCreatesASentinelFileUnderTheNuGetCacheFolder()
         {
             _nugetCacheFolder
@@ -87,7 +87,7 @@ A command is running to initially populate your local package cache, to improve 
                 .HaveFile($"{GetDotnetVersion()}.dotnetSentinel");
     	}
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/cli/issues/7508")]
         public void ItRestoresTheNuGetPackagesToTheNuGetCacheFolder()
         {
             List<string> expectedDirectories = new List<string>()


### PR DESCRIPTION
@MattGal @dsplaisted 

https://github.com/dotnet/cli/issues/7508 tracks getting underlying issue fixed so that we can re-enable.