### PR TITLE
Add -SkipNonVersionedFiles to dotnet-install.{sh,ps1}

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -58,6 +58,9 @@
 .PARAMETER ProxyUseDefaultCredentials
     Default: false
     Use default credentials, when using proxy address.
+.PARAMETER SkipNonVersionedFiles
+    Default: false
+    Skips installing non-versioned files if they already exist, such as dotnet.exe.
 #>
 [cmdletbinding()]
 param(
@@ -71,7 +74,8 @@ param(
    [string]$AzureFeed="https://dotnetcli.azureedge.net/dotnet",
    [string]$UncachedFeed="https://dotnetcli.blob.core.windows.net/dotnet",
    [string]$ProxyAddress,
-   [switch]$ProxyUseDefaultCredentials
+   [switch]$ProxyUseDefaultCredentials,
+   [switch]$SkipNonVersionedFiles
 )
 
 Set-StrictMode -Version Latest
@@ -82,7 +86,7 @@ $BinFolderRelativePath=""
 
 # example path with regex: shared/1.0.0-beta-12345/somepath
 $VersionRegEx="/\d+\.\d+[^/]+/"
-$OverrideNonVersionedFiles=$true
+$OverrideNonVersionedFiles = !$SkipNonVersionedFiles
 
 function Say($str) {
     Write-Output "dotnet-install: $str"

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -541,7 +541,7 @@ extract_dotnet_package() {
     
     local folders_with_version_regex='^.*/[0-9]+\.[0-9]+[^/]+/'
     find $temp_out_path -type f | grep -Eo $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path false
-    find $temp_out_path -type f | grep -Ev $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path true
+    find $temp_out_path -type f | grep -Ev $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path $override_non_versioned_files
     
     rm -rf $temp_out_path
     
@@ -687,6 +687,7 @@ uncached_feed="https://dotnetcli.blob.core.windows.net/dotnet"
 verbose=false
 shared_runtime=false
 runtime_id=""
+override_non_versioned_files=true
 
 while [ $# -ne 0 ]
 do
@@ -732,6 +733,10 @@ do
             shift
             runtime_id="$1"
             ;;
+        --skip-non-versioned-files|-[Ss]kip[Nn]on[Vv]ersioned[Ff]iles)
+            shift
+            override_non_versioned_files=false
+            ;;
         -?|--?|-h|--help|-[Hh]elp)
             script_name="$(basename $0)"
             echo ".NET Tools Installer"
@@ -764,6 +769,8 @@ do
             echo "      --arch,-Architecture,-Arch"
             echo "  --shared-runtime               Installs just the shared runtime bits, not the entire SDK."
             echo "      -SharedRuntime"
+            echo "  --skip-non-versioned-files     Skips non-versioned files if they already exist, such as the dotnet executable."
+            echo "      -SkipNonVersionedFiles"
             echo "  --dry-run,-DryRun              Do not perform installation. Display download link."
             echo "  --no-path, -NoPath             Do not set PATH for the current process."
             echo "  --verbose,-Verbose             Display diagnostics information."


### PR DESCRIPTION
In some of our build scripts, we want to install new versions of the .NET Core runtime, but this can cause write errors if dotnet.exe is currently executing. There was already an internal non-clobber option. This exposes a command-line switch for that option so we can avoid clobbering dotnet.exe.