### PR TITLE
Updating new templates to 2.1.0 versions

### DIFF
--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -2,9 +2,9 @@
   <ItemGroup>
     <BundledTemplate Include="Microsoft.DotNet.Common.ItemTemplates" Version="$(TemplateEngineTemplateVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(TemplateEngineTemplateVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.2.0" Version="$(TemplateEngineTemplate2_0Version)" />
-    <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.0" Version="$(TemplateEngineTemplateVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.0" Version="$(TemplateEngineTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" Version="$(TemplateEngineTemplate2_0Version)" />
+    <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="$(TemplateEngineTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="$(TemplateEngineTemplateVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(SpaTemplateVersion)" />
   </ItemGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -22,9 +22,9 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta2-20170810-304</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170810-304</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170810-304</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20170828-305</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20170828-305</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170828-305</TemplateEngineTemplate2_0Version>
     <PlatformAbstractionsVersion>2.1.0-preview2-25616-02</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.1.0-preview2-25616-02</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.1-alpha-167</CliCommandLineParserVersion>

--- a/test/EndToEnd/GivenDotNetUsesMSBuild.cs
+++ b/test/EndToEnd/GivenDotNetUsesMSBuild.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Tests.EndToEnd
 {
     public class GivenDotNetUsesMSBuild : TestBase
     {
-        [Fact(Skip = "https://github.com/dotnet/cli/issues/7476")]
+        [Fact]
         public void ItCanNewRestoreBuildRunCleanMSBuildProject()
         {
             using (DisposableDirectory directory = Temp.CreateDirectory())

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Cli.Build.Tests
                 .And.HaveStdOutContaining("project.assets.json");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/cli/issues/7476")]
+        [Fact]
         public void ItRunsWhenRestoringToSpecificPackageDir()
         {
             var rootPath = TestAssets.CreateTestDirectory().FullName;

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -77,9 +77,10 @@ namespace Microsoft.DotNet.New.Tests
                 .Should().Pass();
         }
 
-        [Theory(Skip = "https://github.com/dotnet/cli/issues/7476")]
+        [Theory]
         [InlineData("console", "RuntimeFrameworkVersion", "microsoft.netcore.app")]
-        [InlineData("classlib", "NetStandardImplicitPackageVersion", "netstandard.library")]
+        // issue with netstandard2.0 - formerly both test cases were skipped because of: https://github.com/dotnet/cli/issues/7476
+        //[InlineData("classlib", "NetStandardImplicitPackageVersion", "netstandard.library")]
         public void NewProjectRestoresCorrectPackageVersion(string type, string propertyName, string packageName)
         {
             var rootPath = TestAssets.CreateTestDirectory(identifier: $"_{type}").FullName;

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.New.Tests
 
         [Theory]
         [InlineData("console", "RuntimeFrameworkVersion", "microsoft.netcore.app")]
-        // re-enable when this bug is resolved: https://github.com/dotnet/cli/pull/7554
+        // re-enable when this bug is resolved: https://github.com/dotnet/cli/issues/7574
         //[InlineData("classlib", "NetStandardImplicitPackageVersion", "netstandard.library")]
         public void NewProjectRestoresCorrectPackageVersion(string type, string propertyName, string packageName)
         {

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.New.Tests
 
         [Theory]
         [InlineData("console", "RuntimeFrameworkVersion", "microsoft.netcore.app")]
-        // issue with netstandard2.0 - formerly both test cases were skipped because of: https://github.com/dotnet/cli/issues/7476
+        // re-enable when this bug is resolved: https://github.com/dotnet/cli/pull/7554
         //[InlineData("classlib", "NetStandardImplicitPackageVersion", "netstandard.library")]
         public void NewProjectRestoresCorrectPackageVersion(string type, string propertyName, string packageName)
         {

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -20,9 +20,9 @@ namespace Microsoft.DotNet.New.Tests
         [InlineData("C#", "classlib", false, false)]
         [InlineData("C#", "mstest", false, false)]
         [InlineData("C#", "xunit", false, false)]
-        [InlineData("C#", "web", false, false)]
-        [InlineData("C#", "mvc", false, false)]
-        [InlineData("C#", "webapi", false, false)]
+        [InlineData("C#", "web", true, false)]
+        [InlineData("C#", "mvc", true, false)]
+        [InlineData("C#", "webapi", true, false)]
         [InlineData("C#", "angular", false, true)]
         [InlineData("C#", "react", false, true)]
         [InlineData("C#", "reactredux", false, true)]
@@ -62,10 +62,9 @@ namespace Microsoft.DotNet.New.Tests
                 Directory.CreateDirectory(Path.Combine(rootPath, "wwwroot", "dist"));
             }
 
-            // https://github.com/dotnet/templating/issues/946 - remove DisableImplicitAssetTargetFallback once this is fixed.
             new TestCommand("dotnet")
                 .WithWorkingDirectory(rootPath)
-                .Execute($"restore /p:DisableImplicitAssetTargetFallback=true")
+                .Execute($"restore")
                 .Should().Pass();
 
             var buildResult = new TestCommand("dotnet")

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.New.Tests
         [InlineData("C#", "react", false, true)]
         [InlineData("C#", "reactredux", false, true)]
         [InlineData("F#", "console", false, false)]
-        // issue with netstandard2.0 --- formerly was issue with: https://github.com/dotnet/cli/issues/7476
+        // re-enable when this bug is resolved: https://github.com/dotnet/cli/pull/7554
         //[InlineData("F#", "classlib", false, false)]
         [InlineData("F#", "mstest", false, false)]
         [InlineData("F#", "xunit", false, false)]

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.New.Tests
         [InlineData("C#", "react", false, true)]
         [InlineData("C#", "reactredux", false, true)]
         [InlineData("F#", "console", false, false)]
-        //  https://github.com/dotnet/cli/issues/7476
+        // issue with netstandard2.0 --- formerly was issue with: https://github.com/dotnet/cli/issues/7476
         //[InlineData("F#", "classlib", false, false)]
         [InlineData("F#", "mstest", false, false)]
         [InlineData("F#", "xunit", false, false)]

--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.New.Tests
         [InlineData("C#", "react", false, true)]
         [InlineData("C#", "reactredux", false, true)]
         [InlineData("F#", "console", false, false)]
-        // re-enable when this bug is resolved: https://github.com/dotnet/cli/pull/7554
+        // re-enable when this bug is resolved: https://github.com/dotnet/cli/issues/7574
         //[InlineData("F#", "classlib", false, false)]
         [InlineData("F#", "mstest", false, false)]
         [InlineData("F#", "xunit", false, false)]

--- a/test/dotnet-new.Tests/NuGet.tempaspnetpatch.config
+++ b/test/dotnet-new.Tests/NuGet.tempaspnetpatch.config
@@ -5,6 +5,7 @@
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="DotnetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+	<add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
     <add key="aspnet-final" value="https://dotnet.myget.org/F/aspnetcore-2-0-0-preview1-no-timestamp/api/v3/index.json" />
     <add key="aspnet-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
   </packageSources>

--- a/test/dotnet-new.Tests/NuGet.tempaspnetpatch.config
+++ b/test/dotnet-new.Tests/NuGet.tempaspnetpatch.config
@@ -5,7 +5,7 @@
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="DotnetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-	<add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
+    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
     <add key="aspnet-final" value="https://dotnet.myget.org/F/aspnetcore-2-0-0-preview1-no-timestamp/api/v3/index.json" />
     <add key="aspnet-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
   </packageSources>

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -197,7 +197,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             }
         }
 
-        [Fact(Skip = "https://github.com/dotnet/cli/issues/7476")]
+        [Fact]
         public void ItPublishesAppWhenRestoringToSpecificPackageDirectory()
         {
             var rootPath = TestAssets.CreateTestDirectory().FullName;

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -192,7 +192,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                          .And.HaveStdOutContaining("Hello World!");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/cli/issues/7476")]
+        [Fact]
         public void ItRunsAppWhenRestoringToSpecificPackageDirectory()
         {
             var rootPath = TestAssets.CreateTestDirectory().FullName;


### PR DESCRIPTION
These changes include adding a private feed to the file:
`test/dotnet-new.Tests/NuGet.tempaspnetpatch.config`
... which is the current location for some of the packages used by the 2.1.0 templates. That test file will want to be changed once the packages become publically available. Ideally, we should just be able to remove the feed I added, assuming the necessary packages become available in the other feeds.