### PR TITLE
Update to ASP.NET Core 2.0.7 build 228

### DIFF
--- a/build/BundledRuntimes.props
+++ b/build/BundledRuntimes.props
@@ -5,7 +5,7 @@
 
     <!-- only the runtime OSX .pkgs have a `-internal` suffix -->
     <InstallerStartSuffix Condition="'$(HostOSName)' == 'osx'">-internal</InstallerStartSuffix>
-    
+
     <!-- Downloaded Installers + Archives -->
     <DownloadedSharedHostInstallerFileName Condition=" '$(InstallerExtension)' != '' ">dotnet-host$(InstallerStartSuffix)-$(SharedHostVersion)-$(CoreSetupRid)$(InstallerExtension)</DownloadedSharedHostInstallerFileName>
     <DownloadedSharedHostInstallerFile Condition=" '$(InstallerExtension)' != '' ">$(PackagesDirectory)/$(DownloadedSharedHostInstallerFileName)</DownloadedSharedHostInstallerFile>
@@ -34,9 +34,10 @@
 
   <PropertyGroup>
     <AspNetCoreRuntimeInstallerBlobRootUrl>$(CoreSetupBlobRootUrl)aspnetcore/store/$(AspNetCoreRuntimeAzureblobStoresSubfolderName)</AspNetCoreRuntimeInstallerBlobRootUrl>
+    <AspNetCoreRuntimeBuildDropFeed>$(DotnetBlobRootUrl)/aspnetcore/store/$(AspNetCoreRuntimeAzureblobStoresSubfolderName)/packages/index.json</AspNetCoreRuntimeBuildDropFeed>
     <AspNetCoreSharedRuntimeVersionFileName>runtime.version</AspNetCoreSharedRuntimeVersionFileName>
     <AspNetCoreSharedRuntimeVersionFile Condition=" '$(AspNetCoreSharedRuntimeVersionFileName)' != '' ">$(PackagesDirectory)/$(AspNetCoreSharedRuntimeVersionFileName)</AspNetCoreSharedRuntimeVersionFile>
-    
+
     <!-- Examples:    Build.RS.linux.zip    Build.RS.winx86.zip    AspNetCorePackageStoreLibx64.wixlib   -->
     <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(HostOSName)' == 'win' ">$(HostOSName)$(Architecture)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>
     <AspNetCoreRuntimeInstallerArchiveFileNameOSToken Condition=" '$(HostOSName)' == 'osx' ">$(HostOSName)</AspNetCoreRuntimeInstallerArchiveFileNameOSToken>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -58,21 +58,31 @@
     <SharedHostVersion>$(MicrosoftNETCoreAppPackageVersion)</SharedHostVersion>
     <HostFxrVersion>$(MicrosoftNETCoreAppPackageVersion)</HostFxrVersion>
 
-    <AspNetCoreTemplatePackageVersion>2.0.6</AspNetCoreTemplatePackageVersion>
+    <AspNetCoreTemplatePackageVersion>2.0.7</AspNetCoreTemplatePackageVersion>
     <!-- This should either be timestamped or notimestamp as appropriate.
     AspNetCoreRelease is only used if the value of this property is "timestamped" -->
     <AspNetCoreRuntimePackageFlavor>notimestamp</AspNetCoreRuntimePackageFlavor>
 
+    <!-- The runtime store requires us to link each previously released version. Each time we update ASP.NET Core, add the previous verison to this list -->
+    <PreviousAspNetCoreRuntimeStoreVersions>2.0.0;2.0.3;2.0.5;2.0.6</PreviousAspNetCoreRuntimeStoreVersions>
+
     <!--BranchName and AspNetCoreVersion will not always be the same-->
-    <AspNetCoreBranchName>2.0.6</AspNetCoreBranchName>
+    <AspNetCoreBranchName>2.0.7</AspNetCoreBranchName>
     <AspNetCoreRelease>rtm</AspNetCoreRelease>
-    <AspNetCoreVersion>2.0.6</AspNetCoreVersion>
-    <AspNetCoreRuntimePackageTimestamp>10011</AspNetCoreRuntimePackageTimestamp>
+    <AspNetCoreVersion>2.0.7</AspNetCoreVersion>
+    <AspNetCoreRuntimePackageTimestamp>228</AspNetCoreRuntimePackageTimestamp>
+    <CurrentAspNetCoreRuntimeVersion Condition="'$(AspNetCoreRuntimePackageFlavor)'=='notimestamp'">$(AspNetCoreVerison)</CurrentAspNetCoreRuntimeVersion>
+    <CurrentAspNetCoreRuntimeVersion Condition="'$(AspNetCoreRuntimePackageFlavor)'!='notimestamp'">$(AspNetCoreVerison)-$(AspNetCoreRelease)-$(AspNetCoreRuntimePackageTimestamp)</CurrentAspNetCoreRuntimeVersion>
 
     <AspNetCoreRuntimePackageBrandName>aspnetcore-store</AspNetCoreRuntimePackageBrandName>
     <AspNetCoreVersionAndRelease>$(AspNetCoreVersion)-$(AspNetCoreRelease)</AspNetCoreVersionAndRelease>
     <AspNetCoreRuntimeAzureblobStoresSubfolderName>$(AspNetCoreBranchName)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimeAzureblobStoresSubfolderName>
   </PropertyGroup>
+
+  <ItemGroup>
+    <AspNetCoreRuntimeStoreVersion Include="$(PreviousAspNetCoreRuntimeStoreVersions)" />
+    <AspNetCoreRuntimeStoreVersion Include="$(CurrentAspNetCoreRuntimeVersion)" />
+  </ItemGroup>
 
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -63,9 +63,6 @@
     AspNetCoreRelease is only used if the value of this property is "timestamped" -->
     <AspNetCoreRuntimePackageFlavor>notimestamp</AspNetCoreRuntimePackageFlavor>
 
-    <!-- The runtime store requires us to link each previously released version. Each time we update ASP.NET Core, add the previous verison to this list -->
-    <PreviousAspNetCoreRuntimeStoreVersions>2.0.0;2.0.3;2.0.5;2.0.6</PreviousAspNetCoreRuntimeStoreVersions>
-
     <!--BranchName and AspNetCoreVersion will not always be the same-->
     <AspNetCoreBranchName>2.0.7</AspNetCoreBranchName>
     <AspNetCoreRelease>rtm</AspNetCoreRelease>
@@ -80,8 +77,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AspNetCoreRuntimeStoreVersion Include="$(PreviousAspNetCoreRuntimeStoreVersions)" />
+    <!--
+      The runtime store requires us to link each previously released version. Each time we update ASP.NET Core, add the previous verison to this list.
+      This list should be sorted most recent version to oldest.
+    -->
     <AspNetCoreRuntimeStoreVersion Include="$(CurrentAspNetCoreRuntimeVersion)" />
+    <AspNetCoreRuntimeStoreVersion Include="2.0.6" />
+    <AspNetCoreRuntimeStoreVersion Include="2.0.5" />
+    <AspNetCoreRuntimeStoreVersion Include="2.0.3" />
+    <AspNetCoreRuntimeStoreVersion Include="2.0.0" />
   </ItemGroup>
 
   <!-- infrastructure and test only dependencies -->

--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -4,7 +4,7 @@
       <ItemGroup>
         <NugetConfigPrivateFeeds Include="$(ExternalRestoreSources.Split(';'))" />
       </ItemGroup>
-    
+
     <PropertyGroup>
       <NugetConfigHeader>
         <![CDATA[
@@ -21,7 +21,7 @@
 <add key="BlobFeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
 <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
 <add key="templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
-<add key="aspnet" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
+<add key="aspnet" value="$(AspNetCoreRuntimeBuildDropFeed)" />
 <add key="websdkfeed" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
 <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
 <add key="symreader-native" value="https://dotnet.myget.org/f/symreader-native/api/v3/index.json" />
@@ -30,8 +30,6 @@
 <add key="vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
 <add key="web-api" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
 <add key="symreader-native" value="https://dotnet.myget.org/F/symreader-native/api/v3/index.json" />
-<add key="AspNetMaster" value="https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json" />
-<add key="AspNetDev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
 <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
 <add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
         ]]>
@@ -43,13 +41,13 @@
 </configuration>
         ]]>
       </NugetConfigSuffix>
-    
+
   </PropertyGroup>
 
     <WriteLinesToFile File="$(GeneratedNuGetConfig)"
                       Lines="$(NugetConfigHeader)"
                       Overwrite="true" />
-    
+
     <WriteLinesToFile Condition="'$(ExternalRestoreSources)' != '' and '$(DotNetBuildOffline)' != 'true'"
                       File="$(GeneratedNuGetConfig)"
                       Lines="&lt;add key=&quot;PrivateBlobFeed%(NugetConfigPrivateFeeds.Filename)&quot; value=&quot;%(NugetConfigPrivateFeeds.Identity)&quot; /&gt;"

--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -25,10 +25,7 @@
       <Exec Command="sudo dpkg -i $(DownloadedSharedHostInstallerFile)" />
       <Exec Command="sudo dpkg -i $(DownloadedHostFxrInstallerFile)" />
       <Exec Command="sudo dpkg -i $(DownloadedSharedFrameworkInstallerFile)" />
-      <Exec Command="sudo dpkg -i $(DownloadedSharedAspNetCoreRuntime200)" />
-      <Exec Command="sudo dpkg -i $(DownloadedSharedAspNetCoreRuntime203)" />
-      <Exec Command="sudo dpkg -i $(DownloadedSharedAspNetCoreRuntime205)" />
-      <Exec Command="sudo dpkg -i $(DownloadedSharedAspNetCoreRuntime)" />
+      <Exec Command="sudo dpkg -i %(AspNetCoreDebInstallerFile.Identity)" />
 
       <!-- Create layout: Binaries -->
       <Copy
@@ -90,10 +87,7 @@
 
       <!-- Remove Shared Framework and Debian Packages -->
       <Exec Command="sudo dpkg -r $(SdkDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreRuntimePackageName)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreRuntimePackageName205)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreRuntimePackageName203)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreRuntimePackageName200)" />
+      <Exec Command="sudo dpkg -r %(AspNetCoreDebInstallerFile.PackageName)" />
       <Exec Command="sudo dpkg -r $(SharedFxDebianPackageName)" />
       <Exec Command="sudo dpkg -r $(HostFxrDebianPackageName)" />
 
@@ -106,6 +100,7 @@
       Inputs="$(DownloadedSharedHostInstallerFile);
               $(DownloadedHostFxrInstallerFile);
               $(DownloadedSharedFrameworkInstallerFile);
+              @(AspNetCoreDebInstallerFile);
               $(SdkInstallerFile);"
       Outputs="$(DebianTestResultsXmlFile)" >
 
@@ -113,10 +108,7 @@
       <Exec Command="sudo dpkg -i $(DownloadedSharedHostInstallerFile)" />
       <Exec Command="sudo dpkg -i $(DownloadedHostFxrInstallerFile)" />
       <Exec Command="sudo dpkg -i $(DownloadedSharedFrameworkInstallerFile)" />
-      <Exec Command="sudo dpkg -i $(DownloadedSharedAspNetCoreRuntime200)" />
-      <Exec Command="sudo dpkg -i $(DownloadedSharedAspNetCoreRuntime203)" />
-      <Exec Command="sudo dpkg -i $(DownloadedSharedAspNetCoreRuntime205)" />
-      <Exec Command="sudo dpkg -i $(DownloadedSharedAspNetCoreRuntime)" />
+      <Exec Command="sudo dpkg -i %(AspNetCoreDebInstallerFile.Identity)" />
 
       <Exec Command="sudo dpkg -i $(SdkInstallerFile)" />
 
@@ -130,10 +122,7 @@
 
       <!-- Clean up Packages -->
       <Exec Command="sudo dpkg -r $(SdkDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreRuntimePackageName)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreRuntimePackageName205)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreRuntimePackageName203)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreRuntimePackageName200)" />
+      <Exec Command="sudo dpkg -r %(AspNetCoreDebInstallerFile.PackageName)" />
       <Exec Command="sudo dpkg -r $(SharedFxDebianPackageName)" />
       <Exec Command="sudo dpkg -r $(HostFxrDebianPackageName)" />
 

--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -21,11 +21,15 @@
       Inputs="@(CLISdkFiles)"
       Outputs="$(SdkInstallerFile)" >
 
+      <ItemGroup>
+        <AspNetCoreDebInstallerFileReversed Include="@(AspNetCoreDebInstallerFile->Reverse())" />
+      </ItemGroup>
+
       <!-- Install Shared Framework Packages -->
       <Exec Command="sudo dpkg -i $(DownloadedSharedHostInstallerFile)" />
       <Exec Command="sudo dpkg -i $(DownloadedHostFxrInstallerFile)" />
       <Exec Command="sudo dpkg -i $(DownloadedSharedFrameworkInstallerFile)" />
-      <Exec Command="sudo dpkg -i %(AspNetCoreDebInstallerFile.Identity)" />
+      <Exec Command="sudo dpkg -i %(AspNetCoreDebInstallerFileReversed.Identity)" />
 
       <!-- Create layout: Binaries -->
       <Copy
@@ -104,11 +108,15 @@
               $(SdkInstallerFile);"
       Outputs="$(DebianTestResultsXmlFile)" >
 
+      <ItemGroup>
+        <AspNetCoreDebInstallerFileReversed Include="@(AspNetCoreDebInstallerFile->Reverse())" />
+      </ItemGroup>
+
       <!-- Install Dependencies and SDK Packages -->
       <Exec Command="sudo dpkg -i $(DownloadedSharedHostInstallerFile)" />
       <Exec Command="sudo dpkg -i $(DownloadedHostFxrInstallerFile)" />
       <Exec Command="sudo dpkg -i $(DownloadedSharedFrameworkInstallerFile)" />
-      <Exec Command="sudo dpkg -i %(AspNetCoreDebInstallerFile.Identity)" />
+      <Exec Command="sudo dpkg -i %(AspNetCoreDebInstallerFileReversed.Identity)" />
 
       <Exec Command="sudo dpkg -i $(SdkInstallerFile)" />
 

--- a/build/package/Installer.DEB.targets
+++ b/build/package/Installer.DEB.targets
@@ -35,14 +35,6 @@
       <HostFxrDebianPackageName>dotnet-hostfxr-$(HostFxrDebianPackageVersion)</HostFxrDebianPackageName>
       <HostFxrDebianPackageName>$(HostFxrDebianPackageName.ToLower())</HostFxrDebianPackageName>
       <HostDebianPackageName>dotnet-host</HostDebianPackageName>
-      <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageName>
-      <AspNetCoreRuntimePackageName200>$(AspNetCoreRuntimePackageBrandName)-2.0.0</AspNetCoreRuntimePackageName200>
-      <AspNetCoreRuntimePackageName203>$(AspNetCoreRuntimePackageBrandName)-2.0.3</AspNetCoreRuntimePackageName203>
-      <AspNetCoreRuntimePackageName205>$(AspNetCoreRuntimePackageBrandName)-2.0.5</AspNetCoreRuntimePackageName205>
-      <AspNetCoreRuntimePackageName Condition=" '$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp' ">$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersion)</AspNetCoreRuntimePackageName>
-      <HostRidInAspNetCoreRuntimeDebInstallerFileName>$(HostRid)</HostRidInAspNetCoreRuntimeDebInstallerFileName>
-      <AspNetCoreRuntimeDebInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)-$(HostRidInAspNetCoreRuntimeDebInstallerFileName).deb</AspNetCoreRuntimeDebInstallerFileName>
-      <AspNetCoreRuntimeDebInstallerFileName Condition=" '$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp' ">$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersion)-$(HostRidInAspNetCoreRuntimeDebInstallerFileName).deb</AspNetCoreRuntimeDebInstallerFileName>
     </PropertyGroup>
 
     <!-- Inputs -->
@@ -125,26 +117,15 @@
 
   <Target Name="DownloadAspNetCoreRuntimeDebInstaller"
         DependsOnTargets="SetupDebProps">
-    <PropertyGroup>
-      <AspNetCoreRuntimeDebInstallerFileName200>$(AspNetCoreRuntimePackageBrandName)-2.0.0-$(HostRidInAspNetCoreRuntimeDebInstallerFileName).deb</AspNetCoreRuntimeDebInstallerFileName200>
-      <AspNetCoreRuntimeDebInstallerFileName203>$(AspNetCoreRuntimePackageBrandName)-2.0.3-$(HostRidInAspNetCoreRuntimeDebInstallerFileName).deb</AspNetCoreRuntimeDebInstallerFileName203>
-      <AspNetCoreRuntimeDebInstallerFileName205>$(AspNetCoreRuntimePackageBrandName)-2.0.5-$(HostRidInAspNetCoreRuntimeDebInstallerFileName).deb</AspNetCoreRuntimeDebInstallerFileName205>
-      <DownloadedSharedAspNetCoreRuntime200>$(PackagesDirectory)/$(AspNetCoreRuntimeDebInstallerFileName200)</DownloadedSharedAspNetCoreRuntime200>
-      <DownloadedSharedAspNetCoreRuntime203>$(PackagesDirectory)/$(AspNetCoreRuntimeDebInstallerFileName203)</DownloadedSharedAspNetCoreRuntime203>
-      <DownloadedSharedAspNetCoreRuntime205>$(PackagesDirectory)/$(AspNetCoreRuntimeDebInstallerFileName205)</DownloadedSharedAspNetCoreRuntime205>
-      <DownloadedSharedAspNetCoreRuntime>$(PackagesDirectory)/$(AspNetCoreRuntimeDebInstallerFileName)</DownloadedSharedAspNetCoreRuntime>
-    </PropertyGroup>
-    <DownloadFile
-               Uri="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeDebInstallerFileName200)$(CoreSetupBlobAccessTokenParam)"
-               DestinationPath="$(DownloadedSharedAspNetCoreRuntime200)"/>
-    <DownloadFile
-               Uri="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeDebInstallerFileName203)$(CoreSetupBlobAccessTokenParam)"
-               DestinationPath="$(DownloadedSharedAspNetCoreRuntime203)"/>
-    <DownloadFile
-               Uri="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeDebInstallerFileName205)$(CoreSetupBlobAccessTokenParam)"
-               DestinationPath="$(DownloadedSharedAspNetCoreRuntime205)"/>
-    <DownloadFile
-               Uri="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeDebInstallerFileName)$(CoreSetupBlobAccessTokenParam)"
-               DestinationPath="$(DownloadedSharedAspNetCoreRuntime)"/>
+
+    <ItemGroup>
+      <AspNetCoreDebInstallerFile Include="$(PackagesDirectory)/$(AspNetCoreRuntimePackageBrandName)-%(AspNetCoreRuntimeStoreVersion.Identity)-$(HostRid).deb">
+        <Source>$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimePackageBrandName)-%(AspNetCoreRuntimeStoreVersion.Identity)-$(HostRid).deb$(CoreSetupBlobAccessTokenParam)</Source>
+        <PackageName>$(AspNetCoreRuntimePackageBrandName)-%(AspNetCoreRuntimeStoreVersion.Identity)</PackageName>
+      </AspNetCoreDebInstallerFile>
+    </ItemGroup>
+
+    <DownloadFile Uri="%(AspNetCoreDebInstallerFile.Source)"
+                  DestinationPath="%(AspNetCoreDebInstallerFile.Identity)"/>
   </Target>
 </Project>

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -221,11 +221,15 @@
               $(RpmTestResultsXmlFile);"
           Outputs="$(RpmTestResultsXmlFile)" >
 
+    <ItemGroup>
+      <AspNetCoreRpmInstallerFileReversed Include="@(AspNetCoreRpmInstallerFile->Reverse())" />
+    </ItemGroup>
+
     <!-- Install Dependencies and SDK Packages -->
     <Exec Command="sudo yum -y install $(DownloadedSharedHostInstallerFile)" />
     <Exec Command="sudo yum -y install $(DownloadedHostFxrInstallerFile)" />
     <Exec Command="sudo yum -y install $(DownloadedSharedFrameworkInstallerFile)" />
-    <Exec Command="sudo yum -y install %(AspNetCoreRpmInstallerFile.Identity)" />
+    <Exec Command="sudo yum -y install %(AspNetCoreRpmInstallerFileReversed.Identity)" />
 
     <Exec Command="sudo yum -y install $(SdkInstallerFile)" />
 

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -50,16 +50,10 @@
       <HostFxrRpmPackageName>dotnet-hostfxr-$(HostFxrRpmPackageVersion)</HostFxrRpmPackageName>
       <HostFxrRpmPackageName>$(HostFxrRpmPackageName.ToLower())</HostFxrRpmPackageName>
       <HostRpmPackageName>dotnet-host</HostRpmPackageName>
-      <HostRidInAspNetCoreRuntimeRpmInstallerFileName>$(HostRid)</HostRidInAspNetCoreRuntimeRpmInstallerFileName>
       <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageName>
       <AspNetCoreRuntimePackageName Condition="'$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp'">$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersion)</AspNetCoreRuntimePackageName>
       <AspNetCoreRuntimePackageName200>$(AspNetCoreRuntimePackageBrandName)-2.0.0</AspNetCoreRuntimePackageName200>
       <AspNetCoreRuntimePackageName203>$(AspNetCoreRuntimePackageBrandName)-2.0.3</AspNetCoreRuntimePackageName203>
-      <AspNetCoreRuntimePackageName205>$(AspNetCoreRuntimePackageBrandName)-2.0.5</AspNetCoreRuntimePackageName205>
-      <AspNetCoreRuntimePackageVersion>$(AspNetCoreVersion)-$(AspNetCoreRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageVersion>
-      <AspNetCoreRuntimePackageVersion Condition="'$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp'">$(AspNetCoreVersion)</AspNetCoreRuntimePackageVersion>
-      <AspNetCoreRuntimeRpmInstallerFileName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)-$(HostRidInAspNetCoreRuntimeRpmInstallerFileName).rpm</AspNetCoreRuntimeRpmInstallerFileName>
-      <AspNetCoreRuntimeRpmInstallerFileName Condition="'$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp'">$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersion)-$(HostRidInAspNetCoreRuntimeRpmInstallerFileName).rpm</AspNetCoreRuntimeRpmInstallerFileName>
       <AfterInstallHostScriptTemplateFile>$(ScriptsDir)/$(AfterInstallHostScriptName)</AfterInstallHostScriptTemplateFile>
       <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)/$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
     </PropertyGroup>
@@ -187,27 +181,15 @@
 
   <Target Name="DownloadAspNetCoreRuntimeRpmInstaller"
         DependsOnTargets="SetupDebProps">
-    <PropertyGroup>
-      <AspNetCoreRuntimeRpmInstallerFileName200>$(AspNetCoreRuntimePackageBrandName)-2.0.0-$(HostRidInAspNetCoreRuntimeRpmInstallerFileName).rpm</AspNetCoreRuntimeRpmInstallerFileName200>
-      <AspNetCoreRuntimeRpmInstallerFileName203>$(AspNetCoreRuntimePackageBrandName)-2.0.3-$(HostRidInAspNetCoreRuntimeRpmInstallerFileName).rpm</AspNetCoreRuntimeRpmInstallerFileName203>
-      <AspNetCoreRuntimeRpmInstallerFileName205>$(AspNetCoreRuntimePackageBrandName)-2.0.5-$(HostRidInAspNetCoreRuntimeRpmInstallerFileName).rpm</AspNetCoreRuntimeRpmInstallerFileName205>
-      <DownloadedSharedAspNetCoreRuntime200>$(PackagesDirectory)/$(AspNetCoreRuntimeRpmInstallerFileName200)</DownloadedSharedAspNetCoreRuntime200>
-      <DownloadedSharedAspNetCoreRuntime203>$(PackagesDirectory)/$(AspNetCoreRuntimeRpmInstallerFileName203)</DownloadedSharedAspNetCoreRuntime203>
-      <DownloadedSharedAspNetCoreRuntime205>$(PackagesDirectory)/$(AspNetCoreRuntimeRpmInstallerFileName205)</DownloadedSharedAspNetCoreRuntime205>
-      <DownloadedSharedAspNetCoreRuntime>$(PackagesDirectory)/$(AspNetCoreRuntimeRpmInstallerFileName)</DownloadedSharedAspNetCoreRuntime>
-    </PropertyGroup>
-    <DownloadFile
-               Uri="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeRpmInstallerFileName200)$(CoreSetupBlobAccessTokenParam)"
-               DestinationPath="$(DownloadedSharedAspNetCoreRuntime200)"/>
-    <DownloadFile
-               Uri="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeRpmInstallerFileName203)$(CoreSetupBlobAccessTokenParam)"
-               DestinationPath="$(DownloadedSharedAspNetCoreRuntime203)"/>
-    <DownloadFile
-               Uri="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeRpmInstallerFileName205)$(CoreSetupBlobAccessTokenParam)"
-               DestinationPath="$(DownloadedSharedAspNetCoreRuntime205)"/>
-    <DownloadFile
-               Uri="$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimeRpmInstallerFileName)$(CoreSetupBlobAccessTokenParam)"
-               DestinationPath="$(DownloadedSharedAspNetCoreRuntime)"/>
+    <ItemGroup>
+      <AspNetCoreRpmInstallerFile Include="$(PackagesDirectory)/$(AspNetCoreRuntimePackageBrandName)-%(AspNetCoreRuntimeStoreVersion.Identity)-$(HostRid).rpm">
+        <Source>$(AspNetCoreRuntimeInstallerBlobRootUrl)/$(AspNetCoreRuntimePackageBrandName)-%(AspNetCoreRuntimeStoreVersion.Identity)-$(HostRid).rpm$(CoreSetupBlobAccessTokenParam)</Source>
+        <PackageName>$(AspNetCoreRuntimePackageBrandName)-%(AspNetCoreRuntimeStoreVersion.Identity)</PackageName>
+      </AspNetCoreRpmInstallerFile>
+    </ItemGroup>
+
+    <DownloadFile Uri="%(AspNetCoreRpmInstallerFiles.Source)"
+                  DestinationPath="%(AspNetCoreRpmInstallerFiles.Identity)"/>
   </Target>
 
   <Target Name="TestFPMTool">
@@ -235,7 +217,7 @@
           Inputs="$(DownloadedSharedHostInstallerFile);
               $(DownloadedHostFxrInstallerFile);
               $(DownloadedSharedFrameworkInstallerFile);
-              $(DownloadedSharedAspNetCoreRuntime);
+              @(AspNetCoreRpmInstallerFile);
               $(RpmTestResultsXmlFile);"
           Outputs="$(RpmTestResultsXmlFile)" >
 
@@ -243,10 +225,7 @@
     <Exec Command="sudo yum -y install $(DownloadedSharedHostInstallerFile)" />
     <Exec Command="sudo yum -y install $(DownloadedHostFxrInstallerFile)" />
     <Exec Command="sudo yum -y install $(DownloadedSharedFrameworkInstallerFile)" />
-    <Exec Command="sudo yum -y install $(DownloadedSharedAspNetCoreRuntime200)" />
-    <Exec Command="sudo yum -y install $(DownloadedSharedAspNetCoreRuntime203)" />
-    <Exec Command="sudo yum -y install $(DownloadedSharedAspNetCoreRuntime205)" />
-    <Exec Command="sudo yum -y install $(DownloadedSharedAspNetCoreRuntime)" />
+    <Exec Command="sudo yum -y install %(AspNetCoreRpmInstallerFile.Identity)" />
 
     <Exec Command="sudo yum -y install $(SdkInstallerFile)" />
 
@@ -261,10 +240,7 @@
     <!-- Clean up Packages -->
     <Exec Command="sudo yum remove -y $(SdkRpmPackageName)" />
 
-    <Exec Command="sudo yum remove -y $(AspNetCoreRuntimePackageName)" />
-    <Exec Command="sudo yum remove -y $(AspNetCoreRuntimePackageName205)" />
-    <Exec Command="sudo yum remove -y $(AspNetCoreRuntimePackageName203)" />
-    <Exec Command="sudo yum remove -y $(AspNetCoreRuntimePackageName200)" />
+    <Exec Command="sudo yum remove -y %(AspNetCoreRpmInstallerFile.PackageName)" />
     <Exec Command="sudo yum remove -y $(SharedFxRpmPackageName)" />
     <Exec Command="sudo yum remove -y $(HostFxrRpmPackageName)" />
     <Exec Command="sudo yum remove -y $(HostRpmPackageName)" />


### PR DESCRIPTION
FYI @muratg @JunTaoLuo 

Changes:
 - Update version of ASP.NET Core
 - Add a restore feed that sits next to the same place used to download the aspnetcore runtime store

In this build, the restore feed would be https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/store/2.0.7-228/packages/index.json 