### PR TITLE
Updating the ArchiveExtension to be zip everywhere

### DIFF
--- a/build/FileExtensions.props
+++ b/build/FileExtensions.props
@@ -1,8 +1,6 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
-      <ArchiveExtension Condition=" '$(OS)' == 'Windows_NT' ">.zip</ArchiveExtension>
-      <ArchiveExtension Condition=" '$(OS)' != 'Windows_NT' ">.tar.gz</ArchiveExtension>
-
+      <ArchiveExtension>.zip</ArchiveExtension>
       <ExeExtension>.exe</ExeExtension>
       <ExeExtension Condition=" '$(OS)' != 'Windows_NT' "></ExeExtension>
     </PropertyGroup>

--- a/run-build.sh
+++ b/run-build.sh
@@ -19,6 +19,11 @@ check_min_reqs() {
     return 0
 }
 
+function GetVersionsPropsVersion {
+  VersionsProps="$REPOROOT/build/DependencyVersions.props"
+  echo "$( awk -F'[<>]' "/<$1>/{print \$3}" "$VersionsProps" )"
+}
+
 # args:
 # remote_path - $1
 # [out_path] - $2 - stdout if not provided
@@ -151,7 +156,8 @@ export DOTNET_MULTILEVEL_LOOKUP=0
 
 # Install a stage 0
 if [ -z "$DOTNET_TOOL_DIR" ]; then
-    (set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --channel "release/2.0.0" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS)
+    DotNetCliVersion="$( GetVersionsPropsVersion DotNetCoreSdkLKGVersion )"
+    (set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --version "$DotNetCliVersion" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS)
 
     EXIT_CODE=$?
     if [ $EXIT_CODE != 0 ]; then


### PR DESCRIPTION
Packages are agnostic and this greatly simplifies our production/consumption logic for intermediate components.

The final packages (those created in core-sdk that are released for production) will still be platform specific (zip on windows, tar.gz elsewhere).
