### PR TITLE
Fix missing package id error message for install tool command. 

### DIFF
--- a/scripts/cli-build-env.sh
+++ b/scripts/cli-build-env.sh
@@ -13,7 +13,7 @@ done
 
 REPO_ROOT="$( cd -P "$( dirname "$SOURCE" )/../" && pwd )"
 
-STAGE0_DIR=$REPO_ROOT.dotnet_stage0/x64
+STAGE0_DIR=$REPO_ROOT/.dotnet_stage0/x64
 export PATH=$STAGE0_DIR:$PATH
 
 

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -268,6 +268,6 @@
     <value>Path to additional deps.json file.</value>
   </data>
   <data name="InstallDefinition" xml:space="preserve">
-    <value>Add item to development environment.</value>
+    <value>Installs an item into the development environment.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -253,8 +253,8 @@
         <note />
       </trans-unit>
       <trans-unit id="InstallDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/InstallCommandParser.cs
+++ b/src/dotnet/commands/dotnet-install/InstallCommandParser.cs
@@ -11,7 +11,8 @@ namespace Microsoft.DotNet.Cli
         public static Command Install()
         {
             return Create.Command(
-                "install", LocalizableStrings.InstallCommandDefinition,
+                "install",
+                LocalizableStrings.CommandDescription,
                 Accept.NoArguments(),
                 CommonOptions.HelpOption(),
                 InstallToolCommandParser.InstallTool());

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommandParser.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommandParser.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.DotNet.Cli.CommandLine;
-using LocalizableStrings = Microsoft.DotNet.Tools.Install.LocalizableStrings;
+using LocalizableStrings = Microsoft.DotNet.Tools.Install.Tool.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli
 {
@@ -11,17 +11,17 @@ namespace Microsoft.DotNet.Cli
         public static Command InstallTool()
         {
             return Create.Command("tool",
-                LocalizableStrings.InstallToolCommandDefinition,
+                LocalizableStrings.CommandDescription,
                 Accept.ExactlyOneArgument(o => "packageId")
-                    .With(name: "packageId",
-                        description: LocalizableStrings.InstallToolPackageIdDefinition),
+                    .With(name: LocalizableStrings.PackageIdArgumentName,
+                          description: LocalizableStrings.PackageIdArgumentDescription),
                 Create.Option(
                     "--version",
-                    LocalizableStrings.InstallToolVersionDefinition,
+                    LocalizableStrings.VersionOptionDescription,
                     Accept.ExactlyOneArgument()),
                 Create.Option(
                     "--configfile",
-                    LocalizableStrings.InstallToolConfigfileDefinition,
+                    LocalizableStrings.ConfigFileOptionDescription,
                     Accept.ExactlyOneArgument()),
                 Create.Option(
                     "--source",
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Cli
                         .With(name: LocalizableStrings.SourceOptionName)),
                 Create.Option(
                     "-f|--framework",
-                    LocalizableStrings.InstallToolFrameworkDefinition,
+                    LocalizableStrings.FrameworkOptionDescription,
                     Accept.ExactlyOneArgument()),
                 CommonOptions.HelpOption());
         }

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommandParser.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommandParser.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Cli
         {
             return Create.Command("tool",
                 LocalizableStrings.CommandDescription,
-                Accept.ExactlyOneArgument(o => "packageId")
+                Accept.ExactlyOneArgument(errorMessage: o => LocalizableStrings.SpecifyExactlyOnePackageId)
                     .With(name: LocalizableStrings.PackageIdArgumentName,
                           description: LocalizableStrings.PackageIdArgumentDescription),
                 Create.Option(

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/LocalizableStrings.resx
@@ -123,6 +123,9 @@
   <data name="PackageIdArgumentDescription" xml:space="preserve">
     <value>NuGet Package Id of the tool to install.</value>
   </data>
+  <data name="SpecifyExactlyOnePackageId" xml:space="preserve">
+    <value>Please specify one tool Package Id to install.</value>
+  </data>
   <data name="VersionOptionDescription" xml:space="preserve">
     <value>Version of the tool package in NuGet.</value>
   </data>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/LocalizableStrings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,10 +117,56 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="InstallFullCommandNameLocalized" xml:space="preserve">
-    <value>.NET Install Command</value>
+  <data name="PackageIdArgumentName" xml:space="preserve">
+    <value>PACKAGE_ID</value>
   </data>
-  <data name="CommandDescription" xml:space="preserve">
-    <value>Installs an item into the development environment.</value>
+  <data name="PackageIdArgumentDescription" xml:space="preserve">
+    <value>NuGet Package Id of the tool to install.</value>
+  </data>
+  <data name="VersionOptionDescription" xml:space="preserve">
+    <value>Version of the tool package in NuGet.</value>
+  </data>
+    <data name="SourceOptionDescription" xml:space="preserve">
+    <value>Specifies a NuGet package source to use during installation.</value>
+  </data>
+  <data name="SourceOptionName" xml:space="preserve">
+    <value>SOURCE</value>
+  </data>
+    <data name="CommandDescription" xml:space="preserve">
+    <value>Installs a tool for use on the command line.</value>
+  </data>
+  <data name="ConfigFileOptionDescription" xml:space="preserve">
+    <value>The NuGet configuration file to use.</value>
+  </data>
+  <data name="FrameworkOptionDescription" xml:space="preserve">
+    <value>The target framework to install the tool for.</value>
+  </data>
+  <data name="FailedToAddPackage" xml:space="preserve">
+    <value>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</value>
+  </data>
+  <data name="FailedToRestorePackage" xml:space="preserve">
+    <value>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</value>
+  </data>
+  <data name="InstallFailedNuget" xml:space="preserve">
+    <value>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</value>
+  </data>
+  <data name="InstallFailedPackage" xml:space="preserve">
+    <value>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</value>
+  </data>
+  <data name="InstallationSucceeded" xml:space="preserve">
+    <value>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/PackageToProjectFileAdder.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/PackageToProjectFileAdder.cs
@@ -7,7 +7,6 @@ using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools;
 using Microsoft.Extensions.EnvironmentAbstractions;
-using LocalizableStrings = Microsoft.DotNet.Tools.Install.LocalizableStrings;
 
 namespace Microsoft.DotNet.Tools.Install.Tool
 {

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/ProjectRestorer.cs
@@ -9,7 +9,6 @@ using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.Extensions.EnvironmentAbstractions;
-using LocalizableStrings = Microsoft.DotNet.Tools.Install.LocalizableStrings;
 
 namespace Microsoft.DotNet.Tools.Install.Tool
 {

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="SourceOptionDescription">
+        <source>Specifies a NuGet package source to use during installation.</source>
+        <target state="new">Specifies a NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceOptionName">
+        <source>SOURCE</source>
+        <target state="new">SOURCE</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallationSucceeded">
+        <source>
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</source>
+        <target state="new">
+The installation succeeded. If there are no further instructions, you can type the following command in shell directly to invoke: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToAddPackage">
+        <source>Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to add package.
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FailedToRestorePackage">
+        <source>Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</source>
+        <target state="new">Failed to restore package. 
+WorkingDirectory: {0}
+Arguments: {1}
+Output: {2}{3}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedNuget">
+        <source>Install failed. Failed to download package:
+NuGet returned:
+
+{0}</source>
+        <target state="new">Install failed. Failed to download package:
+NuGet returned:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallFailedPackage">
+        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</source>
+        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
+The error was:
+
+{0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentDescription">
+        <source>NuGet Package Id of the tool to install.</source>
+        <target state="new">NuGet Package Id of the tool to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandDescription">
+        <source>Installs a tool for use on the command line.</source>
+        <target state="new">Installs a tool for use on the command line.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ConfigFileOptionDescription">
+        <source>The NuGet configuration file to use.</source>
+        <target state="new">The NuGet configuration file to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FrameworkOptionDescription">
+        <source>The target framework to install the tool for.</source>
+        <target state="new">The target framework to install the tool for.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Version of the tool package in NuGet.</source>
+        <target state="new">Version of the tool package in NuGet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackageIdArgumentName">
+        <source>PACKAGE_ID</source>
+        <target state="new">PACKAGE_ID</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -93,6 +93,11 @@ The error was:
         <target state="new">PACKAGE_ID</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecifyExactlyOnePackageId">
+        <source>Please specify one tool Package Id to install.</source>
+        <target state="new">Please specify one tool Package Id to install.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.cs.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.de.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.es.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.fr.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.it.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ja.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ko.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.pl.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.ru.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.tr.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,100 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="new">Specifies a NuGet package source to use during installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallationSucceeded">
-        <source>
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</source>
-        <target state="new">
-The installation succeeded. If there is no other instruction. You can type the following command in shell directly to invoke: {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallCommandDefinition">
-        <source>Add item to development environment.</source>
-        <target state="new">Add item to development environment.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedNuget">
-        <source>Install failed. Failed to download package:
-NuGet returned:
-
-{0}</source>
-        <target state="new">Install failed. Failed to download package:
-NuGet returned:
-
-{0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallFailedPackage">
-        <source>Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</source>
-        <target state="new">Install failed. The settings file in the tool's NuGet package is not valid. Please contact the owner of the NuGet package.
-The error was:
-
-{0}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallFullCommandNameLocalized">
-        <source>NetInstallCommand</source>
-        <target state="new">NetInstallCommand</target>
+        <source>.NET Install Command</source>
+        <target state="new">.NET Install Command</target>
         <note />
       </trans-unit>
-      <trans-unit id="InstallToolCommandDefinition">
-        <source>Install tool for use on the command line.</source>
-        <target state="new">Install tool for use on the command line.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolConfigfileDefinition">
-        <source>NuGet configuration file</source>
-        <target state="new">NuGet configuration file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolFrameworkDefinition">
-        <source>Target framework to publish for. The target framework has to be specified in the project file.</source>
-        <target state="new">Target framework to publish for. The target framework has to be specified in the project file.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolPackageIdDefinition">
-        <source>Package Id in NuGet</source>
-        <target state="new">Package Id in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InstallToolVersionDefinition">
-        <source>Version of the package in NuGet</source>
-        <target state="new">Version of the package in NuGet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToAddPackage">
-        <source>Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to add package.
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToRestorePackage">
-        <source>Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</source>
-        <target state="new">Failed to restore package. 
-WorkingDirectory: {0}
-Arguments: {1}
-Output: {2}{3}</target>
+      <trans-unit id="CommandDescription">
+        <source>Installs an item into the development environment.</source>
+        <target state="new">Installs an item into the development environment.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -24,6 +24,7 @@
     <EmbeddedResource Update="**\dotnet-clean\*.resx" Namespace="Microsoft.DotNet.Tools.Clean" />
     <EmbeddedResource Update="**\dotnet-help\*.resx" Namespace="Microsoft.DotNet.Tools.Help" />
     <EmbeddedResource Update="**\dotnet-install\*.resx" Namespace="Microsoft.DotNet.Tools.Install" />
+    <EmbeddedResource Update="**\dotnet-install\dotnet-install-tool\*.resx" Namespace="Microsoft.DotNet.Tools.Install.Tool" />
     <EmbeddedResource Update="**\dotnet-list\*.resx" Namespace="Microsoft.DotNet.Tools.List" />
     <EmbeddedResource Update="**\dotnet-list-proj\*.resx" Namespace="Microsoft.DotNet.Tools.List.ProjectsInSolution" />
     <EmbeddedResource Update="**\dotnet-list-reference\*.resx" Namespace="Microsoft.DotNet.Tools.List.ProjectToProjectReferences" />

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -39,7 +39,7 @@ SDK commands:
   msbuild          Runs Microsoft Build Engine (MSBuild).
   vstest           Runs Microsoft Test Execution Command Line Tool.
   store            Stores the specified assemblies in the runtime store.
-  install          Add item to development environment.
+  install          Installs an item into the development environment.
   help             Show help.
 
 Common options:


### PR DESCRIPTION
This PR fixes the error message that is displayed when the `install tool` command is not given a package id to install.

Previously, only `packageId` was output, which was confusing.

Fixes #8381.

This PR also refactors the string resources of the `install` command so that strings related to the subcommands are separated.