### PR TITLE
Remove instruction to install dotnet-dev-certs separately

### DIFF
--- a/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
@@ -151,7 +151,7 @@ Here are some options to fix this error:
     <value>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</value>
   </data>
 </root>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
@@ -62,7 +62,7 @@ Tuto chybu můžete opravit pomocí některé z těchto možností:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
@@ -62,7 +62,7 @@ Im Folgenden finden Sie einige Optionen, um diesen Fehler zu beheben:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
@@ -61,7 +61,7 @@ Estas son algunas opciones para corregir este error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
@@ -62,7 +62,7 @@ Voici quelques options pour corriger cette erreur :
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
@@ -62,7 +62,7 @@ Ecco alcune opzioni per correggere questo errore:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
@@ -62,7 +62,7 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
@@ -62,7 +62,7 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
@@ -62,7 +62,7 @@ Oto kilka opcji naprawiania tego błędu:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
@@ -62,7 +62,7 @@ Aqui estão algumas opções para corrigir este erro:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
@@ -62,7 +62,7 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
@@ -62,7 +62,7 @@ Bu hatayı düzeltmek için bazı seçenekler:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
@@ -62,7 +62,7 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
@@ -62,7 +62,7 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate (Windows and macOS only) first install the dev-certs tool by running 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' and then run 'dotnet-dev-certs https --trust'.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only).
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
         <target state="needs-review-translation">ASP.NET Core
 ------------


### PR DESCRIPTION
Old message doesn't apply anymore now that dev-certs is baked in.

