### PR TITLE
MSBuild 15.6.76

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MicrosoftNETCoreAppPackageVersion>2.0.5</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.6.0-preview-000070-1317370</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.6.0-preview-000076-1343104</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>


### PR DESCRIPTION
This contains 4 fixes approved for 15.6 escrow.

PR: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/104554

Note: Val build is not done so this will likely not go in officially until tonight depending on how long that takes.

Fixes:
https://github.com/Microsoft/msbuild/pull/2913
https://github.com/Microsoft/msbuild/pull/2925
https://github.com/Microsoft/msbuild/pull/2935
https://github.com/Microsoft/msbuild/pull/2931
