### PR TITLE
Add Dockerfile for RHEL 6 builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ if [ -z "$HOME" ]; then
     mkdir -p $HOME
 fi
 
-args=( "$@" )
+args=
 
 while [[ $# > 0 ]]; do
     lowerI="$(echo $1 | awk '{print tolower($0)}')"
@@ -32,22 +32,14 @@ while [[ $# > 0 ]]; do
         --docker)
             export BUILD_IN_DOCKER=1
             export DOCKER_IMAGENAME=$2
-            # remove docker args
-            args=( "${args[@]/$1}" )
-            args=( "${args[@]/$2}" )
             shift
             ;;
         *)
+            args="$args $1"
+            ;;
     esac
     shift
 done
-
-# $args array may have empty elements in it.
-# The easiest way to remove them is to cast to string and back to array.
-# This will actually break quoted arguments, arguments like 
-# -test "hello world" will be broken into three arguments instead of two, as it should.
-temp="${args[@]}"
-args=($temp)
 
 dockerbuild()
 {
@@ -56,7 +48,7 @@ dockerbuild()
 
 # Check if we need to build in docker
 if [ ! -z "$BUILD_IN_DOCKER" ]; then
-    dockerbuild "${args[@]}"
+    dockerbuild $args
 else
-    $DIR/run-build.sh "${args[@]}"
+    $DIR/run-build.sh $args
 fi

--- a/scripts/docker/rhel.6/Dockerfile
+++ b/scripts/docker/rhel.6/Dockerfile
@@ -1,0 +1,42 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# Dockerfile that creates a container suitable to build dotnet-cli
+FROM microsoft/dotnet-buildtools-prereqs:centos-6-783abde-20171304101322
+
+# Install prerequisites for the git build below
+RUN yum -q -y install sudo expat-devel perl-devel autoconf gcc gcc-c++ gettext-devel
+
+# Compile and install a version of the git that supports the features that cli build needs
+RUN \
+    wget https://www.kernel.org/pub/software/scm/git/git-2.9.5.tar.gz && \
+    tar -xf git-2.9.5.tar.gz && \
+    cd  git-2.9.5 && \
+    make configure && \
+    ./configure --prefix=/usr/local --without-tcltk && \
+    make -j $(nproc --all) all && \
+    make install && \
+    cd .. && \
+    rm -r git-2.9.5
+
+# Setup User to match Host User, and give superuser permissions
+ARG USER_ID=0
+RUN useradd -m code_executor -u ${USER_ID} -g root
+RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# With the User Change, we need to change permssions on these directories
+RUN chmod -R a+rwx /usr/local
+RUN chmod -R a+rwx /home
+RUN chmod -R 755 /usr/bin/sudo
+
+# Set user to the one we just created
+USER ${USER_ID}
+
+# Set library path to make CURL and ICU libraries that are in /usr/local/lib visible
+ENV LD_LIBRARY_PATH /usr/local/lib
+
+# Set working directory
+WORKDIR /opt/code
+


### PR DESCRIPTION
This change enables building CLI for RHEL 6 in docker container. I also needed to fix one more place where the parameters were being parsed in a way that was causing a problem if the argument value string matched a substring of another argument. Like ` --runtime-id rhel.6-x64 --docker rhel.6` in the RHEL 6 build.

The Dockerfile builds and installs more recent git that in necessary for building CLI. I will later move it to the original docker image that the image we are building is based on. It takes about a minute only though, so it is not causing a problem.