### PR TITLE
Fix windows keep adding tools path to env:PATH

### DIFF
--- a/src/dotnet/ShellShim/EnvironmentPathFactory.cs
+++ b/src/dotnet/ShellShim/EnvironmentPathFactory.cs
@@ -33,8 +33,7 @@ namespace Microsoft.DotNet.ShellShim
             {
                 environmentPath = new WindowsEnvironmentPath(
                     cliFolderPathCalculator.ExecutablePackagesPath,
-                    Reporter.Output,
-                    environmentProvider);
+                    Reporter.Output);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && hasSuperUserAccess)
             {

--- a/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
+++ b/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
@@ -11,18 +11,14 @@ namespace Microsoft.DotNet.ShellShim
     internal class WindowsEnvironmentPath : IEnvironmentPath
     {
         private readonly IReporter _reporter;
-        private readonly IEnvironmentProvider _environmentProvider;
         private const string PathName = "PATH";
         private readonly string _packageExecutablePath;
 
         public WindowsEnvironmentPath(
-            string packageExecutablePath, IReporter reporter,
-            IEnvironmentProvider environmentProvider)
+            string packageExecutablePath, IReporter reporter)
         {
             _packageExecutablePath
                 = packageExecutablePath ?? throw new ArgumentNullException(nameof(packageExecutablePath));
-            _environmentProvider
-                = environmentProvider ?? throw new ArgumentNullException(nameof(environmentProvider));
             _reporter
                 = reporter ?? throw new ArgumentNullException(nameof(reporter));
         }
@@ -44,7 +40,9 @@ namespace Microsoft.DotNet.ShellShim
 
         private bool PackageExecutablePathExists()
         {
-            return _environmentProvider.GetEnvironmentVariable(PathName).Split(';').Contains(_packageExecutablePath);
+            return Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.User).Split(';').Contains(_packageExecutablePath)
+             || Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Machine).Split(';').Contains(_packageExecutablePath)
+             || Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Process).Split(';').Contains(_packageExecutablePath);
         }
 
         public void PrintAddPathInstructionIfPathDoesNotExist()


### PR DESCRIPTION
Environment.GetEnvironmentVariable(PathName) means

Environment.GetEnvironmentVariable(PathName,
EnvironmentVariableTarget.Process)

However, I have added to .User. So the detection of path existence
failed. And it ends up adding the path again and again

Fix https://github.com/dotnet/cli/issues/8247

why no tests: this is a place hard to test, since it depends on a Windows API. To test it, I would need to play around CI's env:PATH, which is the problem in the beginning. 
