### PR TITLE
Update satellite assemblies and fix up roslyn satellite handling

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,10 +4,10 @@
     <CLI_SharedFrameworkVersion>2.0.1</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.5.0-preview-000113-1032064</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.6.0-beta1-62126-01</CLI_Roslyn_Version>
-    <CLI_Roslyn_Satellites_Version>2.3.0-pre-20170727-1</CLI_Roslyn_Satellites_Version>
+    <CLI_Roslyn_Satellites_Version>2.6.0-pre-20171003-1</CLI_Roslyn_Satellites_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>
     <CLI_FSharp_Version>4.2.0-rtm-170926-0</CLI_FSharp_Version>
-    <CLI_FSharp_Satellites_Version>4.4.1-pre-20170727-1</CLI_FSharp_Satellites_Version>
+    <CLI_FSharp_Satellites_Version>4.4.1-pre-20171003-1</CLI_FSharp_Satellites_Version>
 
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
          cases, so use separate properties but derive one from the other unless we want to

--- a/build/Microsoft.DotNet.Cli.tasks
+++ b/build/Microsoft.DotNet.Cli.tasks
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Test" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="AddMetadataIsPE" AssemblyFile="$(CLIBuildDll)" />
+  <UsingTask TaskName="AddToDeps" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="ChangeEntryPointLibraryName" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="CheckIfAllBuildsHavePublished" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="ChMod" AssemblyFile="$(CLIBuildDll)" />

--- a/build_projects/dotnet-cli-build/AddToDeps.cs
+++ b/build_projects/dotnet-cli-build/AddToDeps.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Linq;
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Microsoft.Extensions.DependencyModel;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    /// <summary>
+    /// Merges additional .deps.json files into target .deps.json files.
+    /// </summary>
+    public class AddToDeps : Task
+    {
+        /// <summary>
+        /// Paths to target .deps.json files, into which <see cref="AdditionalDeps" /> will be merged.
+        /// These files will be overwritten with the merge result.
+        /// </summary>
+        [Required]
+        public string[] TargetDeps { get; set; }
+
+        /// <summary>
+        /// Paths to additional .deps.json files to merge into <see cref="TargetDeps" />.
+        /// </summary>
+        [Required]
+        public string[] AdditionalDeps { get; set; }
+
+        public override bool Execute()
+        {
+            DependencyContext additionalContext = Read(AdditionalDeps.First());
+
+            foreach (string additionalPath in AdditionalDeps.Skip(1))
+            {
+                additionalContext = additionalContext.Merge(Read(additionalPath));
+            }
+
+            foreach (string targetPath in TargetDeps)
+            {
+                DependencyContext targetContext = Read(targetPath).Merge(additionalContext);
+                Write(targetContext, targetPath);
+            }
+
+            return true;
+        }
+
+        private static DependencyContext Read(string path)
+        {
+            using (FileStream stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader = new DependencyContextJsonReader())
+            {
+                return reader.Read(stream);
+            }
+        }
+
+        private static void Write(DependencyContext context, string path)
+        {
+            using (FileStream stream = File.Open(path, FileMode.Create, FileAccess.Write, FileShare.Read))
+            {
+                var writer = new DependencyContextWriter(); // unlike reader, writer is not disposable
+                writer.Write(context, stream);
+            }
+        }
+    }
+}

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -29,5 +29,6 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="$(CLI_MSBuild_Version)" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="$(VersionToolsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
  </ItemGroup>
 </Project>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -24,9 +24,6 @@
     <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(CLI_Roslyn_Version)">
       <ExcludeAssets>All</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="CliDeps.Satellites.Roslyn" Version="$(CLI_Roslyn_Satellites_Version)">
-      <ExcludeAssets>All</ExcludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -77,23 +74,31 @@
           
     <ItemGroup>
       <RoslynBits Include="$(NuGetPackagesDir)/microsoft.netcore.compilers/$(CLI_Roslyn_Version)/tools/**/*" />
-      <RoslynSatelliteBits Include="$(NuGetPackagesDir)/clideps.satellites.roslyn/$(CLI_Roslyn_Satellites_Version)/lib/netstandard1.0/**/*" />
     </ItemGroup>
     <Copy SourceFiles="@(RoslynBits)" DestinationFiles="@(RoslynBits->'$(RoslynDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(RoslynSatelliteBits)" DestinationFiles="@(RoslynSatelliteBits->'$(RoslynDirectory)/bincore/%(RecursiveDir)%(Filename)%(Extension)')" />
     <ItemGroup>
-      <RetargetRuntimeConfigPaths Include="$(RoslynDirectory)/bincore/csc.runtimeconfig.json" />
-      <RetargetRuntimeConfigPaths Include="$(RoslynDirectory)/bincore/vbc.runtimeconfig.json" />
+      <RoslynRuntimeConfigs Include="$(RoslynDirectory)/bincore/csc.runtimeconfig.json" />
+      <RoslynRuntimeConfigs Include="$(RoslynDirectory)/bincore/vbc.runtimeconfig.json" />
+      <RoslynDeps Include="$(RoslynDirectory)/bincore/csc.deps.json" />
+      <RoslynDeps Include="$(RoslynDirectory)/bincore/vbc.deps.json" />
+      <RoslynSatelliteDeps Include="$(RoslynDirectory)/bincore/tool_roslyn_satellites.deps.json" />
     </ItemGroup>
     <PropertyGroup>
       <ReplacementPattern>"version": ".*"</ReplacementPattern>
       <ReplacementString>"version": "$(CLI_SharedFrameworkVersion)"</ReplacementString>
     </PropertyGroup>
     <ReplaceFileContents
-      InputFile="%(RetargetRuntimeConfigPaths.Identity)"
-      DestinationFile="%(RetargetRuntimeConfigPaths.Identity)"
+      InputFile="%(RoslynRuntimeConfigs.Identity)"
+      DestinationFile="%(RoslynRuntimeConfigs.Identity)"
       ReplacementPatterns="$(ReplacementPattern)"
       ReplacementStrings="$(ReplacementString)" />
+    <DotNetPublish
+      ToolPath="$(Stage0Directory)"
+      Configuration="$(Configuration)"
+      ProjectPath="$(SrcDirectory)/tool_roslyn_satellites/tool_roslyn_satellites.csproj" />
+    <AddToDeps TargetDeps="@(RoslynDeps)" AdditionalDeps="@(RoslynSatelliteDeps)" />
+    <Delete Files="@(RoslynSatelliteDeps)" />
   </Target>
 
   <Target Name="PublishFSharp"

--- a/src/tool_roslyn_satellites/tool_roslyn_satellites.csproj
+++ b/src/tool_roslyn_satellites/tool_roslyn_satellites.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.tasks" />
+
+  <PropertyGroup>
+    <VersionPrefix>$(CliVersionPrefix)</VersionPrefix>
+    <TargetFramework>$(CliTargetFramework)</TargetFramework>
+    <RuntimeFrameworkVersion>$(CLI_SharedFrameworkVersion)</RuntimeFrameworkVersion>
+    <PublishDir>$(RoslynDirectory)/bincore</PublishDir>
+    <VersionSuffix>$(CommitCount)</VersionSuffix>
+    <GenerateRuntimeConfigurationFiles>false</GenerateRuntimeConfigurationFiles>
+    <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>
+    <CopyOutputSymbolsToPublishDirectory>false</CopyOutputSymbolsToPublishDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NetCore.App" Version="$(CLI_SharedFrameworkVersion)" />
+    <PackageReference Include="CliDeps.Satellites.Roslyn" Version="$(CLI_Roslyn_Satellites_Version)" />
+  </ItemGroup>
+
+  <Target Name="MoveBuildTasksSatellitesAndRemoveBuildOutputAsset"
+        AfterTargets="Publish">
+
+    <RemoveAssetFromDepsPackages DepsFile="$(PublishDir)/$(TargetName).deps.json"
+                                 SectionName="runtime"
+                                 AssetPath="$(TargetFileName)" />
+
+    <ItemGroup>
+      <BuildTaskSatellites Include="$(PublishDir)/**/Microsoft.Build.Tasks.CodeAnalysis.resources.dll" />
+    </ItemGroup>
+
+    <Move SourceFiles="@(BuildTaskSatellites)"
+          DestinationFiles="@(BuildTaskSatellites->'$(PublishDir)/../%(RecursiveDir)/%(Filename)%(Extension)')" />
+  </Target>
+</Project>


### PR DESCRIPTION
1. Publish satellites with a separate project and merge the resulting .deps.json into (csc|vbc).deps.json

2. Move the build tasks satellites to the correct location next to main assembly (one level higher than bincore\)

3. Update roslyn satellite package to 2.6.x to get matching assembly version and updated strings

4. Update F# satellite package

Marked *no merge* because the CliDeps.Satellites being ingested isn't real-signed.