### PR TITLE
Implement the --tool-path option for list tool command.

### DIFF
--- a/src/dotnet/ToolPackage/ToolPackageStore.cs
+++ b/src/dotnet/ToolPackage/ToolPackageStore.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.ToolPackage
 
         public ToolPackageStore(DirectoryPath root)
         {
-            Root = root;
+            Root = new DirectoryPath(Path.GetFullPath(root.Value));
         }
 
         public DirectoryPath Root { get; private set; }

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/ListToolCommandParser.cs
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/ListToolCommandParser.cs
@@ -17,6 +17,10 @@ namespace Microsoft.DotNet.Cli
                     "-g|--global",
                     LocalizableStrings.GlobalOptionDescription,
                     Accept.NoArguments()),
+                Create.Option(
+                    "--tool-path",
+                    LocalizableStrings.ToolPathDescription,
+                    Accept.ExactlyOneArgument()),
                 CommonOptions.HelpOption());
         }
     }

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/LocalizableStrings.resx
@@ -123,8 +123,14 @@
   <data name="GlobalOptionDescription" xml:space="preserve">
     <value>List user wide tools.</value>
   </data>
-  <data name="ListToolCommandOnlySupportsGlobal" xml:space="preserve">
-    <value>The --global switch (-g) is currently required because only user wide tools are supported.</value>
+  <data name="ToolPathDescription" xml:space="preserve">
+    <value>Location where the tools are installed.</value>
+  </data>
+  <data name="NeedGlobalOrToolPath" xml:space="preserve">
+    <value>Please specify either the global option (--global) or the tool path option (--tool-path).</value>
+  </data>
+  <data name="GlobalAndToolPathConflict" xml:space="preserve">
+    <value>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</value>
   </data>
   <data name="InvalidPackageWarning" xml:space="preserve">
     <value>Warning: tool package '{0}' is invalid: {1}</value>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.cs.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.de.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.es.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.fr.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.it.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ja.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ko.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pl.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ru.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.tr.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/UninstallToolCommand.cs
+++ b/src/dotnet/commands/dotnet-uninstall/tool/UninstallToolCommand.cs
@@ -24,12 +24,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tool
         private readonly IReporter _reporter;
         private readonly IReporter _errorReporter;
         private CreateShellShimRepository _createShellShimRepository;
-        private CreateToolPackageStore _createToolPackageStoreAndInstaller;
+        private CreateToolPackageStore _createToolPackageStore;
 
         public UninstallToolCommand(
             AppliedOption options,
             ParseResult result,
-            CreateToolPackageStore createToolPackageStoreAndInstaller = null,
+            CreateToolPackageStore createToolPackageStore = null,
             CreateShellShimRepository createShellShimRepository = null,
             IReporter reporter = null)
             : base(result)
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tool
             _errorReporter = reporter ?? Reporter.Error;
 
             _createShellShimRepository = createShellShimRepository ?? ShellShimRepositoryFactory.CreateShellShimRepository;
-            _createToolPackageStoreAndInstaller = createToolPackageStoreAndInstaller ?? ToolPackageFactory.CreateToolPackageStore;
+            _createToolPackageStore = createToolPackageStore ?? ToolPackageFactory.CreateToolPackageStore;
         }
 
         public override int Execute()
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tool
                 toolDirectoryPath = new DirectoryPath(toolPath);
             }
 
-            IToolPackageStore toolPackageStore = _createToolPackageStoreAndInstaller(toolDirectoryPath);
+            IToolPackageStore toolPackageStore = _createToolPackageStore(toolDirectoryPath);
             IShellShimRepository shellShimRepository = _createShellShimRepository(toolDirectoryPath);
 
             var packageId = new PackageId(_options.Arguments.Single());

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -637,7 +637,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             FilePath? tempProject = null,
             DirectoryPath? offlineFeed = null)
         {
-            var root = new DirectoryPath(Path.Combine(Path.GetFullPath(TempRoot.Root), Path.GetRandomFileName()));
+            var root = new DirectoryPath(Path.Combine(TempRoot.Root, Path.GetRandomFileName()));
             var reporter = new BufferedReporter();
 
             IFileSystem fileSystem;
@@ -665,6 +665,8 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                     tempProject: tempProject ?? GetUniqueTempProjectPathEachTest(),
                     offlineFeed: offlineFeed ?? new DirectoryPath("does not exist"));
             }
+
+            store.Root.Value.Should().Be(Path.GetFullPath(root.Value));
 
             return (store, installer, reporter, fileSystem);
         }

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageStoreMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageStoreMock.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             IFileSystem fileSystem,
             Action uninstallCallback = null)
         {
-            Root = root;
+            Root = new DirectoryPath(Path.GetFullPath(root.Value));
             _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             _uninstallCallback = uninstallCallback;
         }

--- a/test/dotnet.Tests/CommandTests/UninstallToolCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/UninstallToolCommandTests.cs
@@ -73,7 +73,8 @@ namespace Microsoft.DotNet.Tests.Commands
                     PackageId,
                     PackageVersion));
 
-            var packageDirectory = new DirectoryPath(ToolsDirectory).WithSubDirectories(PackageId, PackageVersion);
+            var packageDirectory = new DirectoryPath(Path.GetFullPath(ToolsDirectory))
+                .WithSubDirectories(PackageId, PackageVersion);
             var shimPath = Path.Combine(
                 ShimsDirectory,
                 ProjectRestorerMock.FakeCommandName +
@@ -114,7 +115,8 @@ namespace Microsoft.DotNet.Tests.Commands
                     PackageId,
                     PackageVersion));
 
-            var packageDirectory = new DirectoryPath(ToolsDirectory).WithSubDirectories(PackageId, PackageVersion);
+            var packageDirectory = new DirectoryPath(Path.GetFullPath(ToolsDirectory))
+                .WithSubDirectories(PackageId, PackageVersion);
             var shimPath = Path.Combine(
                 ShimsDirectory,
                 ProjectRestorerMock.FakeCommandName +

--- a/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
@@ -84,10 +84,10 @@ namespace Microsoft.DotNet.Tests.ParserTests
         public void InstallToolParserCanParseToolPathOption()
         {
             var result =
-                Parser.Instance.Parse(@"dotnet install tool --tool-path C:\TestAssetLocalNugetFeed console.test.app");
+                Parser.Instance.Parse(@"dotnet install tool --tool-path C:\Tools console.test.app");
 
             var appliedOptions = result["dotnet"]["install"]["tool"];
-            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\TestAssetLocalNugetFeed");
+            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\Tools");
         }
     }
 }

--- a/test/dotnet.Tests/ParserTests/ListToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/ListToolParserTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Xunit;
+using Xunit.Abstractions;
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    public class ListToolParserTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public ListToolParserTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void ListToolParserCanGetGlobalOption()
+        {
+            var result = Parser.Instance.Parse("dotnet list tool -g");
+
+            var appliedOptions = result["dotnet"]["list"]["tool"];
+            appliedOptions.ValueOrDefault<bool>("global").Should().Be(true);
+        }
+
+        [Fact]
+        public void ListToolParserCanParseToolPathOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet list tool --tool-path C:\Tools ");
+
+            var appliedOptions = result["dotnet"]["list"]["tool"];
+            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\Tools");
+        }
+    }
+}

--- a/test/dotnet.Tests/ParserTests/UninstallToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/UninstallToolParserTests.cs
@@ -11,17 +11,17 @@ using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tests.ParserTests
 {
-    public class UninstallInstallToolParserTests
+    public class UninstallToolParserTests
     {
         private readonly ITestOutputHelper output;
 
-        public UninstallInstallToolParserTests(ITestOutputHelper output)
+        public UninstallToolParserTests(ITestOutputHelper output)
         {
             this.output = output;
         }
 
         [Fact]
-        public void UninstallGlobaltoolParserCanGetPackageId()
+        public void UninstallToolParserCanGetPackageId()
         {
             var command = Parser.Instance;
             var result = command.Parse("dotnet uninstall tool -g console.test.app");
@@ -46,10 +46,10 @@ namespace Microsoft.DotNet.Tests.ParserTests
         public void UninstallToolParserCanParseToolPathOption()
         {
             var result =
-                Parser.Instance.Parse(@"dotnet uninstall tool --tool-path C:\TestAssetLocalNugetFeed console.test.app");
+                Parser.Instance.Parse(@"dotnet uninstall tool --tool-path C:\Tools console.test.app");
 
             var appliedOptions = result["dotnet"]["uninstall"]["tool"];
-            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\TestAssetLocalNugetFeed");
+            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\Tools");
         }
     }
 }


### PR DESCRIPTION
This PR implements the missing `--tool-path` option for the list tool command.  This enables the command to list locally installed tools.

Fixes #8803.

Also fixes #8829.