### PR TITLE
Template updates for April 2018

### DIFF
--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -23,7 +23,7 @@
     <CLI_WEBSDK_Version>1.0.0-alpha-20170516-2-509</CLI_WEBSDK_Version>
     <CLI_TestPlatform_Version>15.0.0</CLI_TestPlatform_Version>
     <TemplateEngineVersion>1.0.0-beta2-20170629-269</TemplateEngineVersion>
-    <AspnetTemplateVersion>1.1.5-rtm-10863</AspnetTemplateVersion>
+    <AspnetTemplateVersion>1.1.5-rtm-11006</AspnetTemplateVersion>
     <TemplateEngineTemplateVersion>1.0.0-beta2-20170907-306</TemplateEngineTemplateVersion>
     <PlatformAbstractionsVersion>1.0.3</PlatformAbstractionsVersion>
     <DependencyModelVersion>1.0.3</DependencyModelVersion>

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -355,7 +355,7 @@ A command is running to initially populate your local package cache, to improve 
 
             _nugetCacheFolder
                 .GetDirectory("microsoft.aspnetcore.mvc")
-                .Should().HaveDirectories(new string[] { "1.0.6", "1.1.7" });
+                .Should().HaveDirectories(new string[] { "1.0.7", "1.1.7" });
         }
 
         private string GetDotnetVersion()


### PR DESCRIPTION
These are the latest templates built for 1.1.6.

Note this is not going to pass until we push our template package to the aspnetcore-master feed. @pranavkm I still don't have push access to that feed. I'm requesting it for future updates from @Eilon but can you push it in the mean time?