### PR TITLE
Moving the runtime version to 2.0.0 for the SDK.

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>2.0.1</CLI_SharedFrameworkVersion>
+    <CLI_SharedFrameworkVersion>2.0.0</CLI_SharedFrameworkVersion>
     <CLI_MSBuild_Version>15.5.0-preview-000113-1032064</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.6.0-beta1-62126-01</CLI_Roslyn_Version>
     <CLI_Roslyn_Satellites_Version>2.3.0-pre-20170727-1</CLI_Roslyn_Satellites_Version>

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -309,7 +309,7 @@ namespace Microsoft.DotNet.Tests
 
             result.Should().NotBeNull();
 
-            result.Args.Should().Contain("--fx-version 2.0.1");
+            result.Args.Should().Contain("--fx-version 2.0.0");
         }
 
         [Fact]


### PR DESCRIPTION
@dotnet/dotnet-cli 

The 2.0.1 runtime we were referencing has not been release.
