### PR TITLE
Enable Alpine 3.6 CLI build

### DIFF
--- a/TestAssets/TestProjects/AppWithCorruptedLaunchSettings/AppWithCorruptedLaunchSettings.csproj
+++ b/TestAssets/TestProjects/AppWithCorruptedLaunchSettings/AppWithCorruptedLaunchSettings.csproj
@@ -4,6 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithLaunchSettings/AppWithLaunchSettings.csproj
+++ b/TestAssets/TestProjects/AppWithLaunchSettings/AppWithLaunchSettings.csproj
@@ -4,6 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithLaunchSettingsNoDefault/AppWithLaunchSettingsNoDefault.csproj
+++ b/TestAssets/TestProjects/AppWithLaunchSettingsNoDefault/AppWithLaunchSettingsNoDefault.csproj
@@ -4,6 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
+++ b/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
     <RestoreAdditionalProjectSources Condition="'$(TEST_PACKAGES)' != ''">$(TEST_PACKAGES)</RestoreAdditionalProjectSources>
   </PropertyGroup>
 

--- a/build/Branding.props
+++ b/build/Branding.props
@@ -12,12 +12,14 @@
     <ProductMonikerRid Condition=" '$(Rid)' == 'ubuntu.16.04-x64' OR
                                    '$(Rid)' == 'fedora.24-x64' OR
                                    '$(Rid)' == 'rhel.6-x64' OR
+                                   '$(Rid)' == 'alpine.3.6-x64' OR
                                    '$(Rid)' == 'opensuse.42.1-x64' ">$(Rid)</ProductMonikerRid>
     <ProductMonikerRid Condition=" '$(ProductMonikerRid)' == '' ">$(OSName)-$(Architecture)</ProductMonikerRid>
 
     <HostMonikerRid Condition=" '$(HostRid)' == 'ubuntu.16.04-x64' OR
                                 '$(HostRid)' == 'fedora.24-x64' OR
                                 '$(HostRid)' == 'rhel.6-x64' OR
+                                '$(HostRid)' == 'alpine.3.6-x64' OR
                                 '$(HostRid)' == 'opensuse.42.1-x64' ">$(HostRid)</HostMonikerRid>
     <HostMonikerRid Condition=" '$(HostMonikerRid)' == '' ">$(HostOSName)-$(Architecture)</HostMonikerRid>
 

--- a/build/BuildDefaults.props
+++ b/build/BuildDefaults.props
@@ -3,7 +3,7 @@
     <CLITargets Condition=" '$(CLITargets)' == '' ">Prepare;Compile;Test;Package;Publish</CLITargets>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <IncludeNuGetPackageArchive Condition=" '$(IncludeNuGetPackageArchive)' == '' ">true</IncludeNuGetPackageArchive>
-    <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND $(Rid.StartsWith('rhel.6')) AND $(Rid.StartsWith('alpine.3.6'))">true</SkipBuildingInstallers>
+    <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND ($(Rid.StartsWith('rhel.6')) OR $(Rid.StartsWith('alpine.3.6')))">true</SkipBuildingInstallers>
     <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' ">false</SkipBuildingInstallers>
     <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(OSPlatform)' == 'linux' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'alpine.3.6-x64' ">true</UsePortableLinuxSharedFramework>
     <IncludeSharedFrameworksForBackwardsCompatibilityTests Condition=" $(IncludeSharedFrameworksForBackwardsCompatibilityTests) == '' AND '$(Rid)' != 'linux-x64' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'alpine.3.6-x64'">true</IncludeSharedFrameworksForBackwardsCompatibilityTests>

--- a/build/BuildDefaults.props
+++ b/build/BuildDefaults.props
@@ -3,10 +3,10 @@
     <CLITargets Condition=" '$(CLITargets)' == '' ">Prepare;Compile;Test;Package;Publish</CLITargets>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <IncludeNuGetPackageArchive Condition=" '$(IncludeNuGetPackageArchive)' == '' ">true</IncludeNuGetPackageArchive>
-    <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND $(Rid.StartsWith('rhel.6')) ">true</SkipBuildingInstallers>
+    <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND $(Rid.StartsWith('rhel.6')) AND $(Rid.StartsWith('alpine.3.6'))">true</SkipBuildingInstallers>
     <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' ">false</SkipBuildingInstallers>
-    <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(OSPlatform)' == 'linux' AND '$(Rid)' != 'rhel.6-x64' ">true</UsePortableLinuxSharedFramework>
-    <IncludeSharedFrameworksForBackwardsCompatibilityTests Condition=" $(IncludeSharedFrameworksForBackwardsCompatibilityTests) == '' AND '$(Rid)' != 'linux-x64' AND '$(Rid)' != 'rhel.6-x64' ">true</IncludeSharedFrameworksForBackwardsCompatibilityTests>
+    <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(OSPlatform)' == 'linux' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'alpine.3.6-x64' ">true</UsePortableLinuxSharedFramework>
+    <IncludeSharedFrameworksForBackwardsCompatibilityTests Condition=" $(IncludeSharedFrameworksForBackwardsCompatibilityTests) == '' AND '$(Rid)' != 'linux-x64' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'alpine.3.6-x64'">true</IncludeSharedFrameworksForBackwardsCompatibilityTests>
     <HighEntropyVA>true</HighEntropyVA>
 
     <!-- Only use asset target fallback that we set (not implicit one to net461). -->

--- a/build/DerivedHostMachineInfo.props
+++ b/build/DerivedHostMachineInfo.props
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <IsDebianBaseDistro Condition=" '$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian' ">true</IsDebianBaseDistro>
     <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) AND '$(HostRid)' != 'rhel.6-x64' ">true</IsRPMBasedDistro>
-
-    <PublishNativeInstallers Condition=" '$(IslinuxPortable)' != 'true' AND '$(HostRid)' != 'rhel.6-x64' ">true</PublishNativeInstallers>
+    <PublishNativeInstallers Condition=" '$(IslinuxPortable)' != 'true' AND '$(HostRid)' != 'rhel.6-x64' AND '$(HostRid)' != 'alpine.3.6-x64'">true</PublishNativeInstallers>
     <PublishArchives Condition=" '$(IslinuxPortable)' == 'true' OR ('$(IsDebianBaseDistro)' != 'true' AND '$(IsRPMBasedDistro)' != 'true') ">true</PublishArchives>
   </PropertyGroup>
 </Project>

--- a/build/publish/Badge.targets
+++ b/build/publish/Badge.targets
@@ -31,6 +31,7 @@
     <PropertyGroup>
       <VersionBadgeMoniker>$(OSName)_$(Architecture)</VersionBadgeMoniker>
       <VersionBadgeMoniker Condition=" '$(Rid)' == 'rhel.6-x64' ">rhel.6_x64</VersionBadgeMoniker>
+      <VersionBadgeMoniker Condition=" '$(Rid)' == 'alpine.3.6-x64' ">alpine.3.6_x64</VersionBadgeMoniker>
       <VersionBadgeMoniker Condition=" '$(IslinuxPortable)' == 'true' ">linux_x64</VersionBadgeMoniker>
       <VersionBadgeMoniker Condition=" '$(IsBuildingAndPublishingAllLinuxDistrosNativeInstallers)' == 'true' ">all_linux_distros_native_installer</VersionBadgeMoniker>
 

--- a/build_projects/dotnet-cli-build/CheckIfAllBuildsHavePublished.cs
+++ b/build_projects/dotnet-cli-build/CheckIfAllBuildsHavePublished.cs
@@ -54,6 +54,7 @@ namespace Microsoft.DotNet.Cli.Build
                 { "osx_x64", false },
                 { "linux_x64", false },
                 { "rhel.6_x64", false },
+                { "alpine.3.6_x64", false },
                 { "all_linux_distros_native_installer", false}
             };
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -9,7 +9,7 @@ def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
 
-def platformList = ['Linux:x64:Release', 'Debian8.2:x64:Debug', 'Ubuntu:x64:Release', 'Ubuntu16.04:x64:Debug', 'OSX10.12:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT_ES:x64:Debug', 'RHEL7.2:x64:Release', 'CentOS7.1:x64:Debug', 'RHEL6:x64:Debug']
+def platformList = ['Linux:x64:Release', 'Debian8.2:x64:Debug', 'Ubuntu:x64:Release', 'Ubuntu16.04:x64:Debug', 'OSX10.12:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT_ES:x64:Debug', 'RHEL7.2:x64:Release', 'CentOS7.1:x64:Debug', 'RHEL6:x64:Debug', 'Alpine3.6:x64:Debug']
 
 def static getBuildJobName(def configuration, def os, def architecture) {
     return configuration.toLowerCase() + '_' + os.toLowerCase() + '_' + architecture.toLowerCase()
@@ -49,6 +49,10 @@ set DOTNET_CLI_UI_LANGUAGE=es
     else if (os == 'RHEL6') {
         osUsedForMachineAffinity = 'Ubuntu16.04';
         buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --runtime-id rhel.6-x64 --docker rhel.6 --targets Default"
+    }
+    else if (os == 'Alpine3.6') {
+        osUsedForMachineAffinity = 'Ubuntu16.04';
+        buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --runtime-id alpine.3.6-x64 --docker alpine.3.6 --targets Default"
     }
     else {
         // Jenkins non-Ubuntu CI machines don't have docker

--- a/run-build.sh
+++ b/run-build.sh
@@ -155,7 +155,7 @@ export DOTNET_MULTILEVEL_LOOKUP=0
 if [ "$STAGE0_SOURCE_DIR" == "" ]; then
     (set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --version "2.2.0-preview1-007799" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS)
 else
-    echo "Copying bootstrap cli from $BOOTSTRAP_CLI"
+    echo "Copying bootstrap cli from $STAGE0_SOURCE_DIR"
     cp -r $STAGE0_SOURCE_DIR/* "$DOTNET_INSTALL_DIR"
 fi
 

--- a/scripts/docker/alpine.3.6/Dockerfile
+++ b/scripts/docker/alpine.3.6/Dockerfile
@@ -8,18 +8,9 @@ FROM microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156
 
 RUN apk add --no-cache sudo ncurses
 
-# Setup User to match Host User, and give superuser permissions
+# This Dockerfile doesn't use the USER_ID, but the parameter needs to be declared to prevent docker
+# from issuing a warning
 ARG USER_ID=0
-RUN adduser -D -u ${USER_ID} code_executor root
-RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
-# With the User Change, we need to change permssions on these directories
-RUN chmod -R a+rwx /usr/local
-RUN chmod -R a+rwx /home
-RUN chmod -R 755 /usr/bin/sudo
-
-# Set user to the one we just created
-USER ${USER_ID}
 
 # Set working directory
 WORKDIR /opt/code

--- a/scripts/docker/alpine.3.6/Dockerfile
+++ b/scripts/docker/alpine.3.6/Dockerfile
@@ -1,0 +1,26 @@
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+# Dockerfile that creates a container suitable to build dotnet-cli
+FROM microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156
+
+RUN apk add --no-cache sudo ncurses
+
+# Setup User to match Host User, and give superuser permissions
+ARG USER_ID=0
+RUN adduser -D -u ${USER_ID} code_executor root
+RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# With the User Change, we need to change permssions on these directories
+RUN chmod -R a+rwx /usr/local
+RUN chmod -R a+rwx /home
+RUN chmod -R 755 /usr/bin/sudo
+
+# Set user to the one we just created
+USER ${USER_ID}
+
+# Set working directory
+WORKDIR /opt/code
+

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -120,6 +120,10 @@ get_linux_platform_name() {
     else
         if [ -e /etc/os-release ]; then
             . /etc/os-release
+            if [[ $ID == "alpine" ]]; then
+                # remove the last version digit
+                VERSION_ID=${VERSION_ID%.*}
+            fi
             echo "$ID.$VERSION_ID"
             return 0
         elif [ -e /etc/redhat-release ]; then
@@ -146,8 +150,8 @@ get_current_os_name() {
         local linux_platform_name
         linux_platform_name="$(get_linux_platform_name)" || { echo "linux" && return 0 ; }
 
-        if [[ $linux_platform_name == "rhel.6"* ]]; then
-            echo "rhel.6"
+        if [[ $linux_platform_name == "rhel.6" || $linux_platform_name == "alpine.3.6" ]]; then
+            echo $linux_platform_name
             return 0
         else
             echo "linux"
@@ -646,7 +650,7 @@ downloadwget() {
     if [ -z "$out_path" ]; then
         wget -q --tries 10 -O - "$remote_path" || failed=true
     else
-        wget -v --tries 10 -O "$out_path" "$remote_path" || failed=true
+        wget --tries 10 -O "$out_path" "$remote_path" || failed=true
     fi
     if [ "$failed" = true ]; then
         say_verbose "Wget download failed"

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
     <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
+    <PackageReference Include="runtime.alpine.3.6-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/EnvironmentInfo.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/EnvironmentInfo.cs
@@ -15,6 +15,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 {
                     case "fedora.24-x64":
                     case "rhel.6-x64":
+                    case "alpine.3.6-x64":
                     case "opensuse.42.1-x64":
                     case "ubuntu.16.10-x64":
                     case "linux-x64":
@@ -27,6 +28,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 {
                     case "linux-x64":
                     case "rhel.6-x64":
+                    case "alpine.3.6-x64":
                         return false;
                 }
             }
@@ -35,6 +37,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 switch (rid)
                 {
                     case "rhel.6-x64":
+                    case "alpine.3.6-x64":
                         return false;
                 }
             }


### PR DESCRIPTION
This change enables CLI build for Alpine 3.6 and also adds CI job for
it. It is mostly based on changes that were necessary to
enable building of rhel.6 CLI

