### PR TITLE
Crossgen Microsoft.NET.Build.Extensions.Tasks.dll

### DIFF
--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -237,9 +237,6 @@
       <!-- Don't try to CrossGen .NET Framework support assemblies for .NET Standard -->
       <RemainingFiles Remove="$(PublishDir)Microsoft\Microsoft.NET.Build.Extensions\net*\**\*" />
 
-      <!-- Don't try to CrossGen tasks and supporting DLLs compiled for .NET Framework -->
-      <RemainingFiles Remove="$(PublishDir)Microsoft\Microsoft.NET.Build.Extensions\tools\net*\**\*" />
-
       <!-- Don't crossgen satellite assemblies -->
       <RoslynFiles Remove="$(PublishDir)Roslyn\bincore\**\*.resources.dll" />
       <FSharpFiles Remove="$(PublishDir)FSharp\**\*.resources.dll" />


### PR DESCRIPTION
Crossgen'ing one more tasks assembly.  This appears to give another minor bump (~10ms on average) in incremental `dotnet build` scenarios on my machine.