### PR TITLE
MSBuild 15.5.90

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>2.1.0-preview1-25719-04</CLI_SharedFrameworkVersion>
-    <CLI_MSBuild_Version>15.5.0-preview-000074-0946838</CLI_MSBuild_Version>
+    <CLI_MSBuild_Version>15.5.0-preview-000090-0999971</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.3.2-beta1-61921-05</CLI_Roslyn_Version>
     <CLI_Roslyn_Satellites_Version>2.3.0-pre-20170727-1</CLI_Roslyn_Satellites_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>


### PR DESCRIPTION
Update MSBuild to 15.5.90 (package version [15.5.0-preview-000090-0999971](https://dotnet.myget.org/feed/msbuild/package/nuget/Microsoft.Build/15.5.0-preview-000090-0999971)).

Major changes:
https://github.com/Microsoft/msbuild/pull/2513 - Significant perf gain in Linux builds (reduces lock contention).
https://github.com/Microsoft/msbuild/pull/2414 - Add support for `/restore` parameter. This will enable the CLI to not call MSBuild twice (should significantly reduce JIT). Just add `/restore` to any command that you want the `Restore` target to run first.