### PR TITLE
Global tools: treat manifest EntryPoint value as a file path within the package

### DIFF
--- a/src/dotnet/ToolPackage/ToolPackageObtainer.cs
+++ b/src/dotnet/ToolPackage/ToolPackageObtainer.cs
@@ -97,10 +97,7 @@ namespace Microsoft.DotNet.ToolPackage
                 toolConfiguration,
                 toolDirectory.WithSubDirectories(
                     packageId,
-                    packageVersion,
-                    "tools",
-                    targetframework,
-                    "any"));
+                    packageVersion));
         }
 
         private static void MoveToVersionedDirectory(

--- a/test/Microsoft.DotNet.ToolPackage.Tests/SampleGlobalTool/DotnetToolSettings.xml
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/SampleGlobalTool/DotnetToolSettings.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <DotNetCliTool>
   <Commands>
-    <Command Name="demo" EntryPoint="consoledemo.dll" Runner="dotnet" />
+    <Command Name="demo" EntryPoint="tools/netcoreapp2.1/any/consoledemo.dll" Runner="dotnet" />
   </Commands>
 </DotNetCliTool>

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageObtainerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageObtainerTests.cs
@@ -59,9 +59,6 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 .ExecutableDirectory
                 .GetParentPath()
                 .GetParentPath()
-                .GetParentPath()
-                .GetParentPath()
-                .GetParentPath()
                 .WithFile("project.assets.json").Value;
 
             File.Exists(assetJsonPath)


### PR DESCRIPTION
Currently dotnet install tools assumes that EntryPoint is the filename inside `tools/$(BundledTargetFramework)/any/` in the package. This restriction seems unnecessary. This also helps avoid the next-version problem when BundledTargetFramework changes to netcoreapp2.2. Without this, netcoreapp2.1 tool packages would no longer install when CLI is upgraded to a new version.

As a side note, if I've missed something and the `tools/$(BundledTargetFramework)/any/` restriction is important, it seems like you could easily add some kind of assert during install, such as:
```c#
if (Path.GetDirectoryName(toolConfig.EntryPoint) != $"tools/{BundledTargetFramework}/any/")
    throw new Exception("Global tools must put the entry point in tools/{BundledTargetFramework}/any/ for (reasons)");
```