### PR TITLE
Enabling ubuntu.18.04,opensuse.42.3 and fedora.27 in dotnet-install script

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -79,6 +79,10 @@ get_legacy_os_name_from_platform() {
             echo "fedora.23"
             return 0
             ;;
+        "fedora.27")
+            echo "fedora.27"
+            return 0
+            ;;
         "fedora.24")
             echo "fedora.24"
             return 0
@@ -89,6 +93,10 @@ get_legacy_os_name_from_platform() {
             ;;
         "opensuse.42.1")
             echo "opensuse.42.1"
+            return 0
+            ;;
+        "opensuse.42.3")
+            echo "opensuse.42.3"
             return 0
             ;;
         "rhel.7"*)
@@ -105,6 +113,10 @@ get_legacy_os_name_from_platform() {
             ;;
         "ubuntu.16.10")
             echo "ubuntu.16.10"
+            return 0
+            ;;
+        "ubuntu.18.04")
+            echo "ubuntu.18.04"
             return 0
             ;;
         "alpine.3.4.3")


### PR DESCRIPTION
This is required to unblock building core-setup in release/1.x.x branches. https://github.com/dotnet/core-setup/blob/release/1.1.0/build_projects/dotnet-host-build/build.sh#L97 . Once this PR is merged, core-setup will point to dotnet-install script from release/2.1.3xx branch 