### PR TITLE
Bundle dotnet-sql-cache and dotnet-user-secrets in the CLI

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -8,6 +8,7 @@ Documents Index
 - [.NET Core native pre-requisities document](https://github.com/dotnet/core/blob/master/Documentation/prereqs.md)
 - [Roadmap and OS support](https://github.com/dotnet/core/blob/master/roadmap.md)
 - [Comprehensive CLI documentation](https://docs.microsoft.com/en-us/dotnet/articles/core/preview3/tools/)
+- [ASP.NET Core Command Line Tools](general/aspnetcore-tools.md)
 
 ## Working with the CLI repo
 

--- a/Documentation/general/aspnetcore-tools.md
+++ b/Documentation/general/aspnetcore-tools.md
@@ -1,0 +1,10 @@
+ASP.NET Core Command Line Tools
+===============================
+
+The .NET Core CLI includes some commands that are specific to ASP.NET Core projects.
+
+ - dotnet dev-certs
+ - dotnet user-secrets
+ - dotnet sql-cache
+
+For more information on these tools, see <https://github.com/aspnet/DotNetTools>.

--- a/build/BundledDotnetTools.props
+++ b/build/BundledDotnetTools.props
@@ -1,6 +1,8 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <BundledDotnetTools Include="dotnet-watch" Version="$(AspNetCoreVersion)" />
     <BundledDotnetTools Include="dotnet-dev-certs" Version="$(AspNetCoreVersion)" />
+    <BundledDotnetTools Include="dotnet-sql-cache" Version="$(AspNetCoreVersion)" />
+    <BundledDotnetTools Include="dotnet-user-secrets" Version="$(AspNetCoreVersion)" />
+    <BundledDotnetTools Include="dotnet-watch" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Resolves https://github.com/aspnet/DotNetTools/issues/396

Bundles additional bundled dotnet tools so users don't need to execute "dotnet install tool" to acquire aspnetcore tools.

cc @danroth27 @DamianEdwards 