### PR TITLE
Fix update-dependencies by using the correct TFM.

### DIFF
--- a/build_projects/update-dependencies/update-dependencies.csproj
+++ b/build_projects/update-dependencies/update-dependencies.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Description>Updates the repos dependencies</Description>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
stage0 comes with 2.1 runtime now, so need to use netcoreapp2.1.

This worked on my machine because `2.0.0` is installed in ProgramFiles.  However, failed when run on a clean build agent.

Fixing again. PTAL.
