### PR TITLE
Add source option to install tool command.

### DIFF
--- a/src/dotnet/ToolPackage/IProjectRestorer.cs
+++ b/src/dotnet/ToolPackage/IProjectRestorer.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.ToolPackage
         void Restore(
             FilePath projectPath,
             DirectoryPath assetJsonOutput, 
-            FilePath? nugetconfig);
+            FilePath? nugetconfig,
+            string source);
     }
 }

--- a/src/dotnet/ToolPackage/ToolPackageObtainer.cs
+++ b/src/dotnet/ToolPackage/ToolPackageObtainer.cs
@@ -35,7 +35,8 @@ namespace Microsoft.DotNet.ToolPackage
             string packageId,
             string packageVersion = null,
             FilePath? nugetconfig = null,
-            string targetframework = null)
+            string targetframework = null,
+            string source = null)
         {
             if (packageId == null)
             {
@@ -74,7 +75,7 @@ namespace Microsoft.DotNet.ToolPackage
                     packageId);
             }
 
-            InvokeRestore(nugetconfig: nugetconfig, tempProjectPath: tempProjectPath, individualToolVersion: toolDirectory);
+            _projectRestorer.Restore(tempProjectPath, toolDirectory, nugetconfig, source);
 
             if (packageVersionOrPlaceHolder.IsPlaceholder)
             {
@@ -129,14 +130,6 @@ namespace Microsoft.DotNet.ToolPackage
                 ToolConfigurationDeserializer.Deserialize(toolConfigurationPath.Value);
 
             return toolConfiguration;
-        }
-
-        private void InvokeRestore(
-            FilePath? nugetconfig,
-            FilePath tempProjectPath,
-            DirectoryPath individualToolVersion)
-        {
-            _projectRestorer.Restore(tempProjectPath, individualToolVersion, nugetconfig);
         }
 
         private FilePath CreateTempProject(

--- a/src/dotnet/commands/dotnet-install/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-install/LocalizableStrings.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SourceOptionDescription" xml:space="preserve">
+    <value>Specifies a NuGet package source to use during installation.</value>
+  </data>
+  <data name="SourceOptionName" xml:space="preserve">
+    <value>SOURCE</value>
+  </data>
+</root>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommand.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommand.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Tools.Install.Tool
         private static string _packageVersion;
         private static string _configFilePath;
         private static string _framework;
+        private static string _source;
 
         public InstallToolCommand(
             AppliedOption appliedCommand,
@@ -35,25 +36,14 @@ namespace Microsoft.DotNet.Tools.Install.Tool
             _packageVersion = appliedCommand.ValueOrDefault<string>("version");
             _configFilePath = appliedCommand.ValueOrDefault<string>("configfile");
             _framework = appliedCommand.ValueOrDefault<string>("framework");
+            _source = appliedCommand.ValueOrDefault<string>("source");
         }
 
         public override int Execute()
         {
-            FilePath? configFile = null;
-
-            if (_configFilePath != null)
-            {
-                configFile = new FilePath(_configFilePath);
-            }
-
             var executablePackagePath = new DirectoryPath(new CliFolderPathCalculator().ExecutablePackagesPath);
 
-            var toolConfigurationAndExecutableDirectory = ObtainPackage(
-                _packageId,
-                _packageVersion,
-                configFile,
-                _framework,
-                executablePackagePath);
+            var toolConfigurationAndExecutableDirectory = ObtainPackage(executablePackagePath);
 
             DirectoryPath executable = toolConfigurationAndExecutableDirectory
                 .ExecutableDirectory
@@ -80,15 +70,16 @@ namespace Microsoft.DotNet.Tools.Install.Tool
             return 0;
         }
 
-        private static ToolConfigurationAndExecutableDirectory ObtainPackage(
-            string packageId,
-            string packageVersion,
-            FilePath? configFile,
-            string framework,
-            DirectoryPath executablePackagePath)
+        private static ToolConfigurationAndExecutableDirectory ObtainPackage(DirectoryPath executablePackagePath)
         {
             try
             {
+                FilePath? configFile = null;
+                if (_configFilePath != null)
+                {
+                    configFile = new FilePath(_configFilePath);
+                }
+
                 var toolPackageObtainer =
                     new ToolPackageObtainer(
                         executablePackagePath,
@@ -100,10 +91,10 @@ namespace Microsoft.DotNet.Tools.Install.Tool
                         new ProjectRestorer());
 
                 return toolPackageObtainer.ObtainAndReturnExecutablePath(
-                    packageId: packageId,
-                    packageVersion: packageVersion,
+                    packageId: _packageId,
+                    packageVersion: _packageVersion,
                     nugetconfig: configFile,
-                    targetframework: framework);
+                    targetframework: _framework);
             }
             catch (PackageObtainException ex)
             {

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommandParser.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommandParser.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Tools.Install.Tool;
+using LocalizableStrings = Microsoft.DotNet.Tools.Install.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli
 {
@@ -22,6 +25,11 @@ namespace Microsoft.DotNet.Cli
                     "--configfile",
                     "NuGet configuration file",
                     Accept.ExactlyOneArgument()),
+                Create.Option(
+                    "--source",
+                    LocalizableStrings.SourceOptionDescription,
+                    Accept.ExactlyOneArgument()
+                        .With(name: LocalizableStrings.SourceOptionName)),
                 Create.Option(
                     "-f|--framework",
                     "Target framework to publish for. The target framework has to be specified in the project file.",

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/ProjectRestorer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Extensions.EnvironmentAbstractions;
@@ -15,7 +16,8 @@ namespace Microsoft.DotNet.Tools.Install.Tool
         public void Restore(
             FilePath projectPath,
             DirectoryPath assetJsonOutput,
-            FilePath? nugetconfig)
+            FilePath? nugetconfig,
+            string source = null)
         {
             var argsToPassToRestore = new List<string>();
 
@@ -26,6 +28,12 @@ namespace Microsoft.DotNet.Tools.Install.Tool
                 argsToPassToRestore.Add(nugetconfig.Value.Value);
             }
 
+            if (source != null)
+            {
+                argsToPassToRestore.Add("--source");
+                argsToPassToRestore.Add(source);
+            }
+
             argsToPassToRestore.AddRange(new List<string>
             {
                 "--runtime",
@@ -34,9 +42,7 @@ namespace Microsoft.DotNet.Tools.Install.Tool
             });
 
             var command = new DotNetCommandFactory(alwaysRunOutOfProc: true)
-                .Create(
-                    "restore",
-                    argsToPassToRestore)
+                .Create("restore", argsToPassToRestore)
                 .CaptureStdOut()
                 .CaptureStdErr();
 

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.cs.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.de.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.es.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.fr.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.it.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ja.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ko.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.pl.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.pt-BR.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ru.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.tr.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -23,6 +23,7 @@
     <EmbeddedResource Update="**\dotnet-build\*.resx" Namespace="Microsoft.DotNet.Tools.Build" />
     <EmbeddedResource Update="**\dotnet-clean\*.resx" Namespace="Microsoft.DotNet.Tools.Clean" />
     <EmbeddedResource Update="**\dotnet-help\*.resx" Namespace="Microsoft.DotNet.Tools.Help" />
+    <EmbeddedResource Update="**\dotnet-install\*.resx" Namespace="Microsoft.DotNet.Tools.Install" />
     <EmbeddedResource Update="**\dotnet-list\*.resx" Namespace="Microsoft.DotNet.Tools.List" />
     <EmbeddedResource Update="**\dotnet-list-proj\*.resx" Namespace="Microsoft.DotNet.Tools.List.ProjectsInSolution" />
     <EmbeddedResource Update="**\dotnet-list-reference\*.resx" Namespace="Microsoft.DotNet.Tools.List.ProjectToProjectReferences" />

--- a/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
@@ -48,5 +48,16 @@ namespace Microsoft.DotNet.Tests.ParserTests
             parseResult.ValueOrDefault<string>("configfile").Should().Be(@"C:\TestAssetLocalNugetFeed");
             parseResult.ValueOrDefault<string>("framework").Should().Be("netcoreapp2.0");
         }
+
+        [Fact]
+        public void InstallToolParserCanParseSourceOption()
+        {
+            const string expectedSourceValue = "TestSourceValue";
+
+            var result = Parser.Instance.Parse($"dotnet install tool --source {expectedSourceValue} console.test.app");
+
+            var appliedOptions = result["dotnet"]["install"]["tool"];
+            appliedOptions.ValueOrDefault<string>("source").Should().Be(expectedSourceValue);
+        }
     }
 }


### PR DESCRIPTION
This commit adds the `--source` option to the `install tool` command.  This
option is equivalent to the option of the same name for the `restore` command.

The option is forwarded to the underlying restore operation.

Fixes #8226.

