### PR TITLE
Update to aspnetcore 2.1.0-preview1-28042

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-preview1-28042</MicrosoftAspNetCoreAllPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-26109-02</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <MicrosoftBuildPackageVersion>15.6.0-preview-000022-1216653</MicrosoftBuildPackageVersion>
@@ -58,12 +59,9 @@
   <PropertyGroup>
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-25908-02</CLI_NETStandardLibraryNETFrameworkVersion>
 
-    <!-- When ready to pull aspnetcore directly from orchestrated build, move this above the import to OrchestratedPackageVersionsProps. -->
-    <MicrosoftAspNetCoreAppPackageVersion>2.1.0-preview1-28031</MicrosoftAspNetCoreAppPackageVersion>
-
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
-    <AspNetCoreVersion>$(MicrosoftAspNetCoreAppPackageVersion)</AspNetCoreVersion>
+    <AspNetCoreVersion>$(MicrosoftAspNetCoreAllPackageVersion)</AspNetCoreVersion>
   </PropertyGroup>
 
   <!-- infrastructure and test only dependencies -->

--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -15,10 +15,8 @@
 
   <Target Name="GetAspNetSharedFxInstallArgs" DependsOnTargets="EvaluateRuntimeCoherence">
     <PropertyGroup>
-      <!-- Ignored for now while the "trampoline" host feature is in progress -->
-      <InstallAspNetCoreSharedFxArgs> --ignore-depends=aspnetcore-store-2.0.3</InstallAspNetCoreSharedFxArgs>
       <!-- Ignored because versions of aspnetcore-runtime may be in incoherent with the version of dotnet-runtime we want to use. -->
-      <InstallAspNetCoreSharedFxArgs>$(InstallAspNetCoreSharedFxArgs) --ignore-depends=dotnet-runtime-$(AspNetCoreSharedFxBaseRuntimeVersion)</InstallAspNetCoreSharedFxArgs>
+      <InstallAspNetCoreSharedFxArgs>--ignore-depends=dotnet-runtime-$(AspNetCoreSharedFxBaseRuntimeVersion)</InstallAspNetCoreSharedFxArgs>
     </PropertyGroup>
   </Target>
 

--- a/scripts/obtain/uninstall/dotnet-uninstall-debian-packages.sh
+++ b/scripts/obtain/uninstall/dotnet-uninstall-debian-packages.sh
@@ -14,11 +14,9 @@ fi
 
 host_package_name="dotnet-host"
 aspnetcore_runtime_package_name="^aspnetcore-runtime.*"
-aspnetcore_package_store_package_name="^aspnetcore-store.*"
 
 remove_all(){
     apt-get purge -y $aspnetcore_runtime_package_name
-    apt-get purge -y $aspnetcore_package_store_package_name
     apt-get purge -y $host_package_name
 }
 

--- a/scripts/obtain/uninstall/dotnet-uninstall-rpm-packages.sh
+++ b/scripts/obtain/uninstall/dotnet-uninstall-rpm-packages.sh
@@ -13,12 +13,10 @@ if [ $current_userid -ne 0 ]; then
 fi
 
 host_package_name="dotnet-host"
-aspnetcore_package_store_package_name="aspnetcore-store*"
 aspnetcore_runtime_package_name="aspnetcore-runtime*"
 
 remove_all(){
     yum remove -y $host_package_name
-    yum remove -y $aspnetcore_package_store_package_name
     yum remove -y $aspnetcore_runtime_package_name
 }
 


### PR DESCRIPTION
React to this change: https://github.com/aspnet/Universe/pull/765 - removes the Linux package dependency to aspnetcore-store from the aspnetcore-runtime for .deb/.rpm

- Update to 2.1.0-preview1-28042
 - Remove references to the aspnetcore-store package
 - Allow pulling aspnetcore from orchestrated build

