### PR TITLE
add basic support for FreeBSD

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/FileNameSuffixes.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/FileNameSuffixes.cs
@@ -24,6 +24,8 @@ namespace Microsoft.DotNet.Cli.Utils
                         return OSX;
                     case Platform.Linux:
                         return Linux;
+                    case Platform.FreeBSD:
+                        return FreeBSD;
                     default:
                         throw new InvalidOperationException("Unknown Platform");
                 }
@@ -55,6 +57,14 @@ namespace Microsoft.DotNet.Cli.Utils
         };
 
         public static PlatformFileNameSuffixes Linux { get; } = new PlatformFileNameSuffixes
+        {
+            DynamicLib = ".so",
+            Exe = "",
+            ProgramDatabase = ".pdb",
+            StaticLib = ".a"
+        };
+
+        public static PlatformFileNameSuffixes FreeBSD { get; } = new PlatformFileNameSuffixes
         {
             DynamicLib = ".so",
             Exe = "",

--- a/src/Microsoft.DotNet.Cli.Utils/FileNameSuffixes.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/FileNameSuffixes.cs
@@ -64,13 +64,7 @@ namespace Microsoft.DotNet.Cli.Utils
             StaticLib = ".a"
         };
 
-        public static PlatformFileNameSuffixes FreeBSD { get; } = new PlatformFileNameSuffixes
-        {
-            DynamicLib = ".so",
-            Exe = "",
-            ProgramDatabase = ".pdb",
-            StaticLib = ".a"
-        };
+        public static PlatformFileNameSuffixes FreeBSD { get; } = Linux;
 
         public struct PlatformFileNameSuffixes
         {


### PR DESCRIPTION
This is another part of https://github.com/dotnet/corefx/issues/1626

This adds basic handling for platform suffixes. 
With this and previous core-setup changes I was able to get minimal sdk cli functions.  