### PR TITLE
Fix tool json flakiness

### DIFF
--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -267,14 +267,8 @@ namespace Microsoft.DotNet.Tests
 
             var lockFile = new LockFileFormat().Read(lockFilePath);
 
-            var depsJsonFile = Path.Combine(
-                Path.GetDirectoryName(lockFilePath),
-                "dotnet-portable.deps.json");
-
-            if (File.Exists(depsJsonFile))
-            {
-                File.Delete(depsJsonFile);
-            }
+            // NOTE: We must not use the real deps.json path here as it will interfere with tests running in parallel.
+            var depsJsonFile = Path.GetTempFileName();
             File.WriteAllText(depsJsonFile, "temp");
 
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();


### PR DESCRIPTION
Tests often fail in CI with:
```
A JSON parsing exception occurred in [D:\j\workspace\debug_windows---bc3c3f12\.nuget\packages\.tools\dotnet-portable\1.0.0\netcoreapp2.0\dotnet-portable.deps.json]:
 * Line 1, Column 2 Syntax error: Malformed literal
```

Turns out there's a test that deliberately writes "temp" to this file and other tests can observe that in parallel. :trollface: 

Fix #4660 
