### PR TITLE
Changing the /m /v:m default parameters to msbuild to -m and -v:m

### DIFF
--- a/build_projects/dotnet-cli-build/DotNetPack.cs
+++ b/build_projects/dotnet-cli-build/DotNetPack.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             if (!string.IsNullOrEmpty(Runtime))
             {
-                return $"/p:RuntimeIdentifier={Runtime}";
+                return $"-p:RuntimeIdentifier={Runtime}";
             }
 
             return null;

--- a/build_projects/dotnet-cli-build/DotNetPack.cs
+++ b/build_projects/dotnet-cli-build/DotNetPack.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             if (!string.IsNullOrEmpty(Runtime))
             {
-                return $"-p:RuntimeIdentifier={Runtime}";
+                return $"-property:RuntimeIdentifier={Runtime}";
             }
 
             return null;

--- a/build_projects/dotnet-cli-build/DotNetRestore.cs
+++ b/build_projects/dotnet-cli-build/DotNetRestore.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             if (SkipInvalidConfigurations)
             {
-                return "-p:SkipInvalidConfigurations=true";
+                return "-property:SkipInvalidConfigurations=true";
             }
 
             return null;
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             if (!string.IsNullOrEmpty(Runtime))
             {
-                return $"-p:RuntimeIdentifier={Runtime}";
+                return $"-property:RuntimeIdentifier={Runtime}";
             }
 
             return null;

--- a/build_projects/dotnet-cli-build/DotNetRestore.cs
+++ b/build_projects/dotnet-cli-build/DotNetRestore.cs
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             if (SkipInvalidConfigurations)
             {
-                return "/p:SkipInvalidConfigurations=true";
+                return "-p:SkipInvalidConfigurations=true";
             }
 
             return null;
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Cli.Build
         {
             if (!string.IsNullOrEmpty(Runtime))
             {
-                return $"/p:RuntimeIdentifier={Runtime}";
+                return $"-p:RuntimeIdentifier={Runtime}";
             }
 
             return null;

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -354,12 +354,12 @@ namespace Microsoft.DotNet.Cli.Utils
             var args = new List<string>();
 
             args.Add(toolDepsJsonGeneratorProject);
-            args.Add($"/p:ProjectAssetsFile=\"{toolLockFile.Path}\"");
-            args.Add($"/p:ToolName={toolLibrary.Name}");
-            args.Add($"/p:ProjectDepsFilePath={tempDepsFile}");
+            args.Add($"-p:ProjectAssetsFile=\"{toolLockFile.Path}\"");
+            args.Add($"-p:ToolName={toolLibrary.Name}");
+            args.Add($"-p:ProjectDepsFilePath={tempDepsFile}");
 
             var toolTargetFramework = toolLockFile.Targets.First().TargetFramework.GetShortFolderName();
-            args.Add($"/p:TargetFramework={toolTargetFramework}");
+            args.Add($"-p:TargetFramework={toolTargetFramework}");
 
 
             //  Look for the .props file in the Microsoft.NETCore.App package, until NuGet
@@ -384,7 +384,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
                     if (platformLibraryPropsFile != null)
                     {
-                        args.Add($"/p:AdditionalImport={platformLibraryPropsFile}");
+                        args.Add($"-p:AdditionalImport={platformLibraryPropsFile}");
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandResolution/ProjectToolsCommandResolver.cs
@@ -354,12 +354,12 @@ namespace Microsoft.DotNet.Cli.Utils
             var args = new List<string>();
 
             args.Add(toolDepsJsonGeneratorProject);
-            args.Add($"-p:ProjectAssetsFile=\"{toolLockFile.Path}\"");
-            args.Add($"-p:ToolName={toolLibrary.Name}");
-            args.Add($"-p:ProjectDepsFilePath={tempDepsFile}");
+            args.Add($"-property:ProjectAssetsFile=\"{toolLockFile.Path}\"");
+            args.Add($"-property:ToolName={toolLibrary.Name}");
+            args.Add($"-property:ProjectDepsFilePath={tempDepsFile}");
 
             var toolTargetFramework = toolLockFile.Targets.First().TargetFramework.GetShortFolderName();
-            args.Add($"-p:TargetFramework={toolTargetFramework}");
+            args.Add($"-property:TargetFramework={toolTargetFramework}");
 
 
             //  Look for the .props file in the Microsoft.NETCore.App package, until NuGet
@@ -384,7 +384,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
                     if (platformLibraryPropsFile != null)
                     {
-                        args.Add($"-p:AdditionalImport={platformLibraryPropsFile}");
+                        args.Add($"-property:AdditionalImport={platformLibraryPropsFile}");
                     }
                 }
             }

--- a/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli.Utils
             };
 
         private readonly IEnumerable<string> _msbuildRequiredParameters =
-            new List<string> { "/m", "/v:m" };
+            new List<string> { "-m", "-v:m" };
 
         public MSBuildForwardingAppWithoutLogging(IEnumerable<string> argsToForward, string msbuildPath = null)
         {

--- a/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private static string Escape(string arg) =>
              // this is a workaround for https://github.com/Microsoft/msbuild/issues/1622
-             (arg.StartsWith("/p:RestoreSources=", StringComparison.OrdinalIgnoreCase)) ?
+             (arg.StartsWith("-p:RestoreSources=", StringComparison.OrdinalIgnoreCase)) ?
                 arg.Replace(";", "%3B")
                    .Replace("://", ":%2F%2F") :
                 arg;

--- a/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/MSBuildForwardingAppWithoutLogging.cs
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Cli.Utils
             };
 
         private readonly IEnumerable<string> _msbuildRequiredParameters =
-            new List<string> { "-m", "-v:m" };
+            new List<string> { "-maxcpucount", "-verbosity:m" };
 
         public MSBuildForwardingAppWithoutLogging(IEnumerable<string> argsToForward, string msbuildPath = null)
         {
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private static string Escape(string arg) =>
              // this is a workaround for https://github.com/Microsoft/msbuild/issues/1622
-             (arg.StartsWith("-p:RestoreSources=", StringComparison.OrdinalIgnoreCase)) ?
+             IsRestoreSources(arg) ?
                 arg.Replace(";", "%3B")
                    .Replace("://", ":%2F%2F") :
                 arg;
@@ -80,6 +80,14 @@ namespace Microsoft.DotNet.Cli.Utils
         private static string GetDotnetPath()
         {
             return new Muxer().MuxerPath;
+        }
+
+        private static bool IsRestoreSources(string arg)
+        {
+            return arg.StartsWith("/p:RestoreSources=", StringComparison.OrdinalIgnoreCase) ||
+                arg.StartsWith("/property:RestoreSources=", StringComparison.OrdinalIgnoreCase) ||
+                arg.StartsWith("-p:RestoreSources=", StringComparison.OrdinalIgnoreCase) ||
+                arg.StartsWith("-property:RestoreSources=", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/dotnet/CommonOptions.cs
+++ b/src/dotnet/CommonOptions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli
                 Accept.ExactlyOneArgument()
                     .WithSuggestionsFrom(_ => Suggest.TargetFrameworksFromProjectFile())
                     .With(name: "FRAMEWORK")
-                    .ForwardAsSingle(o => $"-p:TargetFramework={o.Arguments.Single()}"));
+                    .ForwardAsSingle(o => $"-property:TargetFramework={o.Arguments.Single()}"));
         
         public static Option RuntimeOption() =>
             Create.Option(
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli
                 Accept.ExactlyOneArgument()
                     .WithSuggestionsFrom(_ => Suggest.RunTimesFromProjectFile())
                     .With(name: "RUNTIME_IDENTIFIER")
-                    .ForwardAsSingle(o => $"-p:RuntimeIdentifier={o.Arguments.Single()}"));
+                    .ForwardAsSingle(o => $"-property:RuntimeIdentifier={o.Arguments.Single()}"));
                 
         public static Option ConfigurationOption() =>
             Create.Option(
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli
                 Accept.ExactlyOneArgument()
                     .With(name: "CONFIGURATION")
                     .WithSuggestionsFrom("DEBUG", "RELEASE")
-                    .ForwardAsSingle(o => $"-p:Configuration={o.Arguments.Single()}"));
+                    .ForwardAsSingle(o => $"-property:Configuration={o.Arguments.Single()}"));
 
         public static Option VersionSuffixOption() =>
             Create.Option(
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Cli
                 CommonLocalizableStrings.CmdVersionSuffixDescription,
                 Accept.ExactlyOneArgument()
                     .With(name: "VERSION_SUFFIX")
-                    .ForwardAsSingle(o => $"-p:VersionSuffix={o.Arguments.Single()}"));
+                    .ForwardAsSingle(o => $"-property:VersionSuffix={o.Arguments.Single()}"));
 
         public static ArgumentsRule DefaultToCurrentDirectory(this ArgumentsRule rule) =>
             rule.With(defaultValue: () => PathUtility.EnsureTrailingSlash(Directory.GetCurrentDirectory()));

--- a/src/dotnet/CommonOptions.cs
+++ b/src/dotnet/CommonOptions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli
                           "n", "normal",
                           "d", "detailed",
                           "diag", "diagnostic")
-                      .ForwardAsSingle(o => $"/verbosity:{o.Arguments.Single()}"));
+                      .ForwardAsSingle(o => $"-verbosity:{o.Arguments.Single()}"));
         
         public static Option FrameworkOption() =>
             Create.Option(
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli
                 Accept.ExactlyOneArgument()
                     .WithSuggestionsFrom(_ => Suggest.TargetFrameworksFromProjectFile())
                     .With(name: "FRAMEWORK")
-                    .ForwardAsSingle(o => $"/p:TargetFramework={o.Arguments.Single()}"));
+                    .ForwardAsSingle(o => $"-p:TargetFramework={o.Arguments.Single()}"));
         
         public static Option RuntimeOption() =>
             Create.Option(
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Cli
                 Accept.ExactlyOneArgument()
                     .WithSuggestionsFrom(_ => Suggest.RunTimesFromProjectFile())
                     .With(name: "RUNTIME_IDENTIFIER")
-                    .ForwardAsSingle(o => $"/p:RuntimeIdentifier={o.Arguments.Single()}"));
+                    .ForwardAsSingle(o => $"-p:RuntimeIdentifier={o.Arguments.Single()}"));
                 
         public static Option ConfigurationOption() =>
             Create.Option(
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli
                 Accept.ExactlyOneArgument()
                     .With(name: "CONFIGURATION")
                     .WithSuggestionsFrom("DEBUG", "RELEASE")
-                    .ForwardAsSingle(o => $"/p:Configuration={o.Arguments.Single()}"));
+                    .ForwardAsSingle(o => $"-p:Configuration={o.Arguments.Single()}"));
 
         public static Option VersionSuffixOption() =>
             Create.Option(
@@ -60,7 +60,7 @@ namespace Microsoft.DotNet.Cli
                 CommonLocalizableStrings.CmdVersionSuffixDescription,
                 Accept.ExactlyOneArgument()
                     .With(name: "VERSION_SUFFIX")
-                    .ForwardAsSingle(o => $"/p:VersionSuffix={o.Arguments.Single()}"));
+                    .ForwardAsSingle(o => $"-p:VersionSuffix={o.Arguments.Single()}"));
 
         public static ArgumentsRule DefaultToCurrentDirectory(this ArgumentsRule rule) =>
             rule.With(defaultValue: () => PathUtility.EnsureTrailingSlash(Directory.GetCurrentDirectory()));

--- a/src/dotnet/commands/RestoringCommand.cs
+++ b/src/dotnet/commands/RestoringCommand.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Tools
             => arguments.Any(a => IsExcludedFromRestore(a));
 
         private static bool IsExcludedFromRestore(string argument) 
-            => argument.StartsWith("-p:TargetFramework=", StringComparison.Ordinal);
+            => argument.StartsWith("-property:TargetFramework=", StringComparison.Ordinal);
 
         public override int Execute()
         {

--- a/src/dotnet/commands/RestoringCommand.cs
+++ b/src/dotnet/commands/RestoringCommand.cs
@@ -36,10 +36,10 @@ namespace Microsoft.DotNet.Tools
 
             if (HasArgumentToExcludeFromRestore(parsedArguments))
             {
-                return Prepend("/nologo", msbuildArgs);
+                return Prepend("-nologo", msbuildArgs);
             }
 
-            return Prepend("/restore", msbuildArgs);
+            return Prepend("-restore", msbuildArgs);
         }
 
         private static RestoreCommand GetSeparateRestoreCommand(
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Tools
             => arguments.Any(a => IsExcludedFromRestore(a));
 
         private static bool IsExcludedFromRestore(string argument) 
-            => argument.StartsWith("/p:TargetFramework=", StringComparison.Ordinal);
+            => argument.StartsWith("-p:TargetFramework=", StringComparison.Ordinal);
 
         public override int Execute()
         {

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
@@ -99,19 +99,19 @@ namespace Microsoft.DotNet.Tools.Add.PackageReference
             args.Add(projectFilePath);
 
             // Pass the task as generate restore Dependency Graph file
-            args.Add("/t:GenerateRestoreGraphFile");
+            args.Add("-t:GenerateRestoreGraphFile");
 
             // Pass Dependency Graph file output path
-            args.Add($"/p:RestoreGraphOutputPath=\"{dgFilePath}\"");
+            args.Add($"-p:RestoreGraphOutputPath=\"{dgFilePath}\"");
 
             // Turn off recursive restore
-            args.Add($"/p:RestoreRecursive=false");
+            args.Add($"-p:RestoreRecursive=false");
 
             // Turn off restore for Dotnet cli tool references so that we do not generate extra dg specs
-            args.Add($"/p:RestoreDotnetCliToolReferences=false");
+            args.Add($"-p:RestoreDotnetCliToolReferences=false");
 
             // Output should not include MSBuild version header
-            args.Add("/nologo");
+            args.Add("-nologo");
 
             var result = new MSBuildForwardingApp(args).Execute();
 

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/Program.cs
@@ -99,16 +99,16 @@ namespace Microsoft.DotNet.Tools.Add.PackageReference
             args.Add(projectFilePath);
 
             // Pass the task as generate restore Dependency Graph file
-            args.Add("-t:GenerateRestoreGraphFile");
+            args.Add("-target:GenerateRestoreGraphFile");
 
             // Pass Dependency Graph file output path
-            args.Add($"-p:RestoreGraphOutputPath=\"{dgFilePath}\"");
+            args.Add($"-property:RestoreGraphOutputPath=\"{dgFilePath}\"");
 
             // Turn off recursive restore
-            args.Add($"-p:RestoreRecursive=false");
+            args.Add($"-property:RestoreRecursive=false");
 
             // Turn off restore for Dotnet cli tool references so that we do not generate extra dg specs
-            args.Add($"-p:RestoreDotnetCliToolReferences=false");
+            args.Add($"-property:RestoreDotnetCliToolReferences=false");
 
             // Output should not include MSBuild version header
             args.Add("-nologo");

--- a/src/dotnet/commands/dotnet-build/BuildCommand.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommand.cs
@@ -37,15 +37,15 @@ namespace Microsoft.DotNet.Tools.Build
 
             var appliedBuildOptions = result["dotnet"]["build"];
 
-            msbuildArgs.Add($"-clp:Summary");
+            msbuildArgs.Add($"-consoleloggerparameters:Summary");
 
             if (appliedBuildOptions.HasOption("--no-incremental"))
             {
-                msbuildArgs.Add("-t:Rebuild");
+                msbuildArgs.Add("-target:Rebuild");
             }
             else
             {
-                msbuildArgs.Add("-t:Build");
+                msbuildArgs.Add("-target:Build");
             }
 
             msbuildArgs.AddRange(appliedBuildOptions.OptionValuesToBeForwarded());

--- a/src/dotnet/commands/dotnet-build/BuildCommand.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommand.cs
@@ -37,15 +37,15 @@ namespace Microsoft.DotNet.Tools.Build
 
             var appliedBuildOptions = result["dotnet"]["build"];
 
-            msbuildArgs.Add($"/clp:Summary");
+            msbuildArgs.Add($"-clp:Summary");
 
             if (appliedBuildOptions.HasOption("--no-incremental"))
             {
-                msbuildArgs.Add("/t:Rebuild");
+                msbuildArgs.Add("-t:Rebuild");
             }
             else
             {
-                msbuildArgs.Add("/t:Build");
+                msbuildArgs.Add("-t:Build");
             }
 
             msbuildArgs.AddRange(appliedBuildOptions.OptionValuesToBeForwarded());

--- a/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.OutputOptionName)
-                          .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
+                          .ForwardAsSingle(o => $"-p:OutputPath={o.Arguments.Single()}")),
                 CommonOptions.FrameworkOption(),
                 CommonOptions.RuntimeOption(),
                 CommonOptions.ConfigurationOption(),
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Cli
                     "--no-dependencies",
                     LocalizableStrings.NoDependenciesOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("/p:BuildProjectReferences=false")),
+                          .ForwardAs("-p:BuildProjectReferences=false")),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());
     }

--- a/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.OutputOptionName)
-                          .ForwardAsSingle(o => $"-p:OutputPath={o.Arguments.Single()}")),
+                          .ForwardAsSingle(o => $"-property:OutputPath={o.Arguments.Single()}")),
                 CommonOptions.FrameworkOption(),
                 CommonOptions.RuntimeOption(),
                 CommonOptions.ConfigurationOption(),
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Cli
                     "--no-dependencies",
                     LocalizableStrings.NoDependenciesOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("-p:BuildProjectReferences=false")),
+                          .ForwardAs("-property:BuildProjectReferences=false")),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());
     }

--- a/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli
                               LocalizableStrings.CmdOutputDirDescription,
                                          Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.CmdOutputDir)
-                        .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-p:OutputPath={o.Arguments.Single()}")),
                 CommonOptions.FrameworkOption(),
                 CommonOptions.RuntimeOption(),
                 CommonOptions.ConfigurationOption(),

--- a/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Cli
                               LocalizableStrings.CmdOutputDirDescription,
                                          Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.CmdOutputDir)
-                        .ForwardAsSingle(o => $"-p:OutputPath={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-property:OutputPath={o.Arguments.Single()}")),
                 CommonOptions.FrameworkOption(),
                 CommonOptions.RuntimeOption(),
                 CommonOptions.ConfigurationOption(),

--- a/src/dotnet/commands/dotnet-clean/Program.cs
+++ b/src/dotnet/commands/dotnet-clean/Program.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Clean
         {
             var msbuildArgs = new List<string>
             {
-                "-v:normal"
+                "-verbosity:normal"
             };
 
             var parser = Parser.Instance;
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Tools.Clean
 
             msbuildArgs.AddRange(parsedClean.Arguments);
                 
-            msbuildArgs.Add("-t:Clean");
+            msbuildArgs.Add("-target:Clean");
 
             msbuildArgs.AddRange(parsedClean.OptionValuesToBeForwarded());
 

--- a/src/dotnet/commands/dotnet-clean/Program.cs
+++ b/src/dotnet/commands/dotnet-clean/Program.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Clean
         {
             var msbuildArgs = new List<string>
             {
-                "/v:normal"
+                "-v:normal"
             };
 
             var parser = Parser.Instance;
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Tools.Clean
 
             msbuildArgs.AddRange(parsedClean.Arguments);
                 
-            msbuildArgs.Add("/t:Clean");
+            msbuildArgs.Add("-t:Clean");
 
             msbuildArgs.AddRange(parsedClean.OptionValuesToBeForwarded());
 

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Tools.MSBuild
                     return argsToForward
                         .Concat(new[]
                         {
-                            $"/distributedlogger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}*{forwardingLoggerType.FullName},{forwardingLoggerType.GetTypeInfo().Assembly.Location}"
+                            $"-distributedlogger:{loggerType.FullName},{loggerType.GetTypeInfo().Assembly.Location}*{forwardingLoggerType.FullName},{forwardingLoggerType.GetTypeInfo().Assembly.Location}"
                         });
                 }
                 catch (Exception)

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Tools.Pack
           
             var msbuildArgs = new List<string>()
             {
-                "/t:pack"
+                "-t:pack"
             };
 
             msbuildArgs.AddRange(parsedPack.OptionValuesToBeForwarded());

--- a/src/dotnet/commands/dotnet-pack/PackCommand.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommand.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Tools.Pack
           
             var msbuildArgs = new List<string>()
             {
-                "-t:pack"
+                "-target:pack"
             };
 
             msbuildArgs.AddRange(parsedPack.OptionValuesToBeForwarded());

--- a/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -22,25 +22,25 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.CmdOutputDirDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.CmdOutputDir)
-                        .ForwardAsSingle(o => $"/p:PackageOutputPath={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-p:PackageOutputPath={o.Arguments.Single()}")),
                 Create.Option(
                     "--no-build",
                     LocalizableStrings.CmdNoBuildOptionDescription,
-                    Accept.NoArguments().ForwardAs("/p:NoBuild=true")),
+                    Accept.NoArguments().ForwardAs("-p:NoBuild=true")),
                 Create.Option(
                     "--include-symbols",
                     LocalizableStrings.CmdIncludeSymbolsDescription,
-                    Accept.NoArguments().ForwardAs("/p:IncludeSymbols=true")),
+                    Accept.NoArguments().ForwardAs("-p:IncludeSymbols=true")),
                 Create.Option(
                     "--include-source",
                     LocalizableStrings.CmdIncludeSourceDescription,
-                    Accept.NoArguments().ForwardAs("/p:IncludeSource=true")),
+                    Accept.NoArguments().ForwardAs("-p:IncludeSource=true")),
                 CommonOptions.ConfigurationOption(),
                 CommonOptions.VersionSuffixOption(),
                 Create.Option(
                     "-s|--serviceable",
                     LocalizableStrings.CmdServiceableDescription,
-                    Accept.NoArguments().ForwardAs("/p:Serviceable=true")),
+                    Accept.NoArguments().ForwardAs("-p:Serviceable=true")),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());
     }

--- a/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -22,25 +22,25 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.CmdOutputDirDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.CmdOutputDir)
-                        .ForwardAsSingle(o => $"-p:PackageOutputPath={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-property:PackageOutputPath={o.Arguments.Single()}")),
                 Create.Option(
                     "--no-build",
                     LocalizableStrings.CmdNoBuildOptionDescription,
-                    Accept.NoArguments().ForwardAs("-p:NoBuild=true")),
+                    Accept.NoArguments().ForwardAs("-property:NoBuild=true")),
                 Create.Option(
                     "--include-symbols",
                     LocalizableStrings.CmdIncludeSymbolsDescription,
-                    Accept.NoArguments().ForwardAs("-p:IncludeSymbols=true")),
+                    Accept.NoArguments().ForwardAs("-property:IncludeSymbols=true")),
                 Create.Option(
                     "--include-source",
                     LocalizableStrings.CmdIncludeSourceDescription,
-                    Accept.NoArguments().ForwardAs("-p:IncludeSource=true")),
+                    Accept.NoArguments().ForwardAs("-property:IncludeSource=true")),
                 CommonOptions.ConfigurationOption(),
                 CommonOptions.VersionSuffixOption(),
                 Create.Option(
                     "-s|--serviceable",
                     LocalizableStrings.CmdServiceableDescription,
-                    Accept.NoArguments().ForwardAs("-p:Serviceable=true")),
+                    Accept.NoArguments().ForwardAs("-property:Serviceable=true")),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());
     }

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tools.Publish
 
             result.ShowHelpOrErrorIfAppropriate();
 
-            msbuildArgs.Add("/t:Publish");
+            msbuildArgs.Add("-t:Publish");
 
             var appliedPublishOption = result["dotnet"]["publish"];
 

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tools.Publish
 
             result.ShowHelpOrErrorIfAppropriate();
 
-            msbuildArgs.Add("-t:Publish");
+            msbuildArgs.Add("-target:Publish");
 
             var appliedPublishOption = result["dotnet"]["publish"];
 

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.OutputOption)
-                        .ForwardAsSingle(o => $"/p:PublishDir={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-p:PublishDir={o.Arguments.Single()}")),
                 CommonOptions.FrameworkOption(),
                 CommonOptions.RuntimeOption(),
                 CommonOptions.ConfigurationOption(),
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.ManifestOptionDescription,
                     Accept.OneOrMoreArguments()
                         .With(name: LocalizableStrings.ManifestOption)
-                        .ForwardAsSingle(o => $"/p:TargetManifestFiles={string.Join("%3B", o.Arguments)}")),
+                        .ForwardAsSingle(o => $"-p:TargetManifestFiles={string.Join("%3B", o.Arguments)}")),
                 Create.Option(
                     "--self-contained",
                     LocalizableStrings.SelfContainedOptionDescription,
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Cli
                         .ForwardAsSingle(o =>
                         {
                             string value = o.Arguments.Any() ? o.Arguments.Single() : "true";
-                            return $"/p:SelfContained={value}";
+                            return $"-p:SelfContained={value}";
                         })),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.OutputOption)
-                        .ForwardAsSingle(o => $"-p:PublishDir={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-property:PublishDir={o.Arguments.Single()}")),
                 CommonOptions.FrameworkOption(),
                 CommonOptions.RuntimeOption(),
                 CommonOptions.ConfigurationOption(),
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.ManifestOptionDescription,
                     Accept.OneOrMoreArguments()
                         .With(name: LocalizableStrings.ManifestOption)
-                        .ForwardAsSingle(o => $"-p:TargetManifestFiles={string.Join("%3B", o.Arguments)}")),
+                        .ForwardAsSingle(o => $"-property:TargetManifestFiles={string.Join("%3B", o.Arguments)}")),
                 Create.Option(
                     "--self-contained",
                     LocalizableStrings.SelfContainedOptionDescription,
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Cli
                         .ForwardAsSingle(o =>
                         {
                             string value = o.Arguments.Any() ? o.Arguments.Single() : "true";
-                            return $"-p:SelfContained={value}";
+                            return $"-property:SelfContained={value}";
                         })),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -35,10 +35,10 @@ namespace Microsoft.DotNet.Tools.Restore
 
             if (noLogo)
             {
-                msbuildArgs.Add("/nologo");
+                msbuildArgs.Add("-nologo");
             }
 
-            msbuildArgs.Add("/t:Restore");
+            msbuildArgs.Add("-t:Restore");
 
             msbuildArgs.AddRange(parsedRestore.OptionValuesToBeForwarded());
 

--- a/src/dotnet/commands/dotnet-restore/Program.cs
+++ b/src/dotnet/commands/dotnet-restore/Program.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Tools.Restore
                 msbuildArgs.Add("-nologo");
             }
 
-            msbuildArgs.Add("-t:Restore");
+            msbuildArgs.Add("-target:Restore");
 
             msbuildArgs.AddRange(parsedRestore.OptionValuesToBeForwarded());
 

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -47,51 +47,51 @@ namespace Microsoft.DotNet.Cli
                     showHelp ? LocalizableStrings.CmdSourceOptionDescription : string.Empty,
                     Accept.OneOrMoreArguments()
                           .With(name: LocalizableStrings.CmdSourceOption)
-                          .ForwardAsSingle(o => $"/p:RestoreSources={string.Join("%3B", o.Arguments)}")),
+                          .ForwardAsSingle(o => $"-p:RestoreSources={string.Join("%3B", o.Arguments)}")),
                 Create.Option(
                     useShortOptions ? "-r|--runtime" : "--runtime" ,
                     LocalizableStrings.CmdRuntimeOptionDescription,
                     Accept.OneOrMoreArguments()
                           .WithSuggestionsFrom(_ => Suggest.RunTimesFromProjectFile())
                           .With(name: LocalizableStrings.CmdRuntimeOption)
-                          .ForwardAsSingle(o => $"/p:RuntimeIdentifiers={string.Join("%3B", o.Arguments)}")),
+                          .ForwardAsSingle(o => $"-p:RuntimeIdentifiers={string.Join("%3B", o.Arguments)}")),
                 Create.Option(
                     "--packages",
                     showHelp ? LocalizableStrings.CmdPackagesOptionDescription : string.Empty,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.CmdPackagesOption)
-                          .ForwardAsSingle(o => $"/p:RestorePackagesPath={o.Arguments.Single()}")),
+                          .ForwardAsSingle(o => $"-p:RestorePackagesPath={o.Arguments.Single()}")),
                 Create.Option(
                     "--disable-parallel",
                     showHelp ? LocalizableStrings.CmdDisableParallelOptionDescription : string.Empty,
                     Accept.NoArguments()
-                          .ForwardAs("/p:RestoreDisableParallel=true")),
+                          .ForwardAs("-p:RestoreDisableParallel=true")),
                 Create.Option(
                     "--configfile",
                     showHelp ? LocalizableStrings.CmdConfigFileOptionDescription : string.Empty,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.CmdConfigFileOption)
-                          .ForwardAsSingle(o => $"/p:RestoreConfigFile={o.Arguments.Single()}")),
+                          .ForwardAsSingle(o => $"-p:RestoreConfigFile={o.Arguments.Single()}")),
                 Create.Option(
                     "--no-cache",
                     showHelp ? LocalizableStrings.CmdNoCacheOptionDescription : string.Empty,
                     Accept.NoArguments()
-                          .ForwardAs("/p:RestoreNoCache=true")),
+                          .ForwardAs("-p:RestoreNoCache=true")),
                 Create.Option(
                     "--ignore-failed-sources",
                     showHelp ? LocalizableStrings.CmdIgnoreFailedSourcesOptionDescription : string.Empty,
                     Accept.NoArguments()
-                          .ForwardAs("/p:RestoreIgnoreFailedSources=true")),
+                          .ForwardAs("-p:RestoreIgnoreFailedSources=true")),
                 Create.Option(
                     "--no-dependencies",
                     LocalizableStrings.CmdNoDependenciesOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("/p:RestoreRecursive=false")),
+                          .ForwardAs("-p:RestoreRecursive=false")),
                 Create.Option(
                     useShortOptions ? "-f|--force" : "--force",
                     LocalizableStrings.CmdForceRestoreOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("/p:RestoreForce=true"))
+                          .ForwardAs("-p:RestoreForce=true"))
             };
         }
     }

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -47,51 +47,51 @@ namespace Microsoft.DotNet.Cli
                     showHelp ? LocalizableStrings.CmdSourceOptionDescription : string.Empty,
                     Accept.OneOrMoreArguments()
                           .With(name: LocalizableStrings.CmdSourceOption)
-                          .ForwardAsSingle(o => $"-p:RestoreSources={string.Join("%3B", o.Arguments)}")),
+                          .ForwardAsSingle(o => $"-property:RestoreSources={string.Join("%3B", o.Arguments)}")),
                 Create.Option(
                     useShortOptions ? "-r|--runtime" : "--runtime" ,
                     LocalizableStrings.CmdRuntimeOptionDescription,
                     Accept.OneOrMoreArguments()
                           .WithSuggestionsFrom(_ => Suggest.RunTimesFromProjectFile())
                           .With(name: LocalizableStrings.CmdRuntimeOption)
-                          .ForwardAsSingle(o => $"-p:RuntimeIdentifiers={string.Join("%3B", o.Arguments)}")),
+                          .ForwardAsSingle(o => $"-property:RuntimeIdentifiers={string.Join("%3B", o.Arguments)}")),
                 Create.Option(
                     "--packages",
                     showHelp ? LocalizableStrings.CmdPackagesOptionDescription : string.Empty,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.CmdPackagesOption)
-                          .ForwardAsSingle(o => $"-p:RestorePackagesPath={o.Arguments.Single()}")),
+                          .ForwardAsSingle(o => $"-property:RestorePackagesPath={o.Arguments.Single()}")),
                 Create.Option(
                     "--disable-parallel",
                     showHelp ? LocalizableStrings.CmdDisableParallelOptionDescription : string.Empty,
                     Accept.NoArguments()
-                          .ForwardAs("-p:RestoreDisableParallel=true")),
+                          .ForwardAs("-property:RestoreDisableParallel=true")),
                 Create.Option(
                     "--configfile",
                     showHelp ? LocalizableStrings.CmdConfigFileOptionDescription : string.Empty,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.CmdConfigFileOption)
-                          .ForwardAsSingle(o => $"-p:RestoreConfigFile={o.Arguments.Single()}")),
+                          .ForwardAsSingle(o => $"-property:RestoreConfigFile={o.Arguments.Single()}")),
                 Create.Option(
                     "--no-cache",
                     showHelp ? LocalizableStrings.CmdNoCacheOptionDescription : string.Empty,
                     Accept.NoArguments()
-                          .ForwardAs("-p:RestoreNoCache=true")),
+                          .ForwardAs("-property:RestoreNoCache=true")),
                 Create.Option(
                     "--ignore-failed-sources",
                     showHelp ? LocalizableStrings.CmdIgnoreFailedSourcesOptionDescription : string.Empty,
                     Accept.NoArguments()
-                          .ForwardAs("-p:RestoreIgnoreFailedSources=true")),
+                          .ForwardAs("-property:RestoreIgnoreFailedSources=true")),
                 Create.Option(
                     "--no-dependencies",
                     LocalizableStrings.CmdNoDependenciesOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("-p:RestoreRecursive=false")),
+                          .ForwardAs("-property:RestoreRecursive=false")),
                 Create.Option(
                     useShortOptions ? "-f|--force" : "--force",
                     LocalizableStrings.CmdForceRestoreOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("-p:RestoreForce=true"))
+                          .ForwardAs("-property:RestoreForce=true"))
             };
         }
     }

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -167,12 +167,12 @@ namespace Microsoft.DotNet.Tools.Run
         {
             List<string> args = new List<string>()
             {
-                "/nologo"
+                "-nologo"
             };
 
-            if (!RestoreArgs.Any(a => a.StartsWith("/verbosity:")))
+            if (!RestoreArgs.Any(a => a.StartsWith("-verbosity:")))
             {
-                args.Add("/verbosity:quiet");
+                args.Add("-verbosity:quiet");
             }
 
             args.AddRange(RestoreArgs);

--- a/src/dotnet/commands/dotnet-store/Program.cs
+++ b/src/dotnet/commands/dotnet-store/Program.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Tools.Store
                 throw new GracefulException(LocalizableStrings.SpecifyManifests);
             }
 
-            msbuildArgs.Add("/t:ComposeStore");
+            msbuildArgs.Add("-t:ComposeStore");
 
             msbuildArgs.AddRange(appliedBuildOptions.OptionValuesToBeForwarded());
 

--- a/src/dotnet/commands/dotnet-store/Program.cs
+++ b/src/dotnet/commands/dotnet-store/Program.cs
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Tools.Store
                 throw new GracefulException(LocalizableStrings.SpecifyManifests);
             }
 
-            msbuildArgs.Add("-t:ComposeStore");
+            msbuildArgs.Add("-target:ComposeStore");
 
             msbuildArgs.AddRange(appliedBuildOptions.OptionValuesToBeForwarded());
 

--- a/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Cli
                                   return new[]
                                   {
                                       materializedString,
-                                      $"/p:AdditionalProjects={string.Join("%3B", o.Arguments.Skip(1))}"
+                                      $"-p:AdditionalProjects={string.Join("%3B", o.Arguments.Skip(1))}"
                                   };
                               }
                           })),
@@ -47,30 +47,30 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.FrameworkVersionOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.FrameworkVersionOption)
-                        .ForwardAsSingle(o => $"/p:RuntimeFrameworkVersion={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-p:RuntimeFrameworkVersion={o.Arguments.Single()}")),
                 CommonOptions.RuntimeOption(),
                 Create.Option(
                     "-o|--output",
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.OutputOption)
-                        .ForwardAsSingle(o => $"/p:ComposeDir={Path.GetFullPath(o.Arguments.Single())}")),
+                        .ForwardAsSingle(o => $"-p:ComposeDir={Path.GetFullPath(o.Arguments.Single())}")),
                 Create.Option(
                     "-w|--working-dir",
                     LocalizableStrings.IntermediateWorkingDirOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.IntermediateWorkingDirOption)
-                        .ForwardAsSingle(o => $"/p:ComposeWorkingDir={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-p:ComposeWorkingDir={o.Arguments.Single()}")),
                 Create.Option(
                     "--skip-optimization",
                     LocalizableStrings.SkipOptimizationOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("/p:SkipOptimization=true")),
+                          .ForwardAs("-p:SkipOptimization=true")),
                 Create.Option(
                     "--skip-symbols",
                     LocalizableStrings.SkipSymbolsOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("/p:CreateProfilingSymbols=false")),
+                          .ForwardAs("-p:CreateProfilingSymbols=false")),
                 CommonOptions.VerbosityOption());
     }
 }

--- a/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Cli
                                   return new[]
                                   {
                                       materializedString,
-                                      $"-p:AdditionalProjects={string.Join("%3B", o.Arguments.Skip(1))}"
+                                      $"-property:AdditionalProjects={string.Join("%3B", o.Arguments.Skip(1))}"
                                   };
                               }
                           })),
@@ -47,30 +47,30 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.FrameworkVersionOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.FrameworkVersionOption)
-                        .ForwardAsSingle(o => $"-p:RuntimeFrameworkVersion={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-property:RuntimeFrameworkVersion={o.Arguments.Single()}")),
                 CommonOptions.RuntimeOption(),
                 Create.Option(
                     "-o|--output",
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.OutputOption)
-                        .ForwardAsSingle(o => $"-p:ComposeDir={Path.GetFullPath(o.Arguments.Single())}")),
+                        .ForwardAsSingle(o => $"-property:ComposeDir={Path.GetFullPath(o.Arguments.Single())}")),
                 Create.Option(
                     "-w|--working-dir",
                     LocalizableStrings.IntermediateWorkingDirOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.IntermediateWorkingDirOption)
-                        .ForwardAsSingle(o => $"-p:ComposeWorkingDir={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-property:ComposeWorkingDir={o.Arguments.Single()}")),
                 Create.Option(
                     "--skip-optimization",
                     LocalizableStrings.SkipOptimizationOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("-p:SkipOptimization=true")),
+                          .ForwardAs("-property:SkipOptimization=true")),
                 Create.Option(
                     "--skip-symbols",
                     LocalizableStrings.SkipSymbolsOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("-p:CreateProfilingSymbols=false")),
+                          .ForwardAs("-property:CreateProfilingSymbols=false")),
                 CommonOptions.VerbosityOption());
     }
 }

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -30,8 +30,8 @@ namespace Microsoft.DotNet.Tools.Test
         {
             var msbuildArgs = new List<string>()
             {
-                "-t:VSTest",
-                "-v:quiet",
+                "-target:VSTest",
+                "-verbosity:quiet",
                 "-nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
                 "-nologo"
             };
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.Tools.Test
             {
                 var runSettingsArg = string.Join(";", runSettingsOptions);
 
-                msbuildArgs.Add($"-p:VSTestCLIRunSettings=\"{runSettingsArg}\"");
+                msbuildArgs.Add($"-property:VSTestCLIRunSettings=\"{runSettingsArg}\"");
             }
 
             var verbosityArg = msbuildArgs.LastOrDefault(arg => arg.StartsWith("-verbosity"));
@@ -67,7 +67,7 @@ namespace Microsoft.DotNet.Tools.Test
                 var verbosity = verbosityArg.Split(':');
                 if (verbosity.Length == 2)
                 {
-                    msbuildArgs.Add($"-p:VSTestVerbosity={verbosity[1]}");
+                    msbuildArgs.Add($"-property:VSTestVerbosity={verbosity[1]}");
                 }
             }
 

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -30,10 +30,10 @@ namespace Microsoft.DotNet.Tools.Test
         {
             var msbuildArgs = new List<string>()
             {
-                "/t:VSTest",
-                "/v:quiet",
-                "/nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
-                "/nologo"
+                "-t:VSTest",
+                "-v:quiet",
+                "-nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
+                "-nologo"
             };
 
             var parser = Parser.Instance;
@@ -57,17 +57,17 @@ namespace Microsoft.DotNet.Tools.Test
             {
                 var runSettingsArg = string.Join(";", runSettingsOptions);
 
-                msbuildArgs.Add($"/p:VSTestCLIRunSettings=\"{runSettingsArg}\"");
+                msbuildArgs.Add($"-p:VSTestCLIRunSettings=\"{runSettingsArg}\"");
             }
 
-            var verbosityArg = msbuildArgs.LastOrDefault(arg => arg.StartsWith("/verbosity"));
+            var verbosityArg = msbuildArgs.LastOrDefault(arg => arg.StartsWith("-verbosity"));
 
             if (!string.IsNullOrEmpty(verbosityArg))
             {
                 var verbosity = verbosityArg.Split(':');
                 if (verbosity.Length == 2)
                 {
-                    msbuildArgs.Add($"/p:VSTestVerbosity={verbosity[1]}");
+                    msbuildArgs.Add($"-p:VSTestVerbosity={verbosity[1]}");
                 }
             }
 

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -25,24 +25,24 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdSettingsDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdSettingsFile)
-                              .ForwardAsSingle(o => $"/p:VSTestSetting={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-p:VSTestSetting={o.Arguments.Single()}")),
                   Create.Option(
                         "-t|--list-tests",
                         LocalizableStrings.CmdListTestsDescription,
                         Accept.NoArguments()
-                              .ForwardAsSingle(o => "/p:VSTestListTests=true")),
+                              .ForwardAsSingle(o => "-p:VSTestListTests=true")),
                   Create.Option(
                         "--filter",
                         LocalizableStrings.CmdTestCaseFilterDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdTestCaseFilterExpression)
-                              .ForwardAsSingle(o => $"/p:VSTestTestCaseFilter={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-p:VSTestTestCaseFilter={o.Arguments.Single()}")),
                   Create.Option(
                         "-a|--test-adapter-path",
                         LocalizableStrings.CmdTestAdapterPathDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdTestAdapterPath)
-                              .ForwardAsSingle(o => $"/p:VSTestTestAdapterPath={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-p:VSTestTestAdapterPath={o.Arguments.Single()}")),
                   Create.Option(
                         "-l|--logger",
                         LocalizableStrings.CmdLoggerDescription,
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli
                                     {
                                           var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
 
-                                          return $"/p:VSTestLogger={loggersString}";
+                                          return $"-p:VSTestLogger={loggersString}";
                                     })),
                   CommonOptions.ConfigurationOption(),
                   CommonOptions.FrameworkOption(),
@@ -61,35 +61,35 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdOutputDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdOutputDir)
-                              .ForwardAsSingle(o => $"/p:OutputPath={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-p:OutputPath={o.Arguments.Single()}")),
                   Create.Option(
                         "-d|--diag",
                         LocalizableStrings.CmdPathTologFileDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdPathToLogFile)
-                              .ForwardAsSingle(o => $"/p:VSTestDiag={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-p:VSTestDiag={o.Arguments.Single()}")),
                   Create.Option(
                         "--no-build",
                         LocalizableStrings.CmdNoBuildDescription,
                         Accept.NoArguments()
-                              .ForwardAsSingle(o => "/p:VSTestNoBuild=true")),
+                              .ForwardAsSingle(o => "-p:VSTestNoBuild=true")),
                   Create.Option(
                         "-r|--results-directory",
                         LocalizableStrings.CmdResultsDirectoryDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdPathToResultsDirectory)
-                              .ForwardAsSingle(o => $"/p:VSTestResultsDirectory={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-p:VSTestResultsDirectory={o.Arguments.Single()}")),
                   Create.Option(
                         "--collect",
                         LocalizableStrings.cmdCollectDescription,
                         Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.cmdCollectFriendlyName)
-                              .ForwardAsSingle(o => $"/p:VSTestCollect=\"{string.Join(";", o.Arguments)}\"")),
+                              .ForwardAsSingle(o => $"-p:VSTestCollect=\"{string.Join(";", o.Arguments)}\"")),
                   Create.Option(
                         "--blame",
                         LocalizableStrings.CmdBlameDescription,
                         Accept.NoArguments()
-                              .ForwardAsSingle(o => "/p:VSTestBlame=true")),
+                              .ForwardAsSingle(o => "-p:VSTestBlame=true")),
                   CommonOptions.NoRestoreOption(),
                   CommonOptions.VerbosityOption());
 

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -25,24 +25,24 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdSettingsDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdSettingsFile)
-                              .ForwardAsSingle(o => $"-p:VSTestSetting={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:VSTestSetting={o.Arguments.Single()}")),
                   Create.Option(
                         "-t|--list-tests",
                         LocalizableStrings.CmdListTestsDescription,
                         Accept.NoArguments()
-                              .ForwardAsSingle(o => "-p:VSTestListTests=true")),
+                              .ForwardAsSingle(o => "-property:VSTestListTests=true")),
                   Create.Option(
                         "--filter",
                         LocalizableStrings.CmdTestCaseFilterDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdTestCaseFilterExpression)
-                              .ForwardAsSingle(o => $"-p:VSTestTestCaseFilter={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:VSTestTestCaseFilter={o.Arguments.Single()}")),
                   Create.Option(
                         "-a|--test-adapter-path",
                         LocalizableStrings.CmdTestAdapterPathDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdTestAdapterPath)
-                              .ForwardAsSingle(o => $"-p:VSTestTestAdapterPath={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:VSTestTestAdapterPath={o.Arguments.Single()}")),
                   Create.Option(
                         "-l|--logger",
                         LocalizableStrings.CmdLoggerDescription,
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli
                                     {
                                           var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
 
-                                          return $"-p:VSTestLogger={loggersString}";
+                                          return $"-property:VSTestLogger={loggersString}";
                                     })),
                   CommonOptions.ConfigurationOption(),
                   CommonOptions.FrameworkOption(),
@@ -61,35 +61,35 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdOutputDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdOutputDir)
-                              .ForwardAsSingle(o => $"-p:OutputPath={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:OutputPath={o.Arguments.Single()}")),
                   Create.Option(
                         "-d|--diag",
                         LocalizableStrings.CmdPathTologFileDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdPathToLogFile)
-                              .ForwardAsSingle(o => $"-p:VSTestDiag={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:VSTestDiag={o.Arguments.Single()}")),
                   Create.Option(
                         "--no-build",
                         LocalizableStrings.CmdNoBuildDescription,
                         Accept.NoArguments()
-                              .ForwardAsSingle(o => "-p:VSTestNoBuild=true")),
+                              .ForwardAsSingle(o => "-property:VSTestNoBuild=true")),
                   Create.Option(
                         "-r|--results-directory",
                         LocalizableStrings.CmdResultsDirectoryDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdPathToResultsDirectory)
-                              .ForwardAsSingle(o => $"-p:VSTestResultsDirectory={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:VSTestResultsDirectory={o.Arguments.Single()}")),
                   Create.Option(
                         "--collect",
                         LocalizableStrings.cmdCollectDescription,
                         Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.cmdCollectFriendlyName)
-                              .ForwardAsSingle(o => $"-p:VSTestCollect=\"{string.Join(";", o.Arguments)}\"")),
+                              .ForwardAsSingle(o => $"-property:VSTestCollect=\"{string.Join(";", o.Arguments)}\"")),
                   Create.Option(
                         "--blame",
                         LocalizableStrings.CmdBlameDescription,
                         Accept.NoArguments()
-                              .ForwardAsSingle(o => "-p:VSTestBlame=true")),
+                              .ForwardAsSingle(o => "-property:VSTestBlame=true")),
                   CommonOptions.NoRestoreOption(),
                   CommonOptions.VerbosityOption());
 

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             {
                 "--runtime",
                 AnyRid,
-                $"-p:BaseIntermediateOutputPath={assetJsonOutput.ToXmlEncodeString()}"
+                $"-property:BaseIntermediateOutputPath={assetJsonOutput.ToXmlEncodeString()}"
             });
 
             argsToPassToRestore.Add($"-verbosity:{verbosity ?? "quiet"}");

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -44,10 +44,10 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             {
                 "--runtime",
                 AnyRid,
-                $"/p:BaseIntermediateOutputPath={assetJsonOutput.ToXmlEncodeString()}"
+                $"-p:BaseIntermediateOutputPath={assetJsonOutput.ToXmlEncodeString()}"
             });
 
-            argsToPassToRestore.Add($"/verbosity:{verbosity ?? "quiet"}");
+            argsToPassToRestore.Add($"-verbosity:{verbosity ?? "quiet"}");
 
             var command = new DotNetCommandFactory(alwaysRunOutOfProc: true)
                 .Create("restore", argsToPassToRestore);

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/DotnetTestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/DotnetTestCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 return null;
             }
 
-            return $"/p:RuntimeIdentifier={_runtime}";
+            return $"-p:RuntimeIdentifier={_runtime}";
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/DotnetTestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/DotnetTestCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 return null;
             }
 
-            return $"-p:RuntimeIdentifier={_runtime}";
+            return $"-property:RuntimeIdentifier={_runtime}";
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 return null;
             }
 
-            return $"/p:RuntimeIdentifier={_runtime}";
+            return $"-p:RuntimeIdentifier={_runtime}";
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/RestoreCommand.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 return null;
             }
 
-            return $"-p:RuntimeIdentifier={_runtime}";
+            return $"-property:RuntimeIdentifier={_runtime}";
         }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -12,22 +12,22 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         const string ExpectedPrefix = "exec <msbuildpath> -m -v:m";
 
         [Theory]
-        [InlineData(new string[] { }, "/t:Build")]
-        [InlineData(new string[] { "-o", "foo" }, "/t:Build /p:OutputPath=foo")]
-        [InlineData(new string[] { "-p:Verbosity=diag" }, "/t:Build -p:Verbosity=diag")]
-        [InlineData(new string[] { "--output", "foo" }, "/t:Build /p:OutputPath=foo")]
-        [InlineData(new string[] { "-o", "foo1 foo2" }, "/t:Build \"/p:OutputPath=foo1 foo2\"")]
-        [InlineData(new string[] { "--no-incremental" }, "/t:Rebuild")]
-        [InlineData(new string[] { "-r", "rid" }, "/t:Build /p:RuntimeIdentifier=rid")]
-        [InlineData(new string[] { "--runtime", "rid" }, "/t:Build /p:RuntimeIdentifier=rid")]
-        [InlineData(new string[] { "-c", "config" }, "/t:Build /p:Configuration=config")]
-        [InlineData(new string[] { "--configuration", "config" }, "/t:Build /p:Configuration=config")]
-        [InlineData(new string[] { "--version-suffix", "mysuffix" }, "/t:Build /p:VersionSuffix=mysuffix")]
-        [InlineData(new string[] { "--no-dependencies" }, "/t:Build /p:BuildProjectReferences=false")]
-        [InlineData(new string[] { "-v", "diag" }, "/t:Build /verbosity:diag")]
-        [InlineData(new string[] { "--verbosity", "diag" }, "/t:Build /verbosity:diag")]
+        [InlineData(new string[] { }, "-t:Build")]
+        [InlineData(new string[] { "-o", "foo" }, "-t:Build -p:OutputPath=foo")]
+        [InlineData(new string[] { "-p:Verbosity=diag" }, "-t:Build -p:Verbosity=diag")]
+        [InlineData(new string[] { "--output", "foo" }, "-t:Build -p:OutputPath=foo")]
+        [InlineData(new string[] { "-o", "foo1 foo2" }, "-t:Build \"-p:OutputPath=foo1 foo2\"")]
+        [InlineData(new string[] { "--no-incremental" }, "-t:Rebuild")]
+        [InlineData(new string[] { "-r", "rid" }, "-t:Build -p:RuntimeIdentifier=rid")]
+        [InlineData(new string[] { "--runtime", "rid" }, "-t:Build -p:RuntimeIdentifier=rid")]
+        [InlineData(new string[] { "-c", "config" }, "-t:Build -p:Configuration=config")]
+        [InlineData(new string[] { "--configuration", "config" }, "-t:Build -p:Configuration=config")]
+        [InlineData(new string[] { "--version-suffix", "mysuffix" }, "-t:Build -p:VersionSuffix=mysuffix")]
+        [InlineData(new string[] { "--no-dependencies" }, "-t:Build -p:BuildProjectReferences=false")]
+        [InlineData(new string[] { "-v", "diag" }, "-t:Build -verbosity:diag")]
+        [InlineData(new string[] { "--verbosity", "diag" }, "-t:Build -verbosity:diag")]
         [InlineData(new string[] { "--no-incremental", "-o", "myoutput", "-r", "myruntime", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
-                                  "/t:Rebuild /p:OutputPath=myoutput /p:RuntimeIdentifier=myruntime /verbosity:diag /ArbitrarySwitchForMSBuild")]
+                                  "-t:Rebuild -p:OutputPath=myoutput -p:RuntimeIdentifier=myruntime -verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
@@ -39,14 +39,14 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             command.GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} /restore /clp:Summary{expectedAdditionalArgs}");
+                   .Be($"{ExpectedPrefix} -restore -clp:Summary{expectedAdditionalArgs}");
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "tfm" }, "/t:Restore", "/t:Build /p:TargetFramework=tfm")]
+        [InlineData(new string[] { "-f", "tfm" }, "-t:Restore", "-t:Build -p:TargetFramework=tfm")]
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
-                                  "/t:Restore /p:OutputPath=myoutput /verbosity:diag /ArbitrarySwitchForMSBuild",
-                                  "/t:Build /p:OutputPath=myoutput /p:TargetFramework=tfm /verbosity:diag /ArbitrarySwitchForMSBuild")]
+                                  "-t:Restore -p:OutputPath=myoutput -verbosity:diag /ArbitrarySwitchForMSBuild",
+                                  "-t:Build -p:OutputPath=myoutput -p:TargetFramework=tfm -verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(
             string[] args, 
             string expectedAdditionalArgsForRestore, 
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             command.GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} /nologo /clp:Summary{expectedAdditionalArgs}");
+                   .Be($"{ExpectedPrefix} -nologo -clp:Summary{expectedAdditionalArgs}");
 
         }
     }

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetBuildInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m";
 
         [Theory]
         [InlineData(new string[] { }, "/t:Build")]

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -9,25 +9,25 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetBuildInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m";
+        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m";
 
         [Theory]
-        [InlineData(new string[] { }, "-t:Build")]
-        [InlineData(new string[] { "-o", "foo" }, "-t:Build -p:OutputPath=foo")]
-        [InlineData(new string[] { "-p:Verbosity=diag" }, "-t:Build -p:Verbosity=diag")]
-        [InlineData(new string[] { "--output", "foo" }, "-t:Build -p:OutputPath=foo")]
-        [InlineData(new string[] { "-o", "foo1 foo2" }, "-t:Build \"-p:OutputPath=foo1 foo2\"")]
-        [InlineData(new string[] { "--no-incremental" }, "-t:Rebuild")]
-        [InlineData(new string[] { "-r", "rid" }, "-t:Build -p:RuntimeIdentifier=rid")]
-        [InlineData(new string[] { "--runtime", "rid" }, "-t:Build -p:RuntimeIdentifier=rid")]
-        [InlineData(new string[] { "-c", "config" }, "-t:Build -p:Configuration=config")]
-        [InlineData(new string[] { "--configuration", "config" }, "-t:Build -p:Configuration=config")]
-        [InlineData(new string[] { "--version-suffix", "mysuffix" }, "-t:Build -p:VersionSuffix=mysuffix")]
-        [InlineData(new string[] { "--no-dependencies" }, "-t:Build -p:BuildProjectReferences=false")]
-        [InlineData(new string[] { "-v", "diag" }, "-t:Build -verbosity:diag")]
-        [InlineData(new string[] { "--verbosity", "diag" }, "-t:Build -verbosity:diag")]
+        [InlineData(new string[] { }, "-target:Build")]
+        [InlineData(new string[] { "-o", "foo" }, "-target:Build -property:OutputPath=foo")]
+        [InlineData(new string[] { "-property:Verbosity=diag" }, "-target:Build -property:Verbosity=diag")]
+        [InlineData(new string[] { "--output", "foo" }, "-target:Build -property:OutputPath=foo")]
+        [InlineData(new string[] { "-o", "foo1 foo2" }, "-target:Build \"-property:OutputPath=foo1 foo2\"")]
+        [InlineData(new string[] { "--no-incremental" }, "-target:Rebuild")]
+        [InlineData(new string[] { "-r", "rid" }, "-target:Build -property:RuntimeIdentifier=rid")]
+        [InlineData(new string[] { "--runtime", "rid" }, "-target:Build -property:RuntimeIdentifier=rid")]
+        [InlineData(new string[] { "-c", "config" }, "-target:Build -property:Configuration=config")]
+        [InlineData(new string[] { "--configuration", "config" }, "-target:Build -property:Configuration=config")]
+        [InlineData(new string[] { "--version-suffix", "mysuffix" }, "-target:Build -property:VersionSuffix=mysuffix")]
+        [InlineData(new string[] { "--no-dependencies" }, "-target:Build -property:BuildProjectReferences=false")]
+        [InlineData(new string[] { "-v", "diag" }, "-target:Build -verbosity:diag")]
+        [InlineData(new string[] { "--verbosity", "diag" }, "-target:Build -verbosity:diag")]
         [InlineData(new string[] { "--no-incremental", "-o", "myoutput", "-r", "myruntime", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
-                                  "-t:Rebuild -p:OutputPath=myoutput -p:RuntimeIdentifier=myruntime -verbosity:diag /ArbitrarySwitchForMSBuild")]
+                                  "-target:Rebuild -property:OutputPath=myoutput -property:RuntimeIdentifier=myruntime -verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
@@ -39,14 +39,14 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             command.GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} -restore -clp:Summary{expectedAdditionalArgs}");
+                   .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary{expectedAdditionalArgs}");
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "tfm" }, "-t:Restore", "-t:Build -p:TargetFramework=tfm")]
+        [InlineData(new string[] { "-f", "tfm" }, "-target:Restore", "-target:Build -property:TargetFramework=tfm")]
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
-                                  "-t:Restore -p:OutputPath=myoutput -verbosity:diag /ArbitrarySwitchForMSBuild",
-                                  "-t:Build -p:OutputPath=myoutput -p:TargetFramework=tfm -verbosity:diag /ArbitrarySwitchForMSBuild")]
+                                  "-target:Restore -property:OutputPath=myoutput -verbosity:diag /ArbitrarySwitchForMSBuild",
+                                  "-target:Build -property:OutputPath=myoutput -property:TargetFramework=tfm -verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(
             string[] args, 
             string expectedAdditionalArgsForRestore, 
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             command.GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} -nologo -clp:Summary{expectedAdditionalArgs}");
+                   .Be($"{ExpectedPrefix} -nologo -consoleloggerparameters:Summary{expectedAdditionalArgs}");
 
         }
     }

--- a/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
@@ -10,26 +10,26 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetCleanInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m /v:normal /t:Clean";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m -v:normal -t:Clean";
 
         [Fact]
         public void ItAddsProjectToMsbuildInvocation()
         {
             var msbuildPath = "<msbuildpath>";
             CleanCommand.FromArgs(new string[] { "<project>" }, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> -m -v:m /v:normal <project> /t:Clean");
+                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> -m -v:m -v:normal <project> -t:Clean");
         }
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-o", "<output>" }, "/p:OutputPath=<output>")]
-        [InlineData(new string[] { "--output", "<output>" }, "/p:OutputPath=<output>")]
-        [InlineData(new string[] { "-f", "<framework>" }, "/p:TargetFramework=<framework>")]
-        [InlineData(new string[] { "--framework", "<framework>" }, "/p:TargetFramework=<framework>")]
-        [InlineData(new string[] { "-c", "<configuration>" }, "/p:Configuration=<configuration>")]
-        [InlineData(new string[] { "--configuration", "<configuration>" }, "/p:Configuration=<configuration>")]
-        [InlineData(new string[] { "-v", "diag" }, "/verbosity:diag")]
-        [InlineData(new string[] { "--verbosity", "diag" }, "/verbosity:diag")]
+        [InlineData(new string[] { "-o", "<output>" }, "-p:OutputPath=<output>")]
+        [InlineData(new string[] { "--output", "<output>" }, "-p:OutputPath=<output>")]
+        [InlineData(new string[] { "-f", "<framework>" }, "-p:TargetFramework=<framework>")]
+        [InlineData(new string[] { "--framework", "<framework>" }, "-p:TargetFramework=<framework>")]
+        [InlineData(new string[] { "-c", "<configuration>" }, "-p:Configuration=<configuration>")]
+        [InlineData(new string[] { "--configuration", "<configuration>" }, "-p:Configuration=<configuration>")]
+        [InlineData(new string[] { "-v", "diag" }, "-verbosity:diag")]
+        [InlineData(new string[] { "--verbosity", "diag" }, "-verbosity:diag")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");

--- a/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
@@ -10,14 +10,14 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetCleanInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /v:normal /t:Clean";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m /v:normal /t:Clean";
 
         [Fact]
         public void ItAddsProjectToMsbuildInvocation()
         {
             var msbuildPath = "<msbuildpath>";
             CleanCommand.FromArgs(new string[] { "<project>" }, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> /m /v:m /v:normal <project> /t:Clean");
+                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> -m -v:m /v:normal <project> /t:Clean");
         }
 
         [Theory]

--- a/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
@@ -10,24 +10,24 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetCleanInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m -v:normal -t:Clean";
+        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -verbosity:normal -target:Clean";
 
         [Fact]
         public void ItAddsProjectToMsbuildInvocation()
         {
             var msbuildPath = "<msbuildpath>";
             CleanCommand.FromArgs(new string[] { "<project>" }, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> -m -v:m -v:normal <project> -t:Clean");
+                .GetProcessStartInfo().Arguments.Should().Be("exec <msbuildpath> -maxcpucount -verbosity:m -verbosity:normal <project> -target:Clean");
         }
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-o", "<output>" }, "-p:OutputPath=<output>")]
-        [InlineData(new string[] { "--output", "<output>" }, "-p:OutputPath=<output>")]
-        [InlineData(new string[] { "-f", "<framework>" }, "-p:TargetFramework=<framework>")]
-        [InlineData(new string[] { "--framework", "<framework>" }, "-p:TargetFramework=<framework>")]
-        [InlineData(new string[] { "-c", "<configuration>" }, "-p:Configuration=<configuration>")]
-        [InlineData(new string[] { "--configuration", "<configuration>" }, "-p:Configuration=<configuration>")]
+        [InlineData(new string[] { "-o", "<output>" }, "-property:OutputPath=<output>")]
+        [InlineData(new string[] { "--output", "<output>" }, "-property:OutputPath=<output>")]
+        [InlineData(new string[] { "-f", "<framework>" }, "-property:TargetFramework=<framework>")]
+        [InlineData(new string[] { "--framework", "<framework>" }, "-property:TargetFramework=<framework>")]
+        [InlineData(new string[] { "-c", "<configuration>" }, "-property:Configuration=<configuration>")]
+        [InlineData(new string[] { "--configuration", "<configuration>" }, "-property:Configuration=<configuration>")]
         [InlineData(new string[] { "-v", "diag" }, "-verbosity:diag")]
         [InlineData(new string[] { "--verbosity", "diag" }, "-verbosity:diag")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -86,8 +86,12 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             result.StdOut.Should().Contain(MSBuildHelpText);
         }
 
-        [Fact]
-        public void WhenRestoreSourcesStartsWithUnixPathThenHttpsSourceIsParsedCorrectly()
+        [Theory]
+        [InlineData("/p")]
+        [InlineData("/property")]
+        [InlineData("-p")]
+        [InlineData("-property")]
+        public void WhenRestoreSourcesStartsWithUnixPathThenHttpsSourceIsParsedCorrectly(string propertyFormat)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -104,7 +108,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             var result = new DotnetCommand()
                 .WithWorkingDirectory(root)
-                .Execute($"msbuild /p:RestoreSources={somePathThatExists};https://api.nuget.org/v3/index.json /t:restore LibraryWithUnresolvablePackageReference.csproj");
+                .Execute($"msbuild {propertyFormat}:RestoreSources={somePathThatExists};https://api.nuget.org/v3/index.json /t:restore LibraryWithUnresolvablePackageReference.csproj");
 
             _output.WriteLine($"[STDOUT]\n{result.StdOut}\n[STDERR]\n{result.StdErr}");
 

--- a/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetMSBuildBuildsProjects.cs
@@ -138,7 +138,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 allArgs.Should().NotBeNull();
 
                 allArgs.Should().Contain(
-                    value => value.IndexOf("/distributedlogger", StringComparison.OrdinalIgnoreCase) >= 0,
+                    value => value.IndexOf("-distributedlogger", StringComparison.OrdinalIgnoreCase) >= 0,
                     "The MSBuild logger argument should be specified when telemetry is enabled.");
             }
         }
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             allArgs.Should().NotBeNull();
 
             allArgs.Should().NotContain(
-                value => value.IndexOf("/Logger", StringComparison.OrdinalIgnoreCase) >= 0,
+                value => value.IndexOf("-logger", StringComparison.OrdinalIgnoreCase) >= 0,
                 $"The MSBuild logger argument should not be specified when telemetry is disabled.");
         }
 

--- a/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
@@ -11,8 +11,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetPackInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /restore /t:pack";
-        const string ExpectedNoBuildPrefix = "exec <msbuildpath> /m /v:m /t:pack";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m /restore /t:pack";
+        const string ExpectedNoBuildPrefix = "exec <msbuildpath> -m -v:m /t:pack";
 
         [Theory]
         [InlineData(new string[] { }, "")]

--- a/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
@@ -11,21 +11,21 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetPackInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m -restore -t:pack";
-        const string ExpectedNoBuildPrefix = "exec <msbuildpath> -m -v:m -t:pack";
+        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -restore -target:pack";
+        const string ExpectedNoBuildPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -target:pack";
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-o", "<packageoutputpath>" }, "-p:PackageOutputPath=<packageoutputpath>")]
-        [InlineData(new string[] { "--output", "<packageoutputpath>" }, "-p:PackageOutputPath=<packageoutputpath>")]
-        [InlineData(new string[] { "--no-build" }, "-p:NoBuild=true")]
-        [InlineData(new string[] { "--include-symbols" }, "-p:IncludeSymbols=true")]
-        [InlineData(new string[] { "--include-source" }, "-p:IncludeSource=true")]
-        [InlineData(new string[] { "-c", "<config>" }, "-p:Configuration=<config>")]
-        [InlineData(new string[] { "--configuration", "<config>" }, "-p:Configuration=<config>")]
-        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-p:VersionSuffix=<versionsuffix>")]
-        [InlineData(new string[] { "-s" }, "-p:Serviceable=true")]
-        [InlineData(new string[] { "--serviceable" }, "-p:Serviceable=true")]
+        [InlineData(new string[] { "-o", "<packageoutputpath>" }, "-property:PackageOutputPath=<packageoutputpath>")]
+        [InlineData(new string[] { "--output", "<packageoutputpath>" }, "-property:PackageOutputPath=<packageoutputpath>")]
+        [InlineData(new string[] { "--no-build" }, "-property:NoBuild=true")]
+        [InlineData(new string[] { "--include-symbols" }, "-property:IncludeSymbols=true")]
+        [InlineData(new string[] { "--include-source" }, "-property:IncludeSource=true")]
+        [InlineData(new string[] { "-c", "<config>" }, "-property:Configuration=<config>")]
+        [InlineData(new string[] { "--configuration", "<config>" }, "-property:Configuration=<config>")]
+        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-property:VersionSuffix=<versionsuffix>")]
+        [InlineData(new string[] { "-s" }, "-property:Serviceable=true")]
+        [InlineData(new string[] { "--serviceable" }, "-property:Serviceable=true")]
         [InlineData(new string[] { "-v", "diag" }, "-verbosity:diag")]
         [InlineData(new string[] { "--verbosity", "diag" }, "-verbosity:diag")]
         [InlineData(new string[] { "<project>" }, "<project>")]

--- a/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
@@ -11,23 +11,23 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetPackInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m /restore /t:pack";
-        const string ExpectedNoBuildPrefix = "exec <msbuildpath> -m -v:m /t:pack";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m -restore -t:pack";
+        const string ExpectedNoBuildPrefix = "exec <msbuildpath> -m -v:m -t:pack";
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-o", "<packageoutputpath>" }, "/p:PackageOutputPath=<packageoutputpath>")]
-        [InlineData(new string[] { "--output", "<packageoutputpath>" }, "/p:PackageOutputPath=<packageoutputpath>")]
-        [InlineData(new string[] { "--no-build" }, "/p:NoBuild=true")]
-        [InlineData(new string[] { "--include-symbols" }, "/p:IncludeSymbols=true")]
-        [InlineData(new string[] { "--include-source" }, "/p:IncludeSource=true")]
-        [InlineData(new string[] { "-c", "<config>" }, "/p:Configuration=<config>")]
-        [InlineData(new string[] { "--configuration", "<config>" }, "/p:Configuration=<config>")]
-        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "/p:VersionSuffix=<versionsuffix>")]
-        [InlineData(new string[] { "-s" }, "/p:Serviceable=true")]
-        [InlineData(new string[] { "--serviceable" }, "/p:Serviceable=true")]
-        [InlineData(new string[] { "-v", "diag" }, "/verbosity:diag")]
-        [InlineData(new string[] { "--verbosity", "diag" }, "/verbosity:diag")]
+        [InlineData(new string[] { "-o", "<packageoutputpath>" }, "-p:PackageOutputPath=<packageoutputpath>")]
+        [InlineData(new string[] { "--output", "<packageoutputpath>" }, "-p:PackageOutputPath=<packageoutputpath>")]
+        [InlineData(new string[] { "--no-build" }, "-p:NoBuild=true")]
+        [InlineData(new string[] { "--include-symbols" }, "-p:IncludeSymbols=true")]
+        [InlineData(new string[] { "--include-source" }, "-p:IncludeSource=true")]
+        [InlineData(new string[] { "-c", "<config>" }, "-p:Configuration=<config>")]
+        [InlineData(new string[] { "--configuration", "<config>" }, "-p:Configuration=<config>")]
+        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-p:VersionSuffix=<versionsuffix>")]
+        [InlineData(new string[] { "-s" }, "-p:Serviceable=true")]
+        [InlineData(new string[] { "--serviceable" }, "-p:Serviceable=true")]
+        [InlineData(new string[] { "-v", "diag" }, "-verbosity:diag")]
+        [InlineData(new string[] { "--verbosity", "diag" }, "-verbosity:diag")]
         [InlineData(new string[] { "<project>" }, "<project>")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {

--- a/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             this.output = output;
         }
 
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m";
 
         [Theory]
         [InlineData(new string[] { }, "")]

--- a/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
@@ -24,16 +24,16 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-r", "<rid>" }, "/p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "--runtime", "<rid>" }, "/p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "-o", "<publishdir>" }, "/p:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "--output", "<publishdir>" }, "/p:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "-c", "<config>" }, "/p:Configuration=<config>")]
-        [InlineData(new string[] { "--configuration", "<config>" }, "/p:Configuration=<config>")]
-        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "/p:VersionSuffix=<versionsuffix>")]
-        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "/p:TargetManifestFiles=<manifestfiles>")]
-        [InlineData(new string[] { "-v", "minimal" }, "/verbosity:minimal")]
-        [InlineData(new string[] { "--verbosity", "minimal" }, "/verbosity:minimal")]
+        [InlineData(new string[] { "-r", "<rid>" }, "-p:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--runtime", "<rid>" }, "-p:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "-o", "<publishdir>" }, "-p:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "--output", "<publishdir>" }, "-p:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "-c", "<config>" }, "-p:Configuration=<config>")]
+        [InlineData(new string[] { "--configuration", "<config>" }, "-p:Configuration=<config>")]
+        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-p:VersionSuffix=<versionsuffix>")]
+        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-p:TargetManifestFiles=<manifestfiles>")]
+        [InlineData(new string[] { "-v", "minimal" }, "-verbosity:minimal")]
+        [InlineData(new string[] { "--verbosity", "minimal" }, "-verbosity:minimal")]
         [InlineData(new string[] { "<project>" }, "<project>")]
         [InlineData(new string[] { "<project>", "<extra-args>" }, "<project> <extra-args>")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
@@ -49,12 +49,12 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             command.GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} /restore /t:Publish{expectedAdditionalArgs}");
+                   .Be($"{ExpectedPrefix} -restore -t:Publish{expectedAdditionalArgs}");
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "<tfm>" }, "/p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "--framework", "<tfm>" }, "/p:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "-f", "<tfm>" }, "-p:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "--framework", "<tfm>" }, "-p:TargetFramework=<tfm>")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
@@ -65,27 +65,27 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             command.SeparateRestoreCommand
                    .GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} /t:Restore");
+                   .Be($"{ExpectedPrefix} -t:Restore");
 
             command.GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} /nologo /t:Publish{expectedAdditionalArgs}");
+                   .Be($"{ExpectedPrefix} -nologo -t:Publish{expectedAdditionalArgs}");
         }
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-f", "<tfm>" }, "/p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "--framework", "<tfm>" }, "/p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "-r", "<rid>" }, "/p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "--runtime", "<rid>" }, "/p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "-o", "<publishdir>" }, "/p:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "--output", "<publishdir>" }, "/p:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "-c", "<config>" }, "/p:Configuration=<config>")]
-        [InlineData(new string[] { "--configuration", "<config>" }, "/p:Configuration=<config>")]
-        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "/p:VersionSuffix=<versionsuffix>")]
-        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "/p:TargetManifestFiles=<manifestfiles>")]
-        [InlineData(new string[] { "-v", "minimal" }, "/verbosity:minimal")]
-        [InlineData(new string[] { "--verbosity", "minimal" }, "/verbosity:minimal")]
+        [InlineData(new string[] { "-f", "<tfm>" }, "-p:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "--framework", "<tfm>" }, "-p:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "-r", "<rid>" }, "-p:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--runtime", "<rid>" }, "-p:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "-o", "<publishdir>" }, "-p:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "--output", "<publishdir>" }, "-p:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "-c", "<config>" }, "-p:Configuration=<config>")]
+        [InlineData(new string[] { "--configuration", "<config>" }, "-p:Configuration=<config>")]
+        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-p:VersionSuffix=<versionsuffix>")]
+        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-p:TargetManifestFiles=<manifestfiles>")]
+        [InlineData(new string[] { "-v", "minimal" }, "-verbosity:minimal")]
+        [InlineData(new string[] { "--verbosity", "minimal" }, "-verbosity:minimal")]
         public void OptionForwardingIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             var expectedArgs = expectedAdditionalArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries);

--- a/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
@@ -20,18 +20,18 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             this.output = output;
         }
 
-        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m";
+        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m";
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-r", "<rid>" }, "-p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "--runtime", "<rid>" }, "-p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "-o", "<publishdir>" }, "-p:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "--output", "<publishdir>" }, "-p:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "-c", "<config>" }, "-p:Configuration=<config>")]
-        [InlineData(new string[] { "--configuration", "<config>" }, "-p:Configuration=<config>")]
-        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-p:VersionSuffix=<versionsuffix>")]
-        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-p:TargetManifestFiles=<manifestfiles>")]
+        [InlineData(new string[] { "-r", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--runtime", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "-o", "<publishdir>" }, "-property:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "--output", "<publishdir>" }, "-property:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "-c", "<config>" }, "-property:Configuration=<config>")]
+        [InlineData(new string[] { "--configuration", "<config>" }, "-property:Configuration=<config>")]
+        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-property:VersionSuffix=<versionsuffix>")]
+        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-property:TargetManifestFiles=<manifestfiles>")]
         [InlineData(new string[] { "-v", "minimal" }, "-verbosity:minimal")]
         [InlineData(new string[] { "--verbosity", "minimal" }, "-verbosity:minimal")]
         [InlineData(new string[] { "<project>" }, "<project>")]
@@ -49,12 +49,12 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             command.GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} -restore -t:Publish{expectedAdditionalArgs}");
+                   .Be($"{ExpectedPrefix} -restore -target:Publish{expectedAdditionalArgs}");
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "<tfm>" }, "-p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "--framework", "<tfm>" }, "-p:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "-f", "<tfm>" }, "-property:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "--framework", "<tfm>" }, "-property:TargetFramework=<tfm>")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
@@ -65,25 +65,25 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             command.SeparateRestoreCommand
                    .GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} -t:Restore");
+                   .Be($"{ExpectedPrefix} -target:Restore");
 
             command.GetProcessStartInfo()
                    .Arguments.Should()
-                   .Be($"{ExpectedPrefix} -nologo -t:Publish{expectedAdditionalArgs}");
+                   .Be($"{ExpectedPrefix} -nologo -target:Publish{expectedAdditionalArgs}");
         }
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-f", "<tfm>" }, "-p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "--framework", "<tfm>" }, "-p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "-r", "<rid>" }, "-p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "--runtime", "<rid>" }, "-p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "-o", "<publishdir>" }, "-p:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "--output", "<publishdir>" }, "-p:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "-c", "<config>" }, "-p:Configuration=<config>")]
-        [InlineData(new string[] { "--configuration", "<config>" }, "-p:Configuration=<config>")]
-        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-p:VersionSuffix=<versionsuffix>")]
-        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-p:TargetManifestFiles=<manifestfiles>")]
+        [InlineData(new string[] { "-f", "<tfm>" }, "-property:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "--framework", "<tfm>" }, "-property:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "-r", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--runtime", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "-o", "<publishdir>" }, "-property:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "--output", "<publishdir>" }, "-property:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "-c", "<config>" }, "-property:Configuration=<config>")]
+        [InlineData(new string[] { "--configuration", "<config>" }, "-property:Configuration=<config>")]
+        [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-property:VersionSuffix=<versionsuffix>")]
+        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-property:TargetManifestFiles=<manifestfiles>")]
         [InlineData(new string[] { "-v", "minimal" }, "-verbosity:minimal")]
         [InlineData(new string[] { "--verbosity", "minimal" }, "-verbosity:minimal")]
         public void OptionForwardingIsCorrect(string[] args, string expectedAdditionalArgs)

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -11,22 +11,22 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetRestoreInvocation
     {
         private const string ExpectedPrefix =
-            "exec <msbuildpath> -m -v:m -nologo -t:Restore";
+            "exec <msbuildpath> -maxcpucount -verbosity:m -nologo -target:Restore";
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-s", "<source>" }, "-p:RestoreSources=<source>")]
-        [InlineData(new string[] { "--source", "<source>" }, "-p:RestoreSources=<source>")]
-        [InlineData(new string[] { "-s", "<source0>", "-s", "<source1>" }, "-p:RestoreSources=<source0>%3B<source1>")]
-        [InlineData(new string[] { "-r", "<runtime>" }, "-p:RuntimeIdentifiers=<runtime>")]
-        [InlineData(new string[] { "--runtime", "<runtime>" }, "-p:RuntimeIdentifiers=<runtime>")]
-        [InlineData(new string[] { "-r", "<runtime0>", "-r", "<runtime1>" }, "-p:RuntimeIdentifiers=<runtime0>%3B<runtime1>")]
-        [InlineData(new string[] { "--packages", "<packages>" }, "-p:RestorePackagesPath=<packages>")]
-        [InlineData(new string[] { "--disable-parallel" }, "-p:RestoreDisableParallel=true")]
-        [InlineData(new string[] { "--configfile", "<config>" }, "-p:RestoreConfigFile=<config>")]
-        [InlineData(new string[] { "--no-cache" }, "-p:RestoreNoCache=true")]
-        [InlineData(new string[] { "--ignore-failed-sources" }, "-p:RestoreIgnoreFailedSources=true")]
-        [InlineData(new string[] { "--no-dependencies" }, "-p:RestoreRecursive=false")]
+        [InlineData(new string[] { "-s", "<source>" }, "-property:RestoreSources=<source>")]
+        [InlineData(new string[] { "--source", "<source>" }, "-property:RestoreSources=<source>")]
+        [InlineData(new string[] { "-s", "<source0>", "-s", "<source1>" }, "-property:RestoreSources=<source0>%3B<source1>")]
+        [InlineData(new string[] { "-r", "<runtime>" }, "-property:RuntimeIdentifiers=<runtime>")]
+        [InlineData(new string[] { "--runtime", "<runtime>" }, "-property:RuntimeIdentifiers=<runtime>")]
+        [InlineData(new string[] { "-r", "<runtime0>", "-r", "<runtime1>" }, "-property:RuntimeIdentifiers=<runtime0>%3B<runtime1>")]
+        [InlineData(new string[] { "--packages", "<packages>" }, "-property:RestorePackagesPath=<packages>")]
+        [InlineData(new string[] { "--disable-parallel" }, "-property:RestoreDisableParallel=true")]
+        [InlineData(new string[] { "--configfile", "<config>" }, "-property:RestoreConfigFile=<config>")]
+        [InlineData(new string[] { "--no-cache" }, "-property:RestoreNoCache=true")]
+        [InlineData(new string[] { "--ignore-failed-sources" }, "-property:RestoreIgnoreFailedSources=true")]
+        [InlineData(new string[] { "--no-dependencies" }, "-property:RestoreRecursive=false")]
         [InlineData(new string[] { "-v", "minimal" }, @"-verbosity:minimal")]
         [InlineData(new string[] { "--verbosity", "minimal" }, @"-verbosity:minimal")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -11,24 +11,24 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetRestoreInvocation
     {
         private const string ExpectedPrefix =
-            "exec <msbuildpath> -m -v:m /nologo /t:Restore";
+            "exec <msbuildpath> -m -v:m -nologo -t:Restore";
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-s", "<source>" }, "/p:RestoreSources=<source>")]
-        [InlineData(new string[] { "--source", "<source>" }, "/p:RestoreSources=<source>")]
-        [InlineData(new string[] { "-s", "<source0>", "-s", "<source1>" }, "/p:RestoreSources=<source0>%3B<source1>")]
-        [InlineData(new string[] { "-r", "<runtime>" }, "/p:RuntimeIdentifiers=<runtime>")]
-        [InlineData(new string[] { "--runtime", "<runtime>" }, "/p:RuntimeIdentifiers=<runtime>")]
-        [InlineData(new string[] { "-r", "<runtime0>", "-r", "<runtime1>" }, "/p:RuntimeIdentifiers=<runtime0>%3B<runtime1>")]
-        [InlineData(new string[] { "--packages", "<packages>" }, "/p:RestorePackagesPath=<packages>")]
-        [InlineData(new string[] { "--disable-parallel" }, "/p:RestoreDisableParallel=true")]
-        [InlineData(new string[] { "--configfile", "<config>" }, "/p:RestoreConfigFile=<config>")]
-        [InlineData(new string[] { "--no-cache" }, "/p:RestoreNoCache=true")]
-        [InlineData(new string[] { "--ignore-failed-sources" }, "/p:RestoreIgnoreFailedSources=true")]
-        [InlineData(new string[] { "--no-dependencies" }, "/p:RestoreRecursive=false")]
-        [InlineData(new string[] { "-v", "minimal" }, @"/verbosity:minimal")]
-        [InlineData(new string[] { "--verbosity", "minimal" }, @"/verbosity:minimal")]
+        [InlineData(new string[] { "-s", "<source>" }, "-p:RestoreSources=<source>")]
+        [InlineData(new string[] { "--source", "<source>" }, "-p:RestoreSources=<source>")]
+        [InlineData(new string[] { "-s", "<source0>", "-s", "<source1>" }, "-p:RestoreSources=<source0>%3B<source1>")]
+        [InlineData(new string[] { "-r", "<runtime>" }, "-p:RuntimeIdentifiers=<runtime>")]
+        [InlineData(new string[] { "--runtime", "<runtime>" }, "-p:RuntimeIdentifiers=<runtime>")]
+        [InlineData(new string[] { "-r", "<runtime0>", "-r", "<runtime1>" }, "-p:RuntimeIdentifiers=<runtime0>%3B<runtime1>")]
+        [InlineData(new string[] { "--packages", "<packages>" }, "-p:RestorePackagesPath=<packages>")]
+        [InlineData(new string[] { "--disable-parallel" }, "-p:RestoreDisableParallel=true")]
+        [InlineData(new string[] { "--configfile", "<config>" }, "-p:RestoreConfigFile=<config>")]
+        [InlineData(new string[] { "--no-cache" }, "-p:RestoreNoCache=true")]
+        [InlineData(new string[] { "--ignore-failed-sources" }, "-p:RestoreIgnoreFailedSources=true")]
+        [InlineData(new string[] { "--no-dependencies" }, "-p:RestoreRecursive=false")]
+        [InlineData(new string[] { "-v", "minimal" }, @"-verbosity:minimal")]
+        [InlineData(new string[] { "--verbosity", "minimal" }, @"-verbosity:minimal")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetRestoreInvocation
     {
         private const string ExpectedPrefix =
-            "exec <msbuildpath> /m /v:m /nologo /t:Restore";
+            "exec <msbuildpath> -m -v:m /nologo /t:Restore";
 
         [Theory]
         [InlineData(new string[] { }, "")]

--- a/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetStoreInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m /t:ComposeStore <project>";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m -t:ComposeStore <project>";
         static readonly string[] ArgsPrefix = { "-m", "<project>" };
 
         [Theory]
@@ -26,11 +26,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "<tfm>" }, @"/p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "--framework", "<tfm>" }, @"/p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "-r", "<rid>" }, @"/p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "--runtime", "<rid>" }, @"/p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "--manifest", "one.xml", "--manifest", "two.xml", "--manifest", "three.xml" }, @"/p:AdditionalProjects=one.xml%3Btwo.xml%3Bthree.xml")]
+        [InlineData(new string[] { "-f", "<tfm>" }, @"-p:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "--framework", "<tfm>" }, @"-p:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "-r", "<rid>" }, @"-p:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--runtime", "<rid>" }, @"-p:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--manifest", "one.xml", "--manifest", "two.xml", "--manifest", "three.xml" }, @"-p:AdditionalProjects=one.xml%3Btwo.xml%3Bthree.xml")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             args = ArgsPrefix.Concat(args).ToArray();
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             var msbuildPath = "<msbuildpath>";
             StoreCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix} /p:ComposeDir={Path.GetFullPath(path)}");
+                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix} -p:ComposeDir={Path.GetFullPath(path)}");
         }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
@@ -11,8 +11,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetStoreInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m -t:ComposeStore <project>";
-        static readonly string[] ArgsPrefix = { "-m", "<project>" };
+        const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -target:ComposeStore <project>";
+        static readonly string[] ArgsPrefix = { "--manifest", "<project>" };
 
         [Theory]
         [InlineData("-m")]
@@ -26,11 +26,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "<tfm>" }, @"-p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "--framework", "<tfm>" }, @"-p:TargetFramework=<tfm>")]
-        [InlineData(new string[] { "-r", "<rid>" }, @"-p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "--runtime", "<rid>" }, @"-p:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "--manifest", "one.xml", "--manifest", "two.xml", "--manifest", "three.xml" }, @"-p:AdditionalProjects=one.xml%3Btwo.xml%3Bthree.xml")]
+        [InlineData(new string[] { "-f", "<tfm>" }, @"-property:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "--framework", "<tfm>" }, @"-property:TargetFramework=<tfm>")]
+        [InlineData(new string[] { "-r", "<rid>" }, @"-property:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--runtime", "<rid>" }, @"-property:RuntimeIdentifier=<rid>")]
+        [InlineData(new string[] { "--manifest", "one.xml", "--manifest", "two.xml", "--manifest", "three.xml" }, @"-property:AdditionalProjects=one.xml%3Btwo.xml%3Bthree.xml")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             args = ArgsPrefix.Concat(args).ToArray();
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
             var msbuildPath = "<msbuildpath>";
             StoreCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix} -p:ComposeDir={Path.GetFullPath(path)}");
+                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix} -property:ComposeDir={Path.GetFullPath(path)}");
         }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetStoreInvocation
     {
-        const string ExpectedPrefix = "exec <msbuildpath> /m /v:m /t:ComposeStore <project>";
+        const string ExpectedPrefix = "exec <msbuildpath> -m -v:m /t:ComposeStore <project>";
         static readonly string[] ArgsPrefix = { "-m", "<project>" };
 
         [Theory]


### PR DESCRIPTION
Changing the /m /v:m default parameters to msbuild to -m and -v:m to avoid confusing that with files on unix machines.

Fixes https://github.com/dotnet/cli/issues/7227

cc @rainersigwald 