### PR TITLE
Update launch settings for ApplicationUrl handling

### DIFF
--- a/TestAssets/TestProjects/AppWithApplicationUrlInLaunchSettings/AppWithApplicationUrlInLaunchSettings.csproj
+++ b/TestAssets/TestProjects/AppWithApplicationUrlInLaunchSettings/AppWithApplicationUrlInLaunchSettings.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+</Project>

--- a/TestAssets/TestProjects/AppWithApplicationUrlInLaunchSettings/AppWithApplicationUrlInLaunchSettings.csproj
+++ b/TestAssets/TestProjects/AppWithApplicationUrlInLaunchSettings/AppWithApplicationUrlInLaunchSettings.csproj
@@ -4,6 +4,5 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithApplicationUrlInLaunchSettings/Program.cs
+++ b/TestAssets/TestProjects/AppWithApplicationUrlInLaunchSettings/Program.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace MSBuildTestApp
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var message = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
+            Console.WriteLine(message);
+        }
+    }
+}

--- a/TestAssets/TestProjects/AppWithApplicationUrlInLaunchSettings/Properties/launchSettings.json
+++ b/TestAssets/TestProjects/AppWithApplicationUrlInLaunchSettings/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:49850/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "First": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://localhost:12345/"
+      },
+      "applicationUrl": "http://localhost:67890/"
+    },
+    "Second": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:54321/"
+    }
+  }
+}

--- a/src/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
+++ b/src/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
@@ -15,6 +15,11 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
         {
             var config = model.ToObject<ProjectLaunchSettingsModel>();
 
+            if (!string.IsNullOrEmpty(config.ApplicationUrl))
+            {
+                command.EnvironmentVariable("ASPNETCORE_URLS", config.ApplicationUrl);
+            }
+
             //For now, ignore everything but the environment variables section
 
             foreach (var entry in config.EnvironmentVariables)
@@ -22,11 +27,6 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                 string value = Environment.ExpandEnvironmentVariables(entry.Value);
                 //NOTE: MSBuild variables are not expanded like they are in VS
                 command.EnvironmentVariable(entry.Key, value);
-            }
-
-            if (!string.IsNullOrEmpty(config.ApplicationUrl))
-            {
-                command.EnvironmentVariable("ASPNETCORE_URLS", config.ApplicationUrl);
             }
 
             return new LaunchSettingsApplyResult(true, null, config.LaunchUrl);

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -365,6 +365,66 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
+        public void ItPrefersTheValueOfApplicationUrlFromEnvironmentVariablesOverTheProperty()
+        {
+            var testAppName = "AppWithApplicationUrlInLaunchSettings";
+            var testInstance = TestAssets.Get(testAppName)
+                            .CreateInstance()
+                            .WithSourceFiles();
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            new RestoreCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("/p:SkipInvalidConfigurations=true")
+                .Should().Pass();
+
+            new BuildCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute()
+                .Should().Pass();
+
+            var cmd = new RunCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("--launch-profile First");
+
+            cmd.Should().Pass()
+                .And.HaveStdOutContaining("http://localhost:12345/");
+                         
+            cmd.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItUsesTheValueOfApplicationUrlIfTheEnvironmentVariableIsNotSet()
+        {
+            var testAppName = "AppWithApplicationUrlInLaunchSettings";
+            var testInstance = TestAssets.Get(testAppName)
+                            .CreateInstance()
+                            .WithSourceFiles();
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            new RestoreCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute("/p:SkipInvalidConfigurations=true")
+                .Should().Pass();
+
+            new BuildCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .Execute()
+                .Should().Pass();
+
+            var cmd = new RunCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("--launch-profile Second");
+
+            cmd.Should().Pass()
+                .And.HaveStdOutContaining("http://localhost:54321/");
+                         
+            cmd.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
         public void ItGivesAnErrorWhenTheLaunchProfileNotFound()
         {
             var testAppName = "AppWithLaunchSettings";

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -365,7 +365,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
-        public void ItPrefersTheValueOfApplicationUrlFromEnvironmentVariablesOverTheProperty()
+        public void ItPrefersTheValueOfAppUrlFromEnvVarOverTheProp()
         {
             var testAppName = "AppWithApplicationUrlInLaunchSettings";
             var testInstance = TestAssets.Get(testAppName)
@@ -395,7 +395,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
-        public void ItUsesTheValueOfApplicationUrlIfTheEnvironmentVariableIsNotSet()
+        public void ItUsesTheValueOfAppUrlIfTheEnvVarIsNotSet()
         {
             var testAppName = "AppWithApplicationUrlInLaunchSettings";
             var testInstance = TestAssets.Get(testAppName)


### PR DESCRIPTION
Per @danroth27, if the user sets the environment variable in a launch profile for ASPNETCORE_URLS, it should override the value of ApplicationUrl. Added tests to check that behavior & verify that ApplicationUrl is being applied in general.