### PR TITLE
Support directories for `sln add`, `sln remove`, `add reference`, and `remove reference` commands.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -51,4 +51,5 @@
 *.vbproj text=auto
 *.fsproj text=auto
 *.dbproj text=auto
+*.xlf text=auto
 *.sln text=auto eol=crlf

--- a/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/Empty/README
+++ b/TestAssets/NonRestoredTestProjects/DotnetAddP2PProjects/Empty/README
@@ -1,0 +1,2 @@
+This directory is intentionally empty.
+

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojFiles/Empty/README
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojFiles/Empty/README
@@ -1,0 +1,2 @@
+This directory is intentionally empty.
+

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojFiles/Multiple/First.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojFiles/Multiple/First.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojFiles/Multiple/Second.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojFiles/Multiple/Second.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojToRemove/Empty/README
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojToRemove/Empty/README
@@ -1,0 +1,2 @@
+This directory is intentionally empty.
+

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojToRemove/Multiple/First.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojToRemove/Multiple/First.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppWithSlnAndCsprojToRemove/Multiple/Second.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndCsprojToRemove/Multiple/Second.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Cli.Utils/PathUtility.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/PathUtility.cs
@@ -330,13 +330,14 @@ namespace Microsoft.DotNet.Tools.Common
 
         public static void EnsureAllPathsExist(
             IReadOnlyCollection<string> paths,
-            string pathDoesNotExistLocalizedFormatString)
+            string pathDoesNotExistLocalizedFormatString,
+            bool allowDirectories = false)
         {
             var notExisting = new List<string>();
 
             foreach (var p in paths)
             {
-                if (!File.Exists(p))
+                if (!File.Exists(p) && (!allowDirectories || !Directory.Exists(p)))
                 {
                     notExisting.Add(p);
                 }

--- a/src/dotnet/CommonLocalizableStrings.resx
+++ b/src/dotnet/CommonLocalizableStrings.resx
@@ -345,9 +345,6 @@
   <data name="SolutionDoesNotExist" xml:space="preserve">
     <value>Specified solution file {0} does not exist, or there is no solution file in the directory.</value>
   </data>
-  <data name="ReferenceDoesNotExist" xml:space="preserve">
-    <value>Reference {0} does not exist.</value>
-  </data>
   <data name="ReferenceIsInvalid" xml:space="preserve">
     <value>Reference `{0}` is invalid.</value>
   </data>

--- a/src/dotnet/CommonLocalizableStrings.resx
+++ b/src/dotnet/CommonLocalizableStrings.resx
@@ -384,6 +384,9 @@
   <data name="ProjectAddedToTheSolution" xml:space="preserve">
     <value>Project `{0}` added to the solution.</value>
   </data>
+  <data name="ProjectRemovedFromTheSolution" xml:space="preserve">
+    <value>Project `{0}` removed from the solution.</value>
+  </data>
   <data name="SolutionAlreadyContainsProject" xml:space="preserve">
     <value>Solution {0} already contains project {1}.</value>
   </data>

--- a/src/dotnet/SlnFileExtensions.cs
+++ b/src/dotnet/SlnFileExtensions.cs
@@ -221,7 +221,7 @@ namespace Microsoft.DotNet.Tools.Common
             if (projectsToRemove.Count == 0)
             {
                 Reporter.Output.WriteLine(string.Format(
-                    CommonLocalizableStrings.ProjectReferenceCouldNotBeFound,
+                    CommonLocalizableStrings.ProjectNotFoundInTheSolution,
                     projectPath));
             }
             else
@@ -244,7 +244,7 @@ namespace Microsoft.DotNet.Tools.Common
 
                     slnFile.Projects.Remove(slnProject);
                     Reporter.Output.WriteLine(
-                        string.Format(CommonLocalizableStrings.ProjectReferenceRemoved, slnProject.FilePath));
+                        string.Format(CommonLocalizableStrings.ProjectRemovedFromTheSolution, slnProject.FilePath));
                 }
 
                 foreach (var project in slnFile.Projects)

--- a/src/dotnet/commands/dotnet-add/dotnet-add-reference/Program.cs
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-reference/Program.cs
@@ -45,9 +45,9 @@ namespace Microsoft.DotNet.Tools.Add.ProjectToProjectReference
 
             var frameworkString = _appliedCommand.ValueOrDefault<string>("framework");
 
-            PathUtility.EnsureAllPathsExist(_appliedCommand.Arguments, CommonLocalizableStrings.ReferenceDoesNotExist);
+            PathUtility.EnsureAllPathsExist(_appliedCommand.Arguments, CommonLocalizableStrings.CouldNotFindProjectOrDirectory, true);
             List<MsbuildProject> refs = _appliedCommand.Arguments
-                                                       .Select((r) => MsbuildProject.FromFile(projects, r))
+                                                       .Select((r) => MsbuildProject.FromFileOrDirectory(projects, r))
                                                        .ToList();
 
             if (frameworkString == null)
@@ -90,9 +90,10 @@ namespace Microsoft.DotNet.Tools.Add.ProjectToProjectReference
                 }
             }
 
-            var relativePathReferences = _appliedCommand.Arguments.Select((r) =>
-                                                                              Path.GetRelativePath(msbuildProj.ProjectDirectory, Path.GetFullPath(r)))
-                                                        .ToList();
+            var relativePathReferences = refs.Select((r) =>
+                                                        Path.GetRelativePath(
+                                                            msbuildProj.ProjectDirectory,
+                                                            r.ProjectRootElement.FullPath)).ToList();
 
             int numberOfAddedReferences = msbuildProj.AddProjectToProjectReferences(
                 frameworkString,

--- a/src/dotnet/commands/dotnet-sln/add/Program.cs
+++ b/src/dotnet/commands/dotnet-sln/add/Program.cs
@@ -40,11 +40,14 @@ namespace Microsoft.DotNet.Tools.Sln.Add
                 throw new GracefulException(CommonLocalizableStrings.SpecifyAtLeastOneProjectToAdd);
             }
 
-            PathUtility.EnsureAllPathsExist(_appliedCommand.Arguments, CommonLocalizableStrings.ProjectDoesNotExist);
+            PathUtility.EnsureAllPathsExist(_appliedCommand.Arguments, CommonLocalizableStrings.CouldNotFindProjectOrDirectory, true);
 
-            var fullProjectPaths = _appliedCommand.Arguments
-                                                  .Select(Path.GetFullPath)
-                                                  .ToList();
+            var fullProjectPaths = _appliedCommand.Arguments.Select(p => {
+                var fullPath = Path.GetFullPath(p);
+                return Directory.Exists(fullPath) ?
+                    MsbuildProject.GetProjectFileFromDirectory(fullPath).FullName :
+                    fullPath;
+            }).ToList();
 
             var preAddProjectCount = slnFile.Projects.Count;
 

--- a/src/dotnet/commands/dotnet-sln/remove/Program.cs
+++ b/src/dotnet/commands/dotnet-sln/remove/Program.cs
@@ -40,11 +40,16 @@ namespace Microsoft.DotNet.Tools.Sln.Remove
         {
             SlnFile slnFile = SlnFileFactory.CreateFromFileOrDirectory(_fileOrDirectory);
 
-            var relativeProjectPaths = _appliedCommand.Arguments.Select(p =>
-                                                                            Path.GetRelativePath(
-                                                                                PathUtility.EnsureTrailingSlash(slnFile.BaseDirectory),
-                                                                                Path.GetFullPath(p)))
-                                                      .ToList();
+            var baseDirectory = PathUtility.EnsureTrailingSlash(slnFile.BaseDirectory);
+            var relativeProjectPaths = _appliedCommand.Arguments.Select(p => {
+                var fullPath = Path.GetFullPath(p);
+                return Path.GetRelativePath(
+                    baseDirectory,
+                    Directory.Exists(fullPath) ?
+                        MsbuildProject.GetProjectFileFromDirectory(fullPath).FullName :
+                        fullPath
+                );
+            });
 
             bool slnChanged = false;
             foreach (var path in relativeProjectPaths)

--- a/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Aplikace</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">Odkaz na {0} neexistuje.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">Odkaz na {0} byl přidán do projektu.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -674,6 +674,11 @@
         <target state="translated">Při spuštění příkazu neprovede implicitní obnovení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -674,6 +674,11 @@
         <target state="translated">Führt beim Ausführen des Befehls keine implizite Wiederherstellung durch.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Anwendung</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">Der Verweis "{0}" ist nicht vorhanden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">Der Verweis "{0}" wurde dem Projekt hinzugefügt.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -674,6 +674,11 @@
         <target state="translated">No realiza una restauración implícita al ejecutar el comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Aplicación</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">La referencia {0} no existe.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">Se ha agregado la referencia "{0}" al proyecto.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -674,6 +674,11 @@
         <target state="translated">Ne fait pas de restauration implicite durant l'exécution de la commande.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Application</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">La référence {0} n'existe pas.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">Référence '{0}' ajoutée au projet.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -674,6 +674,11 @@
         <target state="translated">Non esegue un ripristino implicito durante l'esecuzione del comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Applicazione</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">Il riferimento {0} non esiste.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">Il riferimento `{0}` è stato aggiunto al progetto.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -674,6 +674,11 @@
         <target state="translated">コマンドを実行するときに暗黙的復元を行いません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -97,11 +97,6 @@
         <target state="translated">アプリケーション</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">参照 {0} は存在しません。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">参照 `{0}` がプロジェクトに追加されました。</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -97,11 +97,6 @@
         <target state="translated">응용 프로그램</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">{0} 참조가 없습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">프로젝트에 '{0}' 참조가 추가되었습니다.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -674,6 +674,11 @@
         <target state="translated">명령을 실행할 때 암시적 복원을 수행하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -674,6 +674,11 @@
         <target state="translated">Nie wykonuje niejawnego przywracania podczas wykonywania polecenia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Aplikacja</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">Odwołanie {0} nie istnieje.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">Do projektu zostało dodane odwołanie „{0}”.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Aplicativo</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">A referência {0} não existe.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">A referência ‘{0}’ foi adicionada ao projeto.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -674,6 +674,11 @@
         <target state="translated">Não faz uma restauração implícita ao executar o comando.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Приложение</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">Ссылка {0} не существует.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">Ссылка "{0}" добавлена в проект.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -674,6 +674,11 @@
         <target state="translated">Не выполняет неявное восстановление при выполнении команды.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -674,6 +674,11 @@
         <target state="translated">Komut yürütülürken örtük geri yükleme gerçekleştirmez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -97,11 +97,6 @@
         <target state="translated">Uygulama</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">{0} başvurusu yok.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">`{0}` başvurusu projeye eklendi.</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -97,11 +97,6 @@
         <target state="translated">应用程序</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">引用 {0} 不存在。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">已将引用“{0}”添加到项目。</target>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -674,6 +674,11 @@
         <target state="translated">请勿在执行命令时进行隐式还原。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -674,6 +674,11 @@
         <target state="translated">執行此命令時，請勿進行隱含還原。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectRemovedFromTheSolution">
+        <source>Project `{0}` removed from the solution.</source>
+        <target state="new">Project `{0}` removed from the solution.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -97,11 +97,6 @@
         <target state="translated">應用程式</target>
         <note />
       </trans-unit>
-      <trans-unit id="ReferenceDoesNotExist">
-        <source>Reference {0} does not exist.</source>
-        <target state="translated">參考 {0} 不存在。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ReferenceAddedToTheProject">
         <source>Reference `{0}` added to the project.</source>
         <target state="translated">參考 `{0}` 已新增至專案。</target>

--- a/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
+++ b/test/dotnet-remove-reference.Tests/GivenDotnetRemoveP2P.cs
@@ -506,5 +506,56 @@ Commands:
             csproj.NumberOfItemGroupsWithoutCondition().Should().Be(noCondBefore - 1);
             csproj.NumberOfProjectReferencesWithIncludeContaining(validref.Name).Should().Be(0);
         }
+
+        [Fact]
+        public void WhenDirectoryContainingProjectIsGivenReferenceIsRemoved()
+        {
+            var setup = Setup();
+            var lib = NewLibWithFrameworks(dir: setup.TestRoot);
+            var libref = AddLibRef(setup, lib);
+
+            var result = new RemoveReferenceCommand()
+                    .WithWorkingDirectory(setup.TestRoot)
+                    .WithProject(lib.CsProjPath)
+                    .Execute($"\"{libref.CsProjPath}\"");
+
+            result.Should().Pass();
+            result.StdOut.Should().Be(string.Format(CommonLocalizableStrings.ProjectReferenceRemoved, Path.Combine("Lib", setup.LibCsprojName)));
+            result.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void WhenDirectoryContainsNoProjectsItCancelsWholeOperation()
+        {
+            var setup = Setup();
+            var lib = NewLibWithFrameworks(dir: setup.TestRoot);
+
+            var reference = "Empty";
+            var result = new RemoveReferenceCommand()
+                    .WithWorkingDirectory(setup.TestRoot)
+                    .WithProject(lib.CsProjPath)
+                    .Execute(reference);
+
+            result.Should().Fail();
+            result.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized(HelpText);
+            result.StdErr.Should().Be(string.Format(CommonLocalizableStrings.CouldNotFindAnyProjectInDirectory, Path.Combine(setup.TestRoot, reference)));
+        }
+
+        [Fact]
+        public void WhenDirectoryContainsMultipleProjectsItCancelsWholeOperation()
+        {
+            var setup = Setup();
+            var lib = NewLibWithFrameworks(dir: setup.TestRoot);
+
+            var reference = "MoreThanOne";
+            var result = new RemoveReferenceCommand()
+                    .WithWorkingDirectory(setup.TestRoot)
+                    .WithProject(lib.CsProjPath)
+                    .Execute(reference);
+
+            result.Should().Fail();
+            result.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized(HelpText);
+            result.StdErr.Should().Be(string.Format(CommonLocalizableStrings.MoreThanOneProjectInDirectory, Path.Combine(setup.TestRoot, reference)));
+        }
     }
 }


### PR DESCRIPTION
This PR implements support for specifying directories containing a single project to the following commands:

* `sln add`
* `sln remove`
* `add reference`
* `remove reference`

Additionally, the output of the `sln remove` command has been changed to be consistent with the `sln add` command; specifically, it now speaks of "projects" being removed rather than "references".

Fixes #7343.
