### PR TITLE
Fix RHEL 6 Dockerfile

### DIFF
--- a/scripts/docker/rhel.6/Dockerfile
+++ b/scripts/docker/rhel.6/Dockerfile
@@ -6,7 +6,9 @@
 # Dockerfile that creates a container suitable to build dotnet-cli
 FROM microsoft/dotnet-buildtools-prereqs:centos-6-d485f41-20173404063424
 
-RUN yum -q -y install sudo
+# yum doesn't work with the special curl version we have in the base docker image,
+# so we remove /usr/local/lib from the library path for this command
+RUN LD_LIBRARY_PATH= yum -q -y install sudo
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0


### PR DESCRIPTION
The new base docker image sets the LD_LIBRARY_PATH to /usr/local/lib
and the yum is not compatible with the special CURL version we build.
This change fixes that by clearing the LD_LIBRARY_PATH for the yum
command invocation.
