### PR TITLE
when process has not env, but future will, show the instruction

### DIFF
--- a/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
+++ b/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
@@ -41,9 +41,18 @@ namespace Microsoft.DotNet.ShellShim
 
         private bool PackageExecutablePathExists()
         {
+            return PackageExecutablePathExistsForCurrentProcess() || PackageExecutablePathWillExistForFutureNewProcess();
+        }
+
+        private bool PackageExecutablePathWillExistForFutureNewProcess()
+        {
             return EnvironmentVariableConatinsPackageExecutablePath(Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.User))
-                || EnvironmentVariableConatinsPackageExecutablePath(Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Machine))
-                || EnvironmentVariableConatinsPackageExecutablePath(Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Process));
+                   || EnvironmentVariableConatinsPackageExecutablePath(Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Machine));
+        }
+
+        private bool PackageExecutablePathExistsForCurrentProcess()
+        {
+            return EnvironmentVariableConatinsPackageExecutablePath(Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.Process));
         }
 
         private bool EnvironmentVariableConatinsPackageExecutablePath(string environmentVariable)
@@ -58,21 +67,17 @@ namespace Microsoft.DotNet.ShellShim
 
         public void PrintAddPathInstructionIfPathDoesNotExist()
         {
-            if (!PackageExecutablePathExists())
+            if (!PackageExecutablePathExistsForCurrentProcess() && PackageExecutablePathWillExistForFutureNewProcess())
             {
-                if (Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.User).Split(';')
-                    .Contains(_packageExecutablePath))
-                {
-                    _reporter.WriteLine(
-                        CommonLocalizableStrings.EnvironmentPathWindowsNeedReopen);
-                }
-                else
-                {
-                    _reporter.WriteLine(
-                        string.Format(
-                            CommonLocalizableStrings.EnvironmentPathWindowsManualInstructions,
-                            _packageExecutablePath));
-                }
+                _reporter.WriteLine(
+                    CommonLocalizableStrings.EnvironmentPathWindowsNeedReopen);
+            }
+            else if (!PackageExecutablePathWillExistForFutureNewProcess())
+            {
+                _reporter.WriteLine(
+                    string.Format(
+                        CommonLocalizableStrings.EnvironmentPathWindowsManualInstructions,
+                        _packageExecutablePath));
             }
         }
     }


### PR DESCRIPTION
The detection of needing to reopen CMD windows is wrong. Corrected it. I hope the if else is self explanatory 

Since it is windows env. It is hard to test. Test by hand

![image](https://user-images.githubusercontent.com/6993335/37126453-00bec346-2226-11e8-85d5-54c565f37e41.png)

fix https://github.com/dotnet/cli/issues/8368
