### PR TITLE
Add latest patch versions to BundledVersions.props, and tests to make sure that they are up to date

### DIFF
--- a/Microsoft.DotNet.Cli.sln
+++ b/Microsoft.DotNet.Cli.sln
@@ -33,7 +33,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{89905EC4
 		build\BundledTemplates.proj = build\BundledTemplates.proj
 		build\BundledTemplates.props = build\BundledTemplates.props
 		build\BundledTools.props = build\BundledTools.props
-		build\BundledVersions.targets = build\BundledVersions.targets
 		build\Compile.targets = build\Compile.targets
 		build\CrossGen.props = build\CrossGen.props
 		build\DependencyVersions.props = build\DependencyVersions.props

--- a/TestAssets/TestProjects/TestAppSimple/TestAppSimple.csproj
+++ b/TestAssets/TestProjects/TestAppSimple/TestAppSimple.csproj
@@ -4,7 +4,5 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <!-- Issue: https://github.com/dotnet/sdk/issues/1150 -->
-    <DisableImplicitAssetTargetFallback>true</DisableImplicitAssetTargetFallback>
   </PropertyGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -14,7 +14,7 @@
     <MicrosoftNETCoreCompilersPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNETCoreCompilersPackageVersion>
     <MicrosoftCodeAnalysisBuildTasksPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisBuildTasksPackageVersion>
     <MicrosoftNetCompilersNetcorePackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNetCompilersNetcorePackageVersion>
-    <MicrosoftNETSdkPackageVersion>2.1.300-preview2-62716-01</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>2.1.300-preview2-62730-11</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</MicrosoftNETSdkRazorPackageVersion>
     <MicrosoftNETSdkWebPackageVersion>2.1.300-preview2-20180306-1448279</MicrosoftNETSdkWebPackageVersion>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -143,6 +143,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledNETCorePlatformsPackageVersion>$(_NETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
     <NETCoreSdkVersion>$(SdkVersion)</NETCoreSdkVersion>
     <_NETCoreSdkIsPreview>$(_NETCoreSdkIsPreview)</_NETCoreSdkIsPreview>
+    
+    <!-- Latest patch versions for each minor version of .NET Core -->
+    <LatestPatchVersionForNetCore1_0 Condition="'$(LatestPatchVersionForNetCore1_0)' == ''">1.0.10</LatestPatchVersionForNetCore1_0>
+    <LatestPatchVersionForNetCore1_1 Condition="'$(LatestPatchVersionForNetCore1_1)' == ''">1.1.7</LatestPatchVersionForNetCore1_1>
+    <LatestPatchVersionForNetCore2_0 Condition="'$(LatestPatchVersionForNetCore2_0)' == ''">2.0.6</LatestPatchVersionForNetCore2_0>
   </PropertyGroup>
 </Project>
 ]]>

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -399,6 +399,9 @@ namespace Microsoft.DotNet.Cli.Utils
                 Path.Combine(AppContext.BaseDirectory, "MSBuild.dll") :
                 msBuildExePath;
 
+            Reporter.Verbose.WriteLine(string.Format(LocalizableStrings.MSBuildArgs,
+                ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args)));
+
             var result = new MSBuildForwardingAppWithoutLogging(args, msBuildExePath)
                 .GetProcessStartInfo()
                 .ExecuteAndCaptureOutput(out string stdOut, out string stdErr);

--- a/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
@@ -206,7 +206,7 @@
     <value>Generating deps.json at: {0}</value>
   </data>
   <data name="UnableToGenerateDepsJson" xml:space="preserve">
-    <value>unable to generate deps.json, it may have been already generated: {0}</value>
+    <value>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</value>
   </data>
   <data name="DepsJsonGeneratorProjectNotSet" xml:space="preserve">
     <value>Unable to find deps.json generator project.</value>

--- a/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
@@ -262,4 +262,7 @@
   <data name="UnableToInvokeMemberNameAfterCommand" xml:space="preserve">
     <value>Unable to invoke {0} after the command has been run</value>
   </data>
+  <data name="MSBuildArgs" xml:space="preserve">
+    <value>MSBuild arguments: {0}</value>
+  </data>
 </root>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">Soubor deps.json se nepodařilo vygenerovat, protože už je pravděpodobně vygenerovaný: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">Soubor deps.json se nepodařilo vygenerovat, protože už je pravděpodobně vygenerovaný: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
@@ -244,6 +244,11 @@
         <target state="translated">Běhové prostředí:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">"deps.json" kann nicht erzeugt werden; sie wurde vielleicht bereits erzeugt: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">"deps.json" kann nicht erzeugt werden; sie wurde vielleicht bereits erzeugt: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
@@ -244,6 +244,11 @@
         <target state="translated">Laufzeitumgebung:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
@@ -244,6 +244,11 @@
         <target state="translated">Entorno de tiempo de ejecución:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">no se puede generar deps.json; es posible que ya se haya generado: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">no se puede generar deps.json; es posible que ya se haya generado: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">impossible de générer deps.json, il a peut-être été déjà généré : {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">impossible de générer deps.json, il a peut-être été déjà généré : {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
@@ -244,6 +244,11 @@
         <target state="translated">Environnement d'exécution :</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">non è possibile generare deps.json. Potrebbe essere già stato generato: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">non è possibile generare deps.json. Potrebbe essere già stato generato: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
@@ -244,6 +244,11 @@
         <target state="translated">Ambiente di runtime:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
@@ -244,6 +244,11 @@
         <target state="translated">ランタイム環境:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">deps.json を生成できません。既に生成されている可能性があります: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">deps.json を生成できません。既に生成されている可能性があります: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">deps.json을 생성할 수 없습니다. 이미 생성되었을 수 있습니다. {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">deps.json을 생성할 수 없습니다. 이미 생성되었을 수 있습니다. {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
@@ -244,6 +244,11 @@
         <target state="translated">런타임 환경:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
@@ -244,6 +244,11 @@
         <target state="translated">Środowisko uruchomieniowe:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">nie można wygenerować pliku deps.json, być może został już wygenerowany: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">nie można wygenerować pliku deps.json, być może został już wygenerowany: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">não é possível gerar deps.json; ele pode já ter sido gerado: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">não é possível gerar deps.json; ele pode já ter sido gerado: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
@@ -244,6 +244,11 @@
         <target state="translated">Ambiente de tempo de execução:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">не удается создать deps.json, возможно, он уже создан: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">не удается создать deps.json, возможно, он уже создан: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
@@ -244,6 +244,11 @@
         <target state="translated">Среда выполнения:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
@@ -244,6 +244,11 @@
         <target state="translated">Çalışma Zamanı Ortamı:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">deps.json oluşturulamadı, zaten oluşturulmuş olabilir: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">deps.json oluşturulamadı, zaten oluşturulmuş olabilir: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
@@ -244,6 +244,11 @@
         <target state="translated">运行时环境:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">无法生成 deps.json，该文件可能已生成: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">无法生成 deps.json，该文件可能已生成: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
@@ -140,8 +140,8 @@
         <note />
       </trans-unit>
       <trans-unit id="UnableToGenerateDepsJson">
-        <source>unable to generate deps.json, it may have been already generated: {0}</source>
-        <target state="translated">無法產生 deps.json，可能已產生過: {0}</target>
+        <source>Unable to generate deps.json, it may have been already generated.  You can specify the "-d" option before the tool name for diagnostic output (for example, "dotnet -d &lt;toolname&gt;": {0}</source>
+        <target state="needs-review-translation">無法產生 deps.json，可能已產生過: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="UnableToDeleteTemporaryDepsJson">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
@@ -244,6 +244,11 @@
         <target state="translated">執行階段環境:</target>
         <note />
       </trans-unit>
+      <trans-unit id="MSBuildArgs">
+        <source>MSBuild arguments: {0}</source>
+        <target state="new">MSBuild arguments: {0}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
+++ b/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using Xunit;
+
+namespace EndToEnd
+{
+    public class GivenSelfContainedAppsRollForward : TestBase
+    {
+
+        [Theory]
+        //  MemberData is used instead of InlineData here so we can access it in another test to
+        //  verify that we are covering the latest release of .NET Core
+        [MemberData(nameof(SupportedNetCoreAppVersions))]
+        public void ItRollsForwardToTheLatestVersion(string minorVersion)
+        {
+            var _testInstance = TestAssets.Get("TestAppSimple")
+                .CreateInstance(identifier: minorVersion)
+                .WithSourceFiles();
+
+            string projectDirectory = _testInstance.Root.FullName;
+
+            string projectPath = Path.Combine(projectDirectory, "TestAppSimple.csproj");
+
+            var project = XDocument.Load(projectPath);
+            var ns = project.Root.Name.Namespace;
+
+            //  Update TargetFramework to the right version of .NET Core
+            project.Root.Element(ns + "PropertyGroup")
+                .Element(ns + "TargetFramework")
+                .Value = "netcoreapp" + minorVersion;
+
+            var rid = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
+
+            //  Set RuntimeIdentifier to opt in to roll-forward behavior
+            project.Root.Element(ns + "PropertyGroup")
+                .Add(new XElement(ns + "RuntimeIdentifier", rid));
+
+            project.Save(projectPath);
+
+            //  Get the version rolled forward to
+            new RestoreCommand()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute()
+                    .Should().Pass();
+
+            string assetsFilePath = Path.Combine(projectDirectory, "obj", "project.assets.json");
+            var assetsFile = new LockFileFormat().Read(assetsFilePath);
+
+            var rolledForwardVersion = GetNetCoreAppVersion(assetsFile);
+            rolledForwardVersion.Should().NotBeNull();
+
+            if (rolledForwardVersion.IsPrerelease)
+            {
+                //  If this version of .NET Core is still prerelease, then:
+                //  - Floating the patch by adding ".*" to the major.minor version won't work, but
+                //  - There aren't any patches to roll-forward to, so we skip testing this until the version
+                //    leaves prerelease.
+                return;
+            }
+
+            //  Float the RuntimeFrameworkVersion to get the latest version of the runtime available from feeds
+            Directory.Delete(Path.Combine(projectDirectory, "obj"), true);
+            project.Root.Element(ns + "PropertyGroup")
+                .Add(new XElement(ns + "RuntimeFrameworkVersion", $"{minorVersion}.*"));
+            project.Save(projectPath);
+
+            new RestoreCommand()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute()
+                    .Should().Pass();
+
+            var floatedAssetsFile = new LockFileFormat().Read(assetsFilePath);
+
+            var floatedVersion = GetNetCoreAppVersion(floatedAssetsFile);
+            floatedVersion.Should().NotBeNull();
+
+            rolledForwardVersion.ToNormalizedString().Should().BeEquivalentTo(floatedVersion.ToNormalizedString(),
+                "the latest patch version properties in Microsoft.NETCoreSdk.BundledVersions.props need to be updated " + 
+                "(see MSBuildExtensions.targets in this repo)");
+        }
+
+        private NuGetVersion GetNetCoreAppVersion(LockFile lockFile)
+        {
+            return lockFile?.Targets?.SingleOrDefault(t => t.RuntimeIdentifier != null)
+                ?.Libraries?.SingleOrDefault(l =>
+                    string.Compare(l.Name, "Microsoft.NETCore.App", StringComparison.CurrentCultureIgnoreCase) == 0)
+                ?.Version;
+        }
+
+        [Fact]
+        public void WeCoverLatestNetCoreAppRollForward()
+        {
+            //  Run "dotnet new console", get TargetFramework property, and make sure it's covered in SupportedNetCoreAppVersions
+            using (DisposableDirectory directory = Temp.CreateDirectory())
+            {
+                string projectDirectory = directory.Path;
+
+                new NewCommandShim()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute("console --no-restore")
+                    .Should().Pass();
+
+                string projectPath = Path.Combine(projectDirectory, Path.GetFileName(projectDirectory) + ".csproj");
+
+                var project = XDocument.Load(projectPath);
+                var ns = project.Root.Name.Namespace;
+
+                string targetFramework = project.Root.Element(ns + "PropertyGroup")
+                    .Element(ns + "TargetFramework")
+                    .Value;
+
+                SupportedNetCoreAppVersions.Select(v => $"netcoreapp{v[0]}")
+                    .Should().Contain(targetFramework, $"the {nameof(SupportedNetCoreAppVersions)} property should include the default version " +
+                    "of .NET Core created by \"dotnet new\"");
+                
+            }
+        }
+
+        public static IEnumerable<object[]> SupportedNetCoreAppVersions
+        {
+            get
+            {
+                return new[]
+                {
+                    "1.0",
+                    "1.1",
+                    "2.0",
+                    "2.1"
+                }.Select(version => new object[] { version });
+            }
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
@@ -117,7 +117,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             _testPackages = Environment.GetEnvironmentVariable("TEST_PACKAGES");
             if (string.IsNullOrEmpty(_testPackages))
             {
-                throw new InvalidOperationException("TEST_PACKAGES environment variable not set");
+                _testPackages = Path.Combine(_artifacts, "test", "packages");
             }
 
             _testWorkingFolder = Path.Combine(RepoRoot,


### PR DESCRIPTION
- Add properties to BundledVersions.props for the latest patch version of each minor release of .NET Core.  This will be consumed by dotnet/sdk#2085, which automatically rolls forward self-contained apps to the latest patch version
- Add tests to make sure that the latest patch version properties are up-to-date.  These tests will fail until dotnet/sdk#2085 is merged and inserted into the CLI

I think that these tests will mean that the only thing we will need to do to keep the latest patch numbers up-to-date is to update them when test failures tell us to do so.  The `ItRollsForwardToTheLatestVersion` test compares the resolved version of `Microsoft.NETCore.App` for a self-contained app with the version that is resolved when the `RuntimeFrameworkVersion` floats the patch version (eg `2.0.*`).  If they don't match, then it will fail with a message like the following:

> Expected string to be equivalent to "2.0.6" because the latest patch version properties in Microsoft.NETCoreSdk.BundledVersions.props need to be updated (see MSBuildExtensions.targets in this repo), but "2.0.0" differs near "0" (index 4).

We also need to make sure that the tests cover each minor release of .NET Core.  That's covered by the `WeCoverLatestNetCoreAppRollForward` test, which creates a project via `dotnet new console` and makes sure that the `TargetFramework` from that project has a corresponding entry in the `MemberData` used by the previous test.  So when we update the templates to target a new version of .NET Core, we'll be reminded to update these tests via the following failure message:

> Expected collection {"netcoreapp1.0", "netcoreapp1.1", "netcoreapp2.0"} to contain "netcoreapp2.1" because the SupportedNetCoreAppVersions property should include the default version of .NET Core created by "dotnet new".