### PR TITLE
Update CentOS 6 base docker image

### DIFF
--- a/scripts/docker/rhel.6/Dockerfile
+++ b/scripts/docker/rhel.6/Dockerfile
@@ -4,11 +4,11 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM microsoft/dotnet-buildtools-prereqs:centos-6-d485f41-20173404063424
+FROM microsoft/dotnet-buildtools-prereqs:centos-6-376e1a3-20174311014331
 
 # yum doesn't work with the special curl version we have in the base docker image,
 # so we remove /usr/local/lib from the library path for this command
-RUN LD_LIBRARY_PATH= yum -q -y install sudo
+RUN yum -q -y install sudo
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0


### PR DESCRIPTION
This update fixes problem with git not supporting https protocol (which
wasn't affecting cli, but the other repos). The image now has a build of
CURL that supports file:// protocol and so I am removing the workaround
from the Dockerfile.

