### PR TITLE
Use rhel docker image with sudo built in

### DIFF
--- a/scripts/docker/rhel/Dockerfile
+++ b/scripts/docker/rhel/Dockerfile
@@ -4,11 +4,7 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM microsoft/dotnet-buildtools-prereqs:rhel-7-rpmpkg-c982313-20174116044113
-
-# Install from sudo main package
-RUN yum install -y https://www.sudo.ws/sudo/dist/packages/RHEL/7/sudo-1.8.20-3.el7.x86_64.rpm \
-    && yum clean all
+FROM microsoft/dotnet-buildtools-prereqs:rhel-7-rpmpkg-e1b4a89-20175311035359
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0


### PR DESCRIPTION
So we do not need to download sudo from the internet every time we build

I checked in the docker file change a while a ago.