### PR TITLE
Update Microsoft.DotNet.Archive version.

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -33,7 +33,7 @@
     <MicrosoftDotNetCliCommandLinePackageVersion>0.1.1-alpha-174</MicrosoftDotNetCliCommandLinePackageVersion>
     <MicrosoftDotNetProjectJsonMigrationPackageVersion>1.2.1-alpha-002133</MicrosoftDotNetProjectJsonMigrationPackageVersion>
     <MicrosoftDotNetToolsMigrateCommandPackageVersion>$(MicrosoftDotNetProjectJsonMigrationPackageVersion)</MicrosoftDotNetToolsMigrateCommandPackageVersion>
-    <MicrosoftDotNetArchivePackageVersion>0.2.0-beta-000059</MicrosoftDotNetArchivePackageVersion>
+    <MicrosoftDotNetArchivePackageVersion>0.2.0-beta-62606-02</MicrosoftDotNetArchivePackageVersion>
     <MicrosoftDiaSymReaderNativePackageVersion>1.6.0-beta2-25304</MicrosoftDiaSymReaderNativePackageVersion>
     <NuGetBuildTasksPackageVersion>4.7.0-preview1-4846</NuGetBuildTasksPackageVersion>
     <NuGetBuildTasksPackPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksPackPackageVersion>


### PR DESCRIPTION
This commit updates Microsoft.DotNet.Archive version number to include a fix
for #8288.