### PR TITLE
Add parameter to dotnet-install to support pulling from private blob feeds

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -203,10 +203,9 @@ function GetHTTPResponse([Uri] $Uri)
             # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
             # 10 minutes allows it to work over much slower connections.
             $HttpClient.Timeout = New-TimeSpan -Minutes 10
-            $ActualUri = if (($Uri -like "$AzureFeed*") -or ($Uri -like "$UncachedFeed*")) { "${Uri}${FeedCredential}" } else { $Uri }
-            $Response = $HttpClient.GetAsync($ActualUri).Result
+            $Response = $HttpClient.GetAsync("${Uri}${FeedCredential}").Result
             if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode))) {
-                 # The feed credential is potential sensitive info. Do not log ActualUri to console output.
+                 # The feed credential is potentially sensitive info. Do not log FeedCredential to console output.
                 $ErrorMsg = "Failed to download $Uri."
                 if ($Response -ne $null) {
                     $ErrorMsg += "  $Response"

--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -49,10 +49,13 @@
 .PARAMETER AzureFeed
     Default: https://dotnetcli.azureedge.net/dotnet
     This parameter typically is not changed by the user.
-    It allows to change URL for the Azure feed used by this installer.
+    It allows changing the URL for the Azure feed used by this installer.
 .PARAMETER UncachedFeed
     This parameter typically is not changed by the user.
-    It allows to change URL for the Uncached feed used by this installer.
+    It allows changing the URL for the Uncached feed used by this installer.
+.PARAMETER FeedCredential
+    Used as a query string to append to the Azure feed.
+    It allows changing the URL to use non-public blob storage accounts.
 .PARAMETER ProxyAddress
     If set, the installer will use the proxy when making web requests
 .PARAMETER ProxyUseDefaultCredentials
@@ -73,6 +76,7 @@ param(
    [switch]$NoPath,
    [string]$AzureFeed="https://dotnetcli.azureedge.net/dotnet",
    [string]$UncachedFeed="https://dotnetcli.blob.core.windows.net/dotnet",
+   [string]$FeedCredential,
    [string]$ProxyAddress,
    [switch]$ProxyUseDefaultCredentials,
    [switch]$SkipNonVersionedFiles
@@ -199,8 +203,10 @@ function GetHTTPResponse([Uri] $Uri)
             # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
             # 10 minutes allows it to work over much slower connections.
             $HttpClient.Timeout = New-TimeSpan -Minutes 10
-            $Response = $HttpClient.GetAsync($Uri).Result
+            $ActualUri = if (($Uri -like "$AzureFeed*") -or ($Uri -like "$UncachedFeed*")) { "${Uri}${FeedCredential}" } else { $Uri }
+            $Response = $HttpClient.GetAsync($ActualUri).Result
             if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode))) {
+                 # The feed credential is potential sensitive info. Do not log ActualUri to console output.
                 $ErrorMsg = "Failed to download $Uri."
                 if ($Response -ne $null) {
                     $ErrorMsg += "  $Response"

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -618,6 +618,11 @@ downloadcurl() {
     local remote_path="$1"
     local out_path="${2:-}"
 
+    # Append feed_credential as late as possible before calling curl to avoid logging feed_credential
+    if [[ "$remote_path" == "$azure_feed"* ]] || [[ "$remote_path" == "$uncached_feed"* ]]; then
+        remote_path="${remote_path}${feed_credential}"
+    fi
+
     local failed=false
     if [ -z "$out_path" ]; then
         curl --retry 10 -sSL -f --create-dirs "$remote_path" || failed=true
@@ -635,6 +640,11 @@ downloadwget() {
     eval $invocation
     local remote_path="$1"
     local out_path="${2:-}"
+
+    # Append feed_credential as late as possible before calling wget to avoid logging feed_credential
+    if [[ "$remote_path" == "$azure_feed"* ]] || [[ "$remote_path" == "$uncached_feed"* ]]; then
+        remote_path="${remote_path}${feed_credential}"
+    fi
 
     local failed=false
     if [ -z "$out_path" ]; then
@@ -725,6 +735,7 @@ dry_run=false
 no_path=false
 azure_feed="https://dotnetcli.azureedge.net/dotnet"
 uncached_feed="https://dotnetcli.blob.core.windows.net/dotnet"
+feed_credential=""
 verbose=false
 shared_runtime=false
 runtime_id=""
@@ -770,6 +781,10 @@ do
             shift
             uncached_feed="$1"
             ;;
+        --feed-credential|-[Ff]eed[Cc]redential)
+            shift
+            feed_credential="$1"
+            ;;
         --runtime-id|-[Rr]untime[Ii]d)
             shift
             runtime_id="$1"
@@ -804,22 +819,23 @@ do
             echo "              coherent applies only to SDK downloads"
             echo "          - 3-part version in a format A.B.C - represents specific version of build"
             echo "              examples: 2.0.0-preview2-006120; 1.1.0"
-            echo "  -i,--install-dir <DIR>         Install under specified location (see Install Location below)"
+            echo "  -i,--install-dir <DIR>             Install under specified location (see Install Location below)"
             echo "      -InstallDir"
-            echo "  --architecture <ARCHITECTURE>  Architecture of .NET Tools. Currently only x64 is supported."
+            echo "  --architecture <ARCHITECTURE>      Architecture of .NET Tools. Currently only x64 is supported."
             echo "      --arch,-Architecture,-Arch"
-            echo "  --shared-runtime               Installs just the shared runtime bits, not the entire SDK."
+            echo "  --shared-runtime                   Installs just the shared runtime bits, not the entire SDK."
             echo "      -SharedRuntime"
-            echo "  --skip-non-versioned-files     Skips non-versioned files if they already exist, such as the dotnet executable."
+            echo "  --skip-non-versioned-files         Skips non-versioned files if they already exist, such as the dotnet executable."
             echo "      -SkipNonVersionedFiles"
-            echo "  --dry-run,-DryRun              Do not perform installation. Display download link."
-            echo "  --no-path, -NoPath             Do not set PATH for the current process."
-            echo "  --verbose,-Verbose             Display diagnostics information."
-            echo "  --azure-feed,-AzureFeed        Azure feed location. Defaults to $azure_feed, This parameter typically is not changed by the user."
-            echo "  --uncached-feed,-UncachedFeed  Uncached feed location. This parameter typically is not changed by the user."
-            echo "  --runtime-id                   Installs the .NET Tools for the given platform (use linux-x64 for portable linux)."
+            echo "  --dry-run,-DryRun                  Do not perform installation. Display download link."
+            echo "  --no-path, -NoPath                 Do not set PATH for the current process."
+            echo "  --verbose,-Verbose                 Display diagnostics information."
+            echo "  --azure-feed,-AzureFeed            Azure feed location. Defaults to $azure_feed, This parameter typically is not changed by the user."
+            echo "  --uncached-feed,-UncachedFeed      Uncached feed location. This parameter typically is not changed by the user."
+            echo "  --feed-credential,-FeedCredential  Azure feed shared access token. This parameter typically is not specified."
+            echo "  --runtime-id                       Installs the .NET Tools for the given platform (use linux-x64 for portable linux)."
             echo "      -RuntimeId"
-            echo "  -?,--?,-h,--help,-Help         Shows this help message"
+            echo "  -?,--?,-h,--help,-Help             Shows this help message"
             echo ""
             echo "Install Location:"
             echo "  Location is chosen in following order:"

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -619,9 +619,7 @@ downloadcurl() {
     local out_path="${2:-}"
 
     # Append feed_credential as late as possible before calling curl to avoid logging feed_credential
-    if [[ "$remote_path" == "$azure_feed"* ]] || [[ "$remote_path" == "$uncached_feed"* ]]; then
-        remote_path="${remote_path}${feed_credential}"
-    fi
+    remote_path="${remote_path}${feed_credential}"
 
     local failed=false
     if [ -z "$out_path" ]; then
@@ -642,9 +640,7 @@ downloadwget() {
     local out_path="${2:-}"
 
     # Append feed_credential as late as possible before calling wget to avoid logging feed_credential
-    if [[ "$remote_path" == "$azure_feed"* ]] || [[ "$remote_path" == "$uncached_feed"* ]]; then
-        remote_path="${remote_path}${feed_credential}"
-    fi
+    remote_path="${remote_path}${feed_credential}"
 
     local failed=false
     if [ -z "$out_path" ]; then


### PR DESCRIPTION
Typically this will only be used for internal customers when publishing dotnet-cli assets to private Azure blob feeds.

skip ci please
