### PR TITLE
Updating the websdk version to 2.0.0-rel-20171010-665

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -17,7 +17,7 @@
 
     <CLI_NuGet_Version>4.4.0-preview3-4475</CLI_NuGet_Version>
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.0-preview3-25514-04</CLI_NETStandardLibraryNETFrameworkVersion>
-    <CLI_WEBSDK_Version>2.0.0-rel-20170908-653</CLI_WEBSDK_Version>
+    <CLI_WEBSDK_Version>2.0.0-rel-20171010-665</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.3.0-preview-20170628-02</CLI_TestPlatform_Version>
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>


### PR DESCRIPTION
Package available here - https://dotnet.myget.org/feed/dotnet-web/package/nuget/Microsoft.NET.Sdk.Publish/2.0.0-rel-20171010-665

Bug fix: https://github.com/aspnet/websdk/pull/244/files

@nguerrera @mlorbetske 
