### PR TITLE
Updating the runtime versions and branding of the CLI

### DIFF
--- a/branchinfo.txt
+++ b/branchinfo.txt
@@ -3,7 +3,7 @@
 # Each line is expected to be in the format "[Name]=[Value]".
 MAJOR_VERSION=1
 MINOR_VERSION=1
-PATCH_VERSION=8
+PATCH_VERSION=9
 RELEASE_SUFFIX=servicing
 CHANNEL=rel-1.1.0
 BRANCH_NAME=rel/1.1.0

--- a/build/Microsoft.DotNet.Cli.DependencyVersions.props
+++ b/build/Microsoft.DotNet.Cli.DependencyVersions.props
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CLI_SharedFrameworkVersion>1.1.7</CLI_SharedFrameworkVersion>
-    <CLI_CoreCLRVersion>1.1.7</CLI_CoreCLRVersion>
-    <CLI_JitVersion>1.1.7</CLI_JitVersion>
+    <CLI_SharedFrameworkVersion>1.1.8</CLI_SharedFrameworkVersion>
+    <CLI_CoreCLRVersion>1.1.8</CLI_CoreCLRVersion>
+    <CLI_JitVersion>1.1.8</CLI_JitVersion>
     <CLI_SharedHostVersion>1.1.0</CLI_SharedHostVersion>
     <CLI_HostFxrContainerVersion>1.1.0</CLI_HostFxrContainerVersion>
     <CLI_HostFxrVersion Condition="'$(OS)' != 'Windows_NT'">1.1.0</CLI_HostFxrVersion>
     <CLI_HostFxrVersion Condition="'$(OS)' == 'Windows_NT'">1.1.2</CLI_HostFxrVersion>
 
-    <CLI_SharedFrameworkVersion_1_0>1.0.10</CLI_SharedFrameworkVersion_1_0>
+    <CLI_SharedFrameworkVersion_1_0>1.0.11</CLI_SharedFrameworkVersion_1_0>
     <CLI_SharedHostVersion_1_0>1.0.1</CLI_SharedHostVersion_1_0>
     <CLI_HostFxrContainerVersion_1_0>1.0.1</CLI_HostFxrContainerVersion_1_0>
     <CLI_HostFxrVersion_1_0 Condition="'$(OS)' != 'Windows_NT'">1.0.1</CLI_HostFxrVersion_1_0>

--- a/build/Microsoft.DotNet.Cli.Monikers.props
+++ b/build/Microsoft.DotNet.Cli.Monikers.props
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <SdkBrandName>.NET Core SDK 1.1.8</SdkBrandName>
-    <SharedFrameworkBrandName>Microsoft .NET Core 1.1.7 - Runtime</SharedFrameworkBrandName>
+    <SdkBrandName>.NET Core SDK 1.1.9</SdkBrandName>
+    <SharedFrameworkBrandName>Microsoft .NET Core 1.1.8 - Runtime</SharedFrameworkBrandName>
     <SharedHostBrandName>Microsoft .NET Core 1.1.0 - Host</SharedHostBrandName>
     <HostFxrBrandName>Microsoft .NET Core 1.1.0 - Host FX Resolver</HostFxrBrandName>
     
-    <AdditionalSharedFrameworkBrandName>Microsoft .NET Core 1.0.10 - Runtime</AdditionalSharedFrameworkBrandName>
+    <AdditionalSharedFrameworkBrandName>Microsoft .NET Core 1.0.11 - Runtime</AdditionalSharedFrameworkBrandName>
     <AdditionalSharedHostBrandName>Microsoft .NET Core 1.0.1 - Host</AdditionalSharedHostBrandName>
     <AdditionalHostFxrBrandName>Microsoft .NET Core 1.0.1 - Host FX Resolver</AdditionalHostFxrBrandName>
 

--- a/dir.props
+++ b/dir.props
@@ -13,6 +13,6 @@
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
 
 
-    <CliVersionPrefix>1.1.8</CliVersionPrefix>
+    <CliVersionPrefix>1.1.9</CliVersionPrefix>
   </PropertyGroup>
 </Project>

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -308,7 +308,7 @@ namespace Microsoft.DotNet.Tests
 
             result.Should().NotBeNull();
 
-            result.Args.Should().Contain("--fx-version 1.1.7");
+            result.Args.Should().Contain("--fx-version 1.1.8");
         }
 
         [Fact]


### PR DESCRIPTION
Updating the runtime versions to 1.1.8 and 1.0.11 and updating the CLI branding to 1.1.9.


