### PR TITLE
Fix issues caused by adding RHEL6 support

### DIFF
--- a/run-build.sh
+++ b/run-build.sh
@@ -171,8 +171,8 @@ echo "${args[@]}"
 
 if [ $BUILD -eq 1 ]; then
     dotnet msbuild build.proj /p:Architecture=$ARCHITECTURE $CUSTOM_BUILD_ARGS /p:GeneratePropsFile=true /t:WriteDynamicPropsToStaticPropsFiles
-    dotnet msbuild build.proj /m /v:normal /fl /flp:v=diag /p:Architecture=$ARCHITECTURE $CUSTOM_BUILD_ARGS "${args[@]}"
+    dotnet msbuild build.proj /m /v:normal /fl /flp:v=diag /p:Architecture=$ARCHITECTURE $CUSTOM_BUILD_ARGS $args
 else
     echo "Not building due to --nobuild"
-    echo "Command that would be run is: 'dotnet msbuild build.proj /m /p:Architecture=$ARCHITECTURE $CUSTOM_BUILD_ARGS ${args[@]}'"
+    echo "Command that would be run is: 'dotnet msbuild build.proj /m /p:Architecture=$ARCHITECTURE $CUSTOM_BUILD_ARGS $args'"
 fi

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -207,7 +207,8 @@ check_pre_reqs() {
             LDCONFIG_COMMAND="ldconfig"
         fi
 
-        LDCONFIG_COMMAND="$LDCONFIG_COMMAND -NXv ${LD_LIBRARY_PATH//:/ }"
+        local librarypath=${LD_LIBRARY_PATH:-}
+        LDCONFIG_COMMAND="$LDCONFIG_COMMAND -NXv ${librarypath//:/ }"
 
         [ -z "$($LDCONFIG_COMMAND | grep libunwind)" ] && say_err "Unable to locate libunwind. Install libunwind to continue" && failing=true
         [ -z "$($LDCONFIG_COMMAND | grep libssl)" ] && say_err "Unable to locate libssl. Install libssl to continue" && failing=true


### PR DESCRIPTION
There were two issues. One was that additional arguments that are not
recognized by the build.sh script were incorrectly passed as a single
argument in single-quotes to msbuild.
The second issue was that when LD_LIBRARY_PATH was not set, the
dotnet-install.sh script was failing due to its using of the "set -u"
option that prevents usage of unset variables.

Fix https://github.com/dotnet/cli/issues/7698