### PR TITLE
Prevent default item glgobing when evaluating run properties.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -18,6 +18,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public static readonly string MSBUILD_EXE_PATH = "MSBUILD_EXE_PATH";
         public static readonly string MSBuildExtensionsPath = "MSBuildExtensionsPath";
+        public static readonly string EnableDefaultItems = "EnableDefaultItems";
 
         public static readonly string ProjectArgumentName = "<PROJECT>";
         public static readonly string SolutionArgumentName = "<SLN_FILE>";

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Exceptions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools;
@@ -184,6 +184,9 @@ namespace Microsoft.DotNet.Tools.Run
         {
             var globalProperties = new Dictionary<string, string>
             {
+                // This property disables default item globbing to improve performance
+                // This should be safe because we are not evaluating items, only properties
+                { Constants.EnableDefaultItems,    "false" },
                 { Constants.MSBuildExtensionsPath, AppContext.BaseDirectory }
             };
 
@@ -197,7 +200,7 @@ namespace Microsoft.DotNet.Tools.Run
                 globalProperties.Add("TargetFramework", Framework);
             }
 
-            Project project = new Project(Project, globalProperties, null);
+            var project = new ProjectInstance(Project, globalProperties, null);
 
             string runProgram = project.GetPropertyValue("RunCommand");
             if (string.IsNullOrEmpty(runProgram))
@@ -220,7 +223,7 @@ namespace Microsoft.DotNet.Tools.Run
                 .WorkingDirectory(runWorkingDirectory);
         }
 
-        private void ThrowUnableToRunError(Project project)
+        private void ThrowUnableToRunError(ProjectInstance project)
         {
             string targetFrameworks = project.GetPropertyValue("TargetFrameworks");
             if (!string.IsNullOrEmpty(targetFrameworks))


### PR DESCRIPTION
When `dotnet run` is executed, a project evaluation occurs to obtain properties
related to running the target executable.  Currently, this evaluation causes
the default item globs to be evaluated.  For project directories containing a
large number of files, this can be a bit performance hit since the globbing
happens twice: once for the build and again for evaluating the run properties.

This commit prevents the globbing from taking place when evaluating the run
properties.

Fixes #8103.