### PR TITLE
ASP.NET Core HTTPS development certificate support

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -59,7 +59,9 @@
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-25908-02</CLI_NETStandardLibraryNETFrameworkVersion>
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
-
+    <!-- This is the version for ASP.NET packages that the CLI depends on to build, like the
+         component for generating HTTPS certificates on first run. -->
+    <CLI_ASPNET_Version>2.1.0-preview1-27617</CLI_ASPNET_Version>
     <AspNetCoreTemplatePackageVersion>2.0.3</AspNetCoreTemplatePackageVersion>
     <AspNetCoreRuntimePackageBrandName>aspnetcore-store</AspNetCoreRuntimePackageBrandName>
     <AspNetCoreRuntimePackageFolderName>dev-26623</AspNetCoreRuntimePackageFolderName>

--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -21,6 +21,8 @@
     <add key="BlobFeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
     <add key="aspnet" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
+    <!-- Remove all other 2.0.0 aspnet entries when we start taking new ASP.NET packages -->
+    <add key="aspnet-next" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
     <add key="websdkfeed" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />

--- a/src/Microsoft.DotNet.Configurer/AspNetCertificateSentinel.cs
+++ b/src/Microsoft.DotNet.Configurer/AspNetCertificateSentinel.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Extensions.EnvironmentAbstractions;
+
+namespace Microsoft.DotNet.Configurer
+{
+    public class AspNetCertificateSentinel : IAspNetCertificateSentinel
+    {
+        public static readonly string SENTINEL = $"{Product.Version}.aspNetCertificateSentinel";
+
+        private readonly IFile _file;
+        private readonly IDirectory _directory;
+
+        private string _dotnetUserProfileFolderPath;
+
+        private string SentinelPath => Path.Combine(_dotnetUserProfileFolderPath, SENTINEL);
+
+        public AspNetCertificateSentinel(CliFolderPathCalculator cliFallbackFolderPathCalculator) :
+            this(
+                CliFolderPathCalculator.DotnetUserProfileFolderPath,
+                FileSystemWrapper.Default.File,
+                FileSystemWrapper.Default.Directory)
+        {
+        }
+
+        internal AspNetCertificateSentinel(string dotnetUserProfileFolderPath, IFile file, IDirectory directory)
+        {
+            _file = file;
+            _directory = directory;
+            _dotnetUserProfileFolderPath = dotnetUserProfileFolderPath;
+        }
+
+        public bool Exists()
+        {
+            return _file.Exists(SentinelPath);
+        }
+
+        public void CreateIfNotExists()
+        {
+            if (!Exists())
+            {
+                if (!_directory.Exists(_dotnetUserProfileFolderPath))
+                {
+                    _directory.CreateDirectory(_dotnetUserProfileFolderPath);
+                }
+
+                _file.CreateEmptyFile(SentinelPath);
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Microsoft.DotNet.Configurer/IAspNetCertificateSentinel.cs
+++ b/src/Microsoft.DotNet.Configurer/IAspNetCertificateSentinel.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Configurer
+{
+    public interface IAspNetCertificateSentinel
+    {
+        bool Exists();
+
+        void CreateIfNotExists();
+    }
+}

--- a/src/Microsoft.DotNet.Configurer/IAspNetCoreCertificateGenerator.cs
+++ b/src/Microsoft.DotNet.Configurer/IAspNetCoreCertificateGenerator.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Configurer
+{
+    public interface IAspNetCoreCertificateGenerator
+    {
+        void GenerateAspNetCoreDevelopmentCertificate();
+    }
+}

--- a/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
@@ -137,7 +137,7 @@ A command is running to populate your local package cache to improve restore spe
   <data name="FailedToPrimeCacheError" xml:space="preserve">
     <value>Failed to prime the NuGet cache. {0} failed with: {1}</value>
   </data>
-  <data name="UnauthorizedAccessMessage"  xml:space="preserve">
+  <data name="UnauthorizedAccessMessage" xml:space="preserve">
     <value>Permission denied to modify the '{0}' folder.
 
 Here are some options to fix this error:
@@ -146,5 +146,10 @@ Here are some options to fix this error:
 2. Disabled the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
 3. Copy the .NET Core SDK to a non-protected location and use it from there.
     </value>
+  </data>
+  <data name="AspNetCertificateInstalled" xml:space="preserve">
+    <value>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</value>
   </data>
 </root>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
@@ -57,6 +57,15 @@ Tuto chybu můžete opravit pomocí některé z těchto možností:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
@@ -57,6 +57,15 @@ Im Folgenden finden Sie einige Optionen, um diesen Fehler zu beheben:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
@@ -57,6 +57,15 @@ Estas son algunas opciones para corregir este error:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
@@ -57,6 +57,15 @@ Voici quelques options pour corriger cette erreur :
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
@@ -57,6 +57,15 @@ Ecco alcune opzioni per correggere questo errore:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
@@ -57,6 +57,15 @@ Here are some options to fix this error:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
@@ -57,6 +57,15 @@ Here are some options to fix this error:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
@@ -57,6 +57,15 @@ Oto kilka opcji naprawiania tego błędu:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
@@ -57,6 +57,15 @@ Aqui estão algumas opções para consertar este erro:
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
@@ -57,6 +57,15 @@ Here are some options to fix this error:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
@@ -57,6 +57,15 @@ Bu hatayı düzeltmek için bazı seçenekler:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
@@ -57,6 +57,15 @@ Here are some options to fix this error:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
@@ -57,6 +57,15 @@ Here are some options to fix this error:
     </target>
         <note />
       </trans-unit>
+      <trans-unit id="AspNetCertificateInstalled">
+        <source>ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
+        <target state="new">ASP.NET Core
+------------
+Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/AspNetCoreCertificateGenerator.cs
+++ b/src/dotnet/AspNetCoreCertificateGenerator.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.DeveloperCertificates.XPlat;
+using Microsoft.DotNet.Configurer;
+
+namespace Microsoft.DotNet.Cli
+{
+    public class AspNetCoreCertificateGenerator : IAspNetCoreCertificateGenerator
+    {
+        public void GenerateAspNetCoreDevelopmentCertificate()
+        {
+            CertificateGenerator.GenerateAspNetHttpsCertificate();
+        }
+    }
+}

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -141,6 +141,7 @@ namespace Microsoft.DotNet.Cli
                         ConfigureDotNetForFirstTimeUse(
                             nugetCacheSentinel,
                             firstTimeUseNoticeSentinel,
+                            new AspNetCertificateSentinel(cliFallbackFolderPathCalculator),
                             cliFallbackFolderPathCalculator,
                             hasSuperUserAccess);
 
@@ -204,6 +205,7 @@ namespace Microsoft.DotNet.Cli
         private static void ConfigureDotNetForFirstTimeUse(
             INuGetCacheSentinel nugetCacheSentinel,
             IFirstTimeUseNoticeSentinel firstTimeUseNoticeSentinel,
+            IAspNetCertificateSentinel aspNetCertificateSentinel,
             CliFolderPathCalculator cliFolderPathCalculator,
             bool hasSuperUserAccess)
         {
@@ -219,10 +221,13 @@ namespace Microsoft.DotNet.Cli
                     nugetPackagesArchiver,
                     nugetCacheSentinel,
                     cliFolderPathCalculator);
+                var aspnetCertificateGenerator = new AspNetCoreCertificateGenerator();
                 var dotnetConfigurer = new DotnetFirstTimeUseConfigurer(
                     nugetCachePrimer,
                     nugetCacheSentinel,
                     firstTimeUseNoticeSentinel,
+                    aspNetCertificateSentinel,
+                    aspnetCertificateGenerator,
                     environmentProvider,
                     Reporter.Output,
                     cliFolderPathCalculator.CliFallbackFolderPath,

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -55,6 +55,7 @@
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Private.DataContractSerialization" Version="4.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="$(CLI_ASPNET_Version)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
@@ -18,6 +18,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         private Mock<INuGetCachePrimer> _nugetCachePrimerMock;
         private Mock<INuGetCacheSentinel> _nugetCacheSentinelMock;
         private Mock<IFirstTimeUseNoticeSentinel> _firstTimeUseNoticeSentinelMock;
+        private Mock<IAspNetCertificateSentinel> _aspNetCertificateSentinelMock;
+        private Mock<IAspNetCoreCertificateGenerator> _aspNetCoreCertificateGeneratorMock;
         private Mock<IEnvironmentProvider> _environmentProviderMock;
         private Mock<IReporter> _reporterMock;
         private Mock<IEnvironmentPath> _pathAdder;
@@ -27,6 +29,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             _nugetCachePrimerMock = new Mock<INuGetCachePrimer>();
             _nugetCacheSentinelMock = new Mock<INuGetCacheSentinel>();
             _firstTimeUseNoticeSentinelMock = new Mock<IFirstTimeUseNoticeSentinel>();
+            _aspNetCertificateSentinelMock = new Mock<IAspNetCertificateSentinel>();
+            _aspNetCoreCertificateGeneratorMock = new Mock<IAspNetCoreCertificateGenerator>();
             _environmentProviderMock = new Mock<IEnvironmentProvider>();
             _reporterMock = new Mock<IReporter>();
             _pathAdder = new Mock<IEnvironmentPath>();
@@ -48,6 +52,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -71,6 +77,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -94,6 +102,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -114,6 +124,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -134,6 +146,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -153,6 +167,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -172,6 +188,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -194,6 +212,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -213,6 +233,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -233,6 +255,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -256,6 +280,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -281,6 +307,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 new FakeCreateWillExistNuGetCacheSentinel(false, true), 
                 new FakeCreateWillExistFirstTimeUseNoticeSentinel(false),
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -300,6 +328,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -327,6 +357,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
                 _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
                 _environmentProviderMock.Object,
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -335,6 +367,104 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             dotnetFirstTimeUseConfigurer.Configure();
 
             _nugetCachePrimerMock.Verify(r => r.PrimeCache(), Times.Never);
+        }
+
+        [Fact]
+        public void It_does_not_generate_the_aspnet_https_development_certificate_if_the_sentinel_exists()
+        {
+            _aspNetCertificateSentinelMock.Setup(n => n.Exists()).Returns(true);
+
+            var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
+                _nugetCachePrimerMock.Object,
+                _nugetCacheSentinelMock.Object,
+                _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
+                _environmentProviderMock.Object,
+                _reporterMock.Object,
+                CliFallbackFolderPath,
+                _pathAdder.Object);
+
+            dotnetFirstTimeUseConfigurer.Configure();
+
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.AspNetCertificateInstalled)), Times.Never);
+            _aspNetCoreCertificateGeneratorMock.Verify(s => s.GenerateAspNetCoreDevelopmentCertificate(), Times.Never);
+        }
+
+        [Fact]
+        public void It_does_not_generate_the_aspnet_https_development_certificate_when_the_user_has_set_the_DOTNET_SKIP_FIRST_TIME_EXPERIENCE_environment_variable()
+        {
+            _aspNetCertificateSentinelMock.Setup(n => n.Exists()).Returns(false);
+            _environmentProviderMock
+                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false))
+                .Returns(true);
+
+            var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
+                _nugetCachePrimerMock.Object,
+                _nugetCacheSentinelMock.Object,
+                _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
+                _environmentProviderMock.Object,
+                _reporterMock.Object,
+                CliFallbackFolderPath,
+                _pathAdder.Object);
+
+            dotnetFirstTimeUseConfigurer.Configure();
+
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.AspNetCertificateInstalled)), Times.Never);
+            _aspNetCoreCertificateGeneratorMock.Verify(s => s.GenerateAspNetCoreDevelopmentCertificate(), Times.Never);
+        }
+
+        [Fact]
+        public void It_does_not_generate_the_aspnet_https_development_certificate_when_the_user_has_set_the_DOTNET_GENERATE_ASPNET_CERTIFICATE_environment_variable()
+        {
+            _aspNetCertificateSentinelMock.Setup(n => n.Exists()).Returns(false);
+            _environmentProviderMock
+                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true))
+                .Returns(false);
+
+            var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
+                _nugetCachePrimerMock.Object,
+                _nugetCacheSentinelMock.Object,
+                _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
+                _environmentProviderMock.Object,
+                _reporterMock.Object,
+                CliFallbackFolderPath,
+                _pathAdder.Object);
+
+            dotnetFirstTimeUseConfigurer.Configure();
+
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.AspNetCertificateInstalled)), Times.Never);
+            _aspNetCoreCertificateGeneratorMock.Verify(s => s.GenerateAspNetCoreDevelopmentCertificate(), Times.Never);
+        }
+
+        [Fact]
+        public void It_generates_the_aspnet_https_development_certificate_if_the_sentinel_does_not_exist()
+        {
+            _aspNetCertificateSentinelMock.Setup(n => n.Exists()).Returns(false);
+            _environmentProviderMock.Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true))
+                .Returns(true);
+
+            var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
+                _nugetCachePrimerMock.Object,
+                _nugetCacheSentinelMock.Object,
+                _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
+                _environmentProviderMock.Object,
+                _reporterMock.Object,
+                CliFallbackFolderPath,
+                _pathAdder.Object);
+
+            dotnetFirstTimeUseConfigurer.Configure();
+
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.FirstTimeWelcomeMessage)));
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.NugetCachePrimeMessage)));
+            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.AspNetCertificateInstalled)));
+            _aspNetCoreCertificateGeneratorMock.Verify(s => s.GenerateAspNetCoreDevelopmentCertificate(), Times.Once);
         }
 
         private class FakeCreateWillExistFirstTimeUseNoticeSentinel : IFirstTimeUseNoticeSentinel


### PR DESCRIPTION
Hey @livarcocc. I've put together a PR based on our conversation on Friday. There are a few small issues to figure out but I think the general approach is ok.

Added support for generating the HTTPS development certificate on the CLI first run experience.
There are a bunch of open issues:
* How/where to put the certificate generation component. (For this proof of concept I just inlined it, but we need to figure out the engineering to determine where to house the component and how to share it with the CLI).
* Add tests related to the functionality. (I'm just putting it all together to validate the experience).
* The implementation needs to live in dotnet, as it is netcoreapp2.0 (I didn't want to change the target framework of Microsoft.DotNet.Configurer nor cross-compile unless you tell me otherwise).
* Review messages shown to the user.