### PR TITLE
Sign the MSBuildSdkResolver dll in standard nupkg

### DIFF
--- a/build/Signing.proj
+++ b/build/Signing.proj
@@ -78,7 +78,8 @@
     <ItemGroup>
       <!-- NuPkg contents -->
       <FilesToSign Include="$(BaseOutputDirectory)/bin/Microsoft.DotNet.Cli.Utils/**/Microsoft.DotNet.Cli.Utils.dll;
-                            $(BaseOutputDirectory)/bin/Microsoft.DotNet.Cli.Utils/**/Microsoft.DotNet.Cli.Utils.resources.dll">
+                            $(BaseOutputDirectory)/bin/Microsoft.DotNet.Cli.Utils/**/Microsoft.DotNet.Cli.Utils.resources.dll;
+                            $(BaseOutputDirectory)/bin/Microsoft.DotNet.MSBuildSdkResolver/**/Microsoft.DotNet.MSBuildSdkResolver.dll">
         <Authenticode>$(InternalCertificateId)</Authenticode>
       </FilesToSign>
     </ItemGroup>


### PR DESCRIPTION
We were only signing the copy in the msbuild extensions layout for the VS insertion package, but not the x-plat nupkg we produced for VS Code.



