### PR TITLE
Cherry-pick commits from master to release/2.1.3xx

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
@@ -185,12 +185,6 @@ namespace Microsoft.DotNet.Cli.Utils
 
         internal static bool ShouldSurroundWithQuotes(string argument)
         {
-            // Don't quote already quoted strings
-            if (IsSurroundedWithQuotes(argument))
-            {
-                return false;
-            }
-
             // Only quote if whitespace exists in the string
             return ArgumentContainsWhitespace(argument);
         }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/WindowsExePreferredCommandSpecFactory.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/WindowsExePreferredCommandSpecFactory.cs
@@ -63,7 +63,8 @@ namespace Microsoft.DotNet.Cli.Utils
 
             var cmdEscapedArgs = ArgumentEscaper.EscapeAndConcatenateArgArrayForCmdProcessStart(args);
 
-            if (ArgumentEscaper.ShouldSurroundWithQuotes(command))
+            if (!ArgumentEscaper.IsSurroundedWithQuotes(command) // Don't quote already quoted strings
+                && ArgumentEscaper.ShouldSurroundWithQuotes(command))
             {
                 command = $"\"{command}\"";
             }

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">Sada .NET Core SDK (vyjadřující jakýkoli global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">Běhové prostředí:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">.NET Core SDK (gemäß "global.json"):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">Laufzeitumgebung:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">SDK de .NET Core (reflejando cualquier global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">Entorno de tiempo de ejecución:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">SDK .NET Core (reflétant tous les global.json) :</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">Environnement d'exécution :</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">.NET Core SDK (che rispecchia un qualsiasi file global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">Ambiente di runtime:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">.NET Core SDK (global.json を反映):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">ランタイム環境:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">.NET Core SDK(global.json 반영):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">런타임 환경:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">Zestaw .NET Core SDK (odzwierciedlenie dowolnego pliku global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">Środowisko uruchomieniowe:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">SDK do .NET Core (refletindo qualquer global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">Ambiente de tempo de execução:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">Пакет SDK для .NET Core (отражающий любой global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">Среда выполнения:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">.NET Core SDK (varsa global.json’u yansıtır):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">Çalışma Zamanı Ortamı:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">.NET Core SDK（反映任何 global.json）:</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">运行时环境:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
@@ -236,12 +236,12 @@
       </trans-unit>
       <trans-unit id="DotNetSdkInfoLabel">
         <source>.NET Core SDK (reflecting any global.json):</source>
-        <target state="new">.NET Core SDK (reflecting any global.json):</target>
+        <target state="translated">.NET Core SDK (反映任何 global.json):</target>
         <note />
       </trans-unit>
       <trans-unit id="DotNetRuntimeInfoLabel">
         <source>Runtime Environment:</source>
-        <target state="new">Runtime Environment:</target>
+        <target state="translated">執行階段環境:</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/CommonLocalizableStrings.resx
+++ b/src/dotnet/CommonLocalizableStrings.resx
@@ -626,6 +626,6 @@ setx PATH "%PATH%;{0}"
     <value>Column maximum width must be greater than zero.</value>
   </data>
   <data name="ToolSettingsInvalidLeadingDotCommandName" xml:space="preserve">
-    <value>Command '{0}' has a leading dot.</value>
+    <value>The command name '{0}' cannot begin with a leading dot (.).</value>
   </data>
 </root>

--- a/src/dotnet/PrintableTable.cs
+++ b/src/dotnet/PrintableTable.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Cli
     // Represents a table (with rows of type T) that can be printed to a terminal.
     internal class PrintableTable<T>
     {
-        private const string ColumnDelimiter = "      ";
+        public const string ColumnDelimiter = "      ";
         private List<Column> _columns = new List<Column>();
 
         private class Column

--- a/src/dotnet/ToolPackage/ToolPackageStore.cs
+++ b/src/dotnet/ToolPackage/ToolPackageStore.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.ToolPackage
 
         public ToolPackageStore(DirectoryPath root)
         {
-            Root = root;
+            Root = new DirectoryPath(Path.GetFullPath(root.Value));
         }
 
         public DirectoryPath Root { get; private set; }

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">Vypíše odkaz v projektu.</target>
+        <target state="translated">Zobrazí seznam odkazů projektu nebo nainstalovaných nástrojů.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Odinstaluje položku z vývojového prostředí.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">Verweis im Projekt auflisten.</target>
+        <target state="translated">Hiermit werden Projektverweise oder installierte Tools aufgelistet.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Deinstalliert ein Element aus der Entwicklungsumgebung.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">Muestra referencias en el proyecto.</target>
+        <target state="translated">Enumere las referencias de proyecto o las herramientas instaladas.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Desinstala un elemento en el entorno de desarrollo.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">Listez une référence dans le projet.</target>
+        <target state="translated">Répertoriez des références de projet ou des outils installés.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Désinstalle un élément dans l'environnement de développement.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">Elenca il riferimento nel progetto.</target>
+        <target state="translated">Elenca i riferimenti al progetto o gli strumenti installati.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Disinstalla un elemento dall'ambiente di sviluppo.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">プロジェクト内の参照を一覧表示します。</target>
+        <target state="translated">プロジェクトの参照またはインストール済みツールを一覧表示します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">項目を開発環境からアンインストールします。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">프로젝트의 참조를 나열합니다.</target>
+        <target state="translated">프로젝트 참조 또는 설치된 도구를 나열합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">개발 환경에서 항목을 제거합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">Wyświetl odwołanie w projekcie.</target>
+        <target state="translated">Wyświetl listę odwołań projektu lub zainstalowanych narzędzi.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Odinstalowuje element ze środowiska deweloperskiego.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">Listar referência no projeto.</target>
+        <target state="translated">Listar referências de projeto ou ferramentas instaladas.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Desinstala um item do ambiente de desenvolvimento.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">Список ссылок в проекте.</target>
+        <target state="translated">Перечисление ссылок на проекты или установленных инструментов.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Удаляет элемент из среды разработки.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">Projede başvuruyu listeleyin.</target>
+        <target state="translated">Proje başvurularını veya yüklü araçları listeleyin.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Bir öğeyi geliştirme ortamından kaldırır.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">列出项目中的引用。</target>
+        <target state="translated">列出项目参考或安装的工具。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">从开发环境中卸载项目。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -154,7 +154,7 @@
       </trans-unit>
       <trans-unit id="ListDefinition">
         <source>List project references or installed tools.</source>
-        <target state="needs-review-translation">列出專案中的參考。</target>
+        <target state="translated">列出專案參考或安裝的工具。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDoesNotExist">
@@ -259,7 +259,7 @@
       </trans-unit>
       <trans-unit id="UninstallDefinition">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">將開發環境的項目解除安裝。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateDefinition">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/LocalizableStrings.resx
@@ -148,7 +148,7 @@
     <value>NuGet configuration file '{0}' does not exist.</value>
   </data>
   <data name="InstallationSucceeded" xml:space="preserve">
-    <value>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+    <value>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</value>
   </data>
   <data name="GlobalOptionDescription" xml:space="preserve">
@@ -179,12 +179,12 @@ Tool '{1}' (version '{2}') was successfully installed.</value>
     <value>Specified version '{0}' is not a valid NuGet version range.</value>
   </data>
   <data name="InstallToolCommandNeedGlobalOrToolPath" xml:space="preserve">
-    <value>Need either global or tool-path provided.</value>
+    <value>Please specify either the global option (--global) or the tool path option (--tool-path).</value>
   </data>
   <data name="InstallToolCommandInvalidGlobalAndToolPath" xml:space="preserve">
-    <value>Cannot have global and tool-path as opinion at the same time.</value>
+    <value>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</value>
   </data>
   <data name="ToolPathDescription" xml:space="preserve">
-    <value>Location of shim to access tool</value>
+    <value>Location where the tool will be installed.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
@@ -95,18 +95,18 @@ Nástroj {1} (verze {2}) byl úspěšně nainstalován.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Je potřeba zadat buď globální cestu, nebo cestu k nástroji.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Je potřeba zadat buď globální cestu, nebo cestu k nástroji.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">Globální cesta a cesta k nástroji nemůžou být zadané současně.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Globální cesta a cesta k nástroji nemůžou být zadané současně.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Umístění překrytí pro přístup k nástroji</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">Umístění překrytí pro přístup k nástroji</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 Instalace byla úspěšná. Pokud nejsou další pokyny, můžete přímo do jádra napsat následující příkaz k vyvolání: {0}</target>
@@ -95,18 +95,18 @@ Instalace byla úspěšná. Pokud nejsou další pokyny, můžete přímo do já
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.cs.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-Instalace byla úspěšná. Pokud nejsou další pokyny, můžete přímo do jádra napsat následující příkaz k vyvolání: {0}</target>
+        <target state="translated">Pokud nebyly dostupné žádné další pokyny, můžete zadáním následujícího příkazu nástroj vyvolat: {0}
+Nástroj {1} (verze {2}) byl úspěšně nainstalován.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ Instalace byla úspěšná. Pokud nejsou další pokyny, můžete přímo do já
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">Nástroj {0} je už nainstalovaný.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">Pro nástroj {0} se nepodařilo vytvořit překrytí prostředí: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">Konfigurační soubor NuGet {0} neexistuje.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ Instalace byla úspěšná. Pokud nejsou další pokyny, můžete přímo do já
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">Zadaná verze {0} není platným rozsahem verzí NuGet.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Je potřeba zadat buď globální cestu, nebo cestu k nástroji.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">Globální cesta a cesta k nástroji nemůžou být zadané současně.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Umístění překrytí pro přístup k nástroji</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 Die Installation war erfolgreich. Sofern keine weiteren Anweisungen vorliegen, können Sie für den Aufruf den folgenden Befehl direkt in der Shell eingeben: {0}</target>
@@ -95,18 +95,18 @@ Die Installation war erfolgreich. Sofern keine weiteren Anweisungen vorliegen, k
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-Die Installation war erfolgreich. Sofern keine weiteren Anweisungen vorliegen, können Sie für den Aufruf den folgenden Befehl direkt in der Shell eingeben: {0}</target>
+        <target state="translated">Wenn keine zusätzlichen Anweisungen vorliegen, können Sie den folgenden Befehl zum Aufruf des Tools eingeben: {0}
+Das Tool "{1}" (Version "{2}") wurde erfolgreich installiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ Die Installation war erfolgreich. Sofern keine weiteren Anweisungen vorliegen, k
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">Das Tool "{0}" ist bereits installiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">Fehler beim Erstellen des Shell-Shims für das Tool "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">Die NuGet-Konfigurationsdatei "{0}" ist nicht vorhanden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ Die Installation war erfolgreich. Sofern keine weiteren Anweisungen vorliegen, k
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">Die angegebene Version "{0}" ist kein gültiger NuGet-Versionsbereich.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Es muss entweder "global" oder "tool-path" angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">Die gleichzeitige Angabe von "global" und "tool-path" ist nicht möglich.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Shim-Speicherort für Toolzugriff</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.de.xlf
@@ -95,18 +95,18 @@ Das Tool "{1}" (Version "{2}") wurde erfolgreich installiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Es muss entweder "global" oder "tool-path" angegeben werden.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Es muss entweder "global" oder "tool-path" angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">Die gleichzeitige Angabe von "global" und "tool-path" ist nicht möglich.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Die gleichzeitige Angabe von "global" und "tool-path" ist nicht möglich.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Shim-Speicherort für Toolzugriff</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">Shim-Speicherort für Toolzugriff</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 La instalación se completó correctamente. Si no hay más instrucciones, puede escribir el comando siguiente en el shell directamente para invocar: {0}</target>
@@ -95,18 +95,18 @@ La instalación se completó correctamente. Si no hay más instrucciones, puede 
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-La instalación se completó correctamente. Si no hay más instrucciones, puede escribir el comando siguiente en el shell directamente para invocar: {0}</target>
+        <target state="translated">Si no había instrucciones adicionales, puede escribir el comando siguiente para invocar la herramienta: {0}
+La herramienta "{1}" (versión "{2}") se instaló correctamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ La instalación se completó correctamente. Si no hay más instrucciones, puede 
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">La herramienta “{0}” ya está instalada.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">No se pudieron crear correcciones de compatibilidad (shim) de shell para la herramienta "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">El archivo de configuración de NuGet "{0}" no existe.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ La instalación se completó correctamente. Si no hay más instrucciones, puede 
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">La versión especificada "{0}" no es una gama de versiones de NuGet válida.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Se necesita una ruta global o de herramienta.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">No puede tener una ruta global y de herramienta como opinión al mismo tiempo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Ubicación de las correcciones de compatibilidad (shim) para acceder a la herramienta</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.es.xlf
@@ -95,18 +95,18 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Se necesita una ruta global o de herramienta.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Se necesita una ruta global o de herramienta.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">No puede tener una ruta global y de herramienta como opinión al mismo tiempo.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">No puede tener una ruta global y de herramienta como opinión al mismo tiempo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Ubicación de las correcciones de compatibilidad (shim) para acceder a la herramienta</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">Ubicación de las correcciones de compatibilidad (shim) para acceder a la herramienta</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 L'installation a réussi. En l'absence d'instructions supplémentaires, vous pouvez taper directement la commande suivante dans l'interpréteur de commandes pour appeler : {0}</target>
@@ -95,18 +95,18 @@ L'installation a réussi. En l'absence d'instructions supplémentaires, vous pou
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
@@ -95,18 +95,18 @@ L'outil '{1}' (version '{2}') a été installé.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Un paramètre global ou tool-path doit être fourni.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Un paramètre global ou tool-path doit être fourni.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">Impossible d'avoir une propriété opinion avec les paramètres global et tool-path en même temps.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Impossible d'avoir une propriété opinion avec les paramètres global et tool-path en même temps.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Emplacement de shim pour accéder à l'outil</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">Emplacement de shim pour accéder à l'outil</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.fr.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-L'installation a réussi. En l'absence d'instructions supplémentaires, vous pouvez taper directement la commande suivante dans l'interpréteur de commandes pour appeler : {0}</target>
+        <target state="translated">En l'absence d'instructions supplémentaires, vous pouvez taper la commande suivante pour appeler l'outil : {0}
+L'outil '{1}' (version '{2}') a été installé.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ L'installation a réussi. En l'absence d'instructions supplémentaires, vous pou
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">L'outil '{0}' est déjà installé.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">Échec de création d'un shim d'environnement pour l'outil '{0}' : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">Le fichier config NuGet '{0}' n'existe pas.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ L'installation a réussi. En l'absence d'instructions supplémentaires, vous pou
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">La version spécifiée '{0}' n'est pas une plage de versions NuGet valide.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Un paramètre global ou tool-path doit être fourni.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">Impossible d'avoir une propriété opinion avec les paramètres global et tool-path en même temps.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Emplacement de shim pour accéder à l'outil</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 L'installazione è riuscita. Se non ci sono altre istruzioni, è possibile digitare direttamente nella shell il comando seguente da richiamare: {0}</target>
@@ -95,18 +95,18 @@ L'installazione è riuscita. Se non ci sono altre istruzioni, è possibile digit
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-L'installazione è riuscita. Se non ci sono altre istruzioni, è possibile digitare direttamente nella shell il comando seguente da richiamare: {0}</target>
+        <target state="translated">Se non sono presenti istruzioni aggiuntive, è possibile digitare il comando seguente per richiamare lo strumento: {0}
+Lo strumento '{1}' (versione '{2}') è stato installato.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ L'installazione è riuscita. Se non ci sono altre istruzioni, è possibile digit
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">Lo strumento '{0}' è già installato.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">Non è stato possibile creare lo shim della shell per lo strumento '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">Il file di configurazione NuGet '{0}' non esiste.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ L'installazione è riuscita. Se non ci sono altre istruzioni, è possibile digit
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">La versione specificata '{0}' non è un intervallo di versioni NuGet valido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">È necessario specificare global o tool-path.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">Non è possibile specificare contemporaneamente global e tool-path come opzione.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Percorso dello shim per accedere allo strumento</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.it.xlf
@@ -95,18 +95,18 @@ Lo strumento '{1}' (versione '{2}') è stato installato.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">È necessario specificare global o tool-path.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">È necessario specificare global o tool-path.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">Non è possibile specificare contemporaneamente global e tool-path come opzione.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Non è possibile specificare contemporaneamente global e tool-path come opzione.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Percorso dello shim per accedere allo strumento</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">Percorso dello shim per accedere allo strumento</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 インストールは成功しました。追加の指示がなければ、シェルに次のコマンドを直接入力して呼び出すことができます: {0}</target>
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-インストールは成功しました。追加の指示がなければ、シェルに次のコマンドを直接入力して呼び出すことができます: {0}</target>
+        <target state="translated">追加の指示がない場合、次のコマンドを入力してツールを呼び出すことができます: {0}
+ツール '{1}' (バージョン '{2}') は正常にインストールされました。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">ツール '{0}' は既にインストールされています。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">ツール '{0}' でシェル shim を作成できませんでした: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">NuGet 構成ファイル '{0}' は存在しません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">指定されたバージョン '{0}' は、有効な NuGet バージョン範囲ではありません。</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">global か tool-path を指定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">global と tool-path を意見として同時に指定することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">ツールにアクセスする shim の場所</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ja.xlf
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">global か tool-path を指定する必要があります。</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">global か tool-path を指定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">global と tool-path を意見として同時に指定することはできません。</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">global と tool-path を意見として同時に指定することはできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">ツールにアクセスする shim の場所</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">ツールにアクセスする shim の場所</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 설치했습니다. 추가 지침이 없는 경우 셸에 다음 명령을 직접 입력하여 {0}을(를) 호출할 수 있습니다.</target>
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-설치했습니다. 추가 지침이 없는 경우 셸에 다음 명령을 직접 입력하여 {0}을(를) 호출할 수 있습니다.</target>
+        <target state="translated">추가 지침이 없는 경우 다음 명령을 입력하여 도구를 호출할 수 있습니다. {0}
+도구 '{1}'(버전 '{2}')이(가) 설치되었습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">'{0}' 도구가 이미 설치되어 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">'{0}' 도구에 대해 셸 shim을 만들지 못했습니다. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">NuGet 구성 파일 '{0}'이(가) 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">지정된 버전 '{0}'이(가) 유효한 NuGet 버전 범위가 아닙니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">전역 또는 도구 경로를 제공해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">전역 및 도구 경로를 의견으로 동시에 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">도구에 액세스하는 shim 위치</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ko.xlf
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">전역 또는 도구 경로를 제공해야 합니다.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">전역 또는 도구 경로를 제공해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">전역 및 도구 경로를 의견으로 동시에 사용할 수 없습니다.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">전역 및 도구 경로를 의견으로 동시에 사용할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">도구에 액세스하는 shim 위치</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">도구에 액세스하는 shim 위치</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-Instalacja powiodła się. Jeśli nie ma dodatkowych instrukcji, możesz wpisać następujące polecenie bezpośrednio w powłoce, aby wywołać: {0}</target>
+        <target state="translated">Jeśli nie było dodatkowych instrukcji, możesz wpisać następujące polecenie, aby wywołać narzędzie: {0}
+Pomyślnie zainstalowano narzędzie „{1}” (wersja: „{2}”).</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ Instalacja powiodła się. Jeśli nie ma dodatkowych instrukcji, możesz wpisać
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">Narzędzie „{0}” jest już zainstalowane.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">Nie można utworzyć podkładki powłoki dla narzędzia „{0}”: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">Plik konfiguracji pakietu NuGet „{0}” nie istnieje.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ Instalacja powiodła się. Jeśli nie ma dodatkowych instrukcji, możesz wpisać
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">Określona wersja „{0}” nie należy do prawidłowego zakresu wersji pakietu NuGet.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Należy podać ścieżkę globalną lub ścieżkę narzędzia.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">Nie można jednocześnie używać ścieżki globalnej i ścieżki narzędzia jako opinii.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Lokalizacja podkładki na potrzeby dostępu do narzędzia</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
@@ -95,18 +95,18 @@ Pomyślnie zainstalowano narzędzie „{1}” (wersja: „{2}”).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Należy podać ścieżkę globalną lub ścieżkę narzędzia.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Należy podać ścieżkę globalną lub ścieżkę narzędzia.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">Nie można jednocześnie używać ścieżki globalnej i ścieżki narzędzia jako opinii.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Nie można jednocześnie używać ścieżki globalnej i ścieżki narzędzia jako opinii.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Lokalizacja podkładki na potrzeby dostępu do narzędzia</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">Lokalizacja podkładki na potrzeby dostępu do narzędzia</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pl.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 Instalacja powiodła się. Jeśli nie ma dodatkowych instrukcji, możesz wpisać następujące polecenie bezpośrednio w powłoce, aby wywołać: {0}</target>
@@ -95,18 +95,18 @@ Instalacja powiodła się. Jeśli nie ma dodatkowych instrukcji, możesz wpisać
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-A instalação foi bem-sucedida. Se não houver outras instruções, digite o seguinte comando no shell diretamente para invocar: {0}</target>
+        <target state="translated">Se não houver nenhuma instrução adicional, você poderá digitar o seguinte comando para invocar a ferramenta: {0}
+A ferramenta '{1}' (versão '{2}') foi instalada com êxito.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ A instalação foi bem-sucedida. Se não houver outras instruções, digite o se
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">A ferramenta '{0}' já está instalada.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">Falha ao criar o shim do shell para a ferramenta '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">O arquivo de configuração '{0}' do NuGet não existe.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ A instalação foi bem-sucedida. Se não houver outras instruções, digite o se
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">A versão '{0}' especificada não é um intervalo de versão do NuGet válido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">É necessário o caminho de ferramenta ou global fornecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">Não é possível ter o caminho de ferramenta e o global como opinião ao mesmo tempo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Local do shim para acessar a ferramenta</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -95,18 +95,18 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">É necessário o caminho de ferramenta ou global fornecido.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">É necessário o caminho de ferramenta ou global fornecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">Não é possível ter o caminho de ferramenta e o global como opinião ao mesmo tempo.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Não é possível ter o caminho de ferramenta e o global como opinião ao mesmo tempo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Local do shim para acessar a ferramenta</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">Local do shim para acessar a ferramenta</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 A instalação foi bem-sucedida. Se não houver outras instruções, digite o seguinte comando no shell diretamente para invocar: {0}</target>
@@ -95,18 +95,18 @@ A instalação foi bem-sucedida. Se não houver outras instruções, digite o se
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 Установка завершена. Если других действий не требуется, вы можете непосредственно в оболочке ввести для вызова следующую команду: {0}.</target>
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Требуется указать глобальный параметр или параметр tool-path.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Требуется указать глобальный параметр или параметр tool-path.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">Невозможно указать глобальный параметр и параметр tool-path в качестве оценки одновременно.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Невозможно указать глобальный параметр и параметр tool-path в качестве оценки одновременно.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Расположение оболочки совместимости для доступа к инструменту</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">Расположение оболочки совместимости для доступа к инструменту</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.ru.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-Установка завершена. Если других действий не требуется, вы можете непосредственно в оболочке ввести для вызова следующую команду: {0}.</target>
+        <target state="translated">Если не было других указаний, вы можете ввести для вызова инструмента следующую команду: {0}
+Инструмент "{1}" (версия "{2}") установлен.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">Инструмент "{0}" уже установлен.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">Не удалось создать оболочку совместимости для инструмента "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">Файл конфигурации NuGet "{0}" не существует.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">Указанная версия "{0}" не входит в допустимый диапазон версий NuGet.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Требуется указать глобальный параметр или параметр tool-path.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">Невозможно указать глобальный параметр и параметр tool-path в качестве оценки одновременно.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Расположение оболочки совместимости для доступа к инструменту</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-Yükleme başarılı oldu. Daha fazla yönerge yoksa, çağırmak için şu komutu doğrudan kabuğa yazabilirsiniz: {0}</target>
+        <target state="translated">Başka bir yönerge sağlanmadıysa şu komutu yazarak aracı çağırabilirsiniz: {0}
+'{1}' aracı (sürüm '{2}') başarıyla yüklendi.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ Yükleme başarılı oldu. Daha fazla yönerge yoksa, çağırmak için şu komu
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">'{0}' aracı zaten yüklü.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">'{0}' aracı için kabuk dolgusu oluşturulamadı: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">NuGet yapılandırma dosyası '{0}' yok.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ Yükleme başarılı oldu. Daha fazla yönerge yoksa, çağırmak için şu komu
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">Belirtilen '{0}' sürümü geçerli bir NuGet sürüm aralığı değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Genel yolun veya araç yolunun sağlanması gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">Fikir olarak aynı anda hem genel yol hem de araç yolu kullanılamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Araca erişmek için dolgu konumu</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 Yükleme başarılı oldu. Daha fazla yönerge yoksa, çağırmak için şu komutu doğrudan kabuğa yazabilirsiniz: {0}</target>
@@ -95,18 +95,18 @@ Yükleme başarılı oldu. Daha fazla yönerge yoksa, çağırmak için şu komu
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.tr.xlf
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Genel yolun veya araç yolunun sağlanması gerekir.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Genel yolun veya araç yolunun sağlanması gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">Fikir olarak aynı anda hem genel yol hem de araç yolu kullanılamaz.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Fikir olarak aynı anda hem genel yol hem de araç yolu kullanılamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Araca erişmek için dolgu konumu</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">Araca erişmek için dolgu konumu</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">需要提供全局或工具路径。</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">需要提供全局或工具路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">无法同时主张全局和工具路径。</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">无法同时主张全局和工具路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">填充程序访问工具的位置</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">填充程序访问工具的位置</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 安装成功。如果没有进一步的说明，则可直接在 shell 中键入以下命令进行调用: {0}</target>
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-安装成功。如果没有进一步的说明，则可直接在 shell 中键入以下命令进行调用: {0}</target>
+        <target state="translated">如果没有其他说明，可键入以下命令来调用该工具: {0}
+已成功安装工具“{1}”（版本“{2}”）。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">已安装工具“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">无法为工具“{0}”创建 shell 填充程序: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">NuGet 配置文件“{0}”不存在。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">指定的版本“{0}”是无效的 NuGet 版本范围。</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">需要提供全局或工具路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">无法同时主张全局和工具路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">填充程序访问工具的位置</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -3,7 +3,7 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
       <trans-unit id="InstallationSucceeded">
-        <source>If there were no additional instructions, you can type the following command to invoke the tool: {0}
+        <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
         <target state="needs-review-translation">
 安裝已成功。如果沒有進一步指示，您可以直接在命令介面中鍵入下列命令，以叫用: {0}</target>
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="new">Location where the tool will be installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -5,8 +5,8 @@
       <trans-unit id="InstallationSucceeded">
         <source>You can invoke the tool using the following command: {0}
 Tool '{1}' (version '{2}') was successfully installed.</source>
-        <target state="needs-review-translation">
-安裝已成功。如果沒有進一步指示，您可以直接在命令介面中鍵入下列命令，以叫用: {0}</target>
+        <target state="translated">若無任何其他指示，您可以鍵入下列命令來叫用工具: {0}
+已成功安裝工具 '{1}' ('{2}' 版)。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">
@@ -71,17 +71,17 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="ToolAlreadyInstalled">
         <source>Tool '{0}' is already installed.</source>
-        <target state="new">Tool '{0}' is already installed.</target>
+        <target state="translated">工具 '{0}' 已安裝。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToCreateToolShim">
         <source>Failed to create shell shim for tool '{0}': {1}</source>
-        <target state="new">Failed to create shell shim for tool '{0}': {1}</target>
+        <target state="translated">無法為工具 '{0}' 建立殼層填充碼: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetConfigurationFileDoesNotExist">
         <source>NuGet configuration file '{0}' does not exist.</source>
-        <target state="new">NuGet configuration file '{0}' does not exist.</target>
+        <target state="translated">NuGet 組態檔 '{0}' 不存在。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolInstallationRestoreFailed">
@@ -91,22 +91,22 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
       </trans-unit>
       <trans-unit id="InvalidNuGetVersionRange">
         <source>Specified version '{0}' is not a valid NuGet version range.</source>
-        <target state="new">Specified version '{0}' is not a valid NuGet version range.</target>
+        <target state="translated">指定的版本 '{0}' 不是有效的 NuGet 版本範圍。</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">必須提供全域或工具路徑。</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time.</source>
+        <target state="translated">無法同時將全域與工具路徑作為選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool will be installed.</source>
-        <target state="new">Location where the tool will be installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">存取工具的填充碼位置</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-install/dotnet-install-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -95,18 +95,18 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">必須提供全域或工具路徑。</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">必須提供全域或工具路徑。</target>
         <note />
       </trans-unit>
       <trans-unit id="InstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time.</source>
-        <target state="translated">無法同時將全域與工具路徑作為選項。</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">無法同時將全域與工具路徑作為選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">存取工具的填充碼位置</target>
+        <source>Location where the tool will be installed.</source>
+        <target state="needs-review-translation">存取工具的填充碼位置</target>
         <note />
       </trans-unit>
       <trans-unit id="SourceFeedOptionDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/ListToolCommand.cs
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/ListToolCommand.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Tools.List.Tool
 {
     internal class ListToolCommand : CommandBase
     {
-        private const string CommandDelimiter = ", ";
+        public const string CommandDelimiter = ", ";
         private readonly AppliedOption _options;
         private readonly IToolPackageStore _toolPackageStore;
         private readonly IReporter _reporter;
@@ -66,20 +66,20 @@ namespace Microsoft.DotNet.Tools.List.Tool
                 .ToArray();
         }
 
-        private bool PackageHasCommands(IToolPackage p)
+        private bool PackageHasCommands(IToolPackage package)
         {
             try
             {
                 // Attempt to read the commands collection
                 // If it fails, print a warning and treat as no commands
-                return p.Commands.Count >= 0;
+                return package.Commands.Count >= 0;
             }
             catch (Exception ex) when (ex is ToolConfigurationException)
             {
                 _errorReporter.WriteLine(
                     string.Format(
                         LocalizableStrings.InvalidPackageWarning,
-                        p.Id,
+                        package.Id,
                         ex.Message).Yellow());
                 return false;
             }

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/ListToolCommandParser.cs
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/ListToolCommandParser.cs
@@ -17,6 +17,10 @@ namespace Microsoft.DotNet.Cli
                     "-g|--global",
                     LocalizableStrings.GlobalOptionDescription,
                     Accept.NoArguments()),
+                Create.Option(
+                    "--tool-path",
+                    LocalizableStrings.ToolPathDescription,
+                    Accept.ExactlyOneArgument()),
                 CommonOptions.HelpOption());
         }
     }

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/LocalizableStrings.resx
@@ -123,8 +123,14 @@
   <data name="GlobalOptionDescription" xml:space="preserve">
     <value>List user wide tools.</value>
   </data>
-  <data name="ListToolCommandOnlySupportsGlobal" xml:space="preserve">
-    <value>The --global switch (-g) is currently required because only user wide tools are supported.</value>
+  <data name="ToolPathDescription" xml:space="preserve">
+    <value>Location where the tools are installed.</value>
+  </data>
+  <data name="NeedGlobalOrToolPath" xml:space="preserve">
+    <value>Please specify either the global option (--global) or the tool path option (--tool-path).</value>
+  </data>
+  <data name="GlobalAndToolPathConflict" xml:space="preserve">
+    <value>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</value>
   </data>
   <data name="InvalidPackageWarning" xml:space="preserve">
     <value>Warning: tool package '{0}' is invalid: {1}</value>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.cs.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">Vypíše nástroje nainstalované v aktuálním vývojovém prostředí.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">Vypsat nástroje všech uživatelů</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">Přepínač --global (-g) se aktuálně vyžaduje, protože se podporují jenom nástroje pro všechny uživatele.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Verze</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">Příkazy</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">ID balíčku</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">Upozornění: Balíček nástroje {0} je neplatný: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.cs.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.cs.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Vypsat nástroje všech uživatelů</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">Přepínač --global (-g) se aktuálně vyžaduje, protože se podporují jenom nástroje pro všechny uživatele.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Verze</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.de.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Hiermit werden benutzerweite Tools aufgelistet.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">Die Option --global (-g) ist aktuell erforderlich, weil nur benutzerweite Tools unterstützt werden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Version</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.de.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">Hiermit werden die in der aktuellen Entwicklungsumgebung installierten Tools aufgelistet.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">Hiermit werden benutzerweite Tools aufgelistet.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">Die Option --global (-g) ist aktuell erforderlich, weil nur benutzerweite Tools unterstützt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">Befehle</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">Paket-ID</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">Warnung: Das Toolpaket "{0}" ist ungültig: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.de.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.es.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">Enumera las herramientas instaladas en el entorno de desarrollo actual.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">Enumera las herramientas para todos los usuarios.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">El conmutador --global (g) se requiere actualmente porque solo se admiten herramientas para todos los usuarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Versión</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">Comandos</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">Id. de paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">Advertencia: El paquete de herramientas "{0}" no es válido: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.es.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Enumera las herramientas para todos los usuarios.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">El conmutador --global (g) se requiere actualmente porque solo se admiten herramientas para todos los usuarios.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Versión</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.es.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.fr.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Listez les outils pour tous les utilisateurs.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">Le commutateur --global (-g) est obligatoire, car seuls les outils à l'échelle des utilisateurs sont pris en charge.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Version</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.fr.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.fr.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">Liste les outils installés dans l'environnement de développement actuel.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">Listez les outils pour tous les utilisateurs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">Le commutateur --global (-g) est obligatoire, car seuls les outils à l'échelle des utilisateurs sont pris en charge.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Version</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">Commandes</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">ID de package</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">Avertissement : Le package d'outils '{0}' n'est pas valide : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.it.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.it.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">Elenca gli strumenti installati nell'ambiente di sviluppo corrente.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">Elenca gli strumenti a livello di utente.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">L'opzione --global (-g) è attualmente obbligatoria perché sono supportati solo gli strumenti a livello di utente.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Versione</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">Comandi</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">ID pacchetto</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">Avviso: il pacchetto '{0}' dello strumento non è valido: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.it.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Elenca gli strumenti a livello di utente.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">L'opzione --global (-g) è attualmente obbligatoria perché sono supportati solo gli strumenti a livello di utente.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Versione</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ja.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ja.xlf
@@ -12,11 +12,6 @@
         <target state="translated">ユーザー全体のツールを一覧表示します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">サポートされているのはユーザー全体のツールだけなので、現在 --global スイッチ (-g) が必要です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">バージョン</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ja.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">現在の開発環境にインストールされているツールを一覧表示します。</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">ユーザー全体のツールを一覧表示します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">サポートされているのはユーザー全体のツールだけなので、現在 --global スイッチ (-g) が必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">バージョン</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">コマンド</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">パッケージ ID</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">警告: ツール パッケージ '{0}' が無効です: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ko.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">현재 개발 환경에 설치된 도구를 나열합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">사용자 전체 도구를 나열합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">사용자 전체 도구만 지원되므로 -global 스위치(-g)가 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">버전</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">명령</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">패키지 ID</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">경고: 도구 패키지 '{0}'이(가) 잘못되었습니다. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ko.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ko.xlf
@@ -12,11 +12,6 @@
         <target state="translated">사용자 전체 도구를 나열합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">사용자 전체 도구만 지원되므로 -global 스위치(-g)가 필요합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">버전</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pl.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Wyświetl listę narzędzi użytkownika.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">Obecnie jest wymagany przełącznik --global (-g), ponieważ obsługiwane są tylko narzędzia użytkownika.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Wersja</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pl.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pl.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">Wyświetla listę narzędzi zainstalowanych w bieżącym środowisku deweloperskim.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">Wyświetl listę narzędzi użytkownika.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">Obecnie jest wymagany przełącznik --global (-g), ponieważ obsługiwane są tylko narzędzia użytkownika.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Wersja</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">Polecenia</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">Identyfikator pakietu</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">Ostrzeżenie: pakiet narzędzia „{0}” jest nieprawidłowy: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Listar as ferramentas para todo o usuário.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">A opção --global (-g) é obrigatória, pois somente ferramentas para todo o usuário são compatíveis.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Versão</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">Lista as ferramentas instaladas no ambiente de desenvolvimento atual.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">Listar as ferramentas para todo o usuário.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">A opção --global (-g) é obrigatória, pois somente ferramentas para todo o usuário são compatíveis.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Versão</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">Comandos</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">ID do Pacote</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">Aviso: o pacote de ferramentas '{0}' é inválido: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ru.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">Перечисляет установленные инструменты в текущей среде разработки.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">Перечисление пользовательских инструментов.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">Параметр "--global switch (-g)" сейчас обязателен, так как поддерживаются только инструменты уровня пользователя.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Версия</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">Команды</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">Идентификатор пакета</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">Предупреждение. Пакет инструментов "{0}" недопустим: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ru.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Перечисление пользовательских инструментов.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">Параметр "--global switch (-g)" сейчас обязателен, так как поддерживаются только инструменты уровня пользователя.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Версия</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.ru.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.tr.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">Geçerli geliştirme ortamında yüklü araçları listeler.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">Kullanıcıya yönelik araçları listeleyin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">Yalnızca kullanıcı için araçlar desteklendiğinden --global anahtarı (-g) şu anda gereklidir.</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">Sürüm</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">Komutlar</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">Paket Kimliği</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">Uyarı: '{0}' araç paketi geçersiz: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.tr.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Kullanıcıya yönelik araçları listeleyin.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">Yalnızca kullanıcı için araçlar desteklendiğinden --global anahtarı (-g) şu anda gereklidir.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">Sürüm</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.tr.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">列出当前开发环境中的已安装工具。</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">列出用户范围工具。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">目前需要 --global 开关 (-g)，因为仅支持用户范围工具。</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">版本</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">命令</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">包 ID</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">警告: 工具包“{0}”无效: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,11 +12,6 @@
         <target state="translated">列出用户范围工具。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">目前需要 --global 开关 (-g)，因为仅支持用户范围工具。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">版本</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,11 +12,6 @@
         <target state="translated">列出全體使用者工具。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="translated">因為只支援適用於全體使用者的工具，所以目前必須有 --global 參數 (-g)。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="translated">版本</target>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,11 +12,6 @@
         <target state="new">List user wide tools.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListToolCommandOnlySupportsGlobal">
-        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
-        <target state="new">The --global switch (-g) is currently required because only user wide tools are supported.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
         <target state="new">Version</target>
@@ -35,6 +30,21 @@
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
         <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolPathDescription">
+        <source>Location where the tools are installed.</source>
+        <target state="new">Location where the tools are installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalOrToolPath">
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalAndToolPathConflict">
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -4,32 +4,37 @@
     <body>
       <trans-unit id="CommandDescription">
         <source>Lists installed tools in the current development environment.</source>
-        <target state="new">Lists installed tools in the current development environment.</target>
+        <target state="translated">列出目前開發環境中安裝的工具。</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>List user wide tools.</source>
-        <target state="new">List user wide tools.</target>
+        <target state="translated">列出全體使用者工具。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListToolCommandOnlySupportsGlobal">
+        <source>The --global switch (-g) is currently required because only user wide tools are supported.</source>
+        <target state="translated">因為只支援適用於全體使用者的工具，所以目前必須有 --global 參數 (-g)。</target>
         <note />
       </trans-unit>
       <trans-unit id="VersionColumn">
         <source>Version</source>
-        <target state="new">Version</target>
+        <target state="translated">版本</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsColumn">
         <source>Commands</source>
-        <target state="new">Commands</target>
+        <target state="translated">命令</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
-        <target state="new">Package Id</target>
+        <target state="translated">套件識別碼</target>
         <note />
       </trans-unit>
       <trans-unit id="InvalidPackageWarning">
         <source>Warning: tool package '{0}' is invalid: {1}</source>
-        <target state="new">Warning: tool package '{0}' is invalid: {1}</target>
+        <target state="translated">警告: 工具套件 '{0}' 無效: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">

--- a/src/dotnet/commands/dotnet-uninstall/tool/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-uninstall/tool/LocalizableStrings.resx
@@ -145,12 +145,12 @@
     <value>Failed to uninstall tool '{0}': {1}</value>
   </data>
   <data name="UninstallToolCommandNeedGlobalOrToolPath" xml:space="preserve">
-    <value>Need either global or tool-path provided.</value>
+    <value>Please specify either the global option (--global) or the tool path option (--tool-path).</value>
   </data>
   <data name="ToolPathDescription" xml:space="preserve">
-    <value>Location of shim to access tool</value>
+    <value>Location where the tool was previously installed.</value>
   </data>
   <data name="UninstallToolCommandInvalidGlobalAndToolPath" xml:space="preserve">
-    <value>Cannot have global and tool-path as opinion at the same time."</value>
+    <value>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-uninstall/tool/UninstallToolCommand.cs
+++ b/src/dotnet/commands/dotnet-uninstall/tool/UninstallToolCommand.cs
@@ -24,12 +24,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tool
         private readonly IReporter _reporter;
         private readonly IReporter _errorReporter;
         private CreateShellShimRepository _createShellShimRepository;
-        private CreateToolPackageStore _createToolPackageStoreAndInstaller;
+        private CreateToolPackageStore _createToolPackageStore;
 
         public UninstallToolCommand(
             AppliedOption options,
             ParseResult result,
-            CreateToolPackageStore createToolPackageStoreAndInstaller = null,
+            CreateToolPackageStore createToolPackageStore = null,
             CreateShellShimRepository createShellShimRepository = null,
             IReporter reporter = null)
             : base(result)
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tool
             _errorReporter = reporter ?? Reporter.Error;
 
             _createShellShimRepository = createShellShimRepository ?? ShellShimRepositoryFactory.CreateShellShimRepository;
-            _createToolPackageStoreAndInstaller = createToolPackageStoreAndInstaller ?? ToolPackageFactory.CreateToolPackageStore;
+            _createToolPackageStore = createToolPackageStore ?? ToolPackageFactory.CreateToolPackageStore;
         }
 
         public override int Execute()
@@ -65,7 +65,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tool
                 toolDirectoryPath = new DirectoryPath(toolPath);
             }
 
-            IToolPackageStore toolPackageStore = _createToolPackageStoreAndInstaller(toolDirectoryPath);
+            IToolPackageStore toolPackageStore = _createToolPackageStore(toolDirectoryPath);
             IShellShimRepository shellShimRepository = _createShellShimRepository(toolDirectoryPath);
 
             var packageId = new PackageId(_options.Arguments.Single());

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.cs.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">ID balíčku NuGet nástroje, který se má odinstalovat</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">Odinstaluje nástroj.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">Zadejte prosím jedno ID balíčku nástroje, který se má odinstalovat.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">Odinstalovat pro všechny uživatele</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">Nástroj {0} (verze {1}) byl úspěšně odinstalován.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">Nástroj {0} není momentálně nainstalovaný.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">Nástroj {0} má několik nainstalovaných verzí a nelze ho odinstalovat.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">Nepodařilo se odinstalovat nástroj {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Je potřeba zadat buď globální cestu, nebo cestu k nástroji.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Umístění překrytí pro přístup k nástroji</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">Globální cesta a cesta k nástroji nemůžou být zadané současně.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.cs.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Je potřeba zadat buď globální cestu, nebo cestu k nástroji.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Je potřeba zadat buď globální cestu, nebo cestu k nástroji.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Umístění překrytí pro přístup k nástroji</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">Umístění překrytí pro přístup k nástroji</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">Globální cesta a cesta k nástroji nemůžou být zadané současně.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Globální cesta a cesta k nástroji nemůžou být zadané současně.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.cs.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.de.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Es muss entweder "global" oder "tool-path" angegeben werden.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Es muss entweder "global" oder "tool-path" angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Shim-Speicherort für Toolzugriff</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">Shim-Speicherort für Toolzugriff</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">Die gleichzeitige Angabe von "global" und "tool-path" ist nicht möglich.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Die gleichzeitige Angabe von "global" und "tool-path" ist nicht möglich.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.de.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">NuGet-Paket-ID des Tools, das deinstalliert werden soll.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">Hiermit wird ein Tool deinstalliert.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">Geben Sie eine Toolpaket-ID für die Deinstallation an.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">Benutzerweite Deinstallation.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">Das Tool "{0}" (Version "{1}") wurde erfolgreich deinstalliert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">Das Tool "{0}" ist aktuell nicht installiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">Es sind mehrere Versionen von Tool "{0}" installiert, eine Deinstallation ist nicht möglich.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">Fehler beim Deinstallieren des Tools "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Es muss entweder "global" oder "tool-path" angegeben werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Shim-Speicherort für Toolzugriff</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">Die gleichzeitige Angabe von "global" und "tool-path" ist nicht möglich.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.de.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.es.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.es.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Se necesita una ruta global o de herramienta.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Se necesita una ruta global o de herramienta.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Ubicación de las correcciones de compatibilidad (shim) para acceder a la herramienta</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">Ubicación de las correcciones de compatibilidad (shim) para acceder a la herramienta</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">No puede tener una ruta global y de herramienta como opinión al mismo tiempo."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">No puede tener una ruta global y de herramienta como opinión al mismo tiempo."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.es.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">Id. del paquete de NuGet de la herramienta que se desinstalará.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">Desinstala una herramienta.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">Especifique un id. de paquete de herramienta para desinstalar.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">Desinstale para todos los usuarios.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">La herramienta "{0}" (versión "{1}") se desinstaló correctamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">La herramienta "{0}" no está instalada actualmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">La herramienta "{0}" tiene varias versiones instaladas y no se puede desinstalar.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">No se pudo desinstalar la herramienta "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Se necesita una ruta global o de herramienta.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Ubicación de las correcciones de compatibilidad (shim) para acceder a la herramienta</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">No puede tener una ruta global y de herramienta como opinión al mismo tiempo."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.fr.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">ID de package NuGet de l'outil à désinstaller.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">Désinstalle un outil.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">Spécifiez un ID de package d'outils à désinstaller.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">Effectuez la désinstallation pour tous les utilisateurs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">L'outil '{0}' (version '{1}') a été désinstallé.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">L'outil '{0}' n'est pas installé actuellement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">L'outil '{0}' a plusieurs versions installées et ne peut pas être désinstallé.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">Échec de désinstallation de l'outil '{0}' : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Un paramètre global ou tool-path doit être fourni.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Emplacement de shim pour accéder à l'outil</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">Impossible d'avoir une propriété opinion avec les paramètres global et tool-path en même temps."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.fr.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Un paramètre global ou tool-path doit être fourni.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Un paramètre global ou tool-path doit être fourni.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Emplacement de shim pour accéder à l'outil</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">Emplacement de shim pour accéder à l'outil</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">Impossible d'avoir une propriété opinion avec les paramètres global et tool-path en même temps."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Impossible d'avoir une propriété opinion avec les paramètres global et tool-path en même temps."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.fr.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.it.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">ID pacchetto NuGet dello strumento da disinstallare.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">Disinstalla uno strumento.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">Specificare un ID pacchetto dello strumento da disinstallare.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">Esegue la disinstallazione a livello di utente.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">Lo strumento '{0}' (versione '{1}') è stato disinstallato.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">Lo strumento '{0}' non è attualmente installato.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">Lo strumento '{0}' non può essere disinstallato perché ne sono installate più versioni.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">Non è stato possibile disinstallare lo strumento '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">È necessario specificare global o tool-path.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Percorso dello shim per accedere allo strumento</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">Non è possibile specificare contemporaneamente global e tool-path come opzione."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.it.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.it.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">È necessario specificare global o tool-path.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">È necessario specificare global o tool-path.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Percorso dello shim per accedere allo strumento</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">Percorso dello shim per accedere allo strumento</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">Non è possibile specificare contemporaneamente global e tool-path come opzione."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Non è possibile specificare contemporaneamente global e tool-path come opzione."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ja.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">アンインストールするツールの NuGet パッケージ ID。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">ツールをアンインストールします。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">アンインストールするツール パッケージの ID を 1 つ指定してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">ユーザー全体でアンインストールします。</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">ツール '{0}' (バージョン '{1}') は正常にアンインストールされました。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">ツール '{0}' は現在、インストールされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">ツール '{0}' の複数のバージョンがインストールされており、アンインストールできません。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">ツール '{0}' をアンインストールできませんでした: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">global か tool-path を指定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">ツールにアクセスする shim の場所</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">global と tool-path を意見として同時に指定することはできません。"</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ja.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">global か tool-path を指定する必要があります。</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">global か tool-path を指定する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">ツールにアクセスする shim の場所</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">ツールにアクセスする shim の場所</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">global と tool-path を意見として同時に指定することはできません。"</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">global と tool-path を意見として同時に指定することはできません。"</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ja.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ko.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">제거할 도구의 NuGet 패키지 ID입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">도구를 제거합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">제거할 도구 패키지 ID를 하나 지정하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">사용자 전체 도구를 제거합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">도구 '{0}'(버전 '{1}')을(를) 제거했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">도구 '{0}'이(가) 현재 설치되어 있지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">도구 '{0}'의 여러 버전이 설치되어 있으며 제거할 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">도구 '{0}'을(를) 제거하지 못했습니다. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">전역 또는 도구 경로를 제공해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">도구에 액세스하는 shim 위치</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">전역 및 도구 경로를 의견으로 동시에 사용할 수 없습니다."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ko.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">전역 또는 도구 경로를 제공해야 합니다.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">전역 또는 도구 경로를 제공해야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">도구에 액세스하는 shim 위치</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">도구에 액세스하는 shim 위치</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">전역 및 도구 경로를 의견으로 동시에 사용할 수 없습니다."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">전역 및 도구 경로를 의견으로 동시에 사용할 수 없습니다."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ko.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pl.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">Identyfikator pakietu NuGet narzędzia do odinstalowania.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">Odinstalowuje narzędzie.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">Określ jeden identyfikator pakietu narzędzia do odinstalowania.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">Odinstaluj dla użytkownika.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">Pomyślnie odinstalowano narzędzie „{0}” (wersja: „{1}”).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">Narzędzie „{0}” nie jest obecnie zainstalowane.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">Jest zainstalowanych wiele wersji narzędzia „{0}” i nie można go odinstalować.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">Nie można odinstalować narzędzia „{0}”: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Należy podać ścieżkę globalną lub ścieżkę narzędzia.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Lokalizacja podkładki na potrzeby dostępu do narzędzia</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">Nie można jednocześnie używać ścieżki globalnej i ścieżki narzędzia jako opinii.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pl.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pl.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Należy podać ścieżkę globalną lub ścieżkę narzędzia.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Należy podać ścieżkę globalną lub ścieżkę narzędzia.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Lokalizacja podkładki na potrzeby dostępu do narzędzia</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">Lokalizacja podkładki na potrzeby dostępu do narzędzia</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">Nie można jednocześnie używać ścieżki globalnej i ścieżki narzędzia jako opinii.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Nie można jednocześnie używać ścieżki globalnej i ścieżki narzędzia jako opinii.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">A ID do pacote NuGet da ferramenta a ser desinstalada.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">Desinstala uma ferramenta.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">Especifique uma ID de Pacote da ferramenta a ser desinstalada.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">Desinstale para todo o usuário.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">A ferramenta '{0}' (versão '{1}') foi desinstalada com êxito.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">A ferramenta '{0}' não está instalada no momento.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">A ferramenta '{0}' tem várias versões instaladas e não pode ser desinstalada.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">Falha ao desinstalar a ferramenta '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">É necessário o caminho de ferramenta ou global fornecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Local do shim para acessar a ferramenta</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">Não é possível ter o caminho de ferramenta e o global como opinião ao mesmo tempo."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">É necessário o caminho de ferramenta ou global fornecido.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">É necessário o caminho de ferramenta ou global fornecido.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Local do shim para acessar a ferramenta</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">Local do shim para acessar a ferramenta</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">Não é possível ter o caminho de ferramenta e o global como opinião ao mesmo tempo."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Não é possível ter o caminho de ferramenta e o global como opinião ao mesmo tempo."</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.pt-BR.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ru.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Требуется указать глобальный параметр или параметр tool-path.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Требуется указать глобальный параметр или параметр tool-path.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Расположение оболочки совместимости для доступа к инструменту</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">Расположение оболочки совместимости для доступа к инструменту</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">Невозможно указать глобальный параметр и параметр tool-path в качестве оценки одновременно.</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Невозможно указать глобальный параметр и параметр tool-path в качестве оценки одновременно.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ru.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.ru.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">Идентификатор пакета NuGet удаляемого инструмента.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">Удаляет инструмент.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">Укажите один идентификатор пакета удаляемого инструмента.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">Удаление на уровне пользователя.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">Инструмент "{0}" (версия "{1}") удален.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">Инструмент "{0}" сейчас не установлен.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">Установлено несколько версий инструмента "{0}", и удалить его невозможно.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">Не удалось удалить инструмент "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Требуется указать глобальный параметр или параметр tool-path.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Расположение оболочки совместимости для доступа к инструменту</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">Невозможно указать глобальный параметр и параметр tool-path в качестве оценки одновременно.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.tr.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">Kaldırılacak aracın NuGet Paket Kimliği.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">Bir aracı kaldırır.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">Lütfen kaldırılacak aracın Paket Kimliğini belirtin.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">Kullanıcı için kaldırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">'{0}' aracı (sürüm '{1}') başarıyla kaldırıldı.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">'{0}' aracı şu anda yüklü değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">'{0}' aracının birden fazla sürümü yüklü ve kaldırılamıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">'{0}' aracı kaldırılamadı: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">Genel yolun veya araç yolunun sağlanması gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">Araca erişmek için dolgu konumu</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">Fikir olarak aynı anda hem genel yol hem de araç yolu kullanılamaz.”</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.tr.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.tr.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">Genel yolun veya araç yolunun sağlanması gerekir.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">Genel yolun veya araç yolunun sağlanması gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">Araca erişmek için dolgu konumu</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">Araca erişmek için dolgu konumu</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">Fikir olarak aynı anda hem genel yol hem de araç yolu kullanılamaz.”</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">Fikir olarak aynı anda hem genel yol hem de araç yolu kullanılamaz.”</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">需要提供全局或工具路径。</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">需要提供全局或工具路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">填充程序访问工具的位置</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">填充程序访问工具的位置</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">无法同时主张全局和工具路径。”</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">无法同时主张全局和工具路径。”</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">要卸载的工具的 NuGet 包 ID。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">卸载工具。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">请指定一个要卸载的工具包 ID。</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">卸载用户范围。</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">已成功卸载工具“{0}”（版本“{1}”）。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">工具“{0}”目前尚未安装。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">工具“{0}”已安装多个版本，无法卸载。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">无法卸载工具“{0}”: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">需要提供全局或工具路径。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">填充程序访问工具的位置</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">无法同时主张全局和工具路径。”</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hans.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -4,62 +4,62 @@
     <body>
       <trans-unit id="PackageIdArgumentDescription">
         <source>NuGet Package Id of the tool to uninstall.</source>
-        <target state="new">NuGet Package Id of the tool to uninstall.</target>
+        <target state="translated">要解除安裝之工具的 NuGet 套件識別碼。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls a tool.</source>
-        <target state="new">Uninstalls a tool.</target>
+        <target state="translated">將工具解除安裝。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
-        <target state="new">PACKAGE_ID</target>
+        <target state="translated">PACKAGE_ID</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">
         <source>Please specify one tool Package Id to uninstall.</source>
-        <target state="new">Please specify one tool Package Id to uninstall.</target>
+        <target state="translated">請指定一個要解除安裝的工具套件識別碼。</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalOptionDescription">
         <source>Uninstall user wide.</source>
-        <target state="new">Uninstall user wide.</target>
+        <target state="translated">為全部使用者解除安裝。</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallSucceeded">
         <source>Tool '{0}' (version '{1}') was successfully uninstalled.</source>
-        <target state="new">Tool '{0}' (version '{1}') was successfully uninstalled.</target>
+        <target state="translated">已成功解除安裝工具 '{0}' ('{1}' 版)。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
         <source>Tool '{0}' is not currently installed.</source>
-        <target state="new">Tool '{0}' is not currently installed.</target>
+        <target state="translated">目前未安裝工具 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">
         <source>Tool '{0}' has multiple versions installed and cannot be uninstalled.</source>
-        <target state="new">Tool '{0}' has multiple versions installed and cannot be uninstalled.</target>
+        <target state="translated">工具 '{0}' 有多個安裝的版本，且無法解除安裝。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallTool">
         <source>Failed to uninstall tool '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool '{0}': {1}</target>
+        <target state="translated">無法將工具 '{0}' 解除安裝: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
+        <source>Need either global or tool-path provided.</source>
+        <target state="translated">必須提供全域或工具路徑。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location where the tool was previously installed.</source>
-        <target state="new">Location where the tool was previously installed.</target>
+        <source>Location of shim to access tool</source>
+        <target state="translated">存取工具的填充碼位置</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
-        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <source>Cannot have global and tool-path as opinion at the same time."</source>
+        <target state="translated">無法同時將全域與工具路徑作為選項。」</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="translated">必須提供全域或工具路徑。</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="needs-review-translation">必須提供全域或工具路徑。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="translated">存取工具的填充碼位置</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="needs-review-translation">存取工具的填充碼位置</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="translated">無法同時將全域與工具路徑作為選項。」</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="needs-review-translation">無法同時將全域與工具路徑作為選項。」</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/tool/xlf/LocalizableStrings.zh-Hant.xlf
@@ -48,18 +48,18 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandNeedGlobalOrToolPath">
-        <source>Need either global or tool-path provided.</source>
-        <target state="new">Need either global or tool-path provided.</target>
+        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global) or the tool path option (--tool-path).</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPathDescription">
-        <source>Location of shim to access tool</source>
-        <target state="new">Location of shim to access tool</target>
+        <source>Location where the tool was previously installed.</source>
+        <target state="new">Location where the tool was previously installed.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallToolCommandInvalidGlobalAndToolPath">
-        <source>Cannot have global and tool-path as opinion at the same time."</source>
-        <target state="new">Cannot have global and tool-path as opinion at the same time."</target>
+        <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">Příkaz k odinstalaci rozhraní .NET</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">Identifikátor balíčku NuGet nástroje, který se má odinstalovat</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Odinstaluje položku z vývojového prostředí.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.de.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">Befehl zur Deinstallation von .NET</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">NuGet-Paketbezeichner des Tools, das deinstalliert werden soll.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Deinstalliert ein Element aus der Entwicklungsumgebung.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.es.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">Comando para la desinstalación de .NET</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">Identificador del paquete de NuGet de la herramienta que se desinstalará.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Desinstala un elemento en el entorno de desarrollo.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">Commande de désinstallation .NET</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">Identificateur de package NuGet de l'outil à désinstaller.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Désinstalle un élément dans l'environnement de développement.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.it.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">Comando di disinstallazione .NET</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">Identificatore del pacchetto NuGet dello strumento da disinstallare.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Disinstalla un elemento dall'ambiente di sviluppo.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">.NET アンインストール コマンド</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">アンインストールするツールの NuGet パッケージ ID。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">項目を開発環境からアンインストールします。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">.NET 제거 명령</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">제거할 도구의 NuGet 패키지 식별자입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">개발 환경에서 항목을 제거합니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">Polecenie dezinstalacji platformy .NET</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">Identyfikator pakietu NuGet narzędzia do odinstalowania.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Odinstalowuje element ze środowiska deweloperskiego.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">Comando de desinstalação do .NET</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">O identificador do pacote do NuGet da ferramenta a ser desinstalada.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Desinstala um item do ambiente de desenvolvimento.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">Команда удаления .NET</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">Идентификатор пакета NuGet удаляемого инструмента.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Удаляет элемент из среды разработки.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">.NET Kaldırma Komutu</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">Kaldırılacak aracın NuGet paketi tanımlayıcısı.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">Bir öğeyi geliştirme ortamından kaldırır.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">.NET 卸载命令</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">要卸载的工具的 NuGet 包标识符。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">从开发环境中卸载项目。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -4,17 +4,17 @@
     <body>
       <trans-unit id="UninstallFullCommandName">
         <source>.NET Uninstall Command</source>
-        <target state="new">.NET Uninstall Command</target>
+        <target state="translated">.NET 解除安裝命令</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallArgumentDescription">
         <source>The NuGet package identifier of the tool to uninstall.</source>
-        <target state="new">The NuGet package identifier of the tool to uninstall.</target>
+        <target state="translated">要解除安裝之工具的 NuGet 套件識別碼。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
         <source>Uninstalls an item from the development environment.</source>
-        <target state="new">Uninstalls an item from the development environment.</target>
+        <target state="translated">將開發環境的項目解除安裝。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">Nástroj {0} je už nainstalovaný.</target>
+        <target state="translated">Nástroj {0} (verze {1}) je už nainstalovaný.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">Příkaz {0} koliduje s existujícím příkazem jiného nástroje.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">Pro prázdnou cestu ke spustitelnému souboru nelze vytvořit překrytí prostředí.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">Pro prázdný příkaz nelze vytvořit překrytí prostředí.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">Nepodařilo se načíst konfiguraci nástroje: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Adresář nástrojů {0} není momentálně v proměnné prostředí PATH.
+Pokud používáte bash, přidáte ho do svého profilu spuštěním následujícího příkazu:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
-# Add .NET Core SDK tools
+# Přidání nástrojů sady .NET Core SDK
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Do aktuální relace ho přidáte spuštěním následujícího příkazu:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Adresář nástrojů {0} není momentálně v proměnné prostředí PATH.
+Pokud používáte bash, přidáte ho do svého profilu spuštěním následujícího příkazu:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
-# Add .NET Core SDK tools
+# Přidání nástrojů sady .NET Core SDK
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Do aktuální relace ho přidáte spuštěním následujícího příkazu:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">Adresář nástrojů {0} není momentálně v proměnné prostředí PATH.
 
-You can add the directory to the PATH by running the following command:
+Tento adresář přidáte do proměnné PATH spuštěním následujícího příkazu:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">Pro příkaz {0} se nepodařilo vytvořit překrytí nástroje: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">Pro příkaz {0} se nepodařilo odebrat překrytí nástroje: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">Pro překrytí prostředí se nepodařilo nastavit oprávnění uživatele ke spouštění: {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">Nepodařilo se nainstalovat balíček nástroje {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">Nepodařilo se odinstalovat balíček nástroje {0}: {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">Maximální šířka sloupce musí být větší než nula.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">Soubor vstupního bodu {0} pro příkaz {1} nebyl v balíčku nalezen.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">Soubor s nastavením DotnetToolSettings.xml nebyl v balíčku nalezen.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">Nepodařilo se najít připravený balíček nástroje {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">Příkaz {0} obsahuje úvodní tečku.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.cs.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">Příkaz {0} obsahuje úvodní tečku.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">Příkaz {0} obsahuje úvodní tečku.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -716,32 +716,32 @@
       </trans-unit>
       <trans-unit id="ToolSettingsUnsupportedRunner">
         <source>Command '{0}' uses unsupported runner '{1}'."</source>
-        <target state="translated">Der Befehl "{0}" verwendet die nicht unterstützte Ausführung"{1}".</target>
+        <target state="translated">Der Befehl "{0}" verwendet die nicht unterstützte Ausführung "{1}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">Das Tool "{0}" ist bereits installiert.</target>
+        <target state="translated">Das Tool "{0}" (Version "{1}") ist bereits installiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">Der Befehl "{0}" steht in Konflikt zu einem vorhandenen Befehl aus einem anderen Tool.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">Für einen leeren Pfad einer ausführbaren Datei kann kein Shell-Shim erstellt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">Für einen leeren Befehl kann kein Shell-Shim erstellt werden.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">Fehler beim Abrufen der Toolkonfiguration: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Das Toolverzeichnis "{0}" ist aktuell nicht in der PATH-Umgebungsvariable angegeben.
+Bei Verwendung von Bash können Sie hierzu den folgenden Befehl ausführen:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Um das Verzeichnis der aktuellen Sitzung hinzuzufügen, können Sie den folgenden Befehl ausführen:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Das Toolverzeichnis "{0}" ist aktuell nicht in der PATH-Umgebungsvariable angegeben.
+Bei Verwendung von Bash können Sie hierzu den folgenden Befehl ausführen:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Um das Verzeichnis der aktuellen Sitzung hinzuzufügen, können Sie den folgenden Befehl ausführen:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">Das Toolverzeichnis "{0}" ist aktuell nicht in der PATH-Umgebungsvariable angegeben.
 
-You can add the directory to the PATH by running the following command:
+Um das Verzeichnis zu PATH hinzuzufügen, können Sie den folgenden Befehl ausführen:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">Fehler beim Erstellen des Tool-Shims für den Befehl "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">Fehler beim Entfernen des Tool-Shims für den Befehl "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">Fehler beim Festlegen der Benutzerberechtigungen der ausführbaren Datei für den Shell-Shim: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">Fehler beim Installieren des Toolpakets "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">Fehler beim Deinstallieren des Toolpakets "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">Die maximale Spaltenbreite muss größer als 0 sein.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">Die Einstiegspunktdatei "{0}" für den Befehl "{1}" wurde nicht im Paket gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">Die Einstellungsdatei "DotnetToolSettings.xml" wurde nicht im Paket gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">Das bereitgestellte Toolpaket "{0}" wurde nicht gefunden.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">Der Befehl "{0}" weist einen vorangestellten Punkt auf.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.de.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">Der Befehl "{0}" weist einen vorangestellten Punkt auf.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">Der Befehl "{0}" weist einen vorangestellten Punkt auf.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">La herramienta “{0}” ya está instalada.</target>
+        <target state="translated">La herramienta "{0}" (versión "{1}") ya está instalada.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">El comando "{0}" está en conflicto con un comando existente de otra herramienta.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">No se pueden crear las correcciones de compatibilidad (shim) de shell para una ruta ejecutable vacía.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">No se pueden crear las correcciones de compatibilidad (shim) de shell para un comando vacío.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">Error al recuperar la configuración de la herramienta: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">El directorio de herramientas "{0}" no está actualmente en la variable de entorno PATH.
+Si usa bash, puede agregarlo a su perfil mediante la ejecución de comando siguiente:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Puede agregarlo a la sesión actual mediante la ejecución del comando siguiente:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">El directorio de herramientas "{0}" no está actualmente en la variable de entorno PATH.
+Si usa bash, puede agregarlo a su perfil mediante la ejecución de comando siguiente:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Puede agregarlo a la sesión actual mediante la ejecución del comando siguiente:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">El directorio de herramientas "{0}" no está actualmente en la variable de entorno PATH.
 
-You can add the directory to the PATH by running the following command:
+Puede agregar el directorio a PATH mediante la ejecución del comando siguiente:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">No se pudieron crear correcciones de compatibilidad (shim) de herramientas para el comando "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">No se pudieron quitar correcciones de compatibilidad (shim) de herramientas para el comando "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">No se pudieron establecer los permisos ejecutables del usuario para las correcciones de compatibilidad (shim) de shell: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">No se pudo instalar el paquete de herramientas "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">No se pudo desinstalar el paquete de herramientas "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">El ancho máximo de la columna debe ser superior a cero.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">El archivo de punto de entrada "{0}" para el comando "{1}" no se encontró en el paquete.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">El archivo de configuración "DotnetToolSettings.xml" no se encontró en el paquete.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">No se pudo encontrar el paquete de herramientas almacenado provisionalmente "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">El comando "{0}" tiene un punto al principio.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.es.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">El comando "{0}" tiene un punto al principio.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">El comando "{0}" tiene un punto al principio.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">L'outil '{0}' est déjà installé.</target>
+        <target state="translated">L'outil '{0}' (version '{1}') est déjà installé.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">La commande '{0}' est en conflit avec une commande existante d'un autre outil.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">Impossible de créer un shim d'environnement pour un chemin d'exécutable vide.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">Impossible de créer un shim d'environnement pour une commande vide.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">Échec de récupération de la configuration de l'outil : {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Le répertoire d'outils '{0}' ne se trouve pas actuellement sur la variable d'environnement PATH.
+Si vous utilisez Bash, vous pouvez l'ajouter à votre profil en exécutant la commande suivante :
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Vous pouvez l'ajouter à la session actuelle en exécutant la commande suivante :
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Le répertoire d'outils '{0}' ne se trouve pas actuellement sur la variable d'environnement PATH.
+Si vous utilisez Bash, vous pouvez l'ajouter à votre profil en exécutant la commande suivante :
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Vous pouvez l'ajouter à la session actuelle en exécutant la commande suivante :
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">Le répertoire d'outils '{0}' se ne trouve pas actuellement sur la variable d'environnement PATH.
 
-You can add the directory to the PATH by running the following command:
+Vous pouvez ajouter le répertoire à PATH en exécutant la commande suivante :
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">Échec de création d'un shim d'outil pour la commande '{0}' : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">Échec de suppression d'un shim d'outil pour la commande '{0}' : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">Échec de définition des autorisations utilisateur d'exécutable pour le shim d'environnement : {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">Échec d'installation du package d'outils '{0}' : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">Échec de désinstallation du package d'outils '{0}' : {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">La largeur maximale de colonne doit être supérieure à zéro.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">Le fichier de point d'entrée '{0}' pour la commande '{1}' est introuvable dans le package.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">Le fichier de paramètres 'DotnetToolSettings.xml' est introuvable dans le package.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">Package d'outils intermédiaire '{0}' introuvable.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">La commande '{0}' commence par un point.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.fr.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">La commande '{0}' commence par un point.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">La commande '{0}' commence par un point.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">Lo strumento '{0}' è già installato.</target>
+        <target state="translated">Lo strumento '{0}' (versione '{1}') è già installato.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">Il comando '{0}' è in conflitto con un comando esistente di un altro strumento.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">Non è possibile creare lo shim della shell per un percorso di eseguibile vuoto.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">Non è possibile creare lo shim della shell per un comando vuoto.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">Non è stato possibile recuperare la configurazione dello strumento: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">La directory '{0}' degli strumenti non si trova attualmente nella variabile di ambiente PATH.
+Se si usa using bash, è possibile aggiungerla al profilo eseguendo il comando seguente:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Per aggiungerla alla sessione corrente, eseguire il comando seguente:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">La directory '{0}' degli strumenti non si trova attualmente nella variabile di ambiente PATH.
+Se si usa using bash, è possibile aggiungerla al profilo eseguendo il comando seguente:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Per aggiungerla alla sessione corrente, eseguire il comando seguente:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">La directory '{0}' degli strumenti non si trova attualmente nella variabile di ambiente PATH.
 
-You can add the directory to the PATH by running the following command:
+Per aggiungere la directory a PATH, eseguire il comando seguente:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">Non è stato possibile creare lo shim dello strumento per il comando '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">Non è stato possibile rimuovere lo shim dello strumento per il comando '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">Non è stato possibile impostare le autorizzazioni dell'eseguibile per lo shim della shell: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">Non è stato possibile installare il pacchetto '{0}' dello strumento: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">Non è stato possibile disinstallare il pacchetto '{0}' dello strumento: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">La larghezza massima della colonna deve essere maggiore di zero.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">Il file '{0}' del punto di ingresso per il comando '{1}' non è stato trovato nel pacchetto.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">Il file di impostazioni 'DotnetToolSettings.xml' non è stato trovato nel pacchetto.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">Non è stato possibile trovare il pacchetto '{0}' dello strumento preparato per il commit.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">Il comando '{0}' presenta un punto iniziale.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.it.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">Il comando '{0}' presenta un punto iniziale.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">Il comando '{0}' presenta un punto iniziale.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">コマンド '{0}' の先頭にドットがあります。</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">コマンド '{0}' の先頭にドットがあります。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ja.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">ツール '{0}' は既にインストールされています。</target>
+        <target state="translated">ツール '{0}' (バージョン '{1}') は既にインストールされています。</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">コマンド '{0}' は、別のツールからの既存のコマンドと競合します。</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">空の実行可能パスにシェル shim を作成できませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">空のコマンドにシェル shim を作成できませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">ツールの構成を取得できませんでした: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Tools ディレクトリ '{0}' は現在、PATH 環境変数に含まれていません。
+Bash を使用している場合、次のコマンドを実行して、このディレクトリをプロファイルに追加できます:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+次のコマンドを実行すると、このディレクトリを現在のセッションに追加できます:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Tools ディレクトリ '{0}' は現在、PATH 環境変数に含まれていません。
+Bash を使用している場合、次のコマンドを実行して、このディレクトリをプロファイルに追加できます:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+次のコマンドを実行すると、このディレクトリを現在のセッションに追加できます:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">Tools ディレクトリ '{0}' は現在、PATH 環境変数に含まれていません。
 
-You can add the directory to the PATH by running the following command:
+次のコマンドを実行して、PATH にディレクトリを追加できます:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">コマンド '{0}' でツール shim を作成できませんでした: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">コマンド '{0}' でツール shim を削除できませんでした: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">シェル shim で実行可能なユーザー アクセス許可を設定できませんでした: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">ツール パッケージ '{0}' をインストールできませんでした: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">ツール パッケージ '{0}' をアンインストールできませんでした: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">列の最大幅はゼロより大きくなければなりません。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">コマンド '{1}' のエントリ ポイント ファイル '{0}' がパッケージで見つかりませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">設定ファイル 'DotnetToolSettings.xml' がパッケージで見つかりませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">ステージング済みのツール パッケージ '{0}' が見つかりませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">コマンド '{0}' の先頭にドットがあります。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">명령 '{0}' 앞에 점이 있습니다.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">명령 '{0}' 앞에 점이 있습니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ko.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">'{0}' 도구가 이미 설치되어 있습니다.</target>
+        <target state="translated">'{0}' 도구(버전 '{1}')가 이미 설치되어 있습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">'{0}' 명령이 다른 도구의 기존 명령과 충돌합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">빈 실행 파일 경로에 대해 셸 shim을 만들 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">빈 명령에 대해 셸 shim을 만들 수 없습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">도구 구성을 검색하지 못했습니다. {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">도구 디렉터리 '{0}'이(가) 현재 PATH 환경 변수에 있지 않습니다.
+Bash를 사용하는 경우 다음 명령을 실행하여 프로필에 추가할 수 있습니다.
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+다음 명령을 실행하여 현재 세션에 추가할 수 있습니다.
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">도구 디렉터리 '{0}'이(가) 현재 PATH 환경 변수에 있지 않습니다.
+Bash를 사용하는 경우 다음 명령을 실행하여 프로필에 추가할 수 있습니다.
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+다음 명령을 실행하여 현재 세션에 추가할 수 있습니다.
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">도구 디렉터리 '{0}'이(가) 현재 PATH 환경 변수에 없습니다.
 
-You can add the directory to the PATH by running the following command:
+다음 명령을 실행하여 디렉터리를 PATH에 추가할 수 있습니다. 
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">'{0}' 명령에 대해 도구 shim을 만들지 못했습니다. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">'{0}' 명령에 대해 도구 shim을 제거하지 못했습니다. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">셸 shim에 대해 사용자 실행 파일 권한을 설정하지 못했습니다. {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">도구 패키지 '{0}'을(를) 설치하지 못했습니다. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">도구 패키지 '{0}'을(를) 제거하지 못했습니다. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">열 최대 너비는 0보다 커야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">패키지에서 '{1}' 명령에 대한 진입점 파일 '{0}'을(를) 찾지 못했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">패키지에서 설정 파일 'DotnetToolSettings.xml'을 찾지 못했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">스테이징된 도구 패키지 '{0}'을(를) 찾지 못했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">명령 '{0}' 앞에 점이 있습니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">Narzędzie „{0}” jest już zainstalowane.</target>
+        <target state="translated">Narzędzie „{0}” (wersja: „{1}”) jest już zainstalowane.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">Wystąpił konflikt między poleceniem „{0}” i istniejącym poleceniem z innego narzędzia.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">Nie można utworzyć podkładki powłoki dla pustej ścieżki pliku wykonywalnego.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">Nie można utworzyć podkładki powłoki dla pustego polecenia.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">Nie można pobrać konfiguracji narzędzia: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Katalogu narzędzi „{0}” nie ma obecnie w zmiennej środowiskowej PATH.
+Jeśli używasz powłoki bash, możesz dodać go do profilu przez uruchomienie następującego polecenia:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Możesz dodać go do bieżącej sesji przez uruchomienie następującego polecenia:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Katalogu narzędzi „{0}” nie ma obecnie w zmiennej środowiskowej PATH.
+Jeśli używasz powłoki bash, możesz dodać go do profilu przez uruchomienie następującego polecenia:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Możesz dodać go do bieżącej sesji przez uruchomienie następującego polecenia:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">Katalogu narzędzi „{0}” nie ma obecnie w zmiennej środowiskowej PATH.
 
-You can add the directory to the PATH by running the following command:
+Możesz dodać katalog do zmiennej PATH przez uruchomienie następującego polecenia:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">Nie można utworzyć podkładki narzędzia dla polecenia „{0}”: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">Nie można usunąć podkładki narzędzia dla polecenia „{0}”: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">Nie można ustawić uprawnień pliku wykonywalnego użytkownika dla podkładki powłoki: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">Nie można zainstalować pakietu narzędzia „{0}”: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">Nie można odinstalować pakietu narzędzia „{0}”: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">Maksymalna szerokość kolumny musi być większa niż zero.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">Nie znaleziono pliku punktu wejścia „{0}” polecenia „{1}” w pakiecie.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">Nie znaleziono pliku ustawień „DotnetToolSettings.xml” w pakiecie.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">Nie można odnaleźć etapowego pakietu narzędzia „{0}”.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">Polecenie „{0}” zawiera kropkę na początku.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pl.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">Polecenie „{0}” zawiera kropkę na początku.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">Polecenie „{0}” zawiera kropkę na początku.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">A ferramenta '{0}' já está instalada.</target>
+        <target state="translated">A ferramenta '{0}' (versão '{1}') já está instalada.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">O comando '{0}' conflita com um comando existente de outra ferramenta.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">Não é possível criar o shim do shell para um caminho executável vazio.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">Não é possível criar o shim do shell para um comando vazio.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">Falha ao recuperar a configuração da ferramenta: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">O diretório de ferramentas '{0}' não está na variável de ambiente PATH no momento.
+Se você estiver usando o Bash, poderá adicioná-lo ao seu perfil executando o seguinte comando:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Você pode adicioná-lo à sessão atual executando o seguinte comando:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">O diretório de ferramentas '{0}' não está na variável de ambiente PATH no momento.
+Se você estiver usando o Bash, poderá adicioná-lo ao seu perfil executando o seguinte comando:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Você pode adicioná-lo à sessão atual executando o seguinte comando:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">O diretório de ferramentas '{0}' não está na variável de ambiente PATH no momento.
 
-You can add the directory to the PATH by running the following command:
+Você pode adicionar o diretório à variável PATH executando o seguinte comando:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">Falha ao criar o shim da ferramenta para o comando '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">Falha ao remover o shim da ferramenta para o comando '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">Falha ao definir as permissões do executável do usuário para o shim do shell: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">Falha ao instalar o pacote da ferramenta '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">Falha ao desinstalar o pacote da ferramenta '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">A largura máxima da coluna deve ser maior que zero.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">O arquivo de ponto de entrada '{0}' do comando '{1}' não foi encontrado no pacote.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">O arquivo de configurações 'DotnetToolSettings.xml' não foi encontrado no pacote.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">Falha ao encontrar o pacote de ferramentas preparado '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">O comando '{0}' tem um ponto à esquerda.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.pt-BR.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">O comando '{0}' tem um ponto à esquerda.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">O comando '{0}' tem um ponto à esquerda.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">В начале команды "{0}" стоит точка.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">В начале команды "{0}" стоит точка.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.ru.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">Инструмент "{0}" уже установлен.</target>
+        <target state="translated">Инструмент "{0}" (версия "{1}") уже установлен.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">Команда "{0}" конфликтует с существующей командой в другом инструменте.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">Невозможно создать оболочку совместимости для пустого пути к исполняемому файлу.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">Невозможно создать оболочку совместимости для пустой команды.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">Не удалось получить конфигурацию инструмента: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Каталог инструментов "{0}" сейчас отсутствует в переменной среды PATH.
+Если вы используете Bash, вы можете добавить его в профиль, выполнив следующую команду:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Вы можете добавить его в текущий сеанс, выполнив следующую команду:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">Каталог инструментов "{0}" сейчас отсутствует в переменной среды PATH.
+Если вы используете Bash, вы можете добавить его в профиль, выполнив следующую команду:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Вы можете добавить его в текущий сеанс, выполнив следующую команду:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">Каталог инструментов "{0}" сейчас отсутствует в переменной среды PATH.
 
-You can add the directory to the PATH by running the following command:
+Вы можете добавить каталог в PATH, выполнив следующую команду:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">Не удалось создать оболочку совместимости инструмента для команды "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">Не удалось удалить оболочку совместимости инструмента для команды "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">Не удалось задать разрешения исполняемого файла пользователя для оболочки совместимости: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">Не удалось установить пакет инструментов "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">Не удалось удалить пакет инструментов "{0}": {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">Максимальная ширина столбца должна быть больше нуля.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">Файл точки входа "{0}" для команды "{1}" не найден в пакете.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">Файл параметров "DotnetToolSettings.xml" не найден в пакете.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">Не удалось найти промежуточный пакет инструментов "{0}".</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">В начале команды "{0}" стоит точка.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">'{0}' aracı zaten yüklü.</target>
+        <target state="translated">'{0}' aracı (sürüm '{1}') zaten yüklü.</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">'{0}' komutu, başka bir araçtaki mevcut bir komutla çakışıyor.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">Boş bir yürütülebilir yol için kabuk dolgusu oluşturulamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">Boş bir komut için kabuk dolgusu oluşturulamaz.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">Araç yapılandırması alınamadı: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">'{0}' araç dizini şu anda PATH ortam değişkeni üzerinde değil.
+Bash kullanıyorsanız aşağıdaki komutu çalıştırarak bunu profilinize ekleyebilirsiniz:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
-# Add .NET Core SDK tools
+# .NET Core SDK araçlarını ekle
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Aşağıdaki komutu çalıştırarak geçerli oturuma ekleyebilirsiniz:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">'{0}' araç dizini şu anda PATH ortam değişkeni üzerinde değil.
+Bash kullanıyorsanız aşağıdaki komutu çalıştırarak bunu profilinize ekleyebilirsiniz:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
-# Add .NET Core SDK tools
+# .NET Core SDK araçlarını ekle
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+Aşağıdaki komutu çalıştırarak geçerli oturuma ekleyebilirsiniz:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">'{0}' araç dizini şu anda PATH ortam değişkeni üzerinde değil.
 
-You can add the directory to the PATH by running the following command:
+Aşağıdaki komutu çalıştırarak dizini PATH öğesine ekleyebilirsiniz:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">'{0}' komutu için araç dolgusu oluşturulamadı: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">'{0}' komutu için araç dolgusu kaldırılamadı: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">Kabuk dolgusu için kullanıcı yürütülebilir dosya izinleri ayarlanamadı: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">'{0}' araç paketi başlatılamadı: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">'{0}' araç paketi kaldırılamadı: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">Maksimum sütun genişliği sıfırdan büyük olmalıdır.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">'{1}' komutu için '{0}' giriş noktası dosyası pakette bulunamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">'DotnetToolSettings.xml' ayar dosyası pakette bulunamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">'{0}' adlı hazırlanmış araç paketi bulunamadı.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">'{0}' komutunun başında nokta var.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.tr.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">'{0}' komutunun başında nokta var.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">'{0}' komutunun başında nokta var.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">命令“{0}”有一个前导点。</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">命令“{0}”有一个前导点。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hans.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">已安装工具“{0}”。</target>
+        <target state="translated">已安装工具“{0}”（版本“{1}”）。</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">命令“{0}”与另一个工具中的现有命令相冲突。</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">无法为空的可执行文件路径创建 shell 填充程序。</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">无法为空的命令创建 shell 填充程序。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">无法检索工具配置: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">工具目录“{0}”目前不在 PATH 环境变量中。
+如果你使用的是 bash，可运行以下命令将其添加到配置文件中:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+可通过运行以下命令将其添加到当前会话中: 
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">工具目录“{0}”目前不在 PATH 环境变量中。
+如果你使用的是 bash，可运行以下命令将其添加到配置文件中:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+可通过运行以下命令将其添加到当前会话中: 
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">工具目录“{0}”目前不在 PATH 环境变量中。
 
-You can add the directory to the PATH by running the following command:
+可运行以下命令将目录添加到 PATH:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">未能为命令“{0}”创建工具填充程序: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">未能为命令“{0}”删除工具填充程序: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">未能为 shell 填充程序设置用户可执行文件权限: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">未能安装工具包“{0}”: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">未能卸载工具包“{0}”: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">列的最大宽度必须大于零。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">在包中找不到命令“{1}”的入口点文件“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">在包中找不到设置文件 "DotnetToolSettings.xml"。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">无法找到暂存工具包“{0}”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">命令“{0}”有一个前导点。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="new">Command '{0}' has a leading dot.</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -721,27 +721,27 @@
       </trans-unit>
       <trans-unit id="ToolPackageConflictPackageId">
         <source>Tool '{0}' (version '{1}') is already installed.</source>
-        <target state="needs-review-translation">工具 '{0}' 已安裝。</target>
+        <target state="translated">工具 '{0}' ('\{1\ 版}' 已經安裝。</target>
         <note />
       </trans-unit>
       <trans-unit id="ShellShimConflict">
         <source>Command '{0}' conflicts with an existing command from another tool.</source>
-        <target state="new">Command '{0}' conflicts with an existing command from another tool.</target>
+        <target state="translated">命令 '{0}' 與來自另一個工具的現有命令發生衝突。</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyExecutablePath">
         <source>Cannot create shell shim for an empty executable path.</source>
-        <target state="new">Cannot create shell shim for an empty executable path.</target>
+        <target state="translated">無法為空白的可執行檔路徑建立殼層填充碼。</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotCreateShimForEmptyCommand">
         <source>Cannot create shell shim for an empty command.</source>
-        <target state="new">Cannot create shell shim for an empty command.</target>
+        <target state="translated">無法為空白的命令建立殼層填充碼。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRetrieveToolConfiguration">
         <source>Failed to retrieve tool configuration: {0}</source>
-        <target state="new">Failed to retrieve tool configuration: {0}</target>
+        <target state="translated">無法擷取工具組態: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="EnvironmentPathLinuxManualInstructions">
@@ -757,15 +757,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">工具目錄 '{0}' 目前不在 PATH 環境變數上。
+若您正在使用 Bash，您可執行下列命令將其新增至您的設定檔:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+您可執行下列命令將其新增至目前的工作階段:
 
 export PATH="$PATH:{0}"
 </target>
@@ -784,15 +784,15 @@ You can add it to the current session by running the following command:
 
 export PATH="$PATH:{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
-If you are using bash, you can add it to your profile by running the following command:
+        <target state="translated">工具目錄 '{0}' 目前不在 PATH 環境變數上。
+若您正在使用 Bash，您可執行下列命令將其新增至您的設定檔:
 
 cat &lt;&lt; \EOF &gt;&gt; ~/.bash_profile
 # Add .NET Core SDK tools
 export PATH="$PATH:{0}"
 EOF
 
-You can add it to the current session by running the following command:
+您可執行下列命令將其新增至目前的工作階段:
 
 export PATH="$PATH:{0}"
 </target>
@@ -805,9 +805,9 @@ You can add the directory to the PATH by running the following command:
 
 setx PATH "%PATH%;{0}"
 </source>
-        <target state="new">Tools directory '{0}' is not currently on the PATH environment variable.
+        <target state="translated">工具目錄 '{0}' 目前不在 PATH 環境變數上。
 
-You can add the directory to the PATH by running the following command:
+您可執行下列命令將目錄新增至 PATH:
 
 setx PATH "%PATH%;{0}"
 </target>
@@ -815,52 +815,52 @@ setx PATH "%PATH%;{0}"
       </trans-unit>
       <trans-unit id="FailedToCreateShellShim">
         <source>Failed to create tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to create tool shim for command '{0}': {1}</target>
+        <target state="translated">無法為命令 '{0}' 建立工具填充碼: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToRemoveShellShim">
         <source>Failed to remove tool shim for command '{0}': {1}</source>
-        <target state="new">Failed to remove tool shim for command '{0}': {1}</target>
+        <target state="translated">無法為命令 '{0}' 移除工具填充碼: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedSettingShimPermissions">
         <source>Failed to set user executable permissions for shell shim: {0}</source>
-        <target state="new">Failed to set user executable permissions for shell shim: {0}</target>
+        <target state="translated">無法為殼層填充碼設定使用者可執行檔權限: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToInstallToolPackage">
         <source>Failed to install tool package '{0}': {1}</source>
-        <target state="new">Failed to install tool package '{0}': {1}</target>
+        <target state="translated">無法安裝工具套件 '{0}': {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToUninstallToolPackage">
         <source>Failed to uninstall tool package '{0}': {1}</source>
-        <target state="new">Failed to uninstall tool package '{0}': {1}</target>
+        <target state="translated">無法將工具套件 '{0}' 解除安裝: {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnMaxWidthMustBeGreaterThanZero">
         <source>Column maximum width must be greater than zero.</source>
-        <target state="new">Column maximum width must be greater than zero.</target>
+        <target state="translated">資料行寬度上限必須大於零。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolEntryPointFile">
         <source>Entry point file '{0}' for command '{1}' was not found in the package.</source>
-        <target state="new">Entry point file '{0}' for command '{1}' was not found in the package.</target>
+        <target state="translated">無法在套件中找到命令 '{1}' 的進入點檔案 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="MissingToolSettingsFile">
         <source>Settings file 'DotnetToolSettings.xml' was not found in the package.</source>
-        <target state="new">Settings file 'DotnetToolSettings.xml' was not found in the package.</target>
+        <target state="translated">無法在套件中找到設定檔 'DotnetToolSettings.xml'。</target>
         <note />
       </trans-unit>
       <trans-unit id="FailedToFindStagedToolPackage">
         <source>Failed to find staged tool package '{0}'.</source>
-        <target state="new">Failed to find staged tool package '{0}'.</target>
+        <target state="translated">無法找到分段工具套件 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
-        <target state="new">The command name '{0}' cannot begin with a leading dot (.).</target>
+        <source>Command '{0}' has a leading dot.</source>
+        <target state="translated">命令 '{0}' 的開頭有一個點 (.)。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/xlf/CommonLocalizableStrings.zh-Hant.xlf
@@ -859,8 +859,8 @@ setx PATH "%PATH%;{0}"
         <note />
       </trans-unit>
       <trans-unit id="ToolSettingsInvalidLeadingDotCommandName">
-        <source>Command '{0}' has a leading dot.</source>
-        <target state="translated">命令 '{0}' 的開頭有一個點 (.)。</target>
+        <source>The command name '{0}' cannot begin with a leading dot (.).</source>
+        <target state="needs-review-translation">命令 '{0}' 的開頭有一個點 (.)。</target>
         <note />
       </trans-unit>
     </body>

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/ArgumentEscaperTests.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/ArgumentEscaperTests.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    public class ArgumentEscaperTests
+    {
+        [Theory]
+        [InlineData(new[] { "one", "two", "three" }, "one two three")]
+        [InlineData(new[] { "line1\nline2", "word1\tword2" }, "\"line1\nline2\" \"word1\tword2\"")]
+        [InlineData(new[] { "with spaces" }, "\"with spaces\"")]
+        [InlineData(new[] { @"with\backslash" }, @"with\backslash")]
+        [InlineData(new[] { @"""quotedwith\backslash""" }, @"\""quotedwith\backslash\""")]
+        [InlineData(new[] { @"C:\Users\" }, @"C:\Users\")]
+        [InlineData(new[] { @"C:\Program Files\dotnet\" }, @"""C:\Program Files\dotnet\\""")]
+        [InlineData(new[] { @"backslash\""preceedingquote" }, @"backslash\\\""preceedingquote")]
+        [InlineData(new[] { @""" hello """ }, @"""\"" hello \""""")]
+        public void EscapesArgumentsForProcessStart(string[] args, string expected)
+        {
+            Assert.Equal(expected, ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args));
+        }
+    }
+}

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -685,7 +685,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             FilePath? tempProject = null,
             DirectoryPath? offlineFeed = null)
         {
-            var root = new DirectoryPath(Path.Combine(Path.GetFullPath(TempRoot.Root), Path.GetRandomFileName()));
+            var root = new DirectoryPath(Path.Combine(TempRoot.Root, Path.GetRandomFileName()));
             var reporter = new BufferedReporter();
 
             IFileSystem fileSystem;
@@ -713,6 +713,8 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                     tempProject: tempProject ?? GetUniqueTempProjectPathEachTest(),
                     offlineFeed: offlineFeed ?? new DirectoryPath("does not exist"));
             }
+
+            store.Root.Value.Should().Be(Path.GetFullPath(root.Value));
 
             return (store, installer, reporter, fileSystem);
         }

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageStoreMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageStoreMock.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             IFileSystem fileSystem,
             Action uninstallCallback = null)
         {
-            Root = root;
+            Root = new DirectoryPath(Path.GetFullPath(root.Value));
             _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
             _uninstallCallback = uninstallCallback;
         }

--- a/test/dotnet.Tests/CommandTests/ListToolCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ListToolCommandTests.cs
@@ -62,14 +62,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             command.Execute().Should().Be(0);
 
-            _reporter.Lines.Should().Equal(
-                string.Format(
-                    "{0}      {1}      {2}",
-                    LocalizableStrings.PackageIdColumn,
-                    LocalizableStrings.VersionColumn,
-                    LocalizableStrings.CommandsColumn
-                ),
-                "-------------------------------------");
+            _reporter.Lines.Should().Equal(EnumerateExpectedTableLines(store.Object));
         }
 
         [Fact]
@@ -92,15 +85,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             command.Execute().Should().Be(0);
 
-            _reporter.Lines.Should().Equal(
-                string.Format(
-                    "{0}      {1}            {2}",
-                    LocalizableStrings.PackageIdColumn,
-                    LocalizableStrings.VersionColumn,
-                    LocalizableStrings.CommandsColumn
-                ),
-                "-------------------------------------------",
-                "test.tool       1.3.5-preview      foo     ");
+            _reporter.Lines.Should().Equal(EnumerateExpectedTableLines(store.Object));
         }
 
         [Fact]
@@ -137,17 +122,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             command.Execute().Should().Be(0);
 
-            _reporter.Lines.Should().Equal(
-                string.Format(
-                    "{0}        {1}            {2} ",
-                    LocalizableStrings.PackageIdColumn,
-                    LocalizableStrings.VersionColumn,
-                    LocalizableStrings.CommandsColumn
-                ),
-                "----------------------------------------------",
-                "another.tool      2.7.3              bar      ",
-                "some.tool         1.0.0              fancy-foo",
-                "test.tool         1.3.5-preview      foo      ");
+            _reporter.Lines.Should().Equal(EnumerateExpectedTableLines(store.Object));
         }
 
         [Fact]
@@ -172,15 +147,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             command.Execute().Should().Be(0);
 
-            _reporter.Lines.Should().Equal(
-                string.Format(
-                    "{0}      {1}            {2}     ",
-                    LocalizableStrings.PackageIdColumn,
-                    LocalizableStrings.VersionColumn,
-                    LocalizableStrings.CommandsColumn
-                ),
-                "------------------------------------------------",
-                "test.tool       1.3.5-preview      foo, bar, baz");
+            _reporter.Lines.Should().Equal(EnumerateExpectedTableLines(store.Object));
         }
 
         [Fact]
@@ -212,20 +179,11 @@ namespace Microsoft.DotNet.Tests.Commands
             command.Execute().Should().Be(0);
 
             _reporter.Lines.Should().Equal(
-                string.Format(
-                    LocalizableStrings.InvalidPackageWarning,
-                    "another.tool",
-                    "broken"
-                ).Yellow(),
-                string.Format(
-                    "{0}      {1}            {2} ",
-                    LocalizableStrings.PackageIdColumn,
-                    LocalizableStrings.VersionColumn,
-                    LocalizableStrings.CommandsColumn
-                ),
-                "--------------------------------------------",
-                "some.tool       1.0.0              fancy-foo",
-                "test.tool       1.3.5-preview      foo      ");
+                EnumerateExpectedTableLines(store.Object).Prepend(
+                    string.Format(
+                        LocalizableStrings.InvalidPackageWarning,
+                        "another.tool",
+                        "broken").Yellow()));
         }
 
         private IToolPackage CreateMockToolPackage(string id, string version, IReadOnlyList<CommandSettings> commands)
@@ -256,6 +214,62 @@ namespace Microsoft.DotNet.Tests.Commands
                 result,
                 store,
                 _reporter);
+        }
+
+        private IEnumerable<string> EnumerateExpectedTableLines(IToolPackageStore store)
+        {
+            string GetCommandsString(IToolPackage package)
+            {
+                return string.Join(ListToolCommand.CommandDelimiter, package.Commands.Select(c => c.Name));
+            }
+
+            var packages = store.EnumeratePackages().Where(PackageHasCommands).OrderBy(package => package.Id);
+            var columnDelimiter = PrintableTable<IToolPackageStore>.ColumnDelimiter;
+
+            int packageIdColumnWidth = LocalizableStrings.PackageIdColumn.Length;
+            int versionColumnWidth = LocalizableStrings.VersionColumn.Length;
+            int commandsColumnWidth = LocalizableStrings.CommandsColumn.Length;
+            foreach (var package in packages)
+            {
+                packageIdColumnWidth = Math.Max(packageIdColumnWidth, package.Id.ToString().Length);
+                versionColumnWidth = Math.Max(versionColumnWidth, package.Version.ToNormalizedString().Length);
+                commandsColumnWidth = Math.Max(commandsColumnWidth, GetCommandsString(package).Length);
+            }
+
+            yield return string.Format(
+                "{0}{1}{2}{3}{4}",
+                LocalizableStrings.PackageIdColumn.PadRight(packageIdColumnWidth),
+                columnDelimiter,
+                LocalizableStrings.VersionColumn.PadRight(versionColumnWidth),
+                columnDelimiter,
+                LocalizableStrings.CommandsColumn.PadRight(commandsColumnWidth));
+
+            yield return new string(
+                '-',
+                packageIdColumnWidth + versionColumnWidth + commandsColumnWidth + (columnDelimiter.Length * 2));
+
+            foreach (var package in packages)
+            {
+                yield return string.Format(
+                    "{0}{1}{2}{3}{4}",
+                    package.Id.ToString().PadRight(packageIdColumnWidth),
+                    columnDelimiter,
+                    package.Version.ToNormalizedString().PadRight(versionColumnWidth),
+                    columnDelimiter,
+                    GetCommandsString(package).PadRight(commandsColumnWidth));
+            }
+        }
+
+        private static bool PackageHasCommands(IToolPackage package)
+        {
+            try
+            {
+                return package.Commands.Count >= 0;
+            }
+            catch (Exception ex) when (ex is ToolConfigurationException)
+            {
+                return false;
+            }
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/UninstallToolCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/UninstallToolCommandTests.cs
@@ -73,7 +73,8 @@ namespace Microsoft.DotNet.Tests.Commands
                     PackageId,
                     PackageVersion));
 
-            var packageDirectory = new DirectoryPath(ToolsDirectory).WithSubDirectories(PackageId, PackageVersion);
+            var packageDirectory = new DirectoryPath(Path.GetFullPath(ToolsDirectory))
+                .WithSubDirectories(PackageId, PackageVersion);
             var shimPath = Path.Combine(
                 ShimsDirectory,
                 ProjectRestorerMock.FakeCommandName +
@@ -114,7 +115,8 @@ namespace Microsoft.DotNet.Tests.Commands
                     PackageId,
                     PackageVersion));
 
-            var packageDirectory = new DirectoryPath(ToolsDirectory).WithSubDirectories(PackageId, PackageVersion);
+            var packageDirectory = new DirectoryPath(Path.GetFullPath(ToolsDirectory))
+                .WithSubDirectories(PackageId, PackageVersion);
             var shimPath = Path.Combine(
                 ShimsDirectory,
                 ProjectRestorerMock.FakeCommandName +

--- a/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
@@ -103,10 +103,10 @@ namespace Microsoft.DotNet.Tests.ParserTests
         public void InstallToolParserCanParseToolPathOption()
         {
             var result =
-                Parser.Instance.Parse(@"dotnet install tool --tool-path C:\TestAssetLocalNugetFeed console.test.app");
+                Parser.Instance.Parse(@"dotnet install tool --tool-path C:\Tools console.test.app");
 
             var appliedOptions = result["dotnet"]["install"]["tool"];
-            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\TestAssetLocalNugetFeed");
+            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\Tools");
         }
     }
 }

--- a/test/dotnet.Tests/ParserTests/ListToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/ListToolParserTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Xunit;
+using Xunit.Abstractions;
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    public class ListToolParserTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public ListToolParserTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void ListToolParserCanGetGlobalOption()
+        {
+            var result = Parser.Instance.Parse("dotnet list tool -g");
+
+            var appliedOptions = result["dotnet"]["list"]["tool"];
+            appliedOptions.ValueOrDefault<bool>("global").Should().Be(true);
+        }
+
+        [Fact]
+        public void ListToolParserCanParseToolPathOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet list tool --tool-path C:\Tools ");
+
+            var appliedOptions = result["dotnet"]["list"]["tool"];
+            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\Tools");
+        }
+    }
+}

--- a/test/dotnet.Tests/ParserTests/UninstallToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/UninstallToolParserTests.cs
@@ -11,17 +11,17 @@ using Parser = Microsoft.DotNet.Cli.Parser;
 
 namespace Microsoft.DotNet.Tests.ParserTests
 {
-    public class UninstallInstallToolParserTests
+    public class UninstallToolParserTests
     {
         private readonly ITestOutputHelper output;
 
-        public UninstallInstallToolParserTests(ITestOutputHelper output)
+        public UninstallToolParserTests(ITestOutputHelper output)
         {
             this.output = output;
         }
 
         [Fact]
-        public void UninstallGlobaltoolParserCanGetPackageId()
+        public void UninstallToolParserCanGetPackageId()
         {
             var command = Parser.Instance;
             var result = command.Parse("dotnet uninstall tool -g console.test.app");
@@ -46,10 +46,10 @@ namespace Microsoft.DotNet.Tests.ParserTests
         public void UninstallToolParserCanParseToolPathOption()
         {
             var result =
-                Parser.Instance.Parse(@"dotnet uninstall tool --tool-path C:\TestAssetLocalNugetFeed console.test.app");
+                Parser.Instance.Parse(@"dotnet uninstall tool --tool-path C:\Tools console.test.app");
 
             var appliedOptions = result["dotnet"]["uninstall"]["tool"];
-            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\TestAssetLocalNugetFeed");
+            appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\Tools");
         }
     }
 }


### PR DESCRIPTION
Because the version has already been bumped in master, this PR cherry-picks the commits that have gone into master recently into release/2.1.3xx.

Because the tool command refactoring will be a quite large and there has been a number of changes in master impacting those files, this is intended to prevent a down-the-road merge that will be fraught with conflicts.