### PR TITLE
Fix test folder cannot delete and missing test

### DIFF
--- a/test/Microsoft.DotNet.ShellShim.Tests/ShellShimMakerTests.cs
+++ b/test/Microsoft.DotNet.ShellShim.Tests/ShellShimMakerTests.cs
@@ -93,6 +93,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
             }
         }
 
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public void GivenAnExecutablePathWithExistingSameNameShimItThrows(bool testMockBehaviorIsInSync)
@@ -184,7 +185,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
             const string testAppName = "TestAppSimple";
             const string emptySpaceToTestSpaceInPath = " ";
             TestAssetInstance testInstance = TestAssets.Get(testAppName)
-                .CreateInstance(testAppName + emptySpaceToTestSpaceInPath)
+                .CreateInstance(testAppName + emptySpaceToTestSpaceInPath + "test")
                 .UseCurrentRuntimeFrameworkVersion()
                 .WithRestoreFiles()
                 .WithBuildFiles();


### PR DESCRIPTION
There is a bug that prevent folder with space in the end to be deleted on corefx. I will file it later.

The space in the test is needed due to shim used to cannot handle space in the be PATH.