### PR TITLE
Update ASP.NET Core certificate installation message

### DIFF
--- a/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
@@ -150,6 +150,8 @@ Here are some options to fix this error:
   <data name="AspNetCertificateInstalled" xml:space="preserve">
     <value>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</value>
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</value>
   </data>
 </root>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
@@ -61,8 +61,10 @@ Tuto chybu můžete opravit pomocí některé z těchto možností:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Nainstaloval se vývojový certifikát ASP.NET Core HTTPS. Další informace najdete na https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
@@ -61,8 +61,10 @@ Im Folgenden finden Sie einige Optionen, um diesen Fehler zu beheben:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Installiertes ASP.NET Core-HTTPS-Entwicklungszertifikat. Weitere Informationen finden Sie unter https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
@@ -60,8 +60,10 @@ Estas son algunas opciones para corregir este error:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Se instaló el certificado de desarrollo HTTPS de ASP.NET Core. Para más información, vaya a https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
@@ -61,8 +61,10 @@ Voici quelques options pour corriger cette erreur :
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Certificat de développement HTTPS ASP.NET Core installé. Pour plus d’informations, accédez à https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
@@ -61,8 +61,10 @@ Ecco alcune opzioni per correggere questo errore:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Il certificato di sviluppo HTTPS di ASP.NET Core è stato installato. Per altre informazioni, vedere https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
@@ -61,8 +61,10 @@ Here are some options to fix this error:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 ASP.NET Core HTTPS 開発証明書をインストールしました。詳しくは、https://go.microsoft.com/fwlink/?linkid=84805 をご覧ください</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
@@ -61,8 +61,10 @@ Here are some options to fix this error:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 설치된 ASP.NET Core HTTPS 개발 인증서. 자세한 내용은 https://go.microsoft.com/fwlink/?linkid=84805을(를) 참조하세요.</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
@@ -61,8 +61,10 @@ Oto kilka opcji naprawiania tego błędu:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Zainstalowany certyfikat programistyczny HTTPS ASP.NET Core. Aby uzyskać więcej informacji, przejdź na adres https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
@@ -61,8 +61,10 @@ Aqui estão algumas opções para corrigir este erro:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Certificado de desenvolvimento de HTTPS do ASP.NET Core instalado. Para obter mais informações, vá para https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
@@ -61,8 +61,10 @@ Here are some options to fix this error:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Установлен сертификат для HTTPS-разработки на ASP.NET Core. Дополнительные сведения: https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
@@ -61,8 +61,10 @@ Bu hatayı düzeltmek için bazı seçenekler:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 ASP.NET Core HTTPS geliştirme sertifikası yüklendi. Daha fazla bilgi için bkz. https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
@@ -61,8 +61,10 @@ Here are some options to fix this error:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 安装 ASP.NET Core HTTPS 开发证书。有关详细信息，请转到 https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
@@ -61,8 +61,10 @@ Here are some options to fix this error:
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------
-Installed ASP.NET Core HTTPS development certificate. For more information go to https://go.microsoft.com/fwlink/?linkid=84805</source>
-        <target state="translated">ASP.NET Core
+Successfully installed the ASP.NET Core HTTPS Development Certificate.
+To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet install tool dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 已安裝 ASP.NET Core HTTPS 開發憑證。如需詳細資訊，請前往 https://go.microsoft.com/fwlink/?linkid=84805</target>
         <note />


### PR DESCRIPTION
# Customer scenario

First run reporting an out of date informational message for the ASP.NET Core developer certificate installation.

# Bugs this fixes:

#8511

# Workarounds, if any

None

# Risk

Low

# Performance impact

None, we are changing the content of a message that already comes from a resource file.

# Is this a regression from a previous update?

No

# Root cause analysis:

We didn't have the final text that we wanted displayed to the users at the time the feature got in.