### PR TITLE
Use a multi-proc aware MSBuild logger

### DIFF
--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -28,11 +28,12 @@ namespace Microsoft.DotNet.Tools.MSBuild
                 try
                 {
                     Type loggerType = typeof(MSBuildLogger);
+                    Type forwardingLoggerType = typeof(MSBuildForwardingLogger);
 
                     return argsToForward
                         .Concat(new[]
                         {
-                            $"/Logger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}"
+                            $"/distributedlogger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}*{forwardingLoggerType.FullName},{forwardingLoggerType.GetTypeInfo().Assembly.Location}"
                         });
                 }
                 catch (Exception)

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingLogger.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.DotNet.Tools.MSBuild
+{
+    public sealed class MSBuildForwardingLogger : IForwardingLogger
+    {
+        public LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Minimal;
+
+        public string Parameters { get; set; } = null;
+
+        public IEventRedirector BuildEventRedirector { get; set; }
+
+        public int NodeId { get; set; }
+
+        public void Initialize(IEventSource eventSource)
+        {
+            // Only forward telemetry events
+            if (eventSource is IEventSource2 eventSource2)
+                eventSource2.TelemetryLogged += (sender, args) => BuildEventRedirector.ForwardEvent(args);
+        }
+
+        public void Initialize(IEventSource eventSource, int nodeCount)
+        {
+            Initialize(eventSource);
+        }
+
+        public void Shutdown()
+        {
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingLogger.cs
@@ -7,9 +7,9 @@ namespace Microsoft.DotNet.Tools.MSBuild
 {
     public sealed class MSBuildForwardingLogger : IForwardingLogger
     {
-        public LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Minimal;
+        public LoggerVerbosity Verbosity { get; set; }
 
-        public string Parameters { get; set; } = null;
+        public string Parameters { get; set; }
 
         public IEventRedirector BuildEventRedirector { get; set; }
 

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingLogger.cs
@@ -19,7 +19,9 @@ namespace Microsoft.DotNet.Tools.MSBuild
         {
             // Only forward telemetry events
             if (eventSource is IEventSource2 eventSource2)
+            {
                 eventSource2.TelemetryLogged += (sender, args) => BuildEventRedirector.ForwardEvent(args);
+            }
         }
 
         public void Initialize(IEventSource eventSource, int nodeCount)

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Tools.MSBuild
 {
-    public sealed class MSBuildLogger : Logger
+    public sealed class MSBuildLogger : INodeLogger
     {
         private readonly IFirstTimeUseNoticeSentinel _sentinel =
             new FirstTimeUseNoticeSentinel(new CliFolderPathCalculator());
@@ -38,7 +38,12 @@ namespace Microsoft.DotNet.Tools.MSBuild
             }
         }
 
-        public override void Initialize(IEventSource eventSource)
+        public void Initialize(IEventSource eventSource, int nodeCount)
+        {
+            Initialize(eventSource);
+        }
+
+        public void Initialize(IEventSource eventSource)
         {
             try
             {
@@ -76,7 +81,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             FormatAndSend(_telemetry, args);
         }
 
-        public override void Shutdown()
+        public void Shutdown()
         {
             try
             {
@@ -86,8 +91,10 @@ namespace Microsoft.DotNet.Tools.MSBuild
             {
                 // Exceptions during telemetry shouldn't cause anything else to fail
             }
-
-            base.Shutdown();
         }
+
+        public LoggerVerbosity Verbosity { get; set; }
+
+        public string Parameters { get; set; }
     }
 }

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             }
         }
 
-        public LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Minimal;
+        public LoggerVerbosity Verbosity { get; set; }
 
         public string Parameters { get; set; }
     }

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildLogger.cs
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
             }
         }
 
-        public LoggerVerbosity Verbosity { get; set; }
+        public LoggerVerbosity Verbosity { get; set; } = LoggerVerbosity.Minimal;
 
         public string Parameters { get; set; }
     }

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 allArgs.Should().NotBeNull();
 
                 allArgs.Should().Contain(
-                    value => value.IndexOf("/Logger", StringComparison.OrdinalIgnoreCase) >= 0,
+                    value => value.IndexOf("/distributedlogger", StringComparison.OrdinalIgnoreCase) >= 0,
                     "The MSBuild logger argument should be specified when telemetry is enabled.");
             }
         }


### PR DESCRIPTION
Make use of the MSBuild distributed logger functionality and add a
forwarding logger. When in a multi-proc build, the forwarding logger
will decide which events to forward to the main node to be logged.
Without this, all events are routed and a perf penalty is incurred.

Fixes https://github.com/Microsoft/msbuild/issues/2769

Note: I got unrelated build errors in VS. So I haven't actually tested this. But it should eliminate the perf issue. In my own testing firing off a few thousand events that my forwarding logger ignored had zero perf penalty from no logger while a regular, no-op, logger increased the build time by more than double. Feel free to take this over or let me know which branch, and I might have questions if I have trouble testing.