### PR TITLE
Sign additional files

### DIFF
--- a/build/Signing.proj
+++ b/build/Signing.proj
@@ -38,14 +38,23 @@
       <!-- Built binaries -->
       <FilesToSign Include="$(OutputDirectory)/sdk/**/csc.exe;
                             $(OutputDirectory)/sdk/**/csc.dll;
+                            $(OutputDirectory)/sdk/**/vbc.exe;
+                            $(OutputDirectory)/sdk/**/vbc.dll;
+                            $(OutputDirectory)/sdk/**/fsc.exe;
+                            $(OutputDirectory)/sdk/**/fsi.exe;
+                            $(OutputDirectory)/sdk/**/FSharp.*.dll;
                             $(OutputDirectory)/sdk/**/dotnet.dll;
                             $(OutputDirectory)/sdk/**/dotnet.resources.dll;
                             $(OutputDirectory)/sdk/**/System.*.dll;
                             $(OutputDirectory)/sdk/**/Microsoft.*.dll;
                             $(OutputDirectory)/sdk/**/NuGet*.dll;
                             $(OutputDirectory)/sdk/**/datacollector.dll;
+                            $(OutputDirectory)/sdk/**/datacollector.exe;
                             $(OutputDirectory)/sdk/**/MSBuild.dll;
+                            $(OutputDirectory)/sdk/**/MSBuild.resources.dll;
                             $(OutputDirectory)/sdk/**/testhost.dll;
+                            $(OutputDirectory)/sdk/**/testhost.exe;
+                            $(OutputDirectory)/sdk/**/testhost.x86.exe;
                             $(OutputDirectory)/sdk/**/vstest.console.dll;
                             $(OutputDirectory)/sdk/**/vstest.console.resources.dll">
         <Authenticode>$(InternalCertificateId)</Authenticode>


### PR DESCRIPTION
Some files that get their signature invalidated by crossgen were missing
from the Signing.proj list.

@dsplaisted for review

@MattGertz for approval -- needed for 15.4 P2.
