### PR TITLE
clean debug output from dotnet-install.ps1

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -470,7 +470,6 @@ if ($IsSdkInstalled) {
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 
 $installDrive = $((Get-Item $InstallRoot).PSDrive.Name);
-Write-Output "${installDrive}:";
 $free = Get-CimInstance -Class win32_logicaldisk | where Deviceid -eq "${installDrive}:"
 if ($free.Freespace / 1MB -le 100 ) {
     Say "There is not enough disk space on drive ${installDrive}:"


### PR DESCRIPTION
remove the unnecessary printing of the installation drive during the install

fixes #7526