### PR TITLE
MSBuild 15.6.84

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MicrosoftNETCoreAppPackageVersion>2.0.7-servicing-26322-01</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.6.82</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.6.84</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>

--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -33,6 +33,7 @@
 <add key="AspNetMaster" value="https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json" />
 <add key="AspNetDev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
 <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+<add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
         ]]>
       </NugetConfigCLIFeeds>
 


### PR DESCRIPTION
Updates our NuGet reference to 4.6.2-rtm-5055.
https://github.com/Microsoft/msbuild/pull/3153
https://devdiv.visualstudio.com/DevDiv/MSBuild/_git/VS/pullrequest/113981

No other changes from RTW.