### PR TITLE
MSBuild 15.5.153 (No Double Evaluation Fix)

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>2.0.0</CLI_SharedFrameworkVersion>
-    <CLI_MSBuild_Version>15.5.0-preview-000113-1032064</CLI_MSBuild_Version>
+    <CLI_MSBuild_Version>15.5.0-preview-000153-1054696</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.6.0-beta1-62126-01</CLI_Roslyn_Version>
     <CLI_Roslyn_Satellites_Version>2.6.0-pre-20171003-1</CLI_Roslyn_Satellites_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>


### PR DESCRIPTION
Up to: https://github.com/Microsoft/msbuild/commit/976cca8144a67fa684a2e1365306ee188191305a

Does not include https://github.com/Microsoft/msbuild/pull/2595

In case there are regressions, this is signed and ready to go.