### PR TITLE
Fixing the link to the developer guide

### DIFF
--- a/Documentation/general/intro-to-cli.md
+++ b/Documentation/general/intro-to-cli.md
@@ -45,7 +45,7 @@ The way the `dotnet` driver finds the command it is instructed to run using `dot
 Adding a new command to the .NET Core CLI 
 =========================================
 
-If you want to contribute to the actual .NET Core CLI by adding a new command that you think would be useful, please refer to the [developer guide](developer-guide.md) in this directory. It contains all of the guidance on both the process as well as the infrastructure that you need to adhere to when adding a new command to the CLI toolchain. 
+If you want to contribute to the actual .NET Core CLI by adding a new command that you think would be useful, please refer to the [developer guide](../project-docs/developer-guide.md) in this directory. It contains all of the guidance on both the process as well as the infrastructure that you need to adhere to when adding a new command to the CLI toolchain. 
 
 After you familiarize yourself with the process of working with the source code in the repo, please consult the [CLI UX guidelines](cli-ux-guidelines.md) to get to know the user experience tenants the CLI has. 
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/8256