### PR TITLE
Log kernel version, product type and installation type, and libc version

### DIFF
--- a/src/dotnet/Telemetry/TelemetryCommonProperties.cs
+++ b/src/dotnet/Telemetry/TelemetryCommonProperties.cs
@@ -8,6 +8,8 @@ using Microsoft.DotNet.PlatformAbstractions;
 using System.IO;
 using Microsoft.DotNet.Configurer;
 using System.Linq;
+using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
+using RuntimeInformation = System.Runtime.InteropServices.RuntimeInformation;
 
 namespace Microsoft.DotNet.Cli.Telemetry
 {
@@ -40,6 +42,8 @@ namespace Microsoft.DotNet.Cli.Telemetry
         private const string CurrentPathHash = "Current Path Hash";
         private const string MachineId = "Machine ID";
         private const string DockerContainer = "Docker Container";
+        private const string KernelVersion = "Kernel Version";
+
         private const string TelemetryProfileEnvironmentVariable = "DOTNET_CLI_TELEMETRY_PROFILE";
         private const string CannotFindMacAddress = "Unknown";
 
@@ -57,7 +61,8 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 {TelemetryProfile, Environment.GetEnvironmentVariable(TelemetryProfileEnvironmentVariable)},
                 {DockerContainer, _userLevelCacheWriter.RunWithCache(IsDockerContainerCacheKey, () => _dockerContainerDetector.IsDockerContainer().ToString("G") )},
                 {CurrentPathHash, _hasher(_getCurrentDirectory())},
-                {MachineId, _userLevelCacheWriter.RunWithCache(MachineIdCacheKey, GetMachineId)}
+                {MachineId, _userLevelCacheWriter.RunWithCache(MachineIdCacheKey, GetMachineId)},
+                {KernelVersion, GetKernelVersion()}
             };
         }
 
@@ -72,6 +77,45 @@ namespace Microsoft.DotNet.Cli.Telemetry
             {
                 return Guid.NewGuid().ToString();
             }
+        }
+
+        /// <summary>
+        /// Returns a string identifying the OS kernel.
+        /// For Unix this currently comes from "uname -srv".
+        /// For Windows this currently comes from RtlGetVersion().
+        ///
+        /// Here are some example values:
+        ///
+        ///     Alpine.36        Linux 4.9.60-linuxkit-aufs #1 SMP Mon Nov 6 16:00:12 UTC 2017
+        ///     Centos.73        Linux 3.10.0-514.26.2.el7.x86_64 #1 SMP Tue Jul 4 15:04:05 UTC 2017
+        ///     Debian.87        Linux 3.16.0-4-amd64 #1 SMP Debian 3.16.39-1+deb8u2 (2017-03-07)
+        ///     Debian.90        Linux 4.9.0-2-amd64 #1 SMP Debian 4.9.18-1 (2017-03-30)
+        ///     fedora.25        Linux 4.11.3-202.fc25.x86_64 #1 SMP Mon Jun 5 16:38:21 UTC 2017
+        ///     Fedora.26        Linux 4.14.15-200.fc26.x86_64 #1 SMP Wed Jan 24 04:26:15 UTC 2018
+        ///     Fedora.27        Linux 4.14.14-300.fc27.x86_64 #1 SMP Fri Jan 19 13:19:54 UTC 2018
+        ///     OpenSuse.423     Linux 4.4.104-39-default #1 SMP Thu Jan 4 08:11:03 UTC 2018 (7db1912)
+        ///     RedHat.69        Linux 2.6.32-696.20.1.el6.x86_64 #1 SMP Fri Jan 12 15:07:59 EST 2018
+        ///     RedHat.72        Linux 3.10.0-514.21.1.el7.x86_64 #1 SMP Sat Apr 22 02:41:35 EDT 2017
+        ///     RedHat.73        Linux 3.10.0-514.21.1.el7.x86_64 #1 SMP Sat Apr 22 02:41:35 EDT 2017
+        ///     SLES.12          Linux 4.4.103-6.38-default #1 SMP Mon Dec 25 20:44:33 UTC 2017 (e4b9067)
+        ///     suse.422         Linux 4.4.49-16-default #1 SMP Sun Feb 19 17:40:35 UTC 2017 (70e9954)
+        ///     Ubuntu.1404      Linux 3.19.0-65-generic #73~14.04.1-Ubuntu SMP Wed Jun 29 21:05:22 UTC 2016
+        ///     Ubuntu.1604      Linux 4.13.0-1005-azure #7-Ubuntu SMP Mon Jan 8 21:37:36 UTC 2018
+        ///     Ubuntu.1604.WSL  Linux 4.4.0-43-Microsoft #1-Microsoft Wed Dec 31 14:42:53 PST 2014
+        ///     Ubuntu.1610      Linux 4.8.0-45-generic #48-Ubuntu SMP Fri Mar 24 11:46:39 UTC 2017
+        ///     Ubuntu.1704      Linux 4.10.0-19-generic #21-Ubuntu SMP Thu Apr 6 17:04:57 UTC 2017
+        ///     Ubuntu.1710      Linux 4.13.0-25-generic #29-Ubuntu SMP Mon Jan 8 21:14:41 UTC 2018
+        ///     OSX1012          Darwin 16.7.0 Darwin Kernel Version 16.7.0: Thu Jan 11 22:59:40 PST 2018; root:xnu-3789.73.8~1/RELEASE_X86_64
+        ///     OSX1013          Darwin 17.4.0 Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64
+        ///     Windows.10       Microsoft Windows 10.0.14393
+        ///     Windows.10.Core  Microsoft Windows 10.0.14393
+        ///     Windows.10.Nano  Microsoft Windows 10.0.14393
+        ///     Windows.7        Microsoft Windows 6.1.7601 S
+        ///     Windows.81       Microsoft Windows 6.3.9600
+        /// </summary>
+        private static string GetKernelVersion()
+        {
+            return RuntimeInformation.OSDescription;
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/UnixOnlyFactAttribute.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/UnixOnlyFactAttribute.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.PlatformAbstractions;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public class UnixOnlyFactAttribute : FactAttribute
+    {
+        public UnixOnlyFactAttribute()
+        {
+            if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
+            {
+                this.Skip = "This test requires Unix to run";
+            }
+        }
+    }
+}

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -5,9 +5,11 @@ using FluentAssertions;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
 using System;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Telemetry;
 using Microsoft.DotNet.Configurer;
+using RuntimeEnvironment = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment;
 
 namespace Microsoft.DotNet.Tests
 {
@@ -41,6 +43,13 @@ namespace Microsoft.DotNet.Tests
             var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["Machine ID"];
 
             Guid.TryParse(assignedMachineId, out var _).Should().BeTrue("it should be a guid");
+        }
+
+        [Fact]
+        public void TelemetryCommonPropertiesShouldContainKernelVersion()
+        {
+            var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
+            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["Kernel Version"].Should().Be(RuntimeInformation.OSDescription);
         }
 
         private class NothingCache : IUserLevelCacheWriter

--- a/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryCommonPropertiesTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.Tests
         public void TelemetryCommonPropertiesShouldContainKernelVersion()
         {
             var unitUnderTest = new TelemetryCommonProperties(getMACAddress: () => null, userLevelCacheWriter: new NothingCache());
-            var assignedMachineId = unitUnderTest.GetTelemetryCommonProperties()["Kernel Version"].Should().Be(RuntimeInformation.OSDescription);
+            unitUnderTest.GetTelemetryCommonProperties()["Kernel Version"].Should().Be(RuntimeInformation.OSDescription);
         }
 
         private class NothingCache : IUserLevelCacheWriter


### PR DESCRIPTION
Add 5 telemetry datapoints:

### (1) Kernel version
#### Motivation
If we have an issue associated with a kernel or libc version we can assess the breadth of impact to help determine the priority of a fix, and whether the fix should go out in servicing. We may be able to use this datapoint to help prioritize features that only affect certain kernel versions.
#### Alternatives
We have existing datapoints for distro name and version, but this the exact kernel version can vary. For example, we know "ubuntu.14.04-x64" but this encompasses a [range of kernel versions](http://people.canonical.com/~kernel/info/kernel-version-map.html).
#### Source
Existing API `RuntimeInformation.OSDescription`, which itself comes from `uname -srv` on Unix and `RtlGetVersion()` on Windows.
#### Notes
Not attempting to parse this value on the client, as the format is not consistent. It includes name, version, architecture, and kernel build date. Note that Windows subsystem for Linux ("WSL") can be distinguished by the string "Microsoft".
#### Example values
```
Alpine.36	Linux 4.9.60-linuxkit-aufs #1 SMP Mon Nov 6 16:00:12 UTC 2017
Centos.73 	 Linux 3.10.0-514.26.2.el7.x86_64 #1 SMP Tue Jul 4 15:04:05 UTC 2017
Debian.87 	 Linux 3.16.0-4-amd64 #1 SMP Debian 3.16.39-1+deb8u2 (2017-03-07)
Debian.90 	 Linux 4.9.0-2-amd64 #1 SMP Debian 4.9.18-1 (2017-03-30)
fedora.25 	 Linux 4.11.3-202.fc25.x86_64 #1 SMP Mon Jun 5 16:38:21 UTC 2017
Fedora.26 	 Linux 4.14.15-200.fc26.x86_64 #1 SMP Wed Jan 24 04:26:15 UTC 2018
Fedora.27 	 Linux 4.14.14-300.fc27.x86_64 #1 SMP Fri Jan 19 13:19:54 UTC 2018
OpenSuse.423 	 Linux 4.4.104-39-default #1 SMP Thu Jan 4 08:11:03 UTC 2018 (7db1912)
RedHat.69 	 Linux 2.6.32-696.20.1.el6.x86_64 #1 SMP Fri Jan 12 15:07:59 EST 2018
RedHat.72 	 Linux 3.10.0-514.21.1.el7.x86_64 #1 SMP Sat Apr 22 02:41:35 EDT 2017
RedHat.73 	 Linux 3.10.0-514.21.1.el7.x86_64 #1 SMP Sat Apr 22 02:41:35 EDT 2017
SLES.12 	 Linux 4.4.103-6.38-default #1 SMP Mon Dec 25 20:44:33 UTC 2017 (e4b9067)
suse.422 	 Linux 4.4.49-16-default #1 SMP Sun Feb 19 17:40:35 UTC 2017 (70e9954)
Ubuntu.1404 	 Linux 3.19.0-65-generic #73~14.04.1-Ubuntu SMP Wed Jun 29 21:05:22 UTC 2016
Ubuntu.1604 	 Linux 4.13.0-1005-azure #7-Ubuntu SMP Mon Jan 8 21:37:36 UTC 2018
Ubuntu.1604.WSL 	 Linux 4.4.0-43-Microsoft #1-Microsoft Wed Dec 31 14:42:53 PST 2014
Ubuntu.1610 	 Linux 4.8.0-45-generic #48-Ubuntu SMP Fri Mar 24 11:46:39 UTC 2017
Ubuntu.1704 	 Linux 4.10.0-19-generic #21-Ubuntu SMP Thu Apr 6 17:04:57 UTC 2017
Ubuntu.1710 	 Linux 4.13.0-25-generic #29-Ubuntu SMP Mon Jan 8 21:14:41 UTC 2018
OSX1012 	 Darwin 16.7.0 Darwin Kernel Version 16.7.0: Thu Jan 11 22:59:40 PST 2018; root:xnu-3789.73.8~1/RELEASE_X86_64
OSX1013 	 Darwin 17.4.0 Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64
Windows.10 	 Microsoft Windows 10.0.14393
Windows.10.Core 	 Microsoft Windows 10.0.14393
Windows.10.Nano 	 Microsoft Windows 10.0.14393
Windows.7 	 Microsoft Windows 6.1.7601 S
Windows.81 	 Microsoft Windows 6.3.9600
```

### (2) Windows Installation Type
#### Motivation
This tells us the relative popularity of Server, Client, Server Core, and Nano which will help us inform product decisions (features, performance work, fixes, blogs, documentation, possibly polyfills).
#### Alternatives
 We have an existing datapoint that gives us the OS version (for example "win10-x64"), but this can encompass several installation types.
#### Source
`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion@InstallationType`
#### Example values
```
Nano Server
Server Core
Server
Client
```

### (3) Windows Product Type
#### Motivation
This tells us the relative popularity of Windows SKU's such as Professional and Enterprise. Like Installation Type, this will help us inform investments and product decisions.
#### Alternatives
As above, the existing datapoint does not tell us the SKU.
#### Source
`GetProductInfo()`
#### Notes
Not attempting to parse this on the client, as the bitmap can be extended in new Windows versions.
#### Example values
```
Enterprise - "4" (0x4) 
Professional - "48" (0x30)
```
See https://msdn.microsoft.com/en-us/library/windows/desktop/ms724358(v=vs.85).aspx  for the full list.

#### (4, 5) LibC release and version
#### Motivation
Helps decide whether we can take advantage of new libc features. Conversely helps inform deprecation decisions. Also, if there is a bug specific to certain libc versions, we can establish the level of impact.
#### Alternatives
Existing datapoints do not provide this information.
#### Source
`gnu_get_libc_version()` and `gnu_get_libc_release() `for glibc. For musl (Alpine) it seems one must execute `ldd –version | grep “version”`  so I have deferred this. We do have the Alpine kernel version. Also deferred macOS.
#### Example values
```
2.22   stable
2.23   stable
```

