### PR TITLE
Suppress previous NuGet messages for clean command.

### DIFF
--- a/TestAssets/TestProjects/AppWithNugetWarning/AppWithNugetWarning.csproj
+++ b/TestAssets/TestProjects/AppWithNugetWarning/AppWithNugetWarning.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/TestProjects/AppWithNugetWarning/Program.cs
+++ b/TestAssets/TestProjects/AppWithNugetWarning/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace AppWithNugetWarning
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/AppWithNugetWarning/obj/project.assets.json
+++ b/TestAssets/TestProjects/AppWithNugetWarning/obj/project.assets.json
@@ -1,0 +1,15 @@
+{
+  "version": 3,
+  "targets": {
+    ".NETCoreApp,Version=v2.0": {
+    }
+  },
+  "logs": [
+    {
+      "code": "NU1603",
+      "level": "Warning",
+      "warningLevel": 1,
+      "message": "Test warning."
+    }
+  ]
+}

--- a/src/dotnet/commands/dotnet-clean/Program.cs
+++ b/src/dotnet/commands/dotnet-clean/Program.cs
@@ -19,19 +19,19 @@ namespace Microsoft.DotNet.Tools.Clean
 
         public static CleanCommand FromArgs(string[] args, string msbuildPath = null)
         {
-            var msbuildArgs = new List<string>();
-
-            var parser = Parser.Instance;
-
-            var result = parser.ParseFrom("dotnet clean", args);
+            var result = Parser.Instance.ParseFrom("dotnet clean", args);
 
             result.ShowHelpOrErrorIfAppropriate();
 
             var parsedClean = result["dotnet"]["clean"];
 
+            var msbuildArgs = new List<string>();
+
             msbuildArgs.AddRange(parsedClean.Arguments);
                 
             msbuildArgs.Add("/t:Clean");
+
+            msbuildArgs.Add("/p:EmitAssetsLogMessages=false");
 
             msbuildArgs.AddRange(parsedClean.OptionValuesToBeForwarded());
 

--- a/test/dotnet-clean.Tests/GivenDotnetCleanCleansBuildArtifacts.cs
+++ b/test/dotnet-clean.Tests/GivenDotnetCleanCleansBuildArtifacts.cs
@@ -39,5 +39,21 @@ namespace Microsoft.DotNet.Cli.Clean.Tests
 
             outputFolder.Should().BeEmpty();
         }
+
+        [Fact]
+        public void ItSkipsEmittingAssetLogMessages()
+        {
+            var testInstance = TestAssets.Get("AppWithNugetWarning")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            new CleanCommand()
+                .WithWorkingDirectory(testInstance.Root.FullName)
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .NotHaveStdOutContaining("warning");
+        }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
@@ -10,14 +10,14 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetCleanInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /t:Clean";
+        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /t:Clean /p:EmitAssetsLogMessages=false";
 
         [Fact]
         public void ItAddsProjectToMsbuildInvocation()
         {
             var msbuildPath = "<msbuildpath>";
             CleanCommand.FromArgs(new string[] { "<project>" }, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> /m /v:m <project> /t:Clean");
+                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> /m /v:m <project> /t:Clean /p:EmitAssetsLogMessages=false");
         }
 
         [Theory]


### PR DESCRIPTION
This commit suppresses messages that were previously generated during a restore
operation.  NuGet serializes the messages into `project.assets.json` during a
restore and the `ReportAssetsLogMessages` task reads and logs the messages.
This causes the clean command to print NuGet diagnostic messages even though a
restore operation does not occur.

The fix is to set the `EmitAssetsLogMessages` property to false for the clean
command, which prevents the `ReportAssetsLogMessages` target from executing.

Fixes #8027.
