### PR TITLE
Change required msbuild args to use dash instead of slash

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli.Utils
             };
 
         private readonly IEnumerable<string> _msbuildRequiredParameters =
-            new List<string> { "/m", "/v:m" };
+            new List<string> { "-m", "-v:m" };
 
         public MSBuildForwardingAppWithoutLogging(IEnumerable<string> argsToForward, string msbuildPath = null)
         {

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetBuildInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m";
 
         [Theory]
         [InlineData(new string[] { }, "/t:Build")]

--- a/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
@@ -10,14 +10,14 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetCleanInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /v:normal /t:Clean";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m /v:normal /t:Clean";
 
         [Fact]
         public void ItAddsProjectToMsbuildInvocation()
         {
             var msbuildPath = "<msbuildpath>";
             CleanCommand.FromArgs(new string[] { "<project>" }, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> /m /v:m /v:normal <project> /t:Clean");
+                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> -m -v:m /v:normal <project> /t:Clean");
         }
 
         [Theory]

--- a/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
@@ -11,8 +11,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetPackInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /restore /t:pack";
-        const string ExpectedNoBuildPrefix = "exec <msbuildpath> /m /v:m /t:pack";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m /restore /t:pack";
+        const string ExpectedNoBuildPrefix = "exec <msbuildpath> -m -v:m /t:pack";
 
         [Theory]
         [InlineData(new string[] { }, "")]

--- a/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             this.output = output;
         }
 
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m";
 
         [Theory]
         [InlineData(new string[] { }, "")]

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetRestoreInvocation
     {
         private const string ExpectedPrefix =
-            "exec <msbuildpath> /m /v:m /nologo /t:Restore";
+            "exec <msbuildpath> -m -v:m /nologo /t:Restore";
 
         [Theory]
         [InlineData(new string[] { }, "")]

--- a/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetStoreInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /t:ComposeStore <project>";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m /t:ComposeStore <project>";
         static readonly string[] ArgsPrefix = { "-m", "<project>" };
 
         [Theory]


### PR DESCRIPTION
Helps to protect against https://github.com/Microsoft/msbuild/issues/2351 on *nix systems with an actual `/m` directory / file.

cc @livarcocc @wli3 