### PR TITLE
Ignore incoherent rpm dependency on dotnet-runtime when testing aspnetcore

### DIFF
--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -219,7 +219,8 @@
     <Exec Command="sudo yum -y install $(DownloadedSharedHostInstallerFile)" />
     <Exec Command="sudo yum -y install $(DownloadedHostFxrInstallerFile)" />
     <Exec Command="sudo yum -y install $(DownloadedSharedFrameworkInstallerFile)" />
-    <Exec Command="sudo yum -y install $(DownloadedAspNetCoreSharedFxInstallerFile)" />
+    <!-- Ignore dependencies, which may have an incoherent dependency on dotnet-runtime -->
+    <Exec Command="sudo rpm --install --nodeps $(DownloadedAspNetCoreSharedFxInstallerFile)" />
 
     <Exec Command="sudo yum -y install $(SdkInstallerFile)" />
 


### PR DESCRIPTION
It looks like netci isn't configured correctly to actually run the TestSdkRpm target on PRs, but it fails on official builds.
