### PR TITLE
Remove empty PATH in path resolver

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
@@ -47,6 +47,7 @@ namespace Microsoft.DotNet.Cli.Utils
                         .GetEnvironmentVariable("PATH")
                         .Split(s_pathSeparator)
                         .Select(p => p.Trim(s_quote))
+                        .Where(p => !string.IsNullOrWhiteSpace(p))
                         .Select(p => ExpandTildeSlash(p)));
 
                     _searchPaths = searchPaths;

--- a/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
+++ b/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.ShellShim
 
             Environment.SetEnvironmentVariable(
                 PathName,
-                $"{existingUserEnvPath};{_packageExecutablePath};",
+                $"{existingUserEnvPath};{_packageExecutablePath}",
                 EnvironmentVariableTarget.User);
         }
 

--- a/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
+++ b/src/dotnet/ShellShim/WindowsEnvironmentPath.cs
@@ -33,9 +33,14 @@ namespace Microsoft.DotNet.ShellShim
 
             var existingUserEnvPath = Environment.GetEnvironmentVariable(PathName, EnvironmentVariableTarget.User);
 
+            if (existingUserEnvPath.EndsWith(';'))
+            {
+                existingUserEnvPath = existingUserEnvPath.Substring(0, (existingUserEnvPath.Length - 1));
+            }
+
             Environment.SetEnvironmentVariable(
                 PathName,
-                $"{existingUserEnvPath};{_packageExecutablePath}",
+                $"{existingUserEnvPath};{_packageExecutablePath};",
                 EnvironmentVariableTarget.User);
         }
 


### PR DESCRIPTION
Path adding logic on Windows is wrong. Windows require `;` in the end of the path.

Also filter out empty PATH. So it won't resolve to current directory

https://stackoverflow.com/questions/11391390/placing-the-semicolon-in-the-windows-path-environment-variable