### PR TITLE
Change --source to --source-feed and make it additional

### DIFF
--- a/scripts/cli-test-env.sh
+++ b/scripts/cli-test-env.sh
@@ -16,7 +16,7 @@ REPO_ROOT="$( cd -P "$( dirname "$SOURCE" )/../" && pwd )"
 uname=$(uname)
 if [ "$(uname)" = "Darwin" ]
 then
-  RID=osx.10.13-x64
+  RID=osx-x64
 else
   RID=linux-x64
 fi

--- a/src/dotnet/ToolPackage/IProjectRestorer.cs
+++ b/src/dotnet/ToolPackage/IProjectRestorer.cs
@@ -8,11 +8,9 @@ namespace Microsoft.DotNet.ToolPackage
 {
     internal interface IProjectRestorer
     {
-        void Restore(
-            FilePath project,
+        void Restore(FilePath project,
             DirectoryPath assetJsonOutput,
             FilePath? nugetConfig = null,
-            string source = null,
             string verbosity = null);
     }
 }

--- a/src/dotnet/ToolPackage/IToolPackageInstaller.cs
+++ b/src/dotnet/ToolPackage/IToolPackageInstaller.cs
@@ -10,13 +10,12 @@ namespace Microsoft.DotNet.ToolPackage
 {
     internal interface IToolPackageInstaller
     {
-        IToolPackage InstallPackage(
-            PackageId packageId,
+        IToolPackage InstallPackage(PackageId packageId,
             VersionRange versionRange = null,
             string targetFramework = null,
             FilePath? nugetConfig = null,
             DirectoryPath? rootConfigDirectory = null,
-            string source = null,
+            string[] additionalFeeds = null,
             string verbosity = null);
     }
 }

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommand.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Tools.Install.Tool
         private readonly string _packageVersion;
         private readonly string _configFilePath;
         private readonly string _framework;
-        private readonly string _source;
+        private readonly string[] _source;
         private readonly bool _global;
         private readonly string _verbosity;
         private readonly string _toolPath;
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Install.Tool
             _packageVersion = appliedCommand.ValueOrDefault<string>("version");
             _configFilePath = appliedCommand.ValueOrDefault<string>("configfile");
             _framework = appliedCommand.ValueOrDefault<string>("framework");
-            _source = appliedCommand.ValueOrDefault<string>("source");
+            _source = appliedCommand.ValueOrDefault<string[]>("source-feed");
             _global = appliedCommand.ValueOrDefault<bool>("global");
             _verbosity = appliedCommand.SingleArgumentOrDefault("verbosity");
             _toolPath = appliedCommand.SingleArgumentOrDefault("tool-path");
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.Tools.Install.Tool
                         versionRange: versionRange,
                         targetFramework: _framework,
                         nugetConfig: configFile,
-                        source: _source,
+                        additionalFeeds: _source,
                         verbosity: _verbosity);
 
                     foreach (var command in package.Commands)

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommandParser.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/InstallToolCommandParser.cs
@@ -32,10 +32,10 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.ConfigFileOptionDescription,
                     Accept.ExactlyOneArgument()),
                 Create.Option(
-                    "--source",
-                    LocalizableStrings.SourceOptionDescription,
-                    Accept.ExactlyOneArgument()
-                        .With(name: LocalizableStrings.SourceOptionName)),
+                    "--source-feed",
+                    LocalizableStrings.SourceFeedOptionDescription,
+                    Accept.OneOrMoreArguments()
+                        .With(name: LocalizableStrings.SourceFeedOptionName)),
                 Create.Option(
                     "-f|--framework",
                     LocalizableStrings.FrameworkOptionDescription,

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/LocalizableStrings.resx
@@ -129,11 +129,11 @@
   <data name="VersionOptionDescription" xml:space="preserve">
     <value>Version of the tool package in NuGet.</value>
   </data>
-  <data name="SourceOptionDescription" xml:space="preserve">
-    <value>Specifies a NuGet package source to use during installation.</value>
+  <data name="SourceFeedOptionDescription" xml:space="preserve">
+    <value>Adds an additional NuGet package source to use during installation.</value>
   </data>
-  <data name="SourceOptionName" xml:space="preserve">
-    <value>SOURCE</value>
+  <data name="SourceFeedOptionName" xml:space="preserve">
+    <value>SOURCE_FEED</value>
   </data>
   <data name="CommandDescription" xml:space="preserve">
     <value>Installs a tool for use on the command line.</value>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/ProjectRestorer.cs
@@ -26,11 +26,9 @@ namespace Microsoft.DotNet.Tools.Install.Tool
             _forceOutputRedirection = reporter != null;
         }
 
-        public void Restore(
-            FilePath project,
+        public void Restore(FilePath project,
             DirectoryPath assetJsonOutput,
             FilePath? nugetConfig = null,
-            string source = null,
             string verbosity = null)
         {
             var argsToPassToRestore = new List<string>();
@@ -40,12 +38,6 @@ namespace Microsoft.DotNet.Tools.Install.Tool
             {
                 argsToPassToRestore.Add("--configfile");
                 argsToPassToRestore.Add(nugetConfig.Value.Value);
-            }
-
-            if (source != null)
-            {
-                argsToPassToRestore.Add("--source");
-                argsToPassToRestore.Add(source);
             }
 
             argsToPassToRestore.AddRange(new List<string>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">Určuje zdroj balíčku NuGet, který se použije při instalaci.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ Instalace byla úspěšná. Pokud nejsou další pokyny, můžete přímo do já
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">Gibt eine NuGet-Paketquelle für die Installation an.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ Die Installation war erfolgreich. Sofern keine weiteren Anweisungen vorliegen, k
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">Especifica el origen de un paquete NuGet para usarlo durante la instalación.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">ORIGEN</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ La instalación se completó correctamente. Si no hay más instrucciones, puede 
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">Spécifie un package NuGet source à utiliser durant l'installation.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ L'installation a réussi. En l'absence d'instructions supplémentaires, vous pou
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">Consente di specificare un'origine pacchetto NuGet da usare durante l'installazione.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">ORIGINE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ L'installazione è riuscita. Se non ci sono altre istruzioni, è possibile digit
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">インストール中に使用する NuGet パッケージを指定します。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">설치 중 사용할 NuGet 패키지 소스를 지정합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">Określa źródło pakietu NuGet do użycia podczas instalacji.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">ŹRÓDŁO</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ Instalacja powiodła się. Jeśli nie ma dodatkowych instrukcji, możesz wpisać
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">Especifica uma origem do pacote NuGet a ser usada durante a instalação.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">ORIGEM</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ A instalação foi bem-sucedida. Se não houver outras instruções, digite o se
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">Задает источник пакета NuGet, используемый во время установки.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">Yükleme sırasında kullanılacak bir NuGet paket kaynağı belirtir.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ Yükleme başarılı oldu. Daha fazla yönerge yoksa, çağırmak için şu komu
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">指定安装期间使用的 NuGet 包源。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during installation.</source>
-        <target state="translated">指定於安裝期間要使用的 NuGet 套件來源。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="translated">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InstallationSucceeded">
         <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
@@ -117,6 +107,16 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       <trans-unit id="ToolPathDescription">
         <source>Location of shim to access tool</source>
         <target state="new">Location of shim to access tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during installation.</source>
+        <target state="new">Adds an additional NuGet package source to use during installation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-update/tool/LocalizableStrings.resx
@@ -129,11 +129,11 @@
   <data name="VersionOptionDescription" xml:space="preserve">
     <value>Version of the tool package in NuGet.</value>
   </data>
-  <data name="SourceOptionDescription" xml:space="preserve">
-    <value>Specifies a NuGet package source to use during update.</value>
+  <data name="SourceFeedOptionDescription" xml:space="preserve">
+    <value>Adds an additional NuGet package source to use during update.</value>
   </data>
-  <data name="SourceOptionName" xml:space="preserve">
-    <value>SOURCE</value>
+  <data name="SourceFeedOptionName" xml:space="preserve">
+    <value>SOURCE_FEED</value>
   </data>
   <data name="CommandDescription" xml:space="preserve">
     <value>Updates a tool to the latest stable version for use.</value>

--- a/src/dotnet/commands/dotnet-update/tool/UpdateToolCommand.cs
+++ b/src/dotnet/commands/dotnet-update/tool/UpdateToolCommand.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Tools.Update.Tool
         private readonly PackageId _packageId;
         private readonly string _configFilePath;
         private readonly string _framework;
-        private readonly string _source;
+        private readonly string[] _additionalFeeds;
         private readonly bool _global;
         private readonly string _verbosity;
         private readonly string _toolPath;
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Tools.Update.Tool
             _packageId = new PackageId(appliedCommand.Arguments.Single());
             _configFilePath = appliedCommand.ValueOrDefault<string>("configfile");
             _framework = appliedCommand.ValueOrDefault<string>("framework");
-            _source = appliedCommand.ValueOrDefault<string>("source");
+            _additionalFeeds = appliedCommand.ValueOrDefault<string[]>("source-feed");
             _global = appliedCommand.ValueOrDefault<bool>("global");
             _verbosity = appliedCommand.SingleArgumentOrDefault("verbosity");
             _toolPath = appliedCommand.SingleArgumentOrDefault("tool-path");
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.Tools.Update.Tool
                         packageId: _packageId,
                         targetFramework: _framework,
                         nugetConfig: configFile,
-                        source: _source,
+                        additionalFeeds: _additionalFeeds,
                         verbosity: _verbosity);
 
                     foreach (CommandSettings command in newInstalledPackage.Commands)

--- a/src/dotnet/commands/dotnet-update/tool/UpdateToolCommandParser.cs
+++ b/src/dotnet/commands/dotnet-update/tool/UpdateToolCommandParser.cs
@@ -28,10 +28,10 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.ConfigFileOptionDescription,
                     Accept.ExactlyOneArgument()),
                 Create.Option(
-                    "--source",
-                    LocalizableStrings.SourceOptionDescription,
-                    Accept.ExactlyOneArgument()
-                        .With(name: LocalizableStrings.SourceOptionName)),
+                    "--source-feed",
+                    LocalizableStrings.SourceFeedOptionDescription,
+                    Accept.OneOrMoreArguments()
+                        .With(name: LocalizableStrings.SourceFeedOptionName)),
                 Create.Option(
                     "-f|--framework",
                     LocalizableStrings.FrameworkOptionDescription,

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.cs.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.de.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.es.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.fr.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.it.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.ja.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.ko.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.pl.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.ru.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.tr.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-update/tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -22,16 +22,6 @@
         <target state="new">Version of the tool package in NuGet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SourceOptionDescription">
-        <source>Specifies a NuGet package source to use during update.</source>
-        <target state="new">Specifies a NuGet package source to use during update.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SourceOptionName">
-        <source>SOURCE</source>
-        <target state="new">SOURCE</target>
-        <note />
-      </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Updates a tool to the latest stable version for use.</source>
         <target state="new">Updates a tool to the latest stable version for use.</target>
@@ -100,6 +90,16 @@
       <trans-unit id="UpdateToolFailed">
         <source>Tool '{0}' failed to update due to the following:</source>
         <target state="new">Tool '{0}' failed to update due to the following:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionDescription">
+        <source>Adds an additional NuGet package source to use during update.</source>
+        <target state="new">Adds an additional NuGet package source to use during update.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SourceFeedOptionName">
+        <source>SOURCE_FEED</source>
+        <target state="new">SOURCE_FEED</target>
         <note />
       </trans-unit>
     </body>

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/MockFeedType.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/MockFeedType.cs
@@ -7,7 +7,6 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
     {
         FeedFromLookUpNugetConfig,
         ExplicitNugetConfig,
-        Source,
-        OfflineFeed
+        ImplicitAdditionalFeed
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
@@ -35,13 +35,12 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             _installCallback = installCallback;
         }
 
-        public IToolPackage InstallPackage(
-            PackageId packageId,
+        public IToolPackage InstallPackage(PackageId packageId,
             VersionRange versionRange = null,
             string targetFramework = null,
             FilePath? nugetConfig = null,
             DirectoryPath? rootConfigDirectory = null,
-            string source = null,
+            string[] additionalFeeds = null,
             string verbosity = null)
         {
             var packageRootDirectory = _store.GetRootPackageDirectory(packageId);
@@ -65,7 +64,6 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                         tempProject,
                         stageDirectory,
                         nugetConfig,
-                        source,
                         verbosity);
 
                     if (_installCallback != null)

--- a/test/dotnet.Tests/CommandTests/InstallToolCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/InstallToolCommandTests.cs
@@ -81,17 +81,17 @@ namespace Microsoft.DotNet.Tests.Commands
         public void WhenRunWithPackageIdWithSourceItShouldCreateValidShim()
         {
             const string sourcePath = "http://mysouce.com";
-            ParseResult result = Parser.Instance.Parse($"dotnet install tool -g {PackageId} --source {sourcePath}");
+            ParseResult result = Parser.Instance.Parse($"dotnet install tool -g {PackageId} --source-feed {sourcePath}");
             AppliedOption appliedCommand = result["dotnet"]["install"]["tool"];
             ParseResult parseResult =
-                Parser.Instance.ParseFrom("dotnet install", new[] { "tool", PackageId, "--source", sourcePath });
+                Parser.Instance.ParseFrom("dotnet install", new[] { "tool", PackageId, "--source-feed", sourcePath });
 
 
             var toolToolPackageInstaller = CreateToolPackageInstaller(
             feeds: new MockFeed[] {
                     new MockFeed
                     {
-                        Type = MockFeedType.Source,
+                        Type = MockFeedType.ImplicitAdditionalFeed,
                         Uri = sourcePath,
                         Packages = new List<MockFeedPackage>
                         {

--- a/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
@@ -54,10 +54,29 @@ namespace Microsoft.DotNet.Tests.ParserTests
         {
             const string expectedSourceValue = "TestSourceValue";
 
-            var result = Parser.Instance.Parse($"dotnet install tool -g --source {expectedSourceValue} console.test.app");
+            var result =
+                Parser.Instance.Parse($"dotnet install tool -g --source-feed {expectedSourceValue} console.test.app");
 
             var appliedOptions = result["dotnet"]["install"]["tool"];
-            appliedOptions.ValueOrDefault<string>("source").Should().Be(expectedSourceValue);
+            appliedOptions.ValueOrDefault<string[]>("source-feed").First().Should().Be(expectedSourceValue);
+        }
+
+        [Fact]
+        public void InstallToolParserCanParseMultipleSourceOption()
+        {
+            const string expectedSourceValue1 = "TestSourceValue1";
+            const string expectedSourceValue2 = "TestSourceValue2";
+
+            var result =
+                Parser.Instance.Parse(
+                    $"dotnet install tool -g " +
+                    $"--source-feed {expectedSourceValue1} " +
+                    $"--source-feed {expectedSourceValue2} console.test.app");
+
+            var appliedOptions = result["dotnet"]["install"]["tool"];
+
+            appliedOptions.ValueOrDefault<string[]>("source-feed")[0].Should().Be(expectedSourceValue1);
+            appliedOptions.ValueOrDefault<string[]>("source-feed")[1].Should().Be(expectedSourceValue2);
         }
 
         [Fact]

--- a/test/dotnet.Tests/ParserTests/UpdateToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/UpdateToolParserTests.cs
@@ -62,10 +62,28 @@ namespace Microsoft.DotNet.Tests.ParserTests
             const string expectedSourceValue = "TestSourceValue";
 
             var result =
-                Parser.Instance.Parse($"dotnet update tool -g --source {expectedSourceValue} console.test.app");
+                Parser.Instance.Parse($"dotnet update tool -g --source-feed {expectedSourceValue} console.test.app");
 
             var appliedOptions = result["dotnet"]["update"]["tool"];
-            appliedOptions.ValueOrDefault<string>("source").Should().Be(expectedSourceValue);
+            appliedOptions.ValueOrDefault<string[]>("source-feed").First().Should().Be(expectedSourceValue);
+        }
+
+        [Fact]
+        public void UpdateToolParserCanParseMultipleSourceOption()
+        {
+            const string expectedSourceValue1 = "TestSourceValue1";
+            const string expectedSourceValue2 = "TestSourceValue2";
+
+            var result =
+                Parser.Instance.Parse(
+                    $"dotnet update tool -g " +
+                    $"--source-feed {expectedSourceValue1} " +
+                    $"--source-feed {expectedSourceValue2} console.test.app");
+
+            var appliedOptions = result["dotnet"]["update"]["tool"];
+
+            appliedOptions.ValueOrDefault<string[]>("source-feed")[0].Should().Be(expectedSourceValue1);
+            appliedOptions.ValueOrDefault<string[]>("source-feed")[1].Should().Be(expectedSourceValue2);
         }
 
         [Fact]


### PR DESCRIPTION
Fix https://github.com/dotnet/cli/issues/8561

Other than change source to source-feed and make it additional instead of exclusive. I changed source to be multiple. Because restore support multiple source https://github.com/Microsoft/dotnet/issues/361

As for mock. The offline feed and source feed is considered the same, so remove the category of “source”. 

I renamed source to “AdditionalFeed” because that is more accurate on implementation level.

Note:
NuGet feed don’t have order. Whichever responses the fastest, is the first.
No change on restore.

scripts/cli-test-env.sh change is due to mac 10.13 is finally added to RID graph. And it is “considered” one of the CLI supported RID

