### PR TITLE
Finalize v1.1.3

### DIFF
--- a/TestAssets/TestPackages/Directory.Build.props
+++ b/TestAssets/TestPackages/Directory.Build.props
@@ -1,6 +1,0 @@
-<Project>
-  <Import Project="../../build/Microsoft.DotNet.Cli.DependencyVersions.props" />
-  <PropertyGroup>
-    <RuntimeFrameworkVersion>$(CLI_SharedFrameworkVersion)</RuntimeFrameworkVersion>
-  </PropertyGroup>
-</Project>

--- a/branchinfo.txt
+++ b/branchinfo.txt
@@ -3,7 +3,7 @@
 # Each line is expected to be in the format "[Name]=[Value]".
 MAJOR_VERSION=1
 MINOR_VERSION=1
-PATCH_VERSION=1
+PATCH_VERSION=3
 RELEASE_SUFFIX=servicing
 CHANNEL=rel-1.1.0
 BRANCH_NAME=rel/1.1.0

--- a/build.proj
+++ b/build.proj
@@ -20,13 +20,12 @@
     <CoreSetupChannel>release/1.1.0</CoreSetupChannel>
     <SharedFrameworkName>Microsoft.NETCore.App</SharedFrameworkName>
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
-    <SharedHostVersion>1.1.0</SharedHostVersion>
-    <HostFxrContainerVersion>1.1.0</HostFxrContainerVersion>
-    <HostFxrVersion Condition=" '$(OS)' != 'Windows_NT' ">1.1.0</HostFxrVersion>
-    <HostFxrVersion Condition=" '$(OS)' == 'Windows_NT' ">1.1.2</HostFxrVersion>
+    <SharedHostVersion>$(CLI_SharedHostVersion)</SharedHostVersion>
+    <HostFxrContainerVersion>$(CLI_HostFxrContainerVersion)</HostFxrContainerVersion>
+    <HostFxrVersion>$(CLI_HostFxrVersion)</HostFxrVersion>
 
-    <CoreCLRVersion>1.1.3-servicing-25629-01</CoreCLRVersion>
-    <JitVersion>1.1.3-servicing-25629-01</JitVersion>
+    <CoreCLRVersion>$(CLI_CoreCLRVersion)</CoreCLRVersion>
+    <JitVersion>$(CLI_JitVersion)</JitVersion>
 
     <ExeExtension>.exe</ExeExtension>
     <ExeExtension Condition=" '$(OS)' != 'Windows_NT' "></ExeExtension>

--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -110,24 +110,6 @@
     </ItemGroup>
     <Copy SourceFiles="@(HackFilesToCopy)"
           DestinationFiles="@(HackFilesToCopy->'$(SdkOutputDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" />
-
-    <!-- Begin Workaround lack of a stable package version for depedencies; copy into simulated stable version folders -->
-
-    <ItemGroup>  
-        <Stabilize_SourceFiles_1_1 Include="$(StageDirectory)/shared/Microsoft.NETCore.App/$(CLI_SharedFrameworkVersion)/*.*"/>  
-        <Stabilize_SourceFiles_1_0 Include="$(StageDirectory)/shared/Microsoft.NETCore.App/$(CLI_SharedFrameworkVersion_1_0)/*.*"/>  
-    </ItemGroup>  
-
-    <Copy  
-        SourceFiles="@(Stabilize_SourceFiles_1_0)"  
-        DestinationFiles="@(Stabilize_SourceFiles_1_0->'$(StageDirectory)/shared/Microsoft.NETCore.App/1.0.6/%(RecursiveDir)%(Filename)%(Extension)')"  
-    />  
-    <Copy  
-        SourceFiles="@(Stabilize_SourceFiles_1_1)"  
-        DestinationFiles="@(Stabilize_SourceFiles_1_1->'$(StageDirectory)/shared/Microsoft.NETCore.App/1.1.3/%(RecursiveDir)%(Filename)%(Extension)')"  
-    />   
-
-    <!-- End Workaround lack of a stable package version for depedencies; copy into simulated stable versions -->
     
     <!-- Publish DotNet -->
     <DotNetPublish ToolPath="%(Stage.DotnetDir)"

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>1.1.3-servicing-001611-00</CLI_SharedFrameworkVersion>
-    <CLI_SharedFrameworkVersion_1_0>1.0.6-servicing-004974-00</CLI_SharedFrameworkVersion_1_0>
+    <CLI_SharedFrameworkVersion>1.1.3</CLI_SharedFrameworkVersion>
+    <CLI_CoreCLRVersion>1.1.3-servicing-25629-01</CLI_CoreCLRVersion>
+    <CLI_JitVersion>>1.1.3-servicing-25629-01</CLI_JitVersion>
+    <CLI_SharedHostVersion>1.1.0</CLI_SharedHostVersion>
+    <CLI_HostFxrContainerVersion>1.1.0</CLI_HostFxrContainerVersion>
+    <CLI_HostFxrVersion Condition="'$(OS)' != 'Windows_NT'">1.1.0</CLI_HostFxrVersion>
+    <CLI_HostFxrVersion Condition="'$(OS)' == 'Windows_NT'">1.1.2</CLI_HostFxrVersion>
+
+    <CLI_SharedFrameworkVersion_1_0>1.0.6</CLI_SharedFrameworkVersion_1_0>
+    <CLI_SharedHostVersion_1_0>1.0.1</CLI_SharedHostVersion_1_0>
+    <CLI_HostFxrContainerVersion_1_0>1.0.1</CLI_HostFxrContainerVersion_1_0>
+    <CLI_HostFxrVersion_1_0 Condition="'$(OS)' == 'Windows_NT'">1.0.1</CLI_HostFxrVersion_1_0>
+    <CLI_HostFxrVersion_1_0 Condition="'$(OS)' == 'Windows_NT'">1.0.5</CLI_HostFxrVersion_1_0>
+
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>1.1.3</CLI_SharedFrameworkVersion>
-    <CLI_CoreCLRVersion>1.1.3-servicing-25629-01</CLI_CoreCLRVersion>
-    <CLI_JitVersion>>1.1.3-servicing-25629-01</CLI_JitVersion>
+    <CLI_CoreCLRVersion>1.1.3</CLI_CoreCLRVersion>
+    <CLI_JitVersion>>1.1.3</CLI_JitVersion>
     <CLI_SharedHostVersion>1.1.0</CLI_SharedHostVersion>
     <CLI_HostFxrContainerVersion>1.1.0</CLI_HostFxrContainerVersion>
     <CLI_HostFxrVersion Condition="'$(OS)' != 'Windows_NT'">1.1.0</CLI_HostFxrVersion>
@@ -12,7 +12,7 @@
     <CLI_SharedFrameworkVersion_1_0>1.0.6</CLI_SharedFrameworkVersion_1_0>
     <CLI_SharedHostVersion_1_0>1.0.1</CLI_SharedHostVersion_1_0>
     <CLI_HostFxrContainerVersion_1_0>1.0.1</CLI_HostFxrContainerVersion_1_0>
-    <CLI_HostFxrVersion_1_0 Condition="'$(OS)' == 'Windows_NT'">1.0.1</CLI_HostFxrVersion_1_0>
+    <CLI_HostFxrVersion_1_0 Condition="'$(OS)' != 'Windows_NT'">1.0.1</CLI_HostFxrVersion_1_0>
     <CLI_HostFxrVersion_1_0 Condition="'$(OS)' == 'Windows_NT'">1.0.5</CLI_HostFxrVersion_1_0>
 
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -6,7 +6,7 @@
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>
-    <CLI_NETSDK_Version>1.1.0-alpha-20170726-4</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.1.1-svc-20170822-1</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-rtm-4324</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>

--- a/build/Microsoft.DotNet.Cli.Monikers.props
+++ b/build/Microsoft.DotNet.Cli.Monikers.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SdkBrandName>.NET Core SDK 1.1.1</SdkBrandName>
+    <SdkBrandName>.NET Core SDK 1.1.3</SdkBrandName>
     <SharedFrameworkBrandName>Microsoft .NET Core 1.1.3 - Runtime</SharedFrameworkBrandName>
     <SharedHostBrandName>Microsoft .NET Core 1.1.0 - Host</SharedHostBrandName>
     <HostFxrBrandName>Microsoft .NET Core 1.1.0 - Host FX Resolver</HostFxrBrandName>

--- a/build/Microsoft.DotNet.Cli.Prepare.targets
+++ b/build/Microsoft.DotNet.Cli.Prepare.targets
@@ -145,10 +145,9 @@
     <PropertyGroup Condition=" '$(IncludeAdditionalSharedFrameworks)' == 'true' ">
       <AdditionalCoreSetupChannel>preview</AdditionalCoreSetupChannel>
       <AdditionalSharedFrameworkVersion>$(CLI_SharedFrameworkVersion_1_0)</AdditionalSharedFrameworkVersion>
-      <AdditionalSharedHostVersion>1.0.1</AdditionalSharedHostVersion>
-      <AdditionalHostFxrContainerVersion>1.0.1</AdditionalHostFxrContainerVersion>
-      <AdditionalHostFxrVersion Condition=" '$(OSName)' != 'win' ">1.0.1</AdditionalHostFxrVersion>
-      <AdditionalHostFxrVersion Condition=" '$(OSName)' == 'win' ">1.0.5</AdditionalHostFxrVersion>
+      <AdditionalSharedHostVersion>$(CLI_SharedHostVersion_1_0)</AdditionalSharedHostVersion>
+      <AdditionalHostFxrContainerVersion>$(CLI_HostFxrContainerVersion_1_0)</AdditionalHostFxrContainerVersion>
+      <AdditionalHostFxrVersion>$(CLI_HostFxrVersion_1_0)</AdditionalHostFxrVersion>
 
       <!-- Additional Downloaded Installers + Archives -->
       <AdditionalDownloadedSharedHostInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-host-$(ProductMonikerRid).$(AdditionalSharedHostVersion)$(InstallerExtension)</AdditionalDownloadedSharedHostInstallerFileName>

--- a/build/Microsoft.DotNet.Cli.Signing.proj
+++ b/build/Microsoft.DotNet.Cli.Signing.proj
@@ -35,6 +35,11 @@
       <!-- Built binaries -->
       <FilesToSign Include="$(Stage2Directory)/sdk/**/csc.exe;
                             $(Stage2Directory)/sdk/**/csc.dll;
+                            $(Stage2Directory)/sdk/**/vbc.exe;
+                            $(Stage2Directory)/sdk/**/vbc.dll;
+                            $(Stage2Directory)/sdk/**/fsc.exe;
+                            $(Stage2Directory)/sdk/**/fsi.exe;
+                            $(Stage2Directory)/sdk/**/FSharp.*.dll;
                             $(Stage2Directory)/sdk/**/dotnet.dll;
                             $(Stage2Directory)/sdk/**/System.*.dll;
                             $(Stage2Directory)/sdk/**/Microsoft.*.dll;
@@ -42,7 +47,8 @@
                             $(Stage2Directory)/sdk/**/datacollector.dll;
                             $(Stage2Directory)/sdk/**/MSBuild.dll;
                             $(Stage2Directory)/sdk/**/testhost.dll;
-                            $(Stage2Directory)/sdk/**/vstest.console.dll">
+                            $(Stage2Directory)/sdk/**/vstest.console.dll;
+                            $(Stage2Directory)/sdk/**/vstest.console.resources.dll">
         <Authenticode>$(InternalCertificateId)</Authenticode>
       </FilesToSign>
       <!-- Built files for the packages -->

--- a/build/package/Microsoft.DotNet.Cli.Installer.DEB.proj
+++ b/build/package/Microsoft.DotNet.Cli.Installer.DEB.proj
@@ -125,9 +125,6 @@
       <Exec Command="sudo dpkg -r $(HostDebianPackageName)" />
   </Target>
 
-  <!-- Disable TestSdkDeb for now while 1.x runtime is not stable. It cannot pass due to failed roll forward from stable to unstable -->
-  <Target Name="TestSdkDeb" />
-
   <Target Name="PrepareDotnetDebDirectories">
 
     <!-- Clean the workspace -->

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -17,7 +17,7 @@
       <Version>1.6.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.Runtime.CoreCLR">
-      <Version>1.1.3-servicing-25622-01</Version>
+      <Version>$(CLI_CoreCLR_Version)</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
       <Version>$(CLI_MSBuild_Version)</Version>

--- a/dir.props
+++ b/dir.props
@@ -13,6 +13,6 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
 
 
-    <CliVersionPrefix>1.1.1</CliVersionPrefix>
+    <CliVersionPrefix>1.1.3</CliVersionPrefix>
   </PropertyGroup>
 </Project>

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -87,7 +87,7 @@ A command is running to initially populate your local package cache, to improve 
                      .And.NotContain("Restore completed in");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/cli/issues/7508")]
+        [Fact]
         public void ItCreatesASentinelFileUnderTheNuGetCacheFolder()
         {
             _nugetCacheFolder
@@ -95,7 +95,7 @@ A command is running to initially populate your local package cache, to improve 
                 .HaveFile($"{GetDotnetVersion()}.dotnetSentinel");
     	}
 
-        [Fact(Skip = "https://github.com/dotnet/cli/issues/7508")]
+        [Fact]
         public void ItRestoresTheNuGetPackagesToTheNuGetCacheFolder()
         {
             List<string> expectedDirectories = new List<string>()


### PR DESCRIPTION
* Ingest dotnet/sdk v1.1.1 with bump for standalone 1.0.x/1.1.x package versions
* Revert temporary changes for testing with unstable framework/runtime
* Bump SDK version number to v1.1.3
* Ingest stable runtime/framework packages
* Move all bumped version to DependencyVersion.props
* Port signing fix