### PR TITLE
Added a property to DependencyVersions.props for asp.net template version

### DIFF
--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -1,10 +1,16 @@
 <Project ToolsVersion="15.0">
   <ItemGroup>
     <BundledTemplate Include="Microsoft.DotNet.Common.ItemTemplates" Version="$(TemplateEngineTemplateVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(TemplateEngineTemplateVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.2.0" Version="$(TemplateEngineTemplate2_0Version)" />
     <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.0" Version="$(TemplateEngineTemplateVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.0" Version="$(TemplateEngineTemplateVersion)" />
+
     <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(SpaTemplateVersion)" />
+
+    <BundledTemplate Include="Microsoft.DotNet.Web.Client.ItemTemplates" Version="$(AspnetTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(AspnetTemplateVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.0" Version="$(AspnetTemplateVersion)" />
+	<!--
+    <BundledTemplate Include="Microsoft.AspNetCore.SpaTemplates" Version="$(AspnetTemplateVersion)" />
+	-->
   </ItemGroup>
 </Project>

--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -9,8 +9,5 @@
     <BundledTemplate Include="Microsoft.DotNet.Web.Client.ItemTemplates" Version="$(AspnetTemplateVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(AspnetTemplateVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.0" Version="$(AspnetTemplateVersion)" />
-	<!--
-    <BundledTemplate Include="Microsoft.AspNetCore.SpaTemplates" Version="$(AspnetTemplateVersion)" />
-	-->
   </ItemGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -22,9 +22,10 @@
     <SharedFrameworkVersion>$(CLI_SharedFrameworkVersion)</SharedFrameworkVersion>
     <SharedHostVersion>$(CLI_SharedFrameworkVersion)</SharedHostVersion>
     <HostFxrVersion>$(CLI_SharedFrameworkVersion)</HostFxrVersion>
-    <TemplateEngineVersion>1.0.0-beta2-20170810-304</TemplateEngineVersion>
-    <TemplateEngineTemplateVersion>1.0.0-beta2-20170810-304</TemplateEngineTemplateVersion>
-    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20170810-304</TemplateEngineTemplate2_0Version>
+    <TemplateEngineVersion>1.0.0-beta2-20171004-309</TemplateEngineVersion>
+    <TemplateEngineTemplateVersion>1.0.0-beta2-20171004-309</TemplateEngineTemplateVersion>
+    <TemplateEngineTemplate2_0Version>1.0.0-beta2-20171004-309</TemplateEngineTemplate2_0Version>
+    <AspnetTemplateVersion>1.0.0-beta2-20171004-309</AspnetTemplateVersion>
     <PlatformAbstractionsVersion>2.0.0</PlatformAbstractionsVersion>
     <DependencyModelVersion>2.0.0</DependencyModelVersion>
     <CliCommandLineParserVersion>0.1.1-alpha-167</CliCommandLineParserVersion>


### PR DESCRIPTION
The current values for the template engine versions & aspnet template versions are not the final 15.5 values. We're still waiting on a test sdk update before we can get the final versions. This PR uses the version in #7767. The PR is meant to setup the aspnet version handling.