### PR TITLE
Write UTF-8 BOM for solution files.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
+++ b/src/Microsoft.DotNet.Cli.Sln.Internal/SlnFile.cs
@@ -33,6 +33,7 @@ using System.IO;
 using System.Collections;
 using System.Globalization;
 using System.Reflection;
+using System.Text;
 using Microsoft.DotNet.Cli.Sln.Internal.FileManipulation;
 using Microsoft.DotNet.Tools.Common;
 
@@ -211,7 +212,7 @@ namespace Microsoft.DotNet.Cli.Sln.Internal
             }
             var sw = new StringWriter();
             Write(sw);
-            File.WriteAllText(FullPath, sw.ToString());
+            File.WriteAllText(FullPath, sw.ToString(), Encoding.UTF8);
         }
 
         private void Write(TextWriter writer)


### PR DESCRIPTION
Currently the solution file written out by the `sln` command uses a
UTF-8 encoding without a BOM.  This causes problems when the solution
file contains non-ASCII code points because Visual Studio and MSBuild
will not use a UTF-8 encoding when reading the solution file if the
BOM is omitted.

This commit causes the BOM to always be written when writing the
solution files.

Fixes #8184.
