### PR TITLE
Update SDK version and Rename to BundledNETCorePlatformsPackageVersion

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -14,7 +14,7 @@
     <MicrosoftNETCoreCompilersPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNETCoreCompilersPackageVersion>
     <MicrosoftCodeAnalysisBuildTasksPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisBuildTasksPackageVersion>
     <MicrosoftNetCompilersNetcorePackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNetCompilersNetcorePackageVersion>
-    <MicrosoftNETSdkPackageVersion>2.1.300-preview2-62530-05</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>2.1.300-preview2-62607-04</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftNETSdkWebPackageVersion>2.1.0-release21-20180126-1326543</MicrosoftNETSdkWebPackageVersion>
     <MicrosoftNETSdkPublishPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkPublishPackageVersion>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -97,23 +97,25 @@
       of our build against Microsoft.NETCore.App to find the correct NETStandard.Library version
     -->
     <ItemGroup>
-      <_NETStandardLibraryVersions Include="@(PackageDefinitions->'%(Version)')"
+      <_NETStandardLibraryPackageVersions Include="@(PackageDefinitions->'%(Version)')"
                                    Condition="%(PackageDefinitions.Name) == 'NetStandard.Library'" />
-      <_NETCorePlatformsImplicitPackageVersion Include="@(PackageDefinitions->'%(Version)')"
+      <_NETCorePlatformsPackageVersions Include="@(PackageDefinitions->'%(Version)')"
                                    Condition="%(PackageDefinitions.Name) == 'Microsoft.NETCore.Platforms'" />
     </ItemGroup>
 
-    <Error Condition="@(_NETStandardLibraryVersions->Distinct()->Count()) != 1"
+    <Error Condition="@(_NETStandardLibraryPackageVersions->Distinct()->Count()) != 1"
            Text="Failed to determine the NETStandard.Library version pulled in Microsoft.NETCore.App" />
+    <Error Condition="@(_NETCorePlatformsPackageVersions->Distinct()->Count()) != 1"
+           Text="Failed to determine the Microsoft.NETCore.Platforms version pulled in Microsoft.NETCore.App" />
 
     <PropertyGroup>
       <_NETCoreAppPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</_NETCoreAppPackageVersion>
-      <_NETStandardPackageVersion>@(_NETStandardLibraryVersions->Distinct())</_NETStandardPackageVersion>
-      <_NETCorePlatformsImplicitPackageVersion>@(_NETCorePlatformsImplicitPackageVersion->Distinct())</_NETCorePlatformsImplicitPackageVersion>
+      <_NETStandardLibraryPackageVersion>@(_NETStandardLibraryPackageVersions->Distinct())</_NETStandardLibraryPackageVersion>
+      <_NETCorePlatformsPackageVersion>@(_NETCorePlatformsPackageVersions->Distinct())</_NETCorePlatformsPackageVersion>
 
       <!-- Use only major and minor in target framework version -->
       <_NETCoreAppTargetFrameworkVersion>$(_NETCoreAppPackageVersion.Split('.')[0]).$(_NETCoreAppPackageVersion.Split('.')[1])</_NETCoreAppTargetFrameworkVersion>
-      <_NETStandardTargetFrameworkVersion>$(_NETStandardPackageVersion.Split('.')[0]).$(_NETStandardPackageVersion.Split('.')[1])</_NETStandardTargetFrameworkVersion>
+      <_NETStandardTargetFrameworkVersion>$(_NETStandardLibraryPackageVersion.Split('.')[0]).$(_NETStandardLibraryPackageVersion.Split('.')[1])</_NETStandardTargetFrameworkVersion>
 
       <BundledVersionsPropsContent>
 <![CDATA[
@@ -133,8 +135,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledNETCoreAppTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</BundledNETCoreAppTargetFrameworkVersion>
     <BundledNETCoreAppPackageVersion>$(_NETCoreAppPackageVersion)</BundledNETCoreAppPackageVersion>
     <BundledNETStandardTargetFrameworkVersion>$(_NETStandardTargetFrameworkVersion)</BundledNETStandardTargetFrameworkVersion>
-    <BundledNETStandardPackageVersion>$(_NETStandardPackageVersion)</BundledNETStandardPackageVersion>
-    <NETCorePlatformsImplicitPackageVersion>$(_NETCorePlatformsImplicitPackageVersion)</NETCorePlatformsImplicitPackageVersion>
+    <BundledNETStandardPackageVersion>$(_NETStandardLibraryPackageVersion)</BundledNETStandardPackageVersion>
+    <BundledNETCorePlatformsPackageVersion>$(_NETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
   </PropertyGroup>
 </Project>
 ]]>


### PR DESCRIPTION
This is a continuation of https://github.com/dotnet/sdk/pull/1928 and https://github.com/dotnet/cli/issues/8421

I need to update the sdk version (has the renaming change) and rename it on CLI side in one PR