### PR TITLE
Remove project dependencies when removing a project from a solution.

### DIFF
--- a/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/App.sln
+++ b/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/App.sln
@@ -1,0 +1,44 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27110.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "App\App.csproj", "{BB02B949-F6BD-4872-95CB-96A05B1FE026}"
+	ProjectSection(ProjectDependencies) = postProject
+		{4E952B56-841D-461D-89A9-7977DDCC0625} = {4E952B56-841D-461D-89A9-7977DDCC0625}
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6} = {D53E177A-8ECF-43D5-A01E-98B884D53CA6}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "First", "First\First.csproj", "{D53E177A-8ECF-43D5-A01E-98B884D53CA6}"
+	ProjectSection(ProjectDependencies) = postProject
+		{4E952B56-841D-461D-89A9-7977DDCC0625} = {4E952B56-841D-461D-89A9-7977DDCC0625}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Second", "Second\Second.csproj", "{4E952B56-841D-461D-89A9-7977DDCC0625}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BB02B949-F6BD-4872-95CB-96A05B1FE026}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB02B949-F6BD-4872-95CB-96A05B1FE026}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB02B949-F6BD-4872-95CB-96A05B1FE026}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB02B949-F6BD-4872-95CB-96A05B1FE026}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E952B56-841D-461D-89A9-7977DDCC0625}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E952B56-841D-461D-89A9-7977DDCC0625}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E952B56-841D-461D-89A9-7977DDCC0625}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E952B56-841D-461D-89A9-7977DDCC0625}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F6D9A973-1CFD-41C9-84F2-1471C0FE67DF}
+	EndGlobalSection
+EndGlobal

--- a/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/App/App.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/App/Program.cs
+++ b/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/App/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace App
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/First/Class1.cs
+++ b/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/First/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace First
+{
+    public class Class1
+    {
+    }
+}

--- a/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/First/First.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/First/First.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/Second/Class1.cs
+++ b/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/Second/Class1.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Second
+{
+    public class Class1
+    {
+    }
+}

--- a/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/Second/Second.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnProjectDependencyToRemove/Second/Second.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -285,6 +285,14 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             get { return _sections; }
         }
 
+        public SlnSection Dependencies
+        {
+            get
+            {
+                return _sections.GetSection("ProjectDependencies", SlnSectionType.PostProcess);
+            }
+        }
+
         internal void Read(TextReader reader, string line, ref int curLineNum)
         {
             Line = curLineNum;

--- a/src/dotnet/SlnFileExtensions.cs
+++ b/src/dotnet/SlnFileExtensions.cs
@@ -247,6 +247,22 @@ namespace Microsoft.DotNet.Tools.Common
                         string.Format(CommonLocalizableStrings.ProjectReferenceRemoved, slnProject.FilePath));
                 }
 
+                foreach (var project in slnFile.Projects)
+                {
+                    var dependencies = project.Dependencies;
+                    if (dependencies == null)
+                    {
+                        continue;
+                    }
+
+                    dependencies.SkipIfEmpty = true;
+
+                    foreach (var removed in projectsToRemove)
+                    {
+                        dependencies.Properties.Remove(removed.Id);
+                    }
+                }
+
                 projectRemoved = true;
             }
 

--- a/test/dotnet-sln-remove.Tests/GivenDotnetSlnRemove.cs
+++ b/test/dotnet-sln-remove.Tests/GivenDotnetSlnRemove.cs
@@ -171,6 +171,42 @@ Global
 EndGlobal
 ";
 
+        private const string ExpectedSlnContentsAfterRemoveProjectWithDependencies = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27110.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""App"", ""App\App.csproj"", ""{BB02B949-F6BD-4872-95CB-96A05B1FE026}""
+	ProjectSection(ProjectDependencies) = postProject
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6} = {D53E177A-8ECF-43D5-A01E-98B884D53CA6}
+	EndProjectSection
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""First"", ""First\First.csproj"", ""{D53E177A-8ECF-43D5-A01E-98B884D53CA6}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BB02B949-F6BD-4872-95CB-96A05B1FE026}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BB02B949-F6BD-4872-95CB-96A05B1FE026}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BB02B949-F6BD-4872-95CB-96A05B1FE026}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BB02B949-F6BD-4872-95CB-96A05B1FE026}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D53E177A-8ECF-43D5-A01E-98B884D53CA6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F6D9A973-1CFD-41C9-84F2-1471C0FE67DF}
+	EndGlobalSection
+EndGlobal
+";
+
         [Theory]
         [InlineData("--help")]
         [InlineData("-h")]
@@ -555,6 +591,28 @@ EndGlobal
 
             File.ReadAllText(solutionPath)
                 .Should().BeVisuallyEquivalentTo(ExpectedSlnContentsAfterRemoveLastNestedProj);
+        }
+
+        [Fact]
+        public void WhenProjectIsRemovedThenDependenciesOnProjectAreAlsoRemoved()
+        {
+            var projectDirectory = TestAssets
+                .Get("TestAppWithSlnProjectDependencyToRemove")
+                .CreateInstance()
+                .WithSourceFiles()
+                .Root
+                .FullName;
+
+            var solutionPath = Path.Combine(projectDirectory, "App.sln");
+
+            var projectToRemove = Path.Combine("Second", "Second.csproj");
+            var cmd = new DotnetCommand()
+                .WithWorkingDirectory(projectDirectory)
+                .ExecuteWithCapturedOutput($"sln remove {projectToRemove}");
+            cmd.Should().Pass();
+
+            File.ReadAllText(solutionPath)
+                .Should().BeVisuallyEquivalentTo(ExpectedSlnContentsAfterRemoveProjectWithDependencies);
         }
     }
 }


### PR DESCRIPTION
This commit fixes #6198.

When a project is removed from a solution using the `sln remove`
command, any projects in the solution with a project dependency (note:
this is different from a project reference) on the project should have
the project removed as a dependency.

The fix is to scan the projects in the solution and remove any
dependencies on the projects being removed.  If the dependencies section
is empty after the remove, we skip serialization of the section like
Visual Studio does.