### PR TITLE
Use msbuild /restore instead of a separate process

### DIFF
--- a/src/dotnet/commands/dotnet-build/BuildCommand.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommand.cs
@@ -37,6 +37,8 @@ namespace Microsoft.DotNet.Tools.Build
 
             var appliedBuildOptions = result["dotnet"]["build"];
 
+            msbuildArgs.Add($"/clp:Summary");
+
             if (appliedBuildOptions.HasOption("--no-incremental"))
             {
                 msbuildArgs.Add("/t:Rebuild");
@@ -49,8 +51,6 @@ namespace Microsoft.DotNet.Tools.Build
             msbuildArgs.AddRange(appliedBuildOptions.OptionValuesToBeForwarded());
 
             msbuildArgs.AddRange(appliedBuildOptions.Arguments);
-
-            msbuildArgs.Add($"/clp:Summary");
 
             bool noRestore = appliedBuildOptions.HasOption("--no-restore");
 

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tools.Restore
         {
         }
 
-        public static RestoreCommand FromArgs(string[] args, string msbuildPath = null)
+        public static RestoreCommand FromArgs(string[] args, string msbuildPath = null, bool noLogo = true)
         {
             DebugHelper.HandleDebugSwitch(ref args);
 
@@ -36,11 +36,6 @@ namespace Microsoft.DotNet.Tools.Restore
                 "/NoLogo",
                 "/t:Restore"
             };
-
-            if (!HasVerbosityOption(parsedRestore))
-            {
-                msbuildArgs.Add("/ConsoleLoggerParameters:Verbosity=Minimal");
-            }
 
             msbuildArgs.AddRange(parsedRestore.OptionValuesToBeForwarded());
 
@@ -64,13 +59,6 @@ namespace Microsoft.DotNet.Tools.Restore
             }
             
             return cmd.Execute();
-        }
-
-        private static bool HasVerbosityOption(AppliedOption parsedRestore)
-        {
-            return parsedRestore.HasOption("verbosity") ||
-                   parsedRestore.Arguments.Any(a => a.Contains("/v:")) ||
-                   parsedRestore.Arguments.Any(a => a.Contains("/verbosity:"));
         }
     }
 }

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -31,11 +31,14 @@ namespace Microsoft.DotNet.Tools.Restore
 
             var parsedRestore = result["dotnet"]["restore"];
 
-            var msbuildArgs = new List<string>
+            var msbuildArgs = new List<string>();
+
+            if (noLogo)
             {
-                "/NoLogo",
-                "/t:Restore"
-            };
+                msbuildArgs.Add("/nologo");
+            }
+
+            msbuildArgs.Add("/t:Restore");
 
             msbuildArgs.AddRange(parsedRestore.OptionValuesToBeForwarded());
 

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetBuildInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /clp:Summary";
+        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m";
 
         [Theory]
         [InlineData(new string[] { }, "/t:Build")]
@@ -18,8 +18,6 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--output", "foo" }, "/t:Build /p:OutputPath=foo")]
         [InlineData(new string[] { "-o", "foo1 foo2" }, "/t:Build \"/p:OutputPath=foo1 foo2\"")]
         [InlineData(new string[] { "--no-incremental" }, "/t:Rebuild")]
-        [InlineData(new string[] { "-f", "tfm" }, "/t:Build /p:TargetFramework=tfm")]
-        [InlineData(new string[] { "--framework", "tfm" }, "/t:Build /p:TargetFramework=tfm")]
         [InlineData(new string[] { "-r", "rid" }, "/t:Build /p:RuntimeIdentifier=rid")]
         [InlineData(new string[] { "--runtime", "rid" }, "/t:Build /p:RuntimeIdentifier=rid")]
         [InlineData(new string[] { "-c", "config" }, "/t:Build /p:Configuration=config")]
@@ -28,14 +26,45 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--no-dependencies" }, "/t:Build /p:BuildProjectReferences=false")]
         [InlineData(new string[] { "-v", "diag" }, "/t:Build /verbosity:diag")]
         [InlineData(new string[] { "--verbosity", "diag" }, "/t:Build /verbosity:diag")]
-        [InlineData(new string[] { "--no-incremental", "-o", "myoutput", "-r", "myruntime", "-v", "diag" }, "/t:Rebuild /p:OutputPath=myoutput /p:RuntimeIdentifier=myruntime /verbosity:diag")]
+        [InlineData(new string[] { "--no-incremental", "-o", "myoutput", "-r", "myruntime", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
+                                  "/t:Rebuild /p:OutputPath=myoutput /p:RuntimeIdentifier=myruntime /verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
 
             var msbuildPath = "<msbuildpath>";
-            BuildCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+            var command = BuildCommand.FromArgs(args, msbuildPath);
+
+            command.SeparateRestoreCommand.Should().BeNull();
+
+            command.GetProcessStartInfo()
+                   .Arguments.Should()
+                   .Be($"{ExpectedPrefix} /restore /clp:Summary{expectedAdditionalArgs}");
+        }
+
+        [Theory]
+        [InlineData(new string[] { "-f", "tfm" }, "/t:Restore", "/t:Build /p:TargetFramework=tfm")]
+        [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
+                                  "/t:Restore /p:OutputPath=myoutput /verbosity:diag /ArbitrarySwitchForMSBuild",
+                                  "/t:Build /p:OutputPath=myoutput /p:TargetFramework=tfm /verbosity:diag /ArbitrarySwitchForMSBuild")]
+        public void MsbuildInvocationIsCorrectForSeparateRestore(
+            string[] args, 
+            string expectedAdditionalArgsForRestore, 
+            string expectedAdditionalArgs)
+        {
+            expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
+
+            var msbuildPath = "<msbuildpath>";
+            var command = BuildCommand.FromArgs(args, msbuildPath);
+
+            command.SeparateRestoreCommand.GetProcessStartInfo()
+                   .Arguments.Should()
+                   .Be($"{ExpectedPrefix} {expectedAdditionalArgsForRestore}");
+
+            command.GetProcessStartInfo()
+                   .Arguments.Should()
+                   .Be($"{ExpectedPrefix} /nologo /clp:Summary{expectedAdditionalArgs}");
+
         }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -9,8 +9,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetBuildInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m";
-        const string ExpectedSuffix = "/clp:Summary";
+        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /clp:Summary";
 
         [Theory]
         [InlineData(new string[] { }, "/t:Build")]
@@ -36,7 +35,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             var msbuildPath = "<msbuildpath>";
             BuildCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs} {ExpectedSuffix}");
+                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
         }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetPackInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /t:pack";
+        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /restore /t:pack";
 
         [Theory]
         [InlineData(new string[] { }, "")]
@@ -33,8 +33,10 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
 
             var msbuildPath = "<msbuildpath>";
-            PackCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+            var command = PackCommand.FromArgs(args, msbuildPath);
+
+            command.SeparateRestoreCommand.Should().BeNull();
+            command.GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
         }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -13,9 +13,6 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         private const string ExpectedPrefix =
             "exec <msbuildpath> /m /v:m /NoLogo /t:Restore";
 
-        private string ExpectedPrefixWithConsoleLoggerParamaters =
-            $"{ExpectedPrefix} /ConsoleLoggerParameters:Verbosity=Minimal";
-
         [Theory]
         [InlineData(new string[] { }, "")]
         [InlineData(new string[] { "-s", "<source>" }, "/p:RestoreSources=<source>")]
@@ -30,19 +27,9 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--no-cache" }, "/p:RestoreNoCache=true")]
         [InlineData(new string[] { "--ignore-failed-sources" }, "/p:RestoreIgnoreFailedSources=true")]
         [InlineData(new string[] { "--no-dependencies" }, "/p:RestoreRecursive=false")]
-        public void MsbuildInvocationWithConsoleLoggerParametersIsCorrect(string[] args, string expectedAdditionalArgs)
-        {
-            expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
-
-            var msbuildPath = "<msbuildpath>";
-            RestoreCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments
-                .Should().Be($"{ExpectedPrefixWithConsoleLoggerParamaters}{expectedAdditionalArgs}");
-        }
-
         [InlineData(new string[] { "-v", "minimal" }, @"/verbosity:minimal")]
         [InlineData(new string[] { "--verbosity", "minimal" }, @"/verbosity:minimal")]
-        public void MsbuildInvocationWithVerbosityIsCorrect(string[] args, string expectedAdditionalArgs)
+        public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
 

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetRestoreInvocation
     {
         private const string ExpectedPrefix =
-            "exec <msbuildpath> /m /v:m /NoLogo /t:Restore";
+            "exec <msbuildpath> /m /v:m /nologo /t:Restore";
 
         [Theory]
         [InlineData(new string[] { }, "")]


### PR DESCRIPTION
Use msbuild /restore instead of separate invocations where possible

Fix #7696

This saves 300ms on my machine for incremental build of a simple console app (from 1.4s to 1.1s).

We still have to miss out on this optimization when there is -f|--framework argument because we cannot force a TargetFramework global property on to the restore evaluation. Doing so completely breaks restore by applying the TargetFramework to all projects transitively. The correct behavior is to restore for all frameworks, then build/publish/etc for the given target framework. Achieving that still requires two distinct msbuild process invocations.

This also changes the verbosity of implicit restore from quiet to that of the subsequent command (default=minimal). Similar to global properties, we cannot specify a distinct console verbosity for the /restore portion of the overall execution. For consistency, we apply the same verbosity change to the case where we still use two separate msbuild invocations.

Output Before:
```
[Logo]
  qwert -> D:\temp\qwert\bin\Debug\netcoreapp2.0\qwert.dll.
[Summary]
```

Output After:
```
[Logo]
  Restoring packages for D:\temp\qwert\qwert.csproj...
  Installing Newtonsoft.Json 10.0.3.
  Restore completed in 763.37 ms for D:\temp\qwert\qwert.csproj.
  qwert -> D:\temp\qwert\bin\Debug\netcoreapp2.0\qwert.dll
[Summary]
```

In the incremental no-op restore case, only the line about "Restore completed in X for Y" is added. 

https://github.com/NuGet/Home/issues/4695 tracks reducing restores output when verbosity is minimal.


This also fixes an issue where the separate restore invocation's msbuild log would be overwritten by the subsequent command execution. However, this remains unfixed in the case where we still use two separate msbuild invocations.

The first two commits are strictly separate, but were getting in the way of test changes I needed to make so I tackled them here.
* Remove necessary handling of verbosity in RestoreCommand
* Fix #7009, Cannot pass /clp:NoSummary to dotnet build
