### PR TITLE
Update the SDK to 2.1.0-preview1-20171006-4

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -12,7 +12,7 @@
     <!-- We'll usually want to keep these versions in sync, but we may want to diverge in some
          cases, so use separate properties but derive one from the other unless we want to
          explicitly use different versions. -->
-    <CLI_NETSDK_Version>2.1.0-preview1-20170927-2</CLI_NETSDK_Version>
+    <CLI_NETSDK_Version>2.1.0-preview1-20171006-4</CLI_NETSDK_Version>
     <CLI_MSBuildExtensions_Version>$(CLI_NETSDK_Version)</CLI_MSBuildExtensions_Version>
 
     <CLI_NuGet_Version>4.4.0-preview3-4475</CLI_NuGet_Version>


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/7691 by bringing the SDK with the necessary change.

@dotnet/dotnet-cli 