### PR TITLE
MSBuild 15.7.108 for 2.1.2xx

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MicrosoftNETCoreAppPackageVersion>2.0.6</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.6.82</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.7.0-preview-000108</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>

--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -32,6 +32,7 @@
 <add key="symreader-native" value="https://dotnet.myget.org/F/symreader-native/api/v3/index.json" />
 <add key="AspNetMaster" value="https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json" />
 <add key="AspNetDev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
+<add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
         ]]>
       </NugetConfigCLIFeeds>
 


### PR DESCRIPTION
* Add feed to msbuild myget
* Update MSBuild to 15.7.108 (contains both netcoreapp2.0 and netcoreapp2.1)

Not sure if this will just work as-is and pickup the `netcoreapp2.0` implementation?