### PR TITLE
Make the default verbosity for dotnet clean `normal`. This way we can…

### DIFF
--- a/src/dotnet/commands/dotnet-clean/Program.cs
+++ b/src/dotnet/commands/dotnet-clean/Program.cs
@@ -19,7 +19,10 @@ namespace Microsoft.DotNet.Tools.Clean
 
         public static CleanCommand FromArgs(string[] args, string msbuildPath = null)
         {
-            var msbuildArgs = new List<string>();
+            var msbuildArgs = new List<string>
+            {
+                "/v:normal"
+            };
 
             var parser = Parser.Instance;
 

--- a/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
@@ -10,14 +10,14 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetCleanInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /t:Clean";
+        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /v:normal /t:Clean";
 
         [Fact]
         public void ItAddsProjectToMsbuildInvocation()
         {
             var msbuildPath = "<msbuildpath>";
             CleanCommand.FromArgs(new string[] { "<project>" }, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> /m /v:m <project> /t:Clean");
+                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> /m /v:m /v:normal <project> /t:Clean");
         }
 
         [Theory]

--- a/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
+++ b/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
@@ -34,7 +34,6 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
 
         [Theory]
         [InlineData("build")]
-        [InlineData("clean")]
         [InlineData("msbuild")]
         [InlineData("pack")]
         [InlineData("publish")]


### PR DESCRIPTION
Make the default verbosity for dotnet clean `normal`. This way we can get some meaningful output out of the command.

Fixes https://github.com/dotnet/cli/issues/8049.
