### PR TITLE
added in use info to the --version option

### DIFF
--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -232,7 +232,7 @@
     <value>The path to an application .dll file to execute.</value>
   </data>
   <data name="SDKVersionCommandDefinition" xml:space="preserve">
-    <value>Display .NET Core SDK version.</value>
+    <value>Display .NET Core SDK version in use.</value>
   </data>
   <data name="SDKInfoCommandDefinition" xml:space="preserve">
     <value>Display .NET Core information.</value>

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -49,7 +49,7 @@ Common options:
 Run 'dotnet COMMAND --help' for more information on a command.
 
 sdk-options:
-  --version        Display .NET Core SDK version.
+  --version        Display .NET Core SDK version in use.
   --info           Display .NET Core information.
   --list-sdks      Display the installed SDKs.
   --list-runtimes  Display the installed runtimes.


### PR DESCRIPTION
To make it more clear that --version displays the version in use. Might need to say on the current path too. Thoughts?

/cc @KathleenDollard @Rick-Anderson 