### PR TITLE
Update dotnet-install scripts to support installing the ASP.NET Core runtime

### DIFF
--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -249,7 +249,7 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel, [bool]$Co
     if ($Runtime -eq "dotnet") {
         $VersionFileUrl = "$UncachedFeed/Runtime/$Channel/latest.version"
     }
-    elseif ($Runtime -eq "aspnetcore") {
+    elseif ($Runtime) {
         $VersionFileUrl = "$UncachedFeed/Runtime/$Channel/latest.$Runtime.version"
     }
     else {

--- a/scripts/obtain/dotnet-install.ps1
+++ b/scripts/obtain/dotnet-install.ps1
@@ -34,8 +34,17 @@
     Architecture of dotnet binaries to be installed.
     Possible values are: <auto>, x64 and x86
 .PARAMETER SharedRuntime
+    This parameter is obsolete and may be removed in a future version of this script.
+    The recommended alternative is '-Runtime dotnet'.
+
     Default: false
-    Installs just the shared runtime bits, not the entire SDK
+    Installs just the shared runtime bits, not the entire SDK.
+    This is equivalent to specifying `-Runtime dotnet`.
+.PARAMETER Runtime
+    Installs just a shared runtime, not the entire SDK.
+    Possible values:
+        - dotnet
+        - aspnetcore
 .PARAMETER DryRun
     If set it will not perform installation but instead display what command line to use to consistently install
     currently requested version of dotnet cli. In example if you specify version 'latest' it will display a link
@@ -71,6 +80,9 @@ param(
    [string]$Version="Latest",
    [string]$InstallDir="<auto>",
    [string]$Architecture="<auto>",
+   [ValidateSet("dotnet", "aspnetcore", IgnoreCase = $false)]
+   [string]$Runtime,
+   [Obsolete("This parameter may be removed in a future version of this script. The recommended alternative is '-Runtime dotnet'.")]
    [switch]$SharedRuntime,
    [switch]$DryRun,
    [switch]$NoPath,
@@ -87,6 +99,10 @@ $ErrorActionPreference="Stop"
 $ProgressPreference="SilentlyContinue"
 
 $BinFolderRelativePath=""
+
+if ($SharedRuntime -and (-not $Runtime)) {
+    $Runtime = "dotnet"
+}
 
 # example path with regex: shared/1.0.0-beta-12345/somepath
 $VersionRegEx="/\d+\.\d+[^/]+/"
@@ -230,8 +246,11 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel, [bool]$Co
     Say-Invocation $MyInvocation
 
     $VersionFileUrl = $null
-    if ($SharedRuntime) {
+    if ($Runtime -eq "dotnet") {
         $VersionFileUrl = "$UncachedFeed/Runtime/$Channel/latest.version"
+    }
+    elseif ($Runtime -eq "aspnetcore") {
+        $VersionFileUrl = "$UncachedFeed/Runtime/$Channel/latest.$Runtime.version"
     }
     else {
         if ($Coherent) {
@@ -277,8 +296,8 @@ function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$Channel,
 function Get-Download-Link([string]$AzureFeed, [string]$SpecificVersion, [string]$CLIArchitecture) {
     Say-Invocation $MyInvocation
 
-    if ($SharedRuntime) {
-        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-runtime-$SpecificVersion-win-$CLIArchitecture.zip"
+    if ($Runtime) {
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/$Runtime-runtime-$SpecificVersion-win-$CLIArchitecture.zip"
     }
     else {
         $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-sdk-$SpecificVersion-win-$CLIArchitecture.zip"
@@ -292,11 +311,14 @@ function Get-Download-Link([string]$AzureFeed, [string]$SpecificVersion, [string
 function Get-LegacyDownload-Link([string]$AzureFeed, [string]$SpecificVersion, [string]$CLIArchitecture) {
     Say-Invocation $MyInvocation
 
-    if ($SharedRuntime) {
+    if (-not $Runtime) {
+        $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-dev-win-$CLIArchitecture.$SpecificVersion.zip"
+    }
+    elseif ($Runtime -eq "dotnet") {
         $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-win-$CLIArchitecture.$SpecificVersion.zip"
     }
     else {
-        $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-dev-win-$CLIArchitecture.$SpecificVersion.zip"
+        return $null
     }
 
     Say-Verbose "Constructed legacy payload URL: $PayloadURL"
@@ -465,7 +487,9 @@ $LegacyDownloadLink = Get-LegacyDownload-Link -AzureFeed $AzureFeed -SpecificVer
 if ($DryRun) {
     Say "Payload URLs:"
     Say "Primary - $DownloadLink"
-    Say "Legacy - $LegacyDownloadLink"
+    if ($LegacyDownloadLink) {
+        Say "Legacy - $LegacyDownloadLink"
+    }
     Say "Repeatable invocation: .\$($MyInvocation.Line)"
     exit 0
 }
@@ -473,10 +497,22 @@ if ($DryRun) {
 $InstallRoot = Resolve-Installation-Path $InstallDir
 Say-Verbose "InstallRoot: $InstallRoot"
 
-$IsSdkInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage "sdk" -SpecificVersion $SpecificVersion
-Say-Verbose ".NET SDK installed? $IsSdkInstalled"
-if ($IsSdkInstalled) {
-    Say ".NET SDK version $SpecificVersion is already installed."
+if ($Runtime -eq "dotnet") {
+    $assetName = ".NET Core Runtime"
+    $dotnetPackageRelativePath = "shared\Microsoft.NETCore.App"
+}
+elseif ($Runtime -eq "aspnetcore") {
+    $assetName = "ASP.NET Core Runtime"
+    $dotnetPackageRelativePath = "shared\Microsoft.AspNetCore.All"
+}
+else {
+    $assetName = ".NET Core SDK"
+    $dotnetPackageRelativePath = "sdk"
+}
+
+$isAssetInstalled = Is-Dotnet-Package-Installed -InstallRoot $InstallRoot -RelativePathToPackage $dotnetPackageRelativePath -SpecificVersion $SpecificVersion
+if ($isAssetInstalled) {
+    Say "$assetName version $SpecificVersion is already installed."
     Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
     exit 0
 }
@@ -498,11 +534,16 @@ try {
 }
 catch {
     Say "Cannot download: $DownloadLink"
-    $DownloadLink = $LegacyDownloadLink
-    $ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
-    Say-Verbose "Legacy zip path: $ZipPath"
-    Say "Downloading legacy link: $DownloadLink"
-    DownloadFile -Uri $DownloadLink -OutPath $ZipPath
+    if ($LegacyDownloadLink) {
+        $DownloadLink = $LegacyDownloadLink
+        $ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
+        Say-Verbose "Legacy zip path: $ZipPath"
+        Say "Downloading legacy link: $DownloadLink"
+        DownloadFile -Uri $DownloadLink -OutPath $ZipPath
+    }
+    else {
+        throw "Could not download $assetName version $SpecificVersion"
+    }
 }
 
 Say "Extracting zip from $DownloadLink"


### PR DESCRIPTION
Resolves #8252

Adds support for downloading the aspnetcore shared runtime from the dotnetcli Azure blob feed.

Obsoletes -SharedRuntime in favor of the more-specific `-Runtime <name>` option. 

cc @JunTaoLuo 