### PR TITLE
Implement `buildserver shutdown` command.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/MSBuildProject.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             _projectRoot = msBuildExePath;
 
-            var globalProperties = new Dictionary<string, string>()
+            var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                { "MSBuildExtensionsPath", Path.GetDirectoryName(msBuildExePath) }
             };

--- a/src/Microsoft.DotNet.InternalAbstractions/DirectoryWrapper.cs
+++ b/src/Microsoft.DotNet.InternalAbstractions/DirectoryWrapper.cs
@@ -19,6 +19,11 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
             return new TemporaryDirectory();
         }
 
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+        {
+            return Directory.EnumerateFiles(path, searchPattern);
+        }
+
         public IEnumerable<string> EnumerateFileSystemEntries(string path)
         {
             return Directory.EnumerateFileSystemEntries(path);

--- a/src/Microsoft.DotNet.InternalAbstractions/IDirectory.cs
+++ b/src/Microsoft.DotNet.InternalAbstractions/IDirectory.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
 
         ITemporaryDirectory CreateTemporaryDirectory();
 
+        IEnumerable<string> EnumerateFiles(string path, string searchPattern);
+
         IEnumerable<string> EnumerateFileSystemEntries(string path);
 
         IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern);

--- a/src/dotnet/BuildServer/IBuildServerManager.cs
+++ b/src/dotnet/BuildServer/IBuildServerManager.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.DotNet.BuildServer
+{
+    internal interface IBuildServerManager
+    {
+        string ServerName { get; }
+
+        Task<Result> ShutdownServerAsync();
+    }
+}

--- a/src/dotnet/BuildServer/IRazorAssemblyResolver.cs
+++ b/src/dotnet/BuildServer/IRazorAssemblyResolver.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.EnvironmentAbstractions;
+
+namespace Microsoft.DotNet.BuildServer
+{
+    internal interface IRazorAssemblyResolver
+    {
+        IEnumerable<FilePath> EnumerateRazorToolAssemblies();
+    }
+}

--- a/src/dotnet/BuildServer/LocalizableStrings.resx
+++ b/src/dotnet/BuildServer/LocalizableStrings.resx
@@ -1,0 +1,132 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="MSBuildServer" xml:space="preserve">
+    <value>MSBuild server</value>
+  </data>
+  <data name="VBCSCompilerServer" xml:space="preserve">
+    <value>VB/C# compiler server</value>
+  </data>
+  <data name="RazorServer" xml:space="preserve">
+    <value>Razor build server</value>
+  </data>
+  <data name="NoRazorProjectFound" xml:space="preserve">
+    <value>a Razor project was not found in the current directory.</value>
+  </data>
+</root>

--- a/src/dotnet/BuildServer/MSBuildServerManager.cs
+++ b/src/dotnet/BuildServer/MSBuildServerManager.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.DotNet.BuildServer
+{
+    internal class MSBuildServerManager : IBuildServerManager
+    {
+        public string ServerName => LocalizableStrings.MSBuildServer;
+
+        public Task<Result> ShutdownServerAsync()
+        {
+            return Task.Run(() => {
+                try
+                {
+                    BuildManager.DefaultBuildManager.ShutdownAllNodes();
+                    return new Result(ResultKind.Success);
+                }
+                catch (Exception ex)
+                {
+                    return new Result(ex);
+                }
+            });
+        }
+    }
+}

--- a/src/dotnet/BuildServer/RazorAssemblyResolver.cs
+++ b/src/dotnet/BuildServer/RazorAssemblyResolver.cs
@@ -1,0 +1,52 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.Build.Execution;
+using Microsoft.Extensions.EnvironmentAbstractions;
+
+namespace Microsoft.DotNet.BuildServer
+{
+    internal class RazorAssemblyResolver : IRazorAssemblyResolver
+    {
+        private readonly IDirectory _directory;
+
+        public RazorAssemblyResolver(IDirectory directory = null)
+        {
+            _directory = directory ?? FileSystemWrapper.Default.Directory;
+        }
+
+        public IEnumerable<FilePath> EnumerateRazorToolAssemblies()
+        {
+            HashSet<string> seen = new HashSet<string>();
+
+            var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                // This property disables default item globbing to improve performance
+                // This should be safe because we are not evaluating items, only properties
+                { Constants.EnableDefaultItems, "false" }
+            };
+
+            foreach (var projectFile in _directory.EnumerateFiles(Directory.GetCurrentDirectory(), "*.*proj"))
+            {
+                var project = new ProjectInstance(projectFile, globalProperties, null);
+                var path = project.GetPropertyValue("_RazorToolAssembly");
+                if (string.IsNullOrEmpty(path))
+                {
+                    continue;
+                }
+
+                if (!seen.Add(path))
+                {
+                    continue;
+                }
+
+                yield return new FilePath(path);
+            }
+        }
+    }
+}

--- a/src/dotnet/BuildServer/RazorServerManager.cs
+++ b/src/dotnet/BuildServer/RazorServerManager.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Build.Exceptions;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools;
+using Microsoft.Extensions.EnvironmentAbstractions;
+
+namespace Microsoft.DotNet.BuildServer
+{
+    internal class RazorServerManager : IBuildServerManager
+    {
+        private readonly IRazorAssemblyResolver _resolver;
+        private readonly ICommandFactory _commandFactory;
+
+        public RazorServerManager(IRazorAssemblyResolver resolver = null, ICommandFactory commandFactory = null)
+        {
+            _resolver = resolver ?? new RazorAssemblyResolver();
+            _commandFactory = commandFactory ?? new DotNetCommandFactory(alwaysRunOutOfProc: true);
+        }
+
+        public string ServerName => LocalizableStrings.RazorServer;
+
+        public Task<Result> ShutdownServerAsync()
+        {
+            return Task.Run(() => {
+                try
+                {
+                    bool haveRazorAssembly = false;
+
+                    foreach (var toolAssembly in _resolver.EnumerateRazorToolAssemblies())
+                    {
+                        haveRazorAssembly = true;
+
+                        var command = _commandFactory
+                            .Create("exec", new string[] { toolAssembly.Value, "shutdown" })
+                            .CaptureStdOut()
+                            .CaptureStdErr();
+
+                        var result = command.Execute();
+                        if (result.ExitCode != 0)
+                        {
+                            return new Result(ResultKind.Failure, result.StdErr);
+                        }
+                    }
+
+                    if (!haveRazorAssembly)
+                    {
+                        return new Result(ResultKind.Skipped, LocalizableStrings.NoRazorProjectFound);
+                    }
+
+                    return new Result(ResultKind.Success);
+                }
+                catch (InvalidProjectFileException ex)
+                {
+                    return new Result(ex);
+                }
+            });
+        }
+    }
+}

--- a/src/dotnet/BuildServer/Result.cs
+++ b/src/dotnet/BuildServer/Result.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Microsoft.DotNet.BuildServer
+{
+    internal enum ResultKind
+    {
+        Success,
+        Failure,
+        Skipped
+    }
+
+    internal struct Result
+    {
+        public Result(ResultKind kind, string message = null)
+        {
+            Kind = kind;
+            Message = message;
+            Exception = null;
+        }
+
+        public Result(Exception exception)
+        {
+            Kind = ResultKind.Failure;
+            Message = exception.Message;
+            Exception = exception;
+        }
+
+        public ResultKind Kind { get; private set; }
+
+        public string Message { get; private set; }
+
+        public Exception Exception { get; private set; }
+    }
+}

--- a/src/dotnet/BuildServer/VBCSCompilerServerManager.cs
+++ b/src/dotnet/BuildServer/VBCSCompilerServerManager.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.BuildServer
+{
+    internal class VBCSCompilerServerManager : IBuildServerManager
+    {
+        internal static readonly string VBCSCompilerPath = Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "Roslyn",
+                "bincore",
+                "VBCSCompiler.dll");
+
+        private readonly ICommandFactory _commandFactory;
+
+        public VBCSCompilerServerManager(ICommandFactory commandFactory = null)
+        {
+            _commandFactory = commandFactory ?? new DotNetCommandFactory(alwaysRunOutOfProc: true);
+        }
+
+        public string ServerName => LocalizableStrings.VBCSCompilerServer;
+
+        public Task<Result> ShutdownServerAsync()
+        {
+            return Task.Run(() => {
+                var command = _commandFactory
+                    .Create("exec", new[] { VBCSCompilerPath, "-shutdown" })
+                    .CaptureStdOut()
+                    .CaptureStdErr();
+
+                var result = command.Execute();
+                if (result.ExitCode != 0)
+                {
+                    return new Result(ResultKind.Failure, result.StdErr);
+                }
+
+                return new Result(ResultKind.Success);
+            });
+        }
+    }
+}

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.cs.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.de.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.es.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.fr.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.it.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.ja.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.ko.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.pl.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.pt-BR.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.ru.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.tr.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.zh-Hans.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuildServer/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/BuildServer/xlf/LocalizableStrings.zh-Hant.xlf
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="MSBuildServer">
+        <source>MSBuild server</source>
+        <target state="new">MSBuild server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerServer">
+        <source>VB/C# compiler server</source>
+        <target state="new">VB/C# compiler server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorServer">
+        <source>Razor build server</source>
+        <target state="new">Razor build server</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoRazorProjectFound">
+        <source>a Razor project was not found in the current directory.</source>
+        <target state="new">a Razor project was not found in the current directory.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/BuiltInCommandsCatalog.cs
+++ b/src/dotnet/BuiltInCommandsCatalog.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Tools.Add;
 using Microsoft.DotNet.Tools.Build;
+using Microsoft.DotNet.Tools.BuildServer;
 using Microsoft.DotNet.Tools.Clean;
 using Microsoft.DotNet.Tools.Help;
 using Microsoft.DotNet.Tools.List;
@@ -148,6 +149,10 @@ namespace Microsoft.DotNet.Cli
             ["tool"] = new BuiltInCommandMetadata
             {
                 Command = ToolCommand.Run
+            },
+            ["buildserver"] = new BuiltInCommandMetadata
+            {
+                Command = BuildServerCommand.Run
             },
             ["internal-reportinstallsuccess"] = new BuiltInCommandMetadata
             {

--- a/src/dotnet/Parser.cs
+++ b/src/dotnet/Parser.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.Cli
                                     CompleteCommandParser.Complete(),
                                     InternalReportinstallsuccessCommandParser.InternalReportinstallsuccess(),
                                     ToolCommandParser.Tool(),
+                                    BuildServerCommandParser.CreateCommand(),
                                     CommonOptions.HelpOption(),
                                     Create.Option("--info", ""),
                                     Create.Option("-d", ""),

--- a/src/dotnet/commands/dotnet-buildserver/BuildServerCommand.cs
+++ b/src/dotnet/commands/dotnet-buildserver/BuildServerCommand.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.BuildServer.Shutdown;
+
+namespace Microsoft.DotNet.Tools.BuildServer
+{
+    public class BuildServerCommand : DotNetTopLevelCommandBase
+    {
+        protected override string CommandName => "buildserver";
+        protected override string FullCommandNameLocalized => LocalizableStrings.BuildServerCommandName;
+        protected override string ArgumentName => "";
+        protected override string ArgumentDescriptionLocalized => "";
+
+        internal override Dictionary<string, Func<AppliedOption, CommandBase>> SubCommands =>
+            new Dictionary<string, Func<AppliedOption, CommandBase>>
+            {
+                ["shutdown"] = appliedOption => new BuildServerShutdownCommand(
+                    appliedOption["shutdown"],
+                    ParseResult),
+            };
+
+        public static int Run(string[] args)
+        {
+            return new BuildServerCommand().RunCommand(args);
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-buildserver/BuildServerCommandParser.cs
+++ b/src/dotnet/commands/dotnet-buildserver/BuildServerCommandParser.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.CommandLine;
+using LocalizableStrings = Microsoft.DotNet.Tools.BuildServer.LocalizableStrings;
+
+namespace Microsoft.DotNet.Cli
+{
+    internal static class BuildServerCommandParser
+    {
+        public static Command CreateCommand()
+        {
+            return Create.Command(
+                "buildserver",
+                LocalizableStrings.CommandDescription,
+                Accept.NoArguments(),
+                CommonOptions.HelpOption(),
+                ServerShutdownCommandParser.CreateCommand());
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-buildserver/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-buildserver/LocalizableStrings.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BuildServerCommandName" xml:space="preserve">
+    <value>.NET Build Server Command</value>
+  </data>
+  <data name="CommandDescription" xml:space="preserve">
+    <value>Interact with servers started from a build.</value>
+  </data>
+</root>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/BuildServerShutdownCommand.cs
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/BuildServerShutdownCommand.cs
@@ -1,0 +1,144 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.DotNet.BuildServer;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+
+namespace Microsoft.DotNet.Tools.BuildServer.Shutdown
+{
+    internal class BuildServerShutdownCommand : CommandBase
+    {
+        private readonly bool _useOrderedWait;
+        private readonly IReporter _reporter;
+        private readonly IReporter _errorReporter;
+
+        public BuildServerShutdownCommand(
+            AppliedOption options,
+            ParseResult result,
+            IEnumerable<IBuildServerManager> managers = null,
+            bool useOrderedWait = false,
+            IReporter reporter = null)
+            : base(result)
+        {
+            if (managers == null)
+            {
+                bool msbuild = options.ValueOrDefault<bool>("msbuild");
+                bool vbcscompiler  = options.ValueOrDefault<bool>("vbcscompiler");
+                bool razor = options.ValueOrDefault<bool>("razor");
+                bool all = !msbuild && !vbcscompiler && !razor;
+
+                var enabledManagers = new List<IBuildServerManager>();
+                if (msbuild || all)
+                {
+                    enabledManagers.Add(new MSBuildServerManager());
+                }
+
+                if (vbcscompiler || all)
+                {
+                    enabledManagers.Add(new VBCSCompilerServerManager());
+                }
+
+                if (razor || all)
+                {
+                    enabledManagers.Add(new RazorServerManager());
+                }
+
+                managers = enabledManagers;
+            }
+
+            Managers = managers;
+            _useOrderedWait = useOrderedWait;
+            _reporter = reporter ?? Reporter.Output;
+            _errorReporter = reporter ?? Reporter.Error;
+        }
+
+        public IEnumerable<IBuildServerManager> Managers { get; }
+
+        public override int Execute()
+        {
+            bool success = true;
+
+            var tasks = StartShutdown();
+
+            while (tasks.Count > 0)
+            {
+                var index = WaitForResult(tasks.Select(t => t.Item2).ToArray());
+                var (manager, task) = tasks[index];
+
+                success &= HandleResult(manager, task.Result);
+
+                tasks.RemoveAt(index);
+            }
+
+            return success ? 0 : 1;
+        }
+
+        private List<(IBuildServerManager, Task<Result>)> StartShutdown()
+        {
+            var tasks = new List<(IBuildServerManager, Task<Result>)>();
+            foreach (var manager in Managers)
+            {
+                _reporter.WriteLine(string.Format(LocalizableStrings.ShuttingDownServer, manager.ServerName));
+                tasks.Add((manager, manager.ShutdownServerAsync()));
+            }
+            return tasks;
+        }
+
+        private int WaitForResult(Task[] tasks)
+        {
+            if (_useOrderedWait)
+            {
+                tasks[0].Wait();
+                return 0;
+            }
+            return Task.WaitAny(tasks);
+        }
+
+        private bool HandleResult(IBuildServerManager manager, Result result)
+        {
+            switch (result.Kind)
+            {
+                case ResultKind.Success:
+                    _reporter.WriteLine(
+                        string.Format(
+                            LocalizableStrings.ShutDownSucceeded,
+                            manager.ServerName).Green());
+                    return true;
+
+                case ResultKind.Skipped:
+                    _reporter.WriteLine(
+                        string.Format(
+                            LocalizableStrings.ShutDownSkipped,
+                            manager.ServerName,
+                            result.Message).Cyan());
+                    return true;
+
+                case ResultKind.Failure:
+                    _errorReporter.WriteLine(
+                            string.Format(
+                                LocalizableStrings.ShutDownFailed,
+                                manager.ServerName,
+                                result.Message).Red());
+
+                    if (Reporter.IsVerbose && result.Exception != null)
+                    {
+                        Reporter.Verbose.WriteLine(result.Exception.ToString().Red());
+                    }
+                    return false;
+
+                default:
+                    throw new NotSupportedException(
+                        string.Format(
+                            LocalizableStrings.UnsupportedEnumValue,
+                            result.Kind.ToString(),
+                            nameof(ResultKind)));
+            }
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/BuildServerShutdownCommandParser.cs
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/BuildServerShutdownCommandParser.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.CommandLine;
+using LocalizableStrings = Microsoft.DotNet.Tools.BuildServer.Shutdown.LocalizableStrings;
+
+namespace Microsoft.DotNet.Cli
+{
+    internal static class ServerShutdownCommandParser
+    {
+        public static Command CreateCommand()
+        {
+            return Create.Command(
+                "shutdown",
+                LocalizableStrings.CommandDescription,
+                Create.Option(
+                    "--msbuild",
+                    LocalizableStrings.MSBuildOptionDescription,
+                    Accept.NoArguments()),
+                Create.Option(
+                    "--vbcscompiler",
+                    LocalizableStrings.VBCSCompilerOptionDescription,
+                    Accept.NoArguments()),
+                Create.Option(
+                    "--razor",
+                    LocalizableStrings.RazorOptionDescription,
+                    Accept.NoArguments()),
+                CommonOptions.HelpOption());
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/LocalizableStrings.resx
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CommandDescription" xml:space="preserve">
+    <value>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</value>
+  </data>
+  <data name="MSBuildOptionDescription" xml:space="preserve">
+    <value>Shuts down the MSBuild build server.</value>
+  </data>
+  <data name="VBCSCompilerOptionDescription" xml:space="preserve">
+    <value>Shuts down the VB/C# compiler build server.</value>
+  </data>
+  <data name="RazorOptionDescription" xml:space="preserve">
+    <value>Shuts down the Razor build server.</value>
+  </data>
+  <data name="ShuttingDownServer" xml:space="preserve">
+    <value>Shutting down {0}...</value>
+  </data>
+  <data name="ShutDownSucceeded" xml:space="preserve">
+    <value>{0} shut down successfully.</value>
+  </data>
+  <data name="ShutDownFailed" xml:space="preserve">
+    <value>{0} failed to shut down: {1}</value>
+  </data>
+  <data name="ShutDownSkipped" xml:space="preserve">
+    <value>{0} shut down was skipped: {1}</value>
+  </data>
+  <data name="UnsupportedEnumValue" xml:space="preserve">
+    <value>The value '{0}' for enum type '{1}' is not supported.</value>
+  </data>
+</root>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.cs.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.de.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.es.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.fr.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.it.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.ja.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.ko.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.pl.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.pt-BR.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.ru.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.tr.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.zh-Hans.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/shutdown/xlf/LocalizableStrings.zh-Hant.xlf
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Shuts down build servers that are started from dotnet. By default, all servers are shut down.</source>
+        <target state="new">Shuts down build servers that are started from dotnet. By default, all servers are shut down.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MSBuildOptionDescription">
+        <source>Shuts down the MSBuild build server.</source>
+        <target state="new">Shuts down the MSBuild build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VBCSCompilerOptionDescription">
+        <source>Shuts down the VB/C# compiler build server.</source>
+        <target state="new">Shuts down the VB/C# compiler build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RazorOptionDescription">
+        <source>Shuts down the Razor build server.</source>
+        <target state="new">Shuts down the Razor build server.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShuttingDownServer">
+        <source>Shutting down {0}...</source>
+        <target state="new">Shutting down {0}...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSucceeded">
+        <source>{0} shut down successfully.</source>
+        <target state="new">{0} shut down successfully.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownFailed">
+        <source>{0} failed to shut down: {1}</source>
+        <target state="new">{0} failed to shut down: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ShutDownSkipped">
+        <source>{0} shut down was skipped: {1}</source>
+        <target state="new">{0} shut down was skipped: {1}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UnsupportedEnumValue">
+        <source>The value '{0}' for enum type '{1}' is not supported.</source>
+        <target state="new">The value '{0}' for enum type '{1}' is not supported.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.cs.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.de.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.es.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.fr.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.it.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.ja.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.ko.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.pl.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.pt-BR.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.ru.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.tr.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.zh-Hans.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-buildserver/xlf/LocalizableStrings.zh-Hant.xlf
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
+    <body>
+      <trans-unit id="CommandDescription">
+        <source>Interact with servers started from a build.</source>
+        <target state="new">Interact with servers started from a build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BuildServerCommandName">
+        <source>.NET Build Server Command</source>
+        <target state="new">.NET Build Server Command</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -29,6 +29,7 @@ path-to-application:
   vstest           {LocalizableStrings.VsTestDefinition}
   store            {LocalizableStrings.StoreDefinition}
   tool             {LocalizableStrings.ToolDefinition}
+  buildserver      {LocalizableStrings.BuildServerDefinition}
   help             {LocalizableStrings.HelpDefinition}
 
 {LocalizableStrings.CommonOptions}:

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -270,4 +270,7 @@
   <data name="ToolDefinition" xml:space="preserve">
     <value>Modify tools.</value>
   </data>
+  <data name="BuildServerDefinition" xml:space="preserve">
+    <value>Interact with servers started by a build.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -257,6 +257,11 @@
         <target state="new">Modify tools.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BuildServerDefinition">
+        <source>Interact with servers started by a build.</source>
+        <target state="new">Interact with servers started by a build.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.Tools.Run
 
         private ICommand GetRunCommand()
         {
-            var globalProperties = new Dictionary<string, string>
+            var globalProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 // This property disables default item globbing to improve performance
                 // This should be safe because we are not evaluating items, only properties

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -16,10 +16,13 @@
     <EmbeddedResource Include="commands\dotnet-new\*.zip" />
     <EmbeddedResource Update="**\*.resx" GenerateSource="true" />
     <EmbeddedResource Update="*.resx" Namespace="Microsoft.DotNet.Tools" />
+    <EmbeddedResource Update="BuildServer\*.resx" Namespace="Microsoft.DotNet.BuildServer" />
     <EmbeddedResource Update="**\dotnet-add-package\*.resx" Namespace="Microsoft.DotNet.Tools.Add.PackageReference" />
     <EmbeddedResource Update="**\dotnet-add-reference\*.resx" Namespace="Microsoft.DotNet.Tools.Add.ProjectToProjectReference" />
     <EmbeddedResource Update="**\dotnet-add\*.resx" Namespace="Microsoft.DotNet.Tools.Add" />
     <EmbeddedResource Update="**\dotnet-build\*.resx" Namespace="Microsoft.DotNet.Tools.Build" />
+    <EmbeddedResource Update="**\dotnet-buildserver\*.resx" Namespace="Microsoft.DotNet.Tools.BuildServer" />
+    <EmbeddedResource Update="**\dotnet-buildserver\shutdown\*.resx" Namespace="Microsoft.DotNet.Tools.BuildServer.Shutdown" />
     <EmbeddedResource Update="**\dotnet-clean\*.resx" Namespace="Microsoft.DotNet.Tools.Clean" />
     <EmbeddedResource Update="**\dotnet-help\*.resx" Namespace="Microsoft.DotNet.Tools.Help" />
     <EmbeddedResource Update="**\dotnet-list-reference\*.resx" Namespace="Microsoft.DotNet.Tools.List.ProjectToProjectReferences" />

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenAFirstTimeUseNoticeSentinel.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenAFirstTimeUseNoticeSentinel.cs
@@ -155,6 +155,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 throw new NotImplementedException();
             }
 
+            public IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+            {
+                throw new NotImplementedException();
+            }
+
             public IEnumerable<string> EnumerateFileSystemEntries(string path)
             {
                 throw new NotImplementedException();

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenAFunctionReturnStringAndFakeFileSystem.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenAFunctionReturnStringAndFakeFileSystem.cs
@@ -144,6 +144,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 throw new NotImplementedException();
             }
 
+            public IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+            {
+                throw new NotImplementedException();
+            }
+
             public IEnumerable<string> EnumerateFileSystemEntries(string path)
             {
                 throw new UnauthorizedAccessException();

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCacheSentinel.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenANuGetCacheSentinel.cs
@@ -183,6 +183,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 throw new NotImplementedException();
             }
 
+            public IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+            {
+                throw new NotImplementedException();
+            }
+
             public IEnumerable<string> EnumerateFileSystemEntries(string path)
             {
                 throw new NotImplementedException();

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Mock/FileSystemMockBuilder.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Mock/FileSystemMockBuilder.cs
@@ -150,6 +150,11 @@ namespace Microsoft.Extensions.DependencyModel.Tests
                 return _temporaryDirectory;
             }
 
+            public IEnumerable<string> EnumerateFiles(string path, string searchPattern)
+            {
+                throw new NotImplementedException();
+            }
+
             public IEnumerable<string> EnumerateFileSystemEntries(string path)
             {
                 foreach (var entry in _files.Keys.Where(k => Path.GetDirectoryName(k) == path))

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -40,6 +40,7 @@ SDK commands:
   vstest           Runs Microsoft Test Execution Command Line Tool.
   store            Stores the specified assemblies in the runtime store.
   tool             Modify tools.
+  buildserver      Interact with servers started by a build.
   help             Show help.
 
 Common options:

--- a/test/dotnet.Tests/BuildServerTests/RazorServerManagerTests.cs
+++ b/test/dotnet.Tests/BuildServerTests/RazorServerManagerTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Build.Exceptions;
+using Microsoft.DotNet.BuildServer;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Moq;
+using NuGet.Frameworks;
+using Xunit;
+using LocalizableStrings = Microsoft.DotNet.BuildServer.LocalizableStrings;
+
+namespace Microsoft.DotNet.Tests.BuildServerTests
+{
+    public class RazorServerManagerTests
+    {
+        [Fact]
+        public async Task GivenNoRazorAssemblyShutdownIsSkipped()
+        {
+            var resolverMock = new Mock<IRazorAssemblyResolver>(MockBehavior.Strict);
+            resolverMock.Setup(r => r.EnumerateRazorToolAssemblies()).Returns(new FilePath[] {});
+
+            var commandFactoryMock = new Mock<ICommandFactory>(MockBehavior.Strict);
+
+            var manager = new RazorServerManager(resolverMock.Object, commandFactoryMock.Object);
+
+            var result = await manager.ShutdownServerAsync();
+            result.Kind.Should().Be(ResultKind.Skipped);
+            result.Message.Should().Be(LocalizableStrings.NoRazorProjectFound);
+            result.Exception.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GivenARazorAssemblyShutdownSucceeds()
+        {
+            const string FakeRazorAssemblyPath = "/path/to/razor.dll";
+
+            var resolverMock = new Mock<IRazorAssemblyResolver>(MockBehavior.Strict);
+            resolverMock.Setup(r => r.EnumerateRazorToolAssemblies()).Returns(new FilePath[] { new FilePath(FakeRazorAssemblyPath) });
+
+            var commandMock = new Mock<ICommand>(MockBehavior.Strict);
+            commandMock.Setup(c => c.CaptureStdOut()).Returns(commandMock.Object);
+            commandMock.Setup(c => c.CaptureStdErr()).Returns(commandMock.Object);
+            commandMock.Setup(c => c.Execute()).Returns(new CommandResult(null, 0, "", ""));
+
+            var commandFactoryMock = new Mock<ICommandFactory>(MockBehavior.Strict);
+            commandFactoryMock
+                .Setup(
+                    f => f.Create(
+                        "exec",
+                        new string[] { FakeRazorAssemblyPath, "shutdown" },
+                        It.IsAny<NuGetFramework>(),
+                        Constants.DefaultConfiguration))
+                .Returns(commandMock.Object);
+
+            var manager = new RazorServerManager(resolverMock.Object, commandFactoryMock.Object);
+
+            var result = await manager.ShutdownServerAsync();
+            result.Kind.Should().Be(ResultKind.Success);
+            result.Message.Should().BeNull();
+            result.Exception.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GivenAnInvalidProjectFileShutdownFails()
+        {
+            var exception = new InvalidProjectFileException("invalid project!");
+
+            var resolverMock = new Mock<IRazorAssemblyResolver>(MockBehavior.Strict);
+            resolverMock.Setup(r => r.EnumerateRazorToolAssemblies()).Throws(exception);
+
+            var commandFactoryMock = new Mock<ICommandFactory>(MockBehavior.Strict);
+
+            var manager = new RazorServerManager(resolverMock.Object, commandFactoryMock.Object);
+
+            var result = await manager.ShutdownServerAsync();
+            result.Kind.Should().Be(ResultKind.Failure);
+            result.Message.Should().Be(exception.Message);
+            result.Exception.Should().Be(exception);
+        }
+
+        [Fact]
+        public async Task GivenANonZeroExitCodeShutdownFails()
+        {
+            const string FakeRazorAssemblyPath = "/path/to/razor.dll";
+            const string ErrorMessage = "failed!";
+
+            var resolverMock = new Mock<IRazorAssemblyResolver>(MockBehavior.Strict);
+            resolverMock.Setup(r => r.EnumerateRazorToolAssemblies()).Returns(new FilePath[] { new FilePath(FakeRazorAssemblyPath) });
+
+            var commandMock = new Mock<ICommand>(MockBehavior.Strict);
+            commandMock.Setup(c => c.CaptureStdOut()).Returns(commandMock.Object);
+            commandMock.Setup(c => c.CaptureStdErr()).Returns(commandMock.Object);
+            commandMock.Setup(c => c.Execute()).Returns(new CommandResult(null, 1, "", ErrorMessage));
+
+            var commandFactoryMock = new Mock<ICommandFactory>(MockBehavior.Strict);
+            commandFactoryMock
+                .Setup(
+                    f => f.Create(
+                        "exec",
+                        new string[] { FakeRazorAssemblyPath, "shutdown" },
+                        It.IsAny<NuGetFramework>(),
+                        Constants.DefaultConfiguration))
+                .Returns(commandMock.Object);
+
+            var manager = new RazorServerManager(resolverMock.Object, commandFactoryMock.Object);
+
+            var result = await manager.ShutdownServerAsync();
+            result.Kind.Should().Be(ResultKind.Failure);
+            result.Message.Should().Be(ErrorMessage);
+            result.Exception.Should().BeNull();
+        }
+    }
+}

--- a/test/dotnet.Tests/BuildServerTests/VBCSCompilerServerManagerTests.cs
+++ b/test/dotnet.Tests/BuildServerTests/VBCSCompilerServerManagerTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.BuildServer;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Moq;
+using NuGet.Frameworks;
+using Xunit;
+
+namespace Microsoft.DotNet.Tests.BuildServerTests
+{
+    public class VBCSCompilerServerManagerTests
+    {
+        [Fact]
+        public async Task GivenAZeroExit()
+        {
+            var commandMock = new Mock<ICommand>(MockBehavior.Strict);
+            commandMock.Setup(c => c.CaptureStdOut()).Returns(commandMock.Object);
+            commandMock.Setup(c => c.CaptureStdErr()).Returns(commandMock.Object);
+            commandMock.Setup(c => c.Execute()).Returns(new CommandResult(null, 0, "", ""));
+
+            var commandFactoryMock = new Mock<ICommandFactory>(MockBehavior.Strict);
+            commandFactoryMock
+                .Setup(
+                    f => f.Create(
+                        "exec",
+                        new string[] { VBCSCompilerServerManager.VBCSCompilerPath, "-shutdown" },
+                        It.IsAny<NuGetFramework>(),
+                        Constants.DefaultConfiguration))
+                .Returns(commandMock.Object);
+
+            var manager = new VBCSCompilerServerManager(commandFactoryMock.Object);
+
+            var result = await manager.ShutdownServerAsync();
+            result.Kind.Should().Be(ResultKind.Success);
+            result.Message.Should().BeNull();
+            result.Exception.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task GivenANonZeroExitCodeShutdownFails()
+        {
+            const string ErrorMessage = "failed!";
+
+            var commandMock = new Mock<ICommand>(MockBehavior.Strict);
+            commandMock.Setup(c => c.CaptureStdOut()).Returns(commandMock.Object);
+            commandMock.Setup(c => c.CaptureStdErr()).Returns(commandMock.Object);
+            commandMock.Setup(c => c.Execute()).Returns(new CommandResult(null, 1, "", ErrorMessage));
+
+            var commandFactoryMock = new Mock<ICommandFactory>(MockBehavior.Strict);
+            commandFactoryMock
+                .Setup(
+                    f => f.Create(
+                        "exec",
+                        new string[] { VBCSCompilerServerManager.VBCSCompilerPath, "-shutdown" },
+                        It.IsAny<NuGetFramework>(),
+                        Constants.DefaultConfiguration))
+                .Returns(commandMock.Object);
+
+            var manager = new VBCSCompilerServerManager(commandFactoryMock.Object);
+
+            var result = await manager.ShutdownServerAsync();
+            result.Kind.Should().Be(ResultKind.Failure);
+            result.Message.Should().Be(ErrorMessage);
+            result.Exception.Should().BeNull();
+        }
+    }
+}

--- a/test/dotnet.Tests/CommandTests/BuildServerShutdownCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/BuildServerShutdownCommandTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.DotNet.BuildServer;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.Tools.BuildServer;
+using Microsoft.DotNet.Tools.BuildServer.Shutdown;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Moq;
+using Xunit;
+using Parser = Microsoft.DotNet.Cli.Parser;
+using LocalizableStrings = Microsoft.DotNet.Tools.BuildServer.Shutdown.LocalizableStrings;
+
+namespace Microsoft.DotNet.Tests.Commands
+{
+    public class BuildServerShutdownCommandTests
+    {
+        private readonly BufferedReporter _reporter = new BufferedReporter();
+
+        [Fact]
+        public void GivenNoOptionsAllManagersArePresent()
+        {
+            var command = CreateCommand();
+
+            command.Managers.Select(m => m.ServerName).Should().Equal(
+                DotNet.BuildServer.LocalizableStrings.MSBuildServer,
+                DotNet.BuildServer.LocalizableStrings.VBCSCompilerServer,
+                DotNet.BuildServer.LocalizableStrings.RazorServer
+            );
+        }
+
+        [Fact]
+        public void GivenMSBuildOptionOnlyItIsTheOnlyManager()
+        {
+            var command = CreateCommand("--msbuild");
+
+            command.Managers.Select(m => m.ServerName).Should().Equal(
+                DotNet.BuildServer.LocalizableStrings.MSBuildServer
+            );
+        }
+
+        [Fact]
+        public void GivenVBCSCompilerOptionOnlyItIsTheOnlyManager()
+        {
+            var command = CreateCommand("--vbcscompiler");
+
+            command.Managers.Select(m => m.ServerName).Should().Equal(
+                DotNet.BuildServer.LocalizableStrings.VBCSCompilerServer
+            );
+        }
+
+        [Fact]
+        public void GivenRazorOptionOnlyItIsTheOnlyManager()
+        {
+            var command = CreateCommand("--razor");
+
+            command.Managers.Select(m => m.ServerName).Should().Equal(
+                DotNet.BuildServer.LocalizableStrings.RazorServer
+            );
+        }
+
+        [Fact]
+        public void GivenSuccessfulShutdownsItPrintsSuccess()
+        {
+            var mocks = new[] {
+                CreateManagerMock("first", new Result(ResultKind.Success)),
+                CreateManagerMock("second", new Result(ResultKind.Success)),
+                CreateManagerMock("third", new Result(ResultKind.Success))
+            };
+
+            var command = CreateCommand(managers: mocks.Select(m => m.Object));
+
+            command.Execute().Should().Be(0);
+
+            _reporter.Lines.Should().Equal(
+                FormatShuttingDownMessage(mocks[0].Object),
+                FormatShuttingDownMessage(mocks[1].Object),
+                FormatShuttingDownMessage(mocks[2].Object),
+                FormatSuccessMessage(mocks[0].Object),
+                FormatSuccessMessage(mocks[1].Object),
+                FormatSuccessMessage(mocks[2].Object));
+
+            VerifyShutdownCalls(mocks);
+        }
+
+        [Fact]
+        public void GivenAFailingShutdownItPrintsFailureMessage()
+        {
+            const string FailureMessage = "failed!";
+
+            var mocks = new[] {
+                CreateManagerMock("first", new Result(ResultKind.Success)),
+                CreateManagerMock("second", new Result(ResultKind.Failure, FailureMessage)),
+                CreateManagerMock("third", new Result(ResultKind.Success))
+            };
+
+            var command = CreateCommand(managers: mocks.Select(m => m.Object));
+
+            command.Execute().Should().Be(1);
+
+            _reporter.Lines.Should().Equal(
+                FormatShuttingDownMessage(mocks[0].Object),
+                FormatShuttingDownMessage(mocks[1].Object),
+                FormatShuttingDownMessage(mocks[2].Object),
+                FormatSuccessMessage(mocks[0].Object),
+                FormatFailureMessage(mocks[1].Object, FailureMessage),
+                FormatSuccessMessage(mocks[2].Object));
+
+            VerifyShutdownCalls(mocks);
+        }
+
+        [Fact]
+        public void GivenASkippedShutdownItPrintsSkipMessage()
+        {
+            const string SkipMessage = "skipped!";
+
+            var mocks = new[] {
+                CreateManagerMock("first", new Result(ResultKind.Success)),
+                CreateManagerMock("second", new Result(ResultKind.Success)),
+                CreateManagerMock("third", new Result(ResultKind.Skipped, SkipMessage))
+            };
+
+            var command = CreateCommand(managers: mocks.Select(m => m.Object));
+
+            command.Execute().Should().Be(0);
+
+            _reporter.Lines.Should().Equal(
+                FormatShuttingDownMessage(mocks[0].Object),
+                FormatShuttingDownMessage(mocks[1].Object),
+                FormatShuttingDownMessage(mocks[2].Object),
+                FormatSuccessMessage(mocks[0].Object),
+                FormatSuccessMessage(mocks[1].Object),
+                FormatSkippedMessage(mocks[2].Object, SkipMessage));
+
+            VerifyShutdownCalls(mocks);
+        }
+
+        [Fact]
+        public void GivenSuccessFailureAndSkippedItPrintsAllThree()
+        {
+            const string FailureMessage = "failed!";
+            const string SkipMessage = "skipped!";
+
+            var mocks = new[] {
+                CreateManagerMock("first", new Result(ResultKind.Success)),
+                CreateManagerMock("second", new Result(ResultKind.Failure, FailureMessage)),
+                CreateManagerMock("third", new Result(ResultKind.Skipped, SkipMessage))
+            };
+
+            var command = CreateCommand(managers: mocks.Select(m => m.Object));
+
+            command.Execute().Should().Be(1);
+
+            _reporter.Lines.Should().Equal(
+                FormatShuttingDownMessage(mocks[0].Object),
+                FormatShuttingDownMessage(mocks[1].Object),
+                FormatShuttingDownMessage(mocks[2].Object),
+                FormatSuccessMessage(mocks[0].Object),
+                FormatFailureMessage(mocks[1].Object, FailureMessage),
+                FormatSkippedMessage(mocks[2].Object, SkipMessage));
+
+            VerifyShutdownCalls(mocks);
+        }
+
+        private BuildServerShutdownCommand CreateCommand(string options = "", IEnumerable<IBuildServerManager> managers = null)
+        {
+            ParseResult result = Parser.Instance.Parse("dotnet buildserver shutdown " + options);
+            return new BuildServerShutdownCommand(
+                options: result["dotnet"]["buildserver"]["shutdown"],
+                result: result,
+                managers: managers,
+                useOrderedWait: true,
+                reporter: _reporter);
+        }
+
+        private Mock<IBuildServerManager> CreateManagerMock(string serverName, Result result)
+        {
+            var mock = new Mock<IBuildServerManager>(MockBehavior.Strict);
+
+            mock.SetupGet(m => m.ServerName).Returns(serverName);
+            mock.Setup(m => m.ShutdownServerAsync()).Returns(Task.FromResult(result));
+
+            return mock;
+        }
+
+        private void VerifyShutdownCalls(IEnumerable<Mock<IBuildServerManager>> mocks)
+        {
+            foreach (var mock in mocks)
+            {
+                mock.Verify(m => m.ShutdownServerAsync(), Times.Once());
+            }
+        }
+
+        private static string FormatShuttingDownMessage(IBuildServerManager manager)
+        {
+            return string.Format(LocalizableStrings.ShuttingDownServer, manager.ServerName);
+        }
+
+        private static string FormatSuccessMessage(IBuildServerManager manager)
+        {
+            return string.Format(LocalizableStrings.ShutDownSucceeded, manager.ServerName).Green();
+        }
+
+        private static string FormatFailureMessage(IBuildServerManager manager, string message)
+        {
+            return string.Format(LocalizableStrings.ShutDownFailed, manager.ServerName, message).Red();
+        }
+
+        private static string FormatSkippedMessage(IBuildServerManager manager, string message)
+        {
+            return string.Format(LocalizableStrings.ShutDownSkipped, manager.ServerName, message).Cyan();
+        }
+    }
+}

--- a/test/dotnet.Tests/ParserTests/BuildServerShutdownParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/BuildServerShutdownParserTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Xunit;
+using Xunit.Abstractions;
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    public class BuildServerShutdownParserTests
+    {
+        private readonly ITestOutputHelper output;
+
+        public BuildServerShutdownParserTests(ITestOutputHelper output)
+        {
+            this.output = output;
+        }
+
+        [Fact]
+        public void GivenNoOptionsAllFlagsAreFalse()
+        {
+            var result = Parser.Instance.Parse("dotnet buildserver shutdown");
+
+            var options = result["dotnet"]["buildserver"]["shutdown"];
+            options.ValueOrDefault<bool>("msbuild").Should().Be(false);
+            options.ValueOrDefault<bool>("vbcscompiler").Should().Be(false);
+            options.ValueOrDefault<bool>("razor").Should().Be(false);
+        }
+
+        [Fact]
+        public void GivenMSBuildOptionIsItTrue()
+        {
+            var result = Parser.Instance.Parse("dotnet buildserver shutdown --msbuild");
+
+            var options = result["dotnet"]["buildserver"]["shutdown"];
+            options.ValueOrDefault<bool>("msbuild").Should().Be(true);
+            options.ValueOrDefault<bool>("vbcscompiler").Should().Be(false);
+            options.ValueOrDefault<bool>("razor").Should().Be(false);
+        }
+
+        [Fact]
+        public void GivenVBCSCompilerOptionIsItTrue()
+        {
+            var result = Parser.Instance.Parse("dotnet buildserver shutdown --vbcscompiler");
+
+            var options = result["dotnet"]["buildserver"]["shutdown"];
+            options.ValueOrDefault<bool>("msbuild").Should().Be(false);
+            options.ValueOrDefault<bool>("vbcscompiler").Should().Be(true);
+            options.ValueOrDefault<bool>("razor").Should().Be(false);
+        }
+
+        [Fact]
+        public void GivenRazorOptionIsItTrue()
+        {
+            var result = Parser.Instance.Parse("dotnet buildserver shutdown --razor");
+
+            var options = result["dotnet"]["buildserver"]["shutdown"];
+            options.ValueOrDefault<bool>("msbuild").Should().Be(false);
+            options.ValueOrDefault<bool>("vbcscompiler").Should().Be(false);
+            options.ValueOrDefault<bool>("razor").Should().Be(true);
+        }
+
+        [Fact]
+        public void GivenMultipleOptionsThoseAreTrue()
+        {
+            var result = Parser.Instance.Parse("dotnet buildserver shutdown --razor --msbuild");
+
+            var options = result["dotnet"]["buildserver"]["shutdown"];
+            options.ValueOrDefault<bool>("msbuild").Should().Be(true);
+            options.ValueOrDefault<bool>("vbcscompiler").Should().Be(false);
+            options.ValueOrDefault<bool>("razor").Should().Be(true);
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the `buildserver shutdown` command that can be used to
shutdown MSBuild, VB/C# compiler, and Razor build servers.

By default, all three build servers are shut down.  Options can be passed to
shut down a subset of the build servers.

Fixes #8185.

