### PR TITLE
Moving the runtime dependency to 1.0.7 and 1.1.4.

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>1.1.3</CLI_SharedFrameworkVersion>
-    <CLI_CoreCLRVersion>1.1.3</CLI_CoreCLRVersion>
-    <CLI_JitVersion>1.1.3</CLI_JitVersion>
+    <CLI_SharedFrameworkVersion>1.1.4</CLI_SharedFrameworkVersion>
+    <CLI_CoreCLRVersion>1.1.4</CLI_CoreCLRVersion>
+    <CLI_JitVersion>1.1.4</CLI_JitVersion>
     <CLI_SharedHostVersion>1.1.0</CLI_SharedHostVersion>
     <CLI_HostFxrContainerVersion>1.1.0</CLI_HostFxrContainerVersion>
     <CLI_HostFxrVersion Condition="'$(OS)' != 'Windows_NT'">1.1.0</CLI_HostFxrVersion>
     <CLI_HostFxrVersion Condition="'$(OS)' == 'Windows_NT'">1.1.2</CLI_HostFxrVersion>
 
-    <CLI_SharedFrameworkVersion_1_0>1.0.6</CLI_SharedFrameworkVersion_1_0>
+    <CLI_SharedFrameworkVersion_1_0>1.0.7</CLI_SharedFrameworkVersion_1_0>
     <CLI_SharedHostVersion_1_0>1.0.1</CLI_SharedHostVersion_1_0>
     <CLI_HostFxrContainerVersion_1_0>1.0.1</CLI_HostFxrContainerVersion_1_0>
     <CLI_HostFxrVersion_1_0 Condition="'$(OS)' != 'Windows_NT'">1.0.1</CLI_HostFxrVersion_1_0>

--- a/build_projects/dotnet-cli-build/GenerateNuGetPackagesArchiveVersion.cs
+++ b/build_projects/dotnet-cli-build/GenerateNuGetPackagesArchiveVersion.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Cli.Build
                 {
                     ToolPath = ToolPath,
                     TemplateType = newArgs[0],
-                    TemplateArgs = newArgs[1] + $" --debug:ephemeral-hive -n TempProject -o \"{outputDir}\"",
+                    TemplateArgs = newArgs[1] + $" --no-restore --debug:ephemeral-hive -n TempProject -o \"{outputDir}\"",
                     HostObject = HostObject,
                     BuildEngine = BuildEngine
                 };

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -308,7 +308,7 @@ namespace Microsoft.DotNet.Tests
 
             result.Should().NotBeNull();
 
-            result.Args.Should().Contain("--fx-version 1.1.3");
+            result.Args.Should().Contain("--fx-version 1.1.4");
         }
 
         [Fact]


### PR DESCRIPTION
@dotnet/dotnet-cli @leecow @eerhardt 
