### PR TITLE
MSBuild 15.6.70

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MicrosoftNETCoreAppPackageVersion>2.0.5</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.6.0-preview-000069-1314993</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.6.0-preview-000070-1317370</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>


### PR DESCRIPTION
This went in yesterday for 15.6 preview 4.
https://devdiv.visualstudio.com/DevDiv/MSBuild/_git/VS/pullrequest/103205?_a=overview

It contains a fix for pre-processor output (there was an ordering issue with implicit imports from SDKs in certain cases). Very low priority, only affects `/pp` flag. Feel free to not insert for preview 4 if this is the only item (we've been off by 0.0.1ish in a preview before).