### PR TITLE
Generate symbols on crossgen for profiling

### DIFF
--- a/build/Branding.props
+++ b/build/Branding.props
@@ -21,14 +21,14 @@
     <HostMonikerRid Condition=" '$(HostMonikerRid)' == '' ">$(HostOSName)-$(Architecture)</HostMonikerRid>
 
     <ArtifactNameSdk>dotnet-sdk-internal</ArtifactNameSdk>
-    <ArtifactNameSdkDebug>dotnet-sdk-debug</ArtifactNameSdkDebug>
+    <ArtifactNameSdkSymbols>dotnet-sdk-symbols</ArtifactNameSdkSymbols>
     <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk</ArtifactNameCombinedHostHostFxrFrameworkSdk>
     <ArtifactNameSdkLanguagePack>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-langpack</ArtifactNameSdkLanguagePack>
 
     <ArtifactNameWithVersionSdk>$(ArtifactNameSdk)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionSdk>
     <ArtifactNameWithVersionMSBuildExtensions>dotnet-standard-support-vs2015-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionMSBuildExtensions>
 
-    <ArtifactNameWithVersionSdkDebug>$(ArtifactNameSdkDebug)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionSdkDebug>
+    <ArtifactNameWithVersionSdkSymbols>$(ArtifactNameSdkSymbols)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionSdkSymbols>
     <ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>
     <ArtifactNameWithVersionSdkLanguagePack>$(ArtifactNameSdkLanguagePack)-$(SdkVersion)-$(ProductMonikerRid)</ArtifactNameWithVersionSdkLanguagePack>
     <DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-$(SdkVersion)-$(HostMonikerRid)</DistroSpecificArtifactNameWithVersionCombinedHostHostFxrFrameworkSdk>

--- a/build/package/Layout.targets
+++ b/build/package/Layout.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SdkDebugLayoutOutputDirectory>$(LayoutDirectory)/$(ArtifactNameSdkDebug)</SdkDebugLayoutOutputDirectory>
+    <SdkSymbolsLayoutOutputDirectory>$(LayoutDirectory)/$(ArtifactNameSdkSymbols)</SdkSymbolsLayoutOutputDirectory>
     <CombinedHostHostFxrFrameworkSdkOutputDirectory>$(LayoutDirectory)/$(ArtifactNameCombinedHostHostFxrFrameworkSdk)</CombinedHostHostFxrFrameworkSdkOutputDirectory>
     <SdkLanguagePackOutputDirectory>$(LayoutDirectory)/$(ArtifactNameSdkLanguagePack)</SdkLanguagePackOutputDirectory>
     <SatelliteAssemblies>*.resources.dll</SatelliteAssemblies>
@@ -12,7 +12,7 @@
     <!-- Set up Items with Layout Input Files -->
     <ItemGroup>
       <SdkLayoutInput Include="$(OutputDirectory)/sdk/**/*" />
-      <SdkDebugLayoutInput Include="$(SymbolsDirectory)/sdk/**/*" />
+      <SdkSymbolsLayoutInput Include="$(SymbolsDirectory)/sdk/**/*" />
       <CombinedHostHostFxrFrameworkSdkInput Include="$(OutputDirectory)/**/*" />
       <SdkLanguagePackInput Include="$(OutputDirectory)/sdk/**/$(SatelliteAssemblies)" />
 
@@ -30,9 +30,9 @@
       <Output TaskParameter="RelativePath" ItemName="SdkRelativeOutputFiles" />
     </MakeRelative>
     <MakeRelative
-      Path1="$(SymbolsDirectory)"
-      Path2="%(SdkDebugLayoutInput.Identity)" >
-      <Output TaskParameter="RelativePath" ItemName="SdkDebugRelativeOutputFiles" />
+      Path1="$(SymbolsDirectory)/"
+      Path2="%(SdkSymbolsLayoutInput.Identity)" >
+      <Output TaskParameter="RelativePath" ItemName="SdkSymbolsRelativeOutputFiles" />
     </MakeRelative>
     <MakeRelative
       Path1="$(OutputDirectory)/"
@@ -70,11 +70,11 @@
         <Name>$(ArtifactNameSdk)</Name>
       </LayoutDefinition>
 
-      <LayoutDefinition Include="Debug">
-        <InputFiles>@(SdkDebugLayoutInput)</InputFiles>
-        <OutputFiles>@(SdkDebugRelativeOutputFiles -> '$(SdkDebugLayoutOutputDirectory)/%(Identity)')</OutputFiles>
-        <NameWithVersion>$(ArtifactNameWithVersionSdkDebug)</NameWithVersion>
-        <Name>$(ArtifactNameSdkDebug)</Name>
+      <LayoutDefinition Include="SdkSymbols" Condition="'$(SeparateSymbolsArchive)' != 'false'">
+        <InputFiles>@(SdkSymbolsLayoutInput)</InputFiles>
+        <OutputFiles>@(SdkSymbolsRelativeOutputFiles -> '$(SdkSymbolsLayoutOutputDirectory)/%(Identity)')</OutputFiles>
+        <NameWithVersion>$(ArtifactNameWithVersionSdkSymbols)</NameWithVersion>
+        <Name>$(ArtifactNameSdkSymbols)</Name>
       </LayoutDefinition>
 
       <LayoutDefinition Include="CombinedHostHostFxrFrameworkSdk">

--- a/build/package/Layout.targets
+++ b/build/package/Layout.targets
@@ -30,6 +30,7 @@
       <Output TaskParameter="RelativePath" ItemName="SdkRelativeOutputFiles" />
     </MakeRelative>
     <MakeRelative
+      Condition="'$(SeparateSymbolsArchive)' != 'false'"
       Path1="$(SymbolsDirectory)/"
       Path2="%(SdkSymbolsLayoutInput.Identity)" >
       <Output TaskParameter="RelativePath" ItemName="SdkSymbolsRelativeOutputFiles" />

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -208,6 +208,9 @@
 
       <!-- Don't try to CrossGen tasks and supporting DLLs compiled for .NET Framework -->
       <SdkFiles Remove="$(PublishDir)/Microsoft\Microsoft.NET.Build.Extensions\tools\net*\**\*" />
+
+      <!-- Don't crossgen satellite assemblies -->
+      <SdkFiles Remove="$(PublishDir)/**/*.resources.dll" />
     </ItemGroup>
 
     <AddMetadataIsPE Items="@(SdkFiles)">

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -233,12 +233,18 @@
            Glob="$(CrossgenPath)"
            Mode="u+x" />
 
+    <!-- Crossgen does not support generating symbols on Mac  -->
+    <PropertyGroup Condition="'$(CreateCrossgenSymbols)' == ''">
+      <CreateCrossgenSymbols>true</CreateCrossgenSymbols>
+      <CreateCrossgenSymbols Condition="'$(OSName)' == 'osx'">false</CreateCrossgenSymbols>
+   </PropertyGroup>
+
     <Crossgen SourceAssembly="%(CrossgenTargets.FullPath)"
               DestinationPath="%(CrossgenTargets.FullPath)"
               JITPath="$(LibCLRJitPath)"
               CrossgenPath="$(CrossgenPath)"
               ReadyToRun="True"
-              CreateSymbols="True"
+              CreateSymbols="$(CreateCrossgenSymbols)"
               DiasymReaderPath="@(DiasymReaderPath)"
               PlatformAssemblyPaths="@(PlatformAssemblies);
                                      @(PublishDirSubDirectories);

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -101,7 +101,8 @@
 
     <Delete Files="$(PublishDir)/$(TargetName).deps.json;
                    $(PublishDir)/$(TargetName).runtimeconfig.json;
-                   $(PublishDir)/%(BundledToolProjects.Identity).dll" />
+                   $(PublishDir)/%(BundledToolProjects.Identity).dll;
+                   $(PublishDir)/%(BundledToolProjects.Identity).pdb" />
 
     <ChangeEntryPointLibraryName
           DepsFile="$(PublishDir)/%(BundledTools.Identity).deps.json"
@@ -198,7 +199,7 @@
 
   <Target Name="CrossgenPublishDir"
           Condition=" '$(DISABLE_CROSSGEN)' == '' "
-          AfterTargets="PublishMSBuildExtensions">
+          AfterTargets="GenerateCliRuntimeConfigurationFiles">
     <ItemGroup>
       <!-- Removing Full CLR built TestHost assemblies from getting Crossgen as it is throwing error -->
       <SdkFiles Include="$(PublishDir)/**/*" Exclude="$(PublishDir)/TestHost*/**/*;$(PublishDir)/Sdks/**/*" />
@@ -255,24 +256,16 @@
     <Chmod Mode="755" Glob="$(SdkOutputDirectory)/FSharp/RunFsc.sh" />
   </Target>
 
-  <Target Name="CreateSymbolsDirectory"
-          AfterTargets="CrossgenPublishDir">
+  <Target Name="SeparateSymbolsFromPublishDir"
+          AfterTargets="CrossgenPublishDir"
+          Condition="'$(SeparateSymbolsArchive)' != 'false'">
     <ItemGroup>
-      <_AllSdkFiles Include="$(PublishDir)/**/*" />
+      <PdbsToMove Include="$(PublishDir)/**/*.pdb" />
+      <PdbsToMove Include="$(PublishDir)/**/*.ni.*.map" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(_AllSdkFiles)"
-        DestinationFiles="@(_AllSdkFiles->'$(SymbolsDirectory)/sdk/%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
-
-  <Target Name="RemovePdbsFromPublishDir"
-          AfterTargets="CreateSymbolsDirectory">
-    <ItemGroup>
-      <PdbsToClean Include="$(PublishDir)/**/*.pdb" />
-      <PdbsToClean Include="$(PublishDir)/**/*.ni.*.map" />
-    </ItemGroup>
-
-    <Delete Files="@(PdbsToClean)" />
+    <Move SourceFiles="@(PdbsToMove)" 
+          DestinationFiles="@(PdbsToMove->'$(SymbolsDirectory)/sdk/$(SdkVersion)/%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
   <Target Name="PublishStage2WithBackwardsCompatibleRuntimes"

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -211,6 +211,8 @@
 
       <!-- Don't crossgen satellite assemblies -->
       <SdkFiles Remove="$(PublishDir)/**/*.resources.dll" />
+
+      <DiasymReaderPath Include="$(SharedFrameworkNameVersionPath)/Microsoft.DiaSymReader.Native.*.dll" />
     </ItemGroup>
 
     <AddMetadataIsPE Items="@(SdkFiles)">
@@ -235,6 +237,8 @@
               JITPath="$(LibCLRJitPath)"
               CrossgenPath="$(CrossgenPath)"
               ReadyToRun="True"
+              CreateSymbols="True"
+              DiasymReaderPath="@(DiasymReaderPath)"
               PlatformAssemblyPaths="@(PlatformAssemblies);
                                      @(PublishDirSubDirectories);
                                      $(SharedFrameworkNameVersionPath)" />
@@ -265,6 +269,7 @@
           AfterTargets="CreateSymbolsDirectory">
     <ItemGroup>
       <PdbsToClean Include="$(PublishDir)/**/*.pdb" />
+      <PdbsToClean Include="$(PublishDir)/**/*.ni.*.map" />
     </ItemGroup>
 
     <Delete Files="@(PdbsToClean)" />

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -293,6 +293,7 @@
   </Target>
 
   <Target Name="RetargetVSTestConsole"
+          BeforeTargets="PublishStage2WithBackwardsCompatibleRuntimes"
           AfterTargets="Publish">
     <PropertyGroup>
       <VSTestRuntimeConfigPath>$(PublishDir)/vstest.console.runtimeconfig.json</VSTestRuntimeConfigPath>


### PR DESCRIPTION
Generate .ni.pdb (Windows) and .ni.*.map (Linux) files to get symbols resolved in PerfView.

Also, improve symbols zip archive

We were publishing a -debug zip with sdk code and symbols, but it was captured before publishing was finished and had incorrect code content. Trying to use it would blow up
due to incorrect runtimeconfig.json.

Replace it with a -symbols zip that contains only symbols and that can be overlayed over the main zip. This is just like the -langpack zip that has satellite assemblies.

Also add an option to leave the PDBs in the same directory/packages as code: /p:SeparateSymbolsArchive=false. Setting this on local builds facilitates debugging and profiling by removing the need to adjust symbol paths or copy PDBs around.