### PR TITLE
Separate tool package and shim file location

### DIFF
--- a/src/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
+++ b/src/Microsoft.DotNet.Configurer/CliFolderPathCalculator.cs
@@ -12,20 +12,23 @@ namespace Microsoft.DotNet.Configurer
 {
     public class CliFolderPathCalculator
     {
-        private const string ToolsFolderName = "tools";
+        // ToolsShimFolderName ToolPackageFolderName cannot be the same
+        // or if the PackageId is the same as CommandName, they will conflict on unix.
+        private const string ToolsShimFolderName = "tools";
+        private const string ToolPackageFolderName = "toolspkgs";
         private const string DotnetProfileDirectoryName = ".dotnet";
 
         public string CliFallbackFolderPath => Environment.GetEnvironmentVariable("DOTNET_CLI_TEST_FALLBACKFOLDER") ??
                                                Path.Combine(new DirectoryInfo(AppContext.BaseDirectory).Parent.FullName, "NuGetFallbackFolder");
         
-        public string ExecutablePackagesPath => Path.Combine(DotnetUserProfileFolderPath, ToolsFolderName);
-
-        public BashPathUnderHomeDirectory ExecutablePackagesPathInUnix
+        public string ToolsShimPath => Path.Combine(DotnetUserProfileFolderPath, ToolsShimFolderName);
+        public string ToolsPackagePath => Path.Combine(DotnetUserProfileFolderPath, ToolPackageFolderName);
+        public BashPathUnderHomeDirectory ToolsShimPathInUnix
         {
             get
             {
                 return new BashPathUnderHomeDirectory(Environment.GetEnvironmentVariable("HOME"),
-                    Path.Combine(DotnetProfileDirectoryName, ToolsFolderName));
+                    Path.Combine(DotnetProfileDirectoryName, ToolsShimFolderName));
             }
         }
 

--- a/src/dotnet/ShellShim/EnvironmentPathFactory.cs
+++ b/src/dotnet/ShellShim/EnvironmentPathFactory.cs
@@ -32,20 +32,20 @@ namespace Microsoft.DotNet.ShellShim
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 environmentPath = new WindowsEnvironmentPath(
-                    cliFolderPathCalculator.ExecutablePackagesPath,
+                    cliFolderPathCalculator.ToolsShimPath,
                     Reporter.Output);
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && hasSuperUserAccess)
             {
                 environmentPath = new LinuxEnvironmentPath(
-                    cliFolderPathCalculator.ExecutablePackagesPathInUnix,
+                    cliFolderPathCalculator.ToolsShimPathInUnix,
                     Reporter.Output,
                     environmentProvider, new FileWrapper());
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && hasSuperUserAccess)
             {
                 environmentPath = new OSXEnvironmentPath(
-                    executablePath: cliFolderPathCalculator.ExecutablePackagesPathInUnix,
+                    executablePath: cliFolderPathCalculator.ToolsShimPathInUnix,
                     reporter: Reporter.Output,
                     environmentProvider: environmentProvider,
                     fileSystem: new FileWrapper());

--- a/src/dotnet/ShellShim/ShellShimMaker.cs
+++ b/src/dotnet/ShellShim/ShellShimMaker.cs
@@ -30,6 +30,11 @@ namespace Microsoft.DotNet.ShellShim
         {
             FilePath shimPath = GetShimPath(shellCommandName);
 
+            if (!Directory.Exists(shimPath.GetDirectoryPath().Value))
+            {
+                Directory.CreateDirectory(shimPath.GetDirectoryPath().Value);
+            }
+
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 CreateConfigFile(shimPath.Value + ".config", entryPoint: packageExecutablePath, runner: "dotnet");

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommand.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommand.cs
@@ -49,12 +49,13 @@ namespace Microsoft.DotNet.Tools.Install.Tool
             }
 
             var cliFolderPathCalculator = new CliFolderPathCalculator();
-            var executablePackagePath = new DirectoryPath(cliFolderPathCalculator.ExecutablePackagesPath);
             var offlineFeedPath = new DirectoryPath(cliFolderPathCalculator.CliFallbackFolderPath);
 
-            var toolConfigurationAndExecutablePath = ObtainPackage(executablePackagePath, offlineFeedPath);
+            var toolConfigurationAndExecutablePath = ObtainPackage(
+                executablePackagePath: new DirectoryPath(cliFolderPathCalculator.ToolsPackagePath),
+                offlineFeedPath: offlineFeedPath);
 
-            var shellShimMaker = new ShellShimMaker(executablePackagePath.Value);
+            var shellShimMaker = new ShellShimMaker(cliFolderPathCalculator.ToolsShimPath);
             var commandName = toolConfigurationAndExecutablePath.Configuration.CommandName;
             shellShimMaker.EnsureCommandNameUniqueness(commandName);
 

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenAPathCalculator.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenAPathCalculator.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using FluentAssertions;
+
+namespace Microsoft.DotNet.Configurer.UnitTests
+{
+    public class GivenAPathCalculator
+    {
+        [NonWindowsOnlyFact]
+        public void It_does_not_return_same_path_for_tools_package_and_tool_shim()
+        {
+            // shim name will conflict with the folder that is PackageId, if commandName and packageId are the same.
+            var cliFolderPathCalculator = new CliFolderPathCalculator();
+            cliFolderPathCalculator.ToolsPackagePath.Should().NotBe(cliFolderPathCalculator.ToolsShimPath);
+            cliFolderPathCalculator.ToolsPackagePath.Should().NotBe(cliFolderPathCalculator.ToolsShimPathInUnix.Path);
+        }
+    }
+}

--- a/test/Microsoft.DotNet.ShellShim.Tests/ShellShimMakerTests.cs
+++ b/test/Microsoft.DotNet.ShellShim.Tests/ShellShimMakerTests.cs
@@ -68,6 +68,20 @@ namespace Microsoft.DotNet.ShellShim.Tests
             stdOut.Should().Contain("Hello World");
         }
 
+        [Fact]
+        public void GivenAnExecutablePathDirectoryThatDoesNotExistItCanGenerateShimFile()
+        {
+            var outputDll = MakeHelloWorldExecutableDll();
+            var extraNonExistDirectory = Path.GetRandomFileName();
+            var shellShimMaker = new ShellShimMaker(Path.Combine(TempRoot.Root, extraNonExistDirectory));
+            var shellCommandName = nameof(ShellShimMakerTests) + Path.GetRandomFileName();
+
+            Action a = () => shellShimMaker.CreateShim(
+                outputDll.FullName,
+                shellCommandName);
+            a.ShouldNotThrow<DirectoryNotFoundException>();
+        }
+
         [Theory]
         [InlineData("arg1 arg2", new[] { "arg1", "arg2" })]
         [InlineData(" \"arg1 with space\" arg2", new[] { "arg1 with space", "arg2" })]


### PR DESCRIPTION
**Customer scenario**

Consumer install a global tool on CLI that has the same command name as the package id, for example dotnet-watch. The install will fail with access denied error on macOS and Linux.

**Bugs this fixes**

https://github.com/dotnet/cli/issues/8445

**Workarounds, if any**

Republish the global tools with a different packageId

**Risk**

low

**Performance impact**

no

**Root cause analysis**

Since tools shim and package are stored in the same folder. If the tool command name and the package name is the same, a folder and a file with the same name will be created. And this is not allow in unix file system. More integration test coverage is needed.

**How was the bug found?**

Manual testing
