### PR TITLE
MSBuild 15.5.154

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -15,7 +15,7 @@
     <CLI_NETSDK_Version>2.0.1-servicing-20170926-1</CLI_NETSDK_Version>
     <CLI_MSBuildExtensions_Version>$(CLI_NETSDK_Version)</CLI_MSBuildExtensions_Version>
 
-    <CLI_NuGet_Version>4.5.0-preview1-4526</CLI_NuGet_Version>
+    <CLI_NuGet_Version>4.5.0-preview2-4529</CLI_NuGet_Version>
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.0-preview3-25514-04</CLI_NETStandardLibraryNETFrameworkVersion>
     <CLI_WEBSDK_Version>2.0.0-rel-20171010-665</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.5.0-preview-20171009-10</CLI_TestPlatform_Version>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CLI_SharedFrameworkVersion>2.0.0</CLI_SharedFrameworkVersion>
-    <CLI_MSBuild_Version>15.5.0-preview-000113-1032064</CLI_MSBuild_Version>
+    <CLI_MSBuild_Version>15.5.0-preview-000154-1054573</CLI_MSBuild_Version>
     <CLI_Roslyn_Version>2.6.0-beta1-62126-01</CLI_Roslyn_Version>
     <CLI_Roslyn_Satellites_Version>2.6.0-pre-20171003-1</CLI_Roslyn_Satellites_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>


### PR DESCRIPTION
Contains Double Evaluation Fix: https://github.com/Microsoft/msbuild/pull/2595

RPS with NuGet not complete. To take this change you will need NuGet 4527 or greater.