### PR TITLE
Fixing update dependency by using the new APIs.

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -66,7 +66,7 @@
 
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>
-    <VersionToolsVersion>2.1.0-prerelease-02411-04</VersionToolsVersion>
+    <VersionToolsVersion>2.1.0-prerelease-02430-04</VersionToolsVersion>
     <DotnetDebToolVersion>2.0.0-preview2-25331-01</DotnetDebToolVersion>
     <BuildTasksFeedToolVersion>2.1.0-prerelease-02411-04</BuildTasksFeedToolVersion>
   </PropertyGroup>

--- a/build_projects/update-dependencies/Program.cs
+++ b/build_projects/update-dependencies/Program.cs
@@ -4,6 +4,7 @@
 using Microsoft.DotNet.VersionTools;
 using Microsoft.DotNet.VersionTools.Automation;
 using Microsoft.DotNet.VersionTools.Dependencies;
+using Microsoft.DotNet.VersionTools.Dependencies.BuildOutput;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -29,7 +30,7 @@ namespace Microsoft.DotNet.Scripts
 
             IEnumerable<IDependencyUpdater> updaters = GetUpdaters();
             var dependencyBuildInfos = buildInfos.Select(buildInfo =>
-                new DependencyBuildInfo(
+                new BuildDependencyInfo(
                     buildInfo,
                     upgradeStableVersions: true,
                     disabledPackages: Enumerable.Empty<string>()));
@@ -50,11 +51,14 @@ namespace Microsoft.DotNet.Scripts
                     body += PullRequestCreator.NotificationString(s_config.GitHubPullRequestNotifications);
                 }
 
-                new PullRequestCreator(gitHubAuth, origin, upstreamBranch)
+                new PullRequestCreator(gitHubAuth)
                     .CreateOrUpdateAsync(
                         suggestedMessage,
                         suggestedMessage + $" ({upstreamBranch.Name})",
-                        body)
+                        body,
+                        upstreamBranch,
+                        origin,
+                        new PullRequestOptions())
                     .Wait();
             }
         }


### PR DESCRIPTION
Fixing update dependency by using the new APIs. We broke this when we updated the version of VersionTools.
