### PR TITLE
Fix issue and minor cleanup of the RHEL 6 support

### DIFF
--- a/build/BuildDefaults.props
+++ b/build/BuildDefaults.props
@@ -3,7 +3,7 @@
     <CLITargets Condition=" '$(CLITargets)' == '' ">Prepare;Compile;Test;Package;Publish</CLITargets>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <IncludeNuGetPackageArchive Condition=" '$(IncludeNuGetPackageArchive)' == '' ">true</IncludeNuGetPackageArchive>
-    <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND $(HostRid.StartsWith('rhel.6')) ">true</SkipBuildingInstallers>
+    <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND $(Rid.StartsWith('rhel.6')) ">true</SkipBuildingInstallers>
     <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' ">false</SkipBuildingInstallers>
     <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(OSPlatform)' == 'linux' AND '$(Rid)' != 'rhel.6-x64' ">true</UsePortableLinuxSharedFramework>
     <IncludeSharedFrameworksForBackwardsCompatibilityTests Condition=" $(IncludeSharedFrameworksForBackwardsCompatibilityTests) == '' AND '$(Rid)' != 'linux-x64' AND '$(Rid)' != 'rhel.6-x64' ">true</IncludeSharedFrameworksForBackwardsCompatibilityTests>


### PR DESCRIPTION
This change fixes extraction of the unprocessed args and also implements
few minor changes that @eerhardt has asked for, like renaming the new argument
and changing usage of HostRid to Rid in build/BuildDefaults.props.
