### PR TITLE
Make restore performed by run command default to nologo and quiet.

### DIFF
--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -146,22 +146,38 @@ namespace Microsoft.DotNet.Tools.Run
 
         private void EnsureProjectIsBuilt()
         {
-            List<string> buildArgs = new List<string>();
-
-            buildArgs.Add(Project);
-
-            buildArgs.Add("/nologo");
-            buildArgs.Add("/verbosity:quiet");
-
-            buildArgs.AddRange(RestoreArgs);
+            var restoreArgs = GetRestoreArguments();
 
             var buildResult =
-                new RestoringCommand(buildArgs, RestoreArgs, new [] { Project }, NoRestore).Execute();
+                new RestoringCommand(
+                    restoreArgs.Prepend(Project),
+                    restoreArgs,
+                    new [] { Project },
+                    NoRestore
+                ).Execute();
+
             if (buildResult != 0)
             {
                 Reporter.Error.WriteLine();
                 throw new GracefulException(LocalizableStrings.RunCommandException);
             }
+        }
+
+        private List<string> GetRestoreArguments()
+        {
+            List<string> args = new List<string>()
+            {
+                "/nologo"
+            };
+
+            if (!RestoreArgs.Any(a => a.StartsWith("/verbosity:")))
+            {
+                args.Add("/verbosity:quiet");
+            }
+
+            args.AddRange(RestoreArgs);
+
+            return args;
         }
 
         private ICommand GetRunCommand()

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -152,7 +152,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .WithWorkingDirectory(testProjectDirectory)
                 .ExecuteWithCapturedOutput("--framework netcoreapp2.1")
                 .Should().Pass()
-                         .And.HaveStdOutContaining("Hello World!");
+                         .And.HaveStdOut("Hello World!");
         }
 
         [Fact]


### PR DESCRIPTION
This commit changes the run command such that it will now be `/nologo` and
`/verbosity:quiet` (by default) for the restore operation even if a target
framework is specified.

When a target framework is specified, a separate restore operation is performed
that does not pass `/nologo` and the default verbosity is used.  The fix is to
ensure that the arguments used for the restore operation match those that are
used for the build operation.

Fixes #8118.