### PR TITLE
Avoid importing incompatible .props files for signing build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
 <!--
 Projects which don't import dir.props:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,9 +36,6 @@ tools\TestAssetsDependencies\TestAssetsDependencies.csproj
 
   <Import Project="build/BranchInfo.props" />
 
-  <Import Project="build/BundledTools.props" />
-  <Import Project="build/BundledSdks.props" />
-  <Import Project="build/BundledTemplates.props" />
   <Import Project="build/DependencyVersions.props" />
   <Import Project="build/Version.props" />
   <Import Project="build/Branding.props" />
@@ -49,13 +46,23 @@ tools\TestAssetsDependencies\TestAssetsDependencies.csproj
   <Import Project="build/MSBuildExtensions.props" />
   <Import Project="build/SetupPreviousStage.props" />
   <Import Project="build/OutputDirectories.props" />
-  <Import Project="build/BuildDefaults.props" />
-  <Import Project="build/VersionBadge.props" />
-  <Import Project="build/BundledRuntimes.props" />
-  <Import Project="build/CrossGen.props" />
-  <Import Project="build/BackwardsCompatibilityRuntimes.props" />
 
-  <Import Project="build/AzureInfo.props" />
-  <Import Project="build/InstallerInfo.props" />
-  <Import Project="build/GenerateResxSource.targets" />
+  <ImportGroup Condition=" '$(BuildingSigningProject)' != 'true' ">
+    <!-- These imports aren't required for signing, and some of them have syntax which isn't supported in MSBuild 14,
+         which is what the signing build uses -->
+    <Import Project="build/BundledTools.props" />
+    <Import Project="build/BundledSdks.props" />
+    <Import Project="build/BundledTemplates.props" />
+
+    <Import Project="build/BuildDefaults.props" />
+    <Import Project="build/VersionBadge.props" />
+    <Import Project="build/BundledRuntimes.props" />
+    <Import Project="build/CrossGen.props" />
+    <Import Project="build/BackwardsCompatibilityRuntimes.props" />
+
+    <Import Project="build/AzureInfo.props" />
+    <Import Project="build/InstallerInfo.props" />
+    <Import Project="build/GenerateResxSource.targets" />
+  </ImportGroup>
+  
 </Project>

--- a/build/AzureInfo.props
+++ b/build/AzureInfo.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Product>Sdk</Product>
     <ArtifactContainerName>$(ARTIFACT_STORAGE_CONTAINER)</ArtifactContainerName>

--- a/build/BackwardsCompatibilityRuntimes.props
+++ b/build/BackwardsCompatibilityRuntimes.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Condition=" '$(IncludeSharedFrameworksForBackwardsCompatibilityTests)' == 'true' ">
     <BackwardsCompatibility110CoreSetupChannel>release/1.1.0</BackwardsCompatibility110CoreSetupChannel>
     <BackwardsCompatibility110SharedFrameworkVersion>1.1.2</BackwardsCompatibility110SharedFrameworkVersion>

--- a/build/BranchInfo.props
+++ b/build/BranchInfo.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Channel>master</Channel>
     <BranchName>master</BranchName>

--- a/build/Branding.props
+++ b/build/Branding.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SdkBrandName>Microsoft .NET Core SDK 2.1.0 - Preview</SdkBrandName>
     <MSBuildExtensionsBrandName>.NET Standard Support for Visual Studio 2015</MSBuildExtensionsBrandName>

--- a/build/BuildDefaults.props
+++ b/build/BuildDefaults.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLITargets Condition=" '$(CLITargets)' == '' ">Prepare;Compile;Test;Package;Publish</CLITargets>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/build/BuildInfo.targets
+++ b/build/BuildInfo.targets
@@ -21,7 +21,7 @@
       <OSPlatform Condition=" '$(OSPlatform)' == '' AND '$(IsLinux)' == 'True' ">linux</OSPlatform>
 
       <BuildInfoPropsContent>
-&lt;Project ToolsVersion=&quot;14.0&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
+&lt;Project ToolsVersion=&quot;15.0&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
     &lt;PropertyGroup&gt;
         &lt;Rid&gt;$(Rid)&lt;/Rid&gt;
         &lt;Architecture&gt;$(Architecture)&lt;/Architecture&gt;

--- a/build/BundledRuntimes.props
+++ b/build/BundledRuntimes.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CoreSetupRid>$(HostRid)</CoreSetupRid>
     <CoreSetupRid Condition=" '$(HostOSName)' == 'win' or '$(HostOSName)' == 'osx' ">$(HostMonikerRid)</CoreSetupRid>

--- a/build/BundledSdks.props
+++ b/build/BundledSdks.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <BundledSdk Include="NuGet.Build.Tasks.Pack" Version="$(CLI_NuGet_Version)" />
     <BundledSdk Include="Microsoft.NET.Sdk" Version="$(CLI_NETSDK_Version)" />

--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <BundledTemplate Include="Microsoft.DotNet.Common.ItemTemplates" Version="$(TemplateEngineTemplateVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(TemplateEngineTemplateVersion)" />

--- a/build/BundledTools.props
+++ b/build/BundledTools.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <BundledTools Include="MSBuild;
                            NuGet.CommandLine.XPlat;

--- a/build/CrossGen.props
+++ b/build/CrossGen.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <RuntimeNETCoreAppPackageName>runtime.$(SharedFrameworkRid).microsoft.netcore.app</RuntimeNETCoreAppPackageName>
     <CrossgenPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(CLI_SharedFrameworkVersion)/tools/crossgen$(ExeExtension)</CrossgenPath>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>2.1.0-preview2-25616-02</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.5.0-preview-000074-0946838</CLI_MSBuild_Version>

--- a/build/DerivedHostMachineInfo.props
+++ b/build/DerivedHostMachineInfo.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
       <IsDebianBaseDistro Condition=" '$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian' ">true</IsDebianBaseDistro>
       <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) ">true</IsRPMBasedDistro>

--- a/build/FileExtensions.props
+++ b/build/FileExtensions.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
       <ArchiveExtension Condition=" '$(HostOSName)' == 'win' ">.zip</ArchiveExtension>
       <ArchiveExtension Condition=" '$(HostOSName)' != 'win' ">.tar.gz</ArchiveExtension>

--- a/build/GenerateResxSource.targets
+++ b/build/GenerateResxSource.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <UsingTask TaskName="GenerateResxSource" AssemblyFile="$(CLIBuildDll)" />
 

--- a/build/GitCommitInfo.targets
+++ b/build/GitCommitInfo.targets
@@ -23,7 +23,7 @@
       <GitInfoCommitHash>%(GitInfoCommitHashLines.Identity)</GitInfoCommitHash>
 
       <GitCommitInfoPropsContent>
-&lt;Project ToolsVersion=&quot;15.0&quot;&gt;
+&lt;Project ToolsVersion=&quot;15.0&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
     &lt;PropertyGroup&gt;
         &lt;CommitCount&gt;$(GitInfoCommitCount)&lt;/CommitCount&gt;
         &lt;CommitHash&gt;$(GitInfoCommitHash)&lt;/CommitHash&gt;

--- a/build/HostInfo.targets
+++ b/build/HostInfo.targets
@@ -10,7 +10,7 @@
 
     <PropertyGroup>
       <HostInfoPropsContent>
-&lt;Project ToolsVersion=&quot;15.0&quot;&gt;
+&lt;Project ToolsVersion=&quot;15.0&quot; xmlns=&quot;http://schemas.microsoft.com/developer/msbuild/2003&quot;&gt;
     &lt;PropertyGroup&gt;
         &lt;HostRid&gt;$(HostRid)&lt;/HostRid&gt;
         &lt;HostOSName&gt;$(HostOSName)&lt;/HostOSName&gt;

--- a/build/InputDirectories.props
+++ b/build/InputDirectories.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <DotnetCliBuildDirectory>$(RepoRoot)/build_projects/dotnet-cli-build</DotnetCliBuildDirectory>
     <SrcDirectory>$(RepoRoot)/src</SrcDirectory>

--- a/build/InstallerInfo.props
+++ b/build/InstallerInfo.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <InstallerOutputDirectory>$(PackagesDirectory)</InstallerOutputDirectory>
     <SdkInstallerFile>$(InstallerOutputDirectory)/$(ArtifactNameWithVersionSdk)$(InstallerExtension)</SdkInstallerFile>

--- a/build/MSBuildExtensions.props
+++ b/build/MSBuildExtensions.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildImportsDir>$(RepoRoot)/resources/MSBuildImports</MSBuildImportsDir>
   </PropertyGroup>

--- a/build/OutputDirectories.props
+++ b/build/OutputDirectories.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
       <CliBuildStage Condition="'$(CliBuildStage)' == '' And '$(CliOuterBuildStage)' != ''">$([MSBuild]::Add($(CliOuterBuildStage), '1'))</CliBuildStage>
       <CliBuildStage Condition="'$(CliBuildStage)' == ''">2</CliBuildStage>

--- a/build/SetupPreviousStage.props
+++ b/build/SetupPreviousStage.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup Condition="'$(PreviousStageProps)' == ''">
       <PreviousStageDirectory>$(RepoRoot)/.dotnet_stage0/$(Architecture)</PreviousStageDirectory>
       <PreviousStageDotnet>$(PreviousStageDirectory)/dotnet$(ExeExtension)</PreviousStageDotnet>

--- a/build/Signing.proj
+++ b/build/Signing.proj
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project InitialTargets="SetSigningProperties" DefaultTargets="SignFiles" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <!-- The signing infrastructure runs using MSBuild 14, which doesn't support some of the new syntax we're using.  So set the BuildingSingingProject
+         property here to avoid importing files we don't need for signing which would cause errors if imported when using MSBuild 14. -->
+    <BuildingSigningProject>true</BuildingSigningProject>
+  </PropertyGroup>
+  
   <Import Project="..\dir.props" />
   <Import Project="MicroBuild.props" />
   <Import Project="$(MicroBuildPropsAndTargetsPath)MicroBuild.Core.props" />

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VersionMajor>2</VersionMajor>
     <VersionMinor>1</VersionMinor>

--- a/build/VersionBadge.props
+++ b/build/VersionBadge.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VersionBadgeMoniker>$(OSName)_$(Architecture)</VersionBadgeMoniker>
     <VersionBadgeMoniker Condition=" '$(HostRid)' == 'debian.8-x64' ">debian_8_x64</VersionBadgeMoniker>

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -96,6 +96,11 @@
 
     <ItemGroup>
       <TestSdkRpmTaskEnvironmentVariables Include="PATH=$(RpmInstalledDirectory)$(PathListSeparator)$(PATH)" />
+      <TestSdkRpmTaskEnvironmentVariables Include="TEST_ARTIFACTS=$(TestArtifactsDir)" />
+      <TestSdkRpmTaskEnvironmentVariables Include="TEST_PACKAGES=$(TestPackagesDir)" />
+      <TestSdkRpmTaskEnvironmentVariables Include="PreviousStageProps=$(NextStagePropsPath)" />
+
+      <!-- Consumed By Publish -->
       <GeneratedInstallers Include="$(SdkInstallerFile)" />
     </ItemGroup>
 

--- a/dir.props
+++ b/dir.props
@@ -1,4 +1,4 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Projects which don't import the common targets can import this dir.props file in order to get the common repo build logic -->
   <Import Project="Directory.Build.props" />
 </Project>


### PR DESCRIPTION
Together with #7593, this should fix the signing build, by making sure that all files imported during the signing build are compatible with MSBuild 14.