### PR TITLE
Fix "dotnet" typo in donetclichecksums manifest data

### DIFF
--- a/build/publish/Checksum.targets
+++ b/build/publish/Checksum.targets
@@ -15,7 +15,7 @@
       <ArtifactsForGeneratingChecksums Include="@(ForPublishing)">
         <DestinationPath>%(ForPublishing.FullPath).sha</DestinationPath>
         <RelativeBlobPath>%(ForPublishing.RelativeBlobPath).sha</RelativeBlobPath>
-        <ManifestArtifactData>ShipInstaller=donetclichecksums</ManifestArtifactData>
+        <ManifestArtifactData>ShipInstaller=dotnetclichecksums</ManifestArtifactData>
       </ArtifactsForGeneratingChecksums>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
This fixes up the manifest to let final publish find the checksums.