### PR TITLE
Insert SDK 2.0.2-vspre-20170921-5

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,7 +12,7 @@
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
          cases, so use separate properties but derive one from the other unless we want to
          explicitly use different versions. -->
-    <CLI_NETSDK_Version>2.0.2-vspre-20170915-1</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.0.2-vspre-20170921-5</CLI_NETSDK_Version>
     <CLI_MSBuildExtensions_Version>$(CLI_NETSDK_Version)</CLI_MSBuildExtensions_Version>
 
     <CLI_NuGet_Version>4.4.0-preview3-4475</CLI_NuGet_Version>


### PR DESCRIPTION
Insert SDK 2.0.2-vspre-20170921-5

This includes https://github.com/dotnet/sdk/pull/1585, which syncs to the right NuGet version