### PR TITLE
Revert "Update Roslyn and F# satellite assemblies"

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -6,7 +6,7 @@
     <CLI_Roslyn_Version>2.6.0-beta3-62309-01</CLI_Roslyn_Version>
     <CLI_DiaSymNative_Version>1.6.0-beta2-25304</CLI_DiaSymNative_Version>
     <CLI_FSharp_Version>4.2.0-rtm-171104-0</CLI_FSharp_Version>
-    <CLI_Deps_Satellites_Build>pre-20171121-1</CLI_Deps_Satellites_Build>
+    <CLI_Deps_Satellites_Build>pre-20171012-1</CLI_Deps_Satellites_Build>
     <CLI_Roslyn_Satellites_Version>2.6.0-$(CLI_Deps_Satellites_Build)</CLI_Roslyn_Satellites_Version>
     <CLI_FSharp_Satellites_Version>4.4.1-$(CLI_Deps_Satellites_Build)</CLI_FSharp_Satellites_Version>
 


### PR DESCRIPTION
This reverts commit f91a4906a7eea97a8d265c760b89ec0c3a81b8c1.

It was direct submitted instead of being a PR and it broke the build due to cli-deps-satellites not being pushed to BlobFeed. @johnbeisner is working on having it publish to the blob feed and will resubmit the change when that is available.