### PR TITLE
Signing nupkg contents (Cli.Utils and MSBuildResolver)

### DIFF
--- a/build/Signing.proj
+++ b/build/Signing.proj
@@ -28,7 +28,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="PostCompileSign" DependsOnTargets="GetPostCompileSignFiles;SignFiles" />
+  <Target Name="PostCompileSign" DependsOnTargets="GetPostCompileSignFiles;GetSignNuPkgContentsFiles;GetSignSdkResolverContentsFiles;SignFiles" />
 
   <Target Name="GetPostCompileSignFiles">
     <ItemGroup>
@@ -71,18 +71,21 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="SignNuPkgContents" DependsOnTargets="GetSignNuPkgContentsFiles;SignFiles" />
+  <!-- Keeping this target around so as not to break existing build definitions. -->
+  <Target Name="SignNuPkgContents" />
 
   <Target Name="GetSignNuPkgContentsFiles">
     <ItemGroup>
       <!-- NuPkg contents -->
-      <FilesToSign Include="$(BaseOutputDirectory)/bin/Microsoft.DotNet.Cli.Utils/**/Microsoft.DotNet.Cli.Utils.dll">
+      <FilesToSign Include="$(BaseOutputDirectory)/bin/Microsoft.DotNet.Cli.Utils/**/Microsoft.DotNet.Cli.Utils.dll;
+                            $(BaseOutputDirectory)/bin/Microsoft.DotNet.Cli.Utils/**/Microsoft.DotNet.Cli.Utils.resources.dll">
         <Authenticode>$(InternalCertificateId)</Authenticode>
       </FilesToSign>
     </ItemGroup>
   </Target>
 
-  <Target Name="SignSdkResolverContents" DependsOnTargets="GetSignSdkResolverContentsFiles;SignFiles" />
+  <!-- Keeping this target around so as not to break existing build definitions. -->
+  <Target Name="SignSdkResolverContents" />
 
   <Target Name="GetSignSdkResolverContentsFiles">
     <ItemGroup>


### PR DESCRIPTION
Signing nupkg contents (Cli.Utils and MSBuildResolver) along with the rest of the compiled assemblies.

