### PR TITLE
Bump stage0 to 2.2.0-preview1-007799.

### DIFF
--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -16,17 +16,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppPackageVersion)" />
     <PackageReference Include="Microsoft.Build" Version="15.4.8" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.4.8" />
     <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.4.1-beta-24410-02" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.0.11" />
     <PackageReference Include="WindowsAzure.Storage" Version="7.2.1" />
-    <PackageReference Include="NuGet.CommandLine.XPlat" Version="4.4.0-preview3-4475" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.4.8" />
-    <!-- This dependency was added due to an issue in restore where a lower version of this package coming from nuget.commandline.xplat
-    led to an error. This is tracked as NuGet issue : https://github.com/NuGet/Home/issues/4213 -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.4.8" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="$(VersionToolsVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(BuildTasksFeedToolVersion)" />

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -68,8 +68,8 @@ $env:VSTEST_TRACE_BUILD=1
 # install a stage0
 $dotnetInstallPath = Join-Path $RepoRoot "scripts\obtain\dotnet-install.ps1"
 
-Write-Output "$dotnetInstallPath -version ""2.1.0-preview1-007172"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
-Invoke-Expression "$dotnetInstallPath -version ""2.1.0-preview1-007172"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Write-Output "$dotnetInstallPath -version ""2.2.0-preview1-007799"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+Invoke-Expression "$dotnetInstallPath -version ""2.2.0-preview1-007799"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
 if ($LastExitCode -ne 0)
 {
     Write-Output "The .NET CLI installation failed with exit code $LastExitCode"

--- a/run-build.sh
+++ b/run-build.sh
@@ -153,7 +153,7 @@ export DOTNET_MULTILEVEL_LOOKUP=0
 
 # Install a stage 0
 if [ "$STAGE0_SOURCE_DIR" == "" ]; then
-    (set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --version "2.1.0-preview1-007172" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS)
+    (set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --version "2.2.0-preview1-007799" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS)
 else
     echo "Copying bootstrap cli from $BOOTSTRAP_CLI"
     cp -r $STAGE0_SOURCE_DIR/* "$DOTNET_INSTALL_DIR"


### PR DESCRIPTION
Need to remove some unnecessary dependencies in dotnet-cli-build.csproj because the NuGet.CommandLine.XPlat reference was bringing in an old MSBuild version, which was breaking restore. I didn't see any usages of this reference, so I'm removing it since it is not needed.

```JSON
 "code": "NU1608",
      "level": "Error",
      "message": "Detected package version outside of dependency constraint: Microsoft.Build.Runtime 15.1.1012 requires Microsoft.Build (= 15.1.1012) but version Microsoft.Build 15.4.8 was resolved.",
      "libraryId": "Microsoft.Build",
      "targetGraphs": [
        ".NETCoreApp,Version=v2.1"
      ] 
```

This was caused because

```JSON
"NuGet.CommandLine.XPlat/4.4.0-preview3-4475": {
       "dependencies": {
          "Microsoft.Build.Runtime": "15.1.1012", 
```

and

```JSON
"Microsoft.Build.Runtime/15.1.1012": {
        "type": "package",
        "dependencies": {
          "Microsoft.Build": "[15.1.1012]", 
```

Notice the `[15.1.1012]` version there, meaning that exact version - no higher, no lower.

This unblocks @janvorli's work to bootstrap alpine, since he is putting his locally built alpine SDK in Azure for that version.