### PR TITLE
Ensure ASP.NET Core is included in macos .pkg installer

### DIFF
--- a/build/BundledRuntimes.props
+++ b/build/BundledRuntimes.props
@@ -59,7 +59,7 @@
                              Condition="!Exists('$(AspNetCoreSharedFxArchiveFile)')">
       <Url>$(CoreSetupRootUrl)$(AspNetCoreVersion)/$(AspNetCoreSharedFxArchiveFileName)$(CoreSetupBlobAccessTokenParam)</Url>
       <DownloadFileName>$(AspNetCoreSharedFxArchiveFile)</DownloadFileName>
-      <ExtractDestination>$(SharedFrameworkPublishDirectory)</ExtractDestination>
+      <ExtractDestination>$(AspNetCoreSharedFxPublishDirectory)</ExtractDestination>
     </_DownloadAndExtractItem>
 
     <_DownloadAndExtractItem Include="CombinedSharedHostAndFrameworkArchive"

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-preview1-28124</MicrosoftAspNetCoreAllPackageVersion>
+    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-preview1-28226</MicrosoftAspNetCoreAllPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-26116-04</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <MicrosoftBuildPackageVersion>15.6.0-preview-000054-1286830</MicrosoftBuildPackageVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-preview1-28226</MicrosoftAspNetCoreAllPackageVersion>
+    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-preview1-28228</MicrosoftAspNetCoreAllPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-preview1-26116-04</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <MicrosoftBuildPackageVersion>15.6.0-preview-000054-1286830</MicrosoftBuildPackageVersion>

--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -4,7 +4,7 @@
       <ItemGroup>
         <NugetConfigPrivateFeeds Include="$(ExternalRestoreSources.Split(';'))" />
       </ItemGroup>
-    
+
     <PropertyGroup>
       <NugetConfigHeader>
         <![CDATA[
@@ -20,7 +20,7 @@
         <![CDATA[
     <add key="BlobFeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
-    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
+    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
     <add key="websdkfeed" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
     <add key="cli-deps" value="https://dotnet.myget.org/F/cli-deps/api/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
@@ -29,7 +29,7 @@
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
     <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
-    <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" /> 
+    <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
         ]]>
       </NugetConfigCLIFeeds>
 
@@ -39,13 +39,13 @@
 </configuration>
         ]]>
       </NugetConfigSuffix>
-    
+
   </PropertyGroup>
 
     <WriteLinesToFile File="$(GeneratedNuGetConfig)"
                       Lines="$(NugetConfigHeader)"
                       Overwrite="true" />
-    
+
     <WriteLinesToFile Condition="'$(ExternalRestoreSources)' != '' and '$(DotNetBuildOffline)' != 'true'"
                       File="$(GeneratedNuGetConfig)"
                       Lines="&lt;add key=&quot;PrivateBlobFeed&quot; value=&quot;%(NugetConfigPrivateFeeds.Identity)&quot; /&gt;"

--- a/build/OutputDirectories.props
+++ b/build/OutputDirectories.props
@@ -20,15 +20,14 @@
       <IntermediateDirectory>$(BaseOutputDirectory)/intermediate</IntermediateDirectory>
       <PackagesDirectory>$(BaseOutputDirectory)/packages</PackagesDirectory>
       <SharedFrameworkPublishDirectory>$(IntermediateDirectory)/sharedFrameworkPublish</SharedFrameworkPublishDirectory>
-      <!-- The 'AspNetRuntimePackageStorePublishDirectory' needs to be very short due to path length constraints on Win8.1 -->
-      <AspNetRuntimePackageStorePublishDirectory>$(BaseOutputDirectory)/AspRT</AspNetRuntimePackageStorePublishDirectory>
+      <AspNetCoreSharedFxPublishDirectory>$(IntermediateDirectory)/aspnetSharedFxPublish</AspNetCoreSharedFxPublishDirectory>
       <BackwardsCompatibleSharedFrameworksPublishDirectory>$(IntermediateDirectory)/backwardsCompatibleSharedFrameworksPublish</BackwardsCompatibleSharedFrameworksPublishDirectory>
       <TestOutputDir>$(BaseOutputDirectory)/test/</TestOutputDir>
       <DotnetInOutputDirectory>$(OutputDirectory)/dotnet$(ExeExtension)</DotnetInOutputDirectory>
       <GeneratedMSBuildExtensionsDirectory>$(IntermediateDirectory)/GeneratedMSBuildExtensions</GeneratedMSBuildExtensionsDirectory>
       <MSBuildExtensionsLayoutDirectory>$(IntermediateDirectory)/MSBuildExtensionsLayout</MSBuildExtensionsLayoutDirectory>
       <SdkResolverOutputDirectory>$(MSBuildExtensionsLayoutDirectory)/MSBuildSdkResolver</SdkResolverOutputDirectory>
-    
+
       <NextStagePropsPath>$(BaseOutputDirectory)/PreviousStage.props</NextStagePropsPath>
   </PropertyGroup>
 </Project>

--- a/build/package/Layout.targets
+++ b/build/package/Layout.targets
@@ -16,7 +16,7 @@
       <CombinedHostHostFxrFrameworkSdkInput Include="$(OutputDirectory)/**/*" />
       <SdkLanguagePackInput Include="$(OutputDirectory)/sdk/**/$(SatelliteAssemblies)" />
 
-      <AspNetRuntimeFilesInput Include="$(AspNetRuntimePackageStorePublishDirectory)/**/*" />
+      <AspNetRuntimeFilesInput Include="$(AspNetCoreSharedFxPublishDirectory)/**/*" />
 
       <MSBuildExtensionsInput Include="$(MSBuildExtensionsLayoutDirectory)/msbuildExtensions/**/*" />
       <MSBuildExtensionsVerInput Include="$(MSBuildExtensionsLayoutDirectory)/msbuildExtensions-ver/**/*" />

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -37,15 +37,15 @@
     </Content>
   </ItemGroup>
 
-  <Target Name="PublishAspNetRuntimePackageStore"
+  <Target Name="PublishAspNetSharedFramework"
           AfterTargets="CrossgenPublishDir">
     <ItemGroup>
-      <AspNetRuntimePackageStore Remove="*" />
-      <AspNetRuntimePackageStore Include="$(AspNetRuntimePackageStorePublishDirectory)/**/*" />
+      <AspNetSharedFramework Remove="*" />
+      <AspNetSharedFramework Include="$(AspNetCoreSharedFxPublishDirectory)/**/*" />
     </ItemGroup>
 
-    <Copy SourceFiles="@(AspNetRuntimePackageStore)"
-          DestinationFiles="@(AspNetRuntimePackageStore->'$(OutputDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(AspNetSharedFramework)"
+          DestinationFiles="@(AspNetSharedFramework->'$(OutputDirectory)/%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
   <Target Name="PublishSharedFramework"
@@ -69,7 +69,7 @@
 
   <Target Name="PublishRoslyn"
           BeforeTargets="Publish">
-          
+
     <ItemGroup>
       <RoslynBits Include="$(NuGetPackagesDir)/microsoft.netcore.compilers/$(MicrosoftNETCoreCompilersPackageVersion)/tools/**/*" />
     </ItemGroup>
@@ -104,7 +104,7 @@
 
   <Target Name="PublishFSharp"
           BeforeTargets="Publish">
-          
+
     <DotNetPublish ToolPath="$(PreviousStageDirectory)"
                    Configuration="$(Configuration)"
                    ProjectPath="$(SrcDirectory)/tool_fsharp/tool_fsc.csproj" />
@@ -141,7 +141,7 @@
         <DestinationPath Condition="'%(MSBuildExtensionsContent.DestinationPath)' == ''">$(PublishDir)/%(MSBuildExtensionsContent.DeploymentSubpath)%(RecursiveDir)%(Filename)%(Extension)</DestinationPath>
       </MSBuildExtensionsContent>
     </ItemGroup>
-    
+
       <Copy SourceFiles="@(MSBuildExtensionsContent)"
             DestinationFiles="%(MSBuildExtensionsContent.DestinationPath)" />
 
@@ -262,11 +262,11 @@
       <RoslynTargets Include="%(RoslynFilesWithPEMarker.FullPath)" Condition=" '%(RoslynFilesWithPEMarker.IsPE)' == 'True' " />
       <FSharpTargets Include="%(FSharpFilesWithPEMarker.FullPath)" Condition=" '%(FSharpFilesWithPEMarker.IsPE)' == 'True' " />
       <RemainingTargets Include="%(RemainingFilesWithPEMarker.FullPath)" Condition=" '%(RemainingFilesWithPEMarker.IsPE)' == 'True' " />
- 
+
       <RoslynFolders Include="@(RoslynTargets-&gt;DirectoryName()-&gt;Distinct())" />
       <FSharpFolders Include="@(FSharpTargets-&gt;DirectoryName()-&gt;Distinct())" />
       <RemainingFolders Include="@(RemainingTargets-&gt;DirectoryName()-&gt;Distinct())" />
- 
+
       <!-- FSharp.Build.dll causes the FSharp folder to be included. Remove it, as we don't want other FSharp dlls being included in the crossgen. -->
       <RemainingFolders Remove="$(PublishDir)FSharp\**\*" />
     </ItemGroup>
@@ -291,7 +291,7 @@
         CreateSymbols="$(CreateCrossgenSymbols)"
         DiasymReaderPath="@(DiasymReaderPath)"
         PlatformAssemblyPaths="@(PlatformAssemblies);@(RoslynFolders);$(SharedFrameworkNameVersionPath)" />
- 
+
     <Crossgen
         SourceAssembly="%(FSharpTargets.FullPath)"
         DestinationPath="%(FSharpTargets.FullPath)"
@@ -316,7 +316,7 @@
   <Target Name="ChmodPublishDir"
           AfterTargets="CrossgenPublishDir"
           Condition=" '$(OSName)' != 'win' ">
-    
+
     <Exec Command="find $(SdkOutputDirectory) -type d -exec chmod 755 {} \;" />
     <Exec Command="find $(SdkOutputDirectory) -type f -exec chmod 644 {} \;" />
     <Chmod Mode="755" Glob="$(SdkOutputDirectory)/FSharp/RunFsc.sh" />
@@ -330,7 +330,7 @@
       <PdbsToMove Include="$(PublishDir)/**/*.ni.*.map" />
     </ItemGroup>
 
-    <Move SourceFiles="@(PdbsToMove)" 
+    <Move SourceFiles="@(PdbsToMove)"
           DestinationFiles="@(PdbsToMove->'$(SymbolsDirectory)/sdk/$(SdkVersion)/%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 

--- a/test/dotnet-migrate.Tests/NuGet.tempaspnetpatch.config
+++ b/test/dotnet-migrate.Tests/NuGet.tempaspnetpatch.config
@@ -5,6 +5,6 @@
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="DotnetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
+    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/dotnet-new.Tests/NuGet.tempaspnetpatch.config
+++ b/test/dotnet-new.Tests/NuGet.tempaspnetpatch.config
@@ -5,7 +5,7 @@
     <clear />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="DotnetCore" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
+    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
     <add key="dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Resolves #8529 

Also, updates local builds to use the latest ASP.NET Core from builds from our release/2.1 branch.

cc @JunTaoLuo @Eilon 