### PR TITLE
Obtain ASP.NET templates from new source

### DIFF
--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -1,10 +1,10 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <BundledTemplate Include="Microsoft.DotNet.Common.ItemTemplates" Version="$(TemplateEngineTemplateVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(TemplateEngineTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(AspNetTemplateVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" Version="$(TemplateEngineTemplate2_0Version)" />
     <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="$(TemplateEngineTemplateVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="$(TemplateEngineTemplateVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(SpaTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="$(AspNetTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(AspNetTemplateVersion)" />
   </ItemGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -30,9 +30,9 @@
     <CliCommandLineParserVersion>0.1.1-alpha-167</CliCommandLineParserVersion>
     <CliMigrateVersion>1.2.1-alpha-002133</CliMigrateVersion>
     <MicroBuildVersion>0.2.0</MicroBuildVersion>
-    <SpaTemplateVersion>1.0.417</SpaTemplateVersion>
     <XliffTasksVersion>0.2.0-beta-000042</XliffTasksVersion>
     <DotNetCliArchiverVersion>0.2.0-beta-000059</DotNetCliArchiverVersion>
+    <AspNetTemplateVersion>2.1.0-preview1-10249</AspNetTemplateVersion>
     <AspNetCoreRuntimePackageBrandName>aspnetcore-store</AspNetCoreRuntimePackageBrandName>
     <AspNetCoreRuntimePackageFolderName>dev-26623</AspNetCoreRuntimePackageFolderName>
     <AspNetCoreRuntimePackageVersion>2.1.0-preview1-26623</AspNetCoreRuntimePackageVersion>


### PR DESCRIPTION
Soon, the `AspNetTemplateVersion` prop will be updated by the automatic PRs.

But first we need to be sure this builds OK and produces the right result. It might be that it's not yet able to find these packages - it depends on how the package sources are configured. Will check.