### PR TITLE
Check null for getenv

### DIFF
--- a/src/dotnet/ShellShim/LinuxEnvironmentPath.cs
+++ b/src/dotnet/ShellShim/LinuxEnvironmentPath.cs
@@ -48,8 +48,15 @@ namespace Microsoft.DotNet.ShellShim
 
         private bool PackageExecutablePathExists()
         {
-            return _environmentProvider
-                .GetEnvironmentVariable(PathName)
+            var environmentVariable = _environmentProvider
+                .GetEnvironmentVariable(PathName);
+
+            if (environmentVariable == null)
+            {
+                return false;
+            }
+
+            return environmentVariable
                 .Split(':').Contains(_packageExecutablePath.Path);
         }
 

--- a/src/dotnet/ShellShim/OsxEnvironmentPath.cs
+++ b/src/dotnet/ShellShim/OsxEnvironmentPath.cs
@@ -49,10 +49,15 @@ namespace Microsoft.DotNet.ShellShim
 
         private bool PackageExecutablePathExists()
         {
-            return _environmentProvider.GetEnvironmentVariable(PathName).Split(':')
-                       .Contains(_packageExecutablePath.PathWithTilde) ||
-                   _environmentProvider.GetEnvironmentVariable(PathName).Split(':')
-                       .Contains(_packageExecutablePath.Path);
+            var environmentVariable = _environmentProvider.GetEnvironmentVariable(PathName);
+
+            if (environmentVariable == null)
+            {
+                return false;
+            }
+
+            return environmentVariable.Split(':').Contains(_packageExecutablePath.PathWithTilde)
+                || environmentVariable.Split(':').Contains(_packageExecutablePath.Path);
         }
 
         public void PrintAddPathInstructionIfPathDoesNotExist()

--- a/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
+++ b/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
@@ -40,9 +40,19 @@ namespace Microsoft.DotNet.ShellShim
 
         private bool PackageExecutablePathExists()
         {
-            return Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.User).Split(';').Contains(_packageExecutablePath)
-             || Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Machine).Split(';').Contains(_packageExecutablePath)
-             || Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Process).Split(';').Contains(_packageExecutablePath);
+            return EnvironmentVariableConatinsPackageExecutablePath(Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.User))
+                || EnvironmentVariableConatinsPackageExecutablePath(Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Machine))
+                || EnvironmentVariableConatinsPackageExecutablePath(Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Process));
+        }
+
+        private bool EnvironmentVariableConatinsPackageExecutablePath(string environmentVariable)
+        {
+            if (environmentVariable == null)
+            {
+                return false;
+            }
+
+            return environmentVariable.Split(';').Contains(_packageExecutablePath);
         }
 
         public void PrintAddPathInstructionIfPathDoesNotExist()


### PR DESCRIPTION
As you see, the implementation of the 3 OS to check PATH is different.
There is not too much to extract. And I tried to move the
"contains a folder path in env:path?" to a method. But that
method requires to pass in env:path, targetapath and path separator for
different OS. This method has low value. And people still must
remember to use this method. So I just added simple null check to the
place I used GetEnvPath.
