### PR TITLE
Use temporary path for fake deps.json in test

### DIFF
--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -266,14 +266,8 @@ namespace Microsoft.DotNet.Tests
 
             var lockFile = new LockFileFormat().Read(lockFilePath);
 
-            var depsJsonFile = Path.Combine(
-                Path.GetDirectoryName(lockFilePath),
-                "dotnet-portable.deps.json");
-
-            if (File.Exists(depsJsonFile))
-            {
-                File.Delete(depsJsonFile);
-            }
+            // NOTE: We must not use the real deps.json path here as it will interfere with tests running in parallel.
+            var depsJsonFile = Path.GetTempFileName();
             File.WriteAllText(depsJsonFile, "temp");
 
             var projectToolsCommandResolver = SetupProjectToolsCommandResolver();


### PR DESCRIPTION
Porting from master to release/2.0.0 to let this propagate to the other branches.
