### PR TITLE
Add support for git bash running on windows.

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -612,7 +612,16 @@ extract_dotnet_package() {
     local failed=false
     case $download_link in
       *.zip)
-         unzip "$zip_path" -d "$temp_out_path" || failed=true
+         local exitCode=0
+         unzip -q "$zip_path" -d "$temp_out_path" || exitCode=$?
+         if [ $exitCode -eq 1 ]; then
+            say_warning "unzip encountered warnings"
+         elif [ $exitCode -eq 0 ]; then
+            say_verbose "unzip finished"
+         else
+            say_err "unzip failed"
+            failed=true
+         fi
          ;;
       *.tar.gz)
          tar -xzf "$zip_path" -C "$temp_out_path" > /dev/null || failed=true


### PR DESCRIPTION
This makes it possible to run `curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel Current` in a git bash on windows (as given in the [documentation](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script)) 

