### PR TITLE
Crossgen the Sdks directory.

### DIFF
--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -219,7 +219,7 @@
 
   <Target Name="CrossgenPublishDir"
           Condition=" '$(DISABLE_CROSSGEN)' == '' "
-          AfterTargets="GenerateCliRuntimeConfigurationFiles">
+          AfterTargets="PublishSdks">
     <ItemGroup>
       <RoslynFiles Include="$(PublishDir)Roslyn\bincore\**\*" />
       <FSharpFiles Include="$(PublishDir)FSharp\**\*" Exclude="$(PublishDir)FSharp\FSharp.Build.dll" />
@@ -229,6 +229,10 @@
       <RemainingFiles Remove="$(PublishDir)TestHost*\**\*" />
       <RemainingFiles Remove="$(PublishDir)Sdks\**\*" />
       <RemainingFiles Remove="$(PublishDir)**\Microsoft.TestPlatform.Extensions.EventLogCollector.dll" />
+
+      <!-- Add back the .NET Core assemblies in the Sdks folder -->
+      <RemainingFiles Include="$(PublishDir)Sdks\Microsoft.NET.Sdk\tools\netcoreapp2.0\**\*" />
+      <RemainingFiles Include="$(PublishDir)Sdks\NuGet.Build.Tasks.Pack\CoreCLR\**\*" />
 
       <!-- Don't try to CrossGen .NET Framework support assemblies for .NET Standard -->
       <RemainingFiles Remove="$(PublishDir)Microsoft\Microsoft.NET.Build.Extensions\net*\**\*" />
@@ -297,7 +301,7 @@
         CreateSymbols="$(CreateCrossgenSymbols)"
         DiasymReaderPath="@(DiasymReaderPath)"
         PlatformAssemblyPaths="@(PlatformAssemblies);@(FSharpFolders);$(SharedFrameworkNameVersionPath)" />
- 
+
     <Crossgen
         SourceAssembly="%(RemainingTargets.FullPath)"
         DestinationPath="%(RemainingTargets.FullPath)"


### PR DESCRIPTION
Crossgen'ing the .NET Core assemblies in the `Sdks` folder.

I'm seeing a pretty minor bump in incremental `dotnet build` on this change.  Maybe ~10-20ms on my machine.

However, incremental `dotnet pack` is seeing a much bigger change:

Before my change:
```
PS F:\git\dotnet-cli-perf\scenarios\classlib\core> Measure-Command { F:\dotnet\baseline-master\dotnet.exe pack .\classlib\classlib.csproj }

TotalSeconds      : 1.7312376

PS F:\git\dotnet-cli-perf\scenarios\classlib\core> Measure-Command { F:\dotnet\baseline-master\dotnet.exe pack .\classlib\classlib.csproj }

TotalSeconds      : 1.7063791

PS F:\git\dotnet-cli-perf\scenarios\classlib\core> Measure-Command { F:\dotnet\baseline-master\dotnet.exe pack .\classlib\classlib.csproj }

TotalSeconds      : 1.7347582
```

After my change:
```
PS F:\git\dotnet-cli-perf\scenarios\classlib\core> Measure-Command { F:\cli\bin\2\win10-x64\dotnet\dotnet.exe pack .\classlib\classlib.csproj }

TotalSeconds      : 1.4844696

PS F:\git\dotnet-cli-perf\scenarios\classlib\core> Measure-Command { F:\cli\bin\2\win10-x64\dotnet\dotnet.exe pack .\classlib\classlib.csproj }

TotalSeconds      : 1.5171604


PS F:\git\dotnet-cli-perf\scenarios\classlib\core> Measure-Command { F:\cli\bin\2\win10-x64\dotnet\dotnet.exe pack .\classlib\classlib.csproj }

TotalSeconds      : 1.4780401
```