### PR TITLE
Fixed name of the LogFileName

### DIFF
--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -164,7 +164,7 @@
     <value>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</value>
   </data>
   <data name="CmdConfiguration" xml:space="preserve">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">Zadejte protokolovací nástroj pro výsledky testů. 
                                         Příklad: --logger "trx[;LogFileName=&lt;Standardně se nastaví jedinečný název souboru&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">Geben Sie eine Protokollierung für Testergebnisse an. 
                                         Beispiel: --logger "trx[;LogFileName=&lt;Standardmäßig der eindeutige Dateiname&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">Especifica un registrador para los resultados de prueba.
                                         Ejemplo: --logger "trx[;LogFileName=&lt;Adopta como valor predeterminado un nombre de archivo único&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">Spécifiez un enregistreur d'événements pour les résultats des tests.
                                         Exemple : --logger "trx[;LogFileName=&lt;Nom de fichier unique par défaut&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">Consente di specificare un logger per i risultati dei test.
                                         Esempio: --logger "trx[;LogFileName=&lt;l'impostazione predefinita è un nome file univoco&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">テスト結果のロガーを指定します。
                                         例: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">테스트 결과에 대해 로거를 지정합니다. 
                                         예: --logger "trx[;LogFileName=&lt;고유한 파일 이름을 기본값으로 설정&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">Określ rejestrator wyników testów.
                                         Przykład: --logger "trx[;LogFileName=&lt;domyślnie jest to unikatowa nazwa pliku&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">Especifique um agente para os resultados de teste.
                                         Exemplo: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">Укажите средство ведения журнала для результатов теста.
                                         Пример: --logger "trx[;LogFileName=&lt;по умолчанию используется уникальное имя файла&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">Test sonuçları için bir günlükçü belirtin. 
                                         Örnek: --logger "trx[;LogFileName=&lt;Varsayılan olarak benzersiz dosya adı kullanılır&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">指定测试结果的记录器。
                                         示例: --logger "trx[;LogFileName=&lt;Defaults to unique file name&gt;]"

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -75,7 +75,7 @@
         <source>Specify a logger for test results.
                                         Examples:
                                         Log in trx format using a unqiue file name: --logger trx
-                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.resx&gt;"
+                                        Log in trx format using the specified file name: --logger "trx;LogFileName=&lt;TestResults.trx&gt;"
                                         More info on logger arguments support:https://aka.ms/vstest-report</source>
         <target state="needs-review-translation">指定測試結果的記錄器。
                                         範例: --logger "trx[;LogFileName=&lt;預設為唯一的檔案名稱&gt;]"


### PR DESCRIPTION
Fixed up extension in the help file from #7406