### PR TITLE
Fix update-dependencies.

### DIFF
--- a/build_projects/update-dependencies/Directory.Build.props
+++ b/build_projects/update-dependencies/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+<!--
+  Empty Directory.Build.props so the repo's root Directory.Build.props isn't imported,
+  since it imports generated .props files that aren't necessary for update-dependencies.
+-->
+  
+</Project>

--- a/build_projects/update-dependencies/update-dependencies.ps1
+++ b/build_projects/update-dependencies/update-dependencies.ps1
@@ -34,6 +34,8 @@ if (!$env:DOTNET_INSTALL_DIR)
     $env:DOTNET_INSTALL_DIR="$RepoRoot\.dotnet_stage0\$Architecture"
 }
 
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
 # Install a stage 0
 Write-Output "Installing .NET Core CLI Stage 0"
 & "$RepoRoot\scripts\obtain\dotnet-install.ps1" -Channel "master" -Architecture $Architecture
@@ -41,11 +43,6 @@ if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
 # Put the stage0 on the path
 $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
-
-# Restore the app
-Write-Output "Restoring $ProjectPath..."
-dotnet restore "$ProjectPath"
-if($LASTEXITCODE -ne 0) { throw "Failed to restore" }
 
 # Run the app
 Write-Output "Invoking App $ProjectPath..."

--- a/build_projects/update-dependencies/update-dependencies.sh
+++ b/build_projects/update-dependencies/update-dependencies.sh
@@ -30,6 +30,8 @@ if [ -z "${DOTNET_INSTALL_DIR:-}" ]; then
    export DOTNET_INSTALL_DIR=$REPO_ROOT/.dotnet_stage0/x64
 fi
 
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
 # Install a stage 0
 echo "Installing .NET Core CLI Stage 0"
 $REPO_ROOT/scripts/obtain/dotnet-install.sh -Channel master -Architecture x64
@@ -41,14 +43,6 @@ fi
 
 # Put the stage 0 on the path
 export PATH=$DOTNET_INSTALL_DIR:$PATH
-
-echo "Restoring $PROJECT_PATH..."
-dotnet restore "$PROJECT_PATH"
-
-if [ $? -ne 0 ]; then
-    echo "Failed to restore"
-    exit 1
-fi
 
 echo "Invoking App $PROJECT_PATH..."
 dotnet run -p "$PROJECT_PATH" $@


### PR DESCRIPTION
Don't import the root Directory.Build.props during update-dependencies because it imports generated .props files that don't exist outside of the build.