### PR TITLE
Make --no-build imply --no-restore for run, pack, and test commands.

### DIFF
--- a/src/dotnet/Parser.cs
+++ b/src/dotnet/Parser.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli
         private static void ConfigureCommandLineLocalizedStrings()
         {
             DefaultHelpViewText.AdditionalArgumentsSection =
-                $"{UsageCommandsAdditionalArgsHeader}:{NewLine}  {LocalizableStrings.RunCommandAdditionalArgsHelpText}";
+                $"{UsageCommandsAdditionalArgsHeader}{NewLine}  {LocalizableStrings.RunCommandAdditionalArgsHelpText}";
             DefaultHelpViewText.ArgumentsSection.Title = UsageArgumentsHeader;
             DefaultHelpViewText.CommandsSection.Title = UsageCommandsHeader;
             DefaultHelpViewText.OptionsSection.Title = UsageOptionsHeader;

--- a/src/dotnet/commands/dotnet-pack/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-pack/LocalizableStrings.resx
@@ -130,7 +130,7 @@
     <value>Directory in which to place built packages.</value>
   </data>
   <data name="CmdNoBuildOptionDescription" xml:space="preserve">
-    <value>Skip building the project prior to packing. By default, the project will be built.</value>
+    <value>Do not build project before packing.  Implies --no-restore.</value>
   </data>
   <data name="CmdIncludeSymbolsDescription" xml:space="preserve">
     <value>Include packages with symbols in addition to regular packages in output directory.</value>

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tools.Pack
 
             msbuildArgs.AddRange(parsedPack.Arguments);
 
-            bool noRestore = parsedPack.HasOption("--no-restore");
+            bool noRestore = parsedPack.HasOption("--no-restore") || parsedPack.HasOption("--no-build");
 
             return new PackCommand(
                 msbuildArgs,

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.cs.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">Přeskočí sestavení projektu, dokud ho nezabalíte. Projekt se sestaví automaticky.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Přeskočí sestavení projektu, dokud ho nezabalíte. Projekt se sestaví automaticky.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.de.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">Hiermit wird das Projekt nicht vor dem Packen erstellt. Standardmäßig wird das Projekt erstellt.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Hiermit wird das Projekt nicht vor dem Packen erstellt. Standardmäßig wird das Projekt erstellt.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.es.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">Omita la compilación del proyecto antes de empaquetar. El proyecto se compilará de manera predeterminada.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Omita la compilación del proyecto antes de empaquetar. El proyecto se compilará de manera predeterminada.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.fr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">Ignorez la génération du projet avant la compression. Par défaut, le projet est généré.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Ignorez la génération du projet avant la compression. Par défaut, le projet est généré.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.it.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">Consente di ignorare la compilazione del progetto prima di creare il pacchetto. Per impostazione predefinita, il progetto verrà compilato.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Consente di ignorare la compilazione del progetto prima di creare il pacchetto. Per impostazione predefinita, il progetto verrà compilato.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ja.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">パッキングの前に、プロジェクトの構築をスキップします。既定では、プロジェクトは構築されます。</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">パッキングの前に、プロジェクトの構築をスキップします。既定では、プロジェクトは構築されます。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ko.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">압축하기 전에 프로젝트를 빌드하지 않습니다. 기본적으로 프로젝트가 빌드됩니다.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">압축하기 전에 프로젝트를 빌드하지 않습니다. 기본적으로 프로젝트가 빌드됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pl.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">Pomiń kompilację projektu przed pakowaniem. Domyślnie projekt zostanie skompilowany.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Pomiń kompilację projektu przed pakowaniem. Domyślnie projekt zostanie skompilowany.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">Ignorar a compilação do projeto antes do empacotamento. Por padrão, o projeto será compilado.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Ignorar a compilação do projeto antes do empacotamento. Por padrão, o projeto será compilado.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ru.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">Пропуск сборки проекта перед упаковкой. По умолчанию выполняется сборка проекта.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Пропуск сборки проекта перед упаковкой. По умолчанию выполняется сборка проекта.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.tr.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">Projeyi paketlemeden önce derlemeyi atlayın. Varsayılan olarak, proje derlenir.</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Projeyi paketlemeden önce derlemeyi atlayın. Varsayılan olarak, proje derlenir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">在打包之前跳过生成项目。默认情况下，将生成项目。</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">在打包之前跳过生成项目。默认情况下，将生成项目。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildOptionDescription">
-        <source>Skip building the project prior to packing. By default, the project will be built.</source>
-        <target state="translated">在封裝前跳過建置專案。預設會建置專案。</target>
+        <source>Do not build project before packing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">在封裝前跳過建置專案。預設會建置專案。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdIncludeSymbolsDescription">

--- a/src/dotnet/commands/dotnet-run/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-run/LocalizableStrings.resx
@@ -124,13 +124,10 @@
     <value>Command used to run .NET apps</value>
   </data>
   <data name="CommandOptionNoBuildDescription" xml:space="preserve">
-    <value>Skip building the project prior to running. By default, the project will be built.</value>
+    <value>Do not build project before running.  Implies --no-restore.</value>
   </data>
   <data name="CommandOptionFrameworkDescription" xml:space="preserve">
     <value>Build and run the app using the specified framework. The framework has to be specified in the project file. </value>
-  </data>
-  <data name="CommandOptionNoBuild" xml:space="preserve">
-    <value>Do not build the project before running.</value>
   </data>
   <data name="CommandOptionProjectDescription" xml:space="preserve">
     <value>The path to the project file to run (defaults to the current directory if there is only one project).</value>

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Cli
                         project: o.SingleArgumentOrDefault("--project"),
                         launchProfile: o.SingleArgumentOrDefault("--launch-profile"),
                         noLaunchProfile: o.HasOption("--no-launch-profile"),
-                        noRestore: o.HasOption("--no-restore"),
+                        noRestore: o.HasOption("--no-restore") || o.HasOption("--no-build"),
                         restoreArgs: o.OptionValuesToBeForwarded(),
                         args: o.Arguments
                     )),

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -51,7 +51,8 @@ namespace Microsoft.DotNet.Cli
                         "--no-build",
                         LocalizableStrings.CommandOptionNoBuildDescription,
                         Accept.NoArguments()),
-                    CommonOptions.NoRestoreOption()
+                    CommonOptions.NoRestoreOption(),
+                    CommonOptions.VerbosityOption()
                 });
     }
 }

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">Před spuštěním vynechá sestavení projektu. Standardně se projekt sestaví.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">Před spuštěním nesestavovat projekt</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Před spuštěním vynechá sestavení projektu. Standardně se projekt sestaví.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">Überspringen Sie die Erstellung des Projekts vor dem Ausführen. Das Projekt wird standardmäßig erstellt.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">Erstellen Sie das Projekt nicht vor dem Ausführen.</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Überspringen Sie die Erstellung des Projekts vor dem Ausführen. Das Projekt wird standardmäßig erstellt.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">Omite la compilación del proyecto antes de ejecutarlo. El proyecto se compilará de manera predeterminada.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">No se compila el proyecto antes de ejecutarlo.</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Omite la compilación del proyecto antes de ejecutarlo. El proyecto se compilará de manera predeterminada.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">Ignorez la génération du projet avant l'exécution. Par défaut, le projet est généré.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">Ne générez pas le projet avant l'exécution.</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Ignorez la génération du projet avant l'exécution. Par défaut, le projet est généré.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">Consente di ignorare la compilazione del progetto prima dell'esecuzione. Per impostazione predefinita, il progetto verrà compilato.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">Non compilare il progetto prima dell'esecuzione.</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Consente di ignorare la compilazione del progetto prima dell'esecuzione. Per impostazione predefinita, il progetto verrà compilato.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">実行の前に、プロジェクトのビルドをスキップします。既定では、プロジェクトはビルドされます。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">実行する前にプロジェクトをビルドしません。</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">実行の前に、プロジェクトのビルドをスキップします。既定では、プロジェクトはビルドされます。</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">실행하기 전에 프로젝트를 빌드하지 않습니다. 기본적으로 프로젝트가 빌드됩니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">실행하기 전에 프로젝트를 빌드하지 않습니다.</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">실행하기 전에 프로젝트를 빌드하지 않습니다. 기본적으로 프로젝트가 빌드됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">Pomiń kompilację projektu przed uruchomieniem. Domyślnie projekt zostanie skompilowany.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">Nie kompiluj projektu przed uruchomieniem.</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Pomiń kompilację projektu przed uruchomieniem. Domyślnie projekt zostanie skompilowany.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">Ignorar a compilação do projeto antes da execução. Por padrão, o projeto será compilado.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">Não compilar o projeto antes da execução.</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Ignorar a compilação do projeto antes da execução. Por padrão, o projeto será compilado.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">Пропуск сборки проекта перед запуском. По умолчанию выполняется сборка проекта.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">Не выполнять сборку проекта перед запуском.</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Пропуск сборки проекта перед запуском. По умолчанию выполняется сборка проекта.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">Projeyi çalıştırmadan önce derlemeyi atlayın. Varsayılan olarak, proje derlenir.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">Projeyi çalıştırmadan önce derleme.</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Projeyi çalıştırmadan önce derlemeyi atlayın. Varsayılan olarak, proje derlenir.</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">在运行之前跳过项目生成操作。将默认生成项目。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">运行之前不要生成项目。</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">在运行之前跳过项目生成操作。将默认生成项目。</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,13 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CommandOptionNoBuildDescription">
-        <source>Skip building the project prior to running. By default, the project will be built.</source>
-        <target state="translated">在執行之前跳過建置該專案。根據預設，將會建置該專案。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CommandOptionNoBuild">
-        <source>Do not build the project before running.</source>
-        <target state="translated">請勿在執行之前建置專案。</target>
+        <source>Do not build project before running.  Implies --no-restore.</source>
+        <target state="needs-review-translation">在執行之前跳過建置該專案。根據預設，將會建置該專案。</target>
         <note />
       </trans-unit>
       <trans-unit id="RunCommandExceptionUnableToRunSpecifyFramework">

--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -193,7 +193,7 @@
                                         Logs are written to the provided file.</value>
   </data>
   <data name="CmdNoBuildDescription" xml:space="preserve">
-    <value>Do not build project before testing.</value>
+    <value>Do not build project before testing.  Implies --no-restore.</value>
   </data>
   <data name="CmdResultsDirectoryDescription" xml:space="preserve">
     <value>The directory where the test results are going to be placed. The specified directory will be created if it does not exist.

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Tools.Test
                 }
             }
 
-            bool noRestore = parsedTest.HasOption("--no-restore");
+            bool noRestore = parsedTest.HasOption("--no-restore") || parsedTest.HasOption("--no-build");
 
             return new TestCommand(
                 msbuildArgs,

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">Nesestavujte projekt dříve, než ho otestujete.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Nesestavujte projekt dříve, než ho otestujete.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">Erstellen Sie das Projekt nicht vor dem Testen.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Erstellen Sie das Projekt nicht vor dem Testen.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">El proyecto no se compila antes de probarlo.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">El proyecto no se compila antes de probarlo.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">Ne générez pas le projet avant les tests.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Ne générez pas le projet avant les tests.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">Il progetto non viene compilato prima del test.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Il progetto non viene compilato prima del test.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">テストする前にプロジェクトを構築しないでください。</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">テストする前にプロジェクトを構築しないでください。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">테스트하기 전에 프로젝트를 빌드하지 않습니다.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">테스트하기 전에 프로젝트를 빌드하지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">Nie kompiluj projektu przed przeprowadzeniem testów.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Nie kompiluj projektu przed przeprowadzeniem testów.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">Não compile o projeto antes de testar.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Não compile o projeto antes de testar.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">Не выполнять сборку проектов перед тестированием.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Не выполнять сборку проектов перед тестированием.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">Projeyi derlemeden önce test edin.</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">Projeyi derlemeden önce test edin.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">测试之前不要生成项目。</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">测试之前不要生成项目。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -125,8 +125,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdNoBuildDescription">
-        <source>Do not build project before testing.</source>
-        <target state="translated">請勿在測試前建置專案。</target>
+        <source>Do not build project before testing.  Implies --no-restore.</source>
+        <target state="needs-review-translation">請勿在測試前建置專案。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdTestAdapterPath">

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/CommandResultAssertions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Assertions/CommandResultAssertions.cs
@@ -69,6 +69,13 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return new AndConstraint<CommandResultAssertions>(this);
         }
 
+        public AndConstraint<CommandResultAssertions> NotHaveStdOutContaining(string pattern)
+        {
+            Execute.Assertion.ForCondition(!_commandResult.StdOut.Contains(pattern))
+                .FailWith(AppendDiagnosticsTo($"The command output contained a result it should not have contained: {pattern}{Environment.NewLine}"));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
         public AndConstraint<CommandResultAssertions> HaveStdOutMatching(string pattern, RegexOptions options = RegexOptions.None)
         {
             Execute.Assertion.ForCondition(Regex.Match(_commandResult.StdOut, pattern, options).Success)

--- a/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetPackInvocation
     {
         const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /restore /t:pack";
+        const string ExpectedNoBuildPrefix = "exec <msbuildpath> /m /v:m /t:pack";
 
         [Theory]
         [InlineData(new string[] { }, "")]
@@ -34,9 +35,10 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             var msbuildPath = "<msbuildpath>";
             var command = PackCommand.FromArgs(args, msbuildPath);
+            var expectedPrefix = args.FirstOrDefault() == "--no-build" ? ExpectedNoBuildPrefix : ExpectedPrefix;
 
             command.SeparateRestoreCommand.Should().BeNull();
-            command.GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+            command.GetProcessStartInfo().Arguments.Should().Be($"{expectedPrefix}{expectedAdditionalArgs}");
         }
     }
 }

--- a/test/dotnet-pack.Tests/PackTests.cs
+++ b/test/dotnet-pack.Tests/PackTests.cs
@@ -187,6 +187,25 @@ namespace Microsoft.DotNet.Tools.Pack.Tests
         }
 
         [Fact]
+        public void ItDoesNotImplicitlyBuildAProjectWhenPackagingWithTheNoBuildOption()
+        {
+            var testInstance = TestAssets.Get("TestAppSimple")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            var result = new PackCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .ExecuteWithCapturedOutput("--no-build");
+
+            result.Should().Fail();
+            if (!DotnetUnderTest.IsLocalized())
+            {
+                result.Should().NotHaveStdOutContaining("Restore")
+                    .And.HaveStdOutContaining("project.assets.json");
+            }
+        }
+
+        [Fact]
         public void ItDoesNotImplicitlyRestoreAProjectWhenPackagingWithTheNoRestoreOption()
         {
             var testInstance = TestAssets.Get("TestAppSimple")

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -518,5 +518,27 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .And.HaveStdOutContaining("(NO MESSAGE)")
                 .And.HaveStdErrContaining(string.Format(LocalizableStrings.RunCommandExceptionCouldNotApplyLaunchSettings, LocalizableStrings.DefaultLaunchProfileDisplayName, "").Trim());
         }
+
+        [Fact]
+        public void ItRunsWithTheSpecifiedVerbosity()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                            .CreateInstance()
+                            .WithSourceFiles();
+
+            var result = new RunCommand()
+                .WithWorkingDirectory( testInstance.Root.FullName)
+                .ExecuteWithCapturedOutput("-v:n");
+
+            result.Should().Pass()
+                .And.HaveStdOutContaining("Hello World!");
+
+            if (!DotnetUnderTest.IsLocalized())
+            {
+                result.Should().HaveStdOutContaining("Restore")
+                    .And.HaveStdOutContaining("CoreCompile");
+            }
+        }
     }
 }

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -76,6 +76,25 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
+        public void ItDoesNotImplicitlyBuildAProjectWhenRunningWithTheNoBuildOption()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                            .CreateInstance()
+                            .WithSourceFiles();
+
+            var result = new RunCommand()
+                .WithWorkingDirectory(testInstance.Root.FullName)
+                .ExecuteWithCapturedOutput("--no-build -v:m");
+
+            result.Should().Fail();
+            if (!DotnetUnderTest.IsLocalized())
+            {
+                result.Should().NotHaveStdOutContaining("Restore");
+            }
+        }
+
+        [Fact]
         public void ItDoesNotImplicitlyRestoreAProjectWhenRunningWithTheNoRestoreOption()
         {
             var testAppName = "MSBuildTestApp";

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -123,11 +123,12 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Call test
             CommandResult result = new DotnetTestCommand()
                                        .WithWorkingDirectory(testProjectDirectory)
-                                       .ExecuteWithCapturedOutput("--no-build");
+                                       .ExecuteWithCapturedOutput("--no-build -v:m");
 
             // Verify
             if (!DotnetUnderTest.IsLocalized())
             {
+                result.StdOut.Should().NotContain("Restore");
                 result.StdErr.Should().Contain(expectedError);
             }
 


### PR DESCRIPTION
These commits makes the `--no-build` option for the `run`, `pack`, and `test` commands automatically imply `--no-restore`.

Additionally, the verbosity option has been added to the `run` command to support tests.

Fixes issue #7472.
