### PR TITLE
Defend against forthcoming breaking change in SDK

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -86,7 +86,7 @@
     </MSBuild>
   </Target>
 
-  <Target Name="GenerateBundledVersionsProps">
+  <Target Name="GenerateBundledVersionsProps" DependsOnTargets="RunResolvePackageDependencies">
     <PropertyGroup>
       <BundledVersionsPropsFileName>Microsoft.NETCoreSdk.BundledVersions.props</BundledVersionsPropsFileName>
     </PropertyGroup>

--- a/src/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="NETStandard.Library" Version="1.6.0" />
   </ItemGroup>
 
-  <Target Name="ResolveHostfxrCopyLocalContent" Condition="'$(TargetFramework)' == 'net46'" DependsOnTargets="ResolvePackageDependenciesForBuild" BeforeTargets="AssignTargetPaths">
+  <Target Name="ResolveHostfxrCopyLocalContent" Condition="'$(TargetFramework)' == 'net46'" DependsOnTargets="RunResolvePackageDependencies" BeforeTargets="AssignTargetPaths">
     <ItemGroup>
       <Content Include="@(FileDefinitions->'%(ResolvedPath)')" Condition="'%(FileDefinitions.Path)' == 'runtimes/win-x86/native/hostfxr.dll'">
         <Link>x86/hostfxr.dll</Link>


### PR DESCRIPTION
There were a couple of places where our custom build steps were reaching in to the items produced by RunResolvePackageDependencies.

This target will not be run by default with https://github.com/dotnet/sdk/pull/1857. Changing the code now to a form that works before and after that change so that we don't hit the break when an SDK insertion becomes the new stage0.

(There are better ways to write these with the new items, but this is the easiest way to make the code work before and after the change.)