### PR TITLE
Fix version displayed after install, provide information on more installed packeges

### DIFF
--- a/build/package/Installer.MSI.targets
+++ b/build/package/Installer.MSI.targets
@@ -154,7 +154,14 @@
                       '$(SimpleVersion)'
                       '$(NugetVersion)'
                       '$(CombinedFrameworkSDKHostInstallerUpgradeCode)'
-                      '$(Architecture)'" />
+                      '$(Architecture)'
+                      '$(SharedFrameworkVersion)'
+                      '$(AspNetCoreRuntimePackageVersion)'
+                      '$(CLI_Roslyn_Version)'
+                      '$(CLI_FSharp_Version)'
+                      '$(CLI_MSBuild_Version)'
+                      '$(CLI_NuGet_Version)'
+                      '$(CLI_TestPlatform_Version)'" />
     </Target>
 
     <Target Name="GenerateSdkNupkg"

--- a/packaging/windows/clisdk/bundle.wxl
+++ b/packaging/windows/clisdk/bundle.wxl
@@ -49,19 +49,26 @@
   <String Id="FilesInUseCancelButton">&amp;Cancel</String>
   <String Id="FirstTimeWelcomeMessage">The installation was successful
 
-The following were installed at [DOTNETHOME]
-    • .NET Core SDK 2.0.0
-    • .NET Core Runtime 2.0.0
-    • Runtime Store
-
 This product collects usage data
     • More information and opt-out https://aka.ms/dotnet-cli-telemetry
+
+The following were installed at [DOTNETHOME]
+    • .NET Core SDK [DotNetSdkVersion]
+    • .NET Core Runtime [DotNetRuntimeVersion]
+    • Asp.Net Core [AspNetCoreVersion]
+    • Roslyn Compiler [RoslynVersion]
+    • F Sharp (F#) [FSharpVersion]
+    • MSBuild [MSBuildVersion]  
+    • NuGet [NuGetVersion]
+    • MS Test Platform [TestPlatformVersion]
 
 Resources
     • Core Documentation https://aka.ms/dotnet-docs
     • SDK Documentation https://aka.ms/dotnet-cli-docs
     • Release Notes https://aka.ms/20-p2-rel-notes
-    • Tutorials https://aka.ms/dotnet-tutorials</String>
+    • Tutorials https://aka.ms/dotnet-tutorials
+
+</String>
   <String Id="WelcomeHeaderMessage">.NET Core SDK</String>
   <String Id="WelcomeDescription">
     .NET Core is a development platform that you can use to build command-line applications, microservices and modern websites. It is open source, cross-platform, and supported by Microsoft. We hope you enjoy it!</String>

--- a/packaging/windows/clisdk/bundle.wxs
+++ b/packaging/windows/clisdk/bundle.wxs
@@ -24,6 +24,15 @@
 
     <Variable Name="DOTNETHOME" Type="string" Value="[ProgramFiles6432Folder]dotnet" bal:Overridable="no" />
     <Variable Name="BUNDLEMONIKER" Type="string" Value="$(var.ProductMoniker)" bal:Overridable="no" />
+    <Variable Name="DotNetSdkVersion" Type="string" Value="$(var.DisplayVersion)" bal:Overridable="no" />
+    <Variable Name="DotNetRuntimeVersion" Type="string" Value="$(var.DotNetRuntimeVersion)" bal:Overridable="no" />
+    <Variable Name="AspNetCoreVersion" Type="string" Value="$(var.AspNetCoreVersion)" bal:Overridable="no" />
+    <Variable Name="RoslynVersion" Type="string" Value="$(var.RoslynCompilerVersion)" bal:Overridable="no" />
+    <Variable Name="FSharpVersion" Type="string" Value="$(var.FSharpVersion)" bal:Overridable="no" />
+    <Variable Name="MSBuildVersion" Type="string" Value="$(var.MSBuildVersion)" bal:Overridable="no" />
+    <Variable Name="NuGetVersion" Type="string" Value="$(var.NuGetVersion)" bal:Overridable="no" />
+    <Variable Name="TestPlatformVersion" Type="string" Value="$(var.TestPlatformVersion)" bal:Overridable="no" />
+
 
     <Chain DisableSystemRestore="yes" ParallelCache="yes">
       <MsiPackage SourceFile="$(var.SharedFXMsiSourcePath)">

--- a/packaging/windows/clisdk/generatebundle.ps1
+++ b/packaging/windows/clisdk/generatebundle.ps1
@@ -14,7 +14,14 @@ param(
     [Parameter(Mandatory=$true)][string]$DotnetCLIDisplayVersion,
     [Parameter(Mandatory=$true)][string]$DotnetCLINugetVersion,
     [Parameter(Mandatory=$true)][string]$UpgradeCode,
-    [Parameter(Mandatory=$true)][string]$Architecture
+    [Parameter(Mandatory=$true)][string]$Architecture,
+    [Parameter(Mandatory=$true)][string]$DotNetRuntimeVersion,
+    [Parameter(Mandatory=$true)][string]$AspNetCoreVersion,
+    [Parameter(Mandatory=$true)][string]$RoslynCompilerVersion,
+    [Parameter(Mandatory=$true)][string]$FSharpVersion,
+    [Parameter(Mandatory=$true)][string]$MSBuildVersion,
+    [Parameter(Mandatory=$true)][string]$NuGetVersion,
+    [Parameter(Mandatory=$true)][string]$TestPlatformVersion
 )
 
 . "$PSScriptRoot\..\..\..\scripts\common\_common.ps1"
@@ -43,6 +50,13 @@ function RunCandleForBundle
         -dAdditionalSharedFXMsiSourcePath="$AdditionalSharedFxMSIFile" `
         -dAdditionalHostFXRMsiSourcePath="$AdditionalHostFxrMSIFile" `
         -dAdditionalSharedHostMsiSourcePath="$AdditionalSharedHostMSIFile" `
+        -dDotNetRuntimeVersion="$DotNetRuntimeVersion" `
+        -dRoslynCompilerVersion="$RoslynCompilerVersion" `
+        -dFSharpVersion="$FSharpVersion" `
+        -dMSBuildVersion="$MSBuildVersion" `
+        -dAspNetCoreVersion="$AspNetCoreVersion" `
+        -dNuGetVersion="$NuGetVersion" `
+        -dTestPlatformVersion="$TestPlatformVersion" `
         -arch "$Architecture" `
         -ext WixBalExtension.dll `
         -ext WixUtilExtension.dll `


### PR DESCRIPTION
Partially fixes #8042 

PR adds information about versions of runtime, packages and tools installed with bundle installer
displaying them at the last successful install view. Version data are read from src/DependencyVersions.deps
file what allows for automatic updates to installer UI keeping it in sync with changing source.
