### PR TITLE
Workaround for test execution in the absence of stable package versions.  skip ci please

### DIFF
--- a/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/dotnet-hello.csproj
+++ b/TestAssets/TestPackages/dotnet-hello/v1/dotnet-hello/dotnet-hello.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>dotnet-hello</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/dotnet-hello.csproj
+++ b/TestAssets/TestPackages/dotnet-hello/v2/dotnet-hello/dotnet-hello.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>dotnet-hello</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;opensuse.13.2-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.10-x64;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/Microsoft.DotNet.Cli.Compile.targets
+++ b/build/Microsoft.DotNet.Cli.Compile.targets
@@ -110,6 +110,24 @@
     </ItemGroup>
     <Copy SourceFiles="@(HackFilesToCopy)"
           DestinationFiles="@(HackFilesToCopy->'$(SdkOutputDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" />
+
+    <!-- Begin Workaround lack of a stable package version for depedencies; copy into simulated stable version folders -->
+
+    <ItemGroup>  
+        <Stabilize_SourceFiles_1_1 Include="$(StageDirectory)/shared/Microsoft.NETCore.App/$(CLI_SharedFrameworkVersion)/*.*"/>  
+        <Stabilize_SourceFiles_1_0 Include="$(StageDirectory)/shared/Microsoft.NETCore.App/$(CLI_SharedFrameworkVersion_1_0)/*.*"/>  
+    </ItemGroup>  
+
+    <Copy  
+        SourceFiles="@(Stabilize_SourceFiles_1_0)"  
+        DestinationFiles="@(Stabilize_SourceFiles_1_0->'$(StageDirectory)/shared/Microsoft.NETCore.App/1.0.6/%(RecursiveDir)%(Filename)%(Extension)')"  
+    />  
+    <Copy  
+        SourceFiles="@(Stabilize_SourceFiles_1_1)"  
+        DestinationFiles="@(Stabilize_SourceFiles_1_1->'$(StageDirectory)/shared/Microsoft.NETCore.App/1.1.3/%(RecursiveDir)%(Filename)%(Extension)')"  
+    />   
+
+    <!-- End Workaround lack of a stable package version for depedencies; copy into simulated stable versions -->
     
     <!-- Publish DotNet -->
     <DotNetPublish ToolPath="%(Stage.DotnetDir)"

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>1.1.3-servicing-001602-00</CLI_SharedFrameworkVersion>
+    <CLI_SharedFrameworkVersion_1_0>1.0.6-servicing-004969-00</CLI_SharedFrameworkVersion_1_0>
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -47,6 +47,6 @@
       InputFile="$(VSTestRuntimeConfigPath)"
       DestinationFile="$(VSTestRuntimeConfigPath)"
       ReplacementPatterns="1.0.0"
-      ReplacementStrings="1.1.0" />
+      ReplacementStrings="$(CLI_SharedFrameworkVersion)" />
   </Target>
 </Project>


### PR DESCRIPTION
- If this PR should not run tests please add text "skip ci please" (remove the marked text, no quotes).

- Workaround test failures by copying unstable package versions into stable-named folders
- Remove dead Rids from test build projects
- Put version from props file in src/redist/redist.csproj to pick up current version.


