### PR TITLE
Correctly check for existence of shared runtime in dotnet-install scripts

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -472,10 +472,15 @@ if ($DryRun) {
 $InstallRoot = Resolve-Installation-Path $InstallDir
 Say-Verbose "InstallRoot: $InstallRoot"
 
-$IsSdkInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage "sdk" -SpecificVersion $SpecificVersion
-Say-Verbose ".NET SDK installed? $IsSdkInstalled"
-if ($IsSdkInstalled) {
-    Say ".NET SDK version $SpecificVersion is already installed."
+$dotnetPackageRelativePath = if ($SharedRuntime) { "shared\Microsoft.NETCore.App" } else { "sdk" }
+
+$isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $SpecificVersion
+if ($isAssetInstalled) {
+    if ($SharedRuntime) {
+        Say ".NET Core Runtime version $SpecificVersion is already installed."
+    } else {
+        Say ".NET Core SDK version $SpecificVersion is already installed."
+    }
     Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
     exit 0
 }

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -688,9 +688,16 @@ install_dotnet() {
     eval $invocation
     local download_failed=false
 
-    if is_dotnet_package_installed "$install_root" "sdk" "$specific_version"; then
-        say ".NET SDK version $specific_version is already installed."
-        return 0
+    if [ "$shared_runtime" = true ]; then
+        if is_dotnet_package_installed "$install_root" "shared/Microsoft.NETCore.App" "$specific_version"; then
+            say ".NET Core Runtime version $specific_version is already installed."
+            return 0
+        fi
+    else
+        if is_dotnet_package_installed "$install_root" "sdk" "$specific_version"; then
+            say ".NET Core SDK version $specific_version is already installed."
+            return 0
+        fi
     fi
     
     mkdir -p "$install_root"
@@ -786,7 +793,6 @@ do
             runtime_id="$1"
             ;;
         --skip-non-versioned-files|-[Ss]kip[Nn]on[Vv]ersioned[Ff]iles)
-            shift
             override_non_versioned_files=false
             ;;
         -?|--?|-h|--help|-[Hh]elp)


### PR DESCRIPTION
When `-SharedRuntime` (ps1) or `--shared-runtime` (sh) is specified, the "is installed?" check was looking for the SDK by the same version, not the shared runtime, and may skip installation even if the shared runtime is missing.

