### PR TITLE
Do not bump self-contained app framework version [1.1.x]

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -18,7 +18,7 @@
     <CLI_MSBuild_Version>15.3.409</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_FSharp_Version>4.2.0-rc-170630-0</CLI_FSharp_Version>
-    <CLI_NETSDK_Version>1.1.1-svc-20170822-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>1.1.0-alpha-20170726-4</CLI_NETSDK_Version>
     <CLI_NuGet_Version>4.3.0-rtm-4324</CLI_NuGet_Version>
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>


### PR DESCRIPTION
The only change since 1.1.0 SDK was to bump self-contained app version, which we no longer want to do.

This reverts commit b66ad963fd605723244da54df6170723afe6f170.