### PR TITLE
Removing the explicit dependency on System.Diagnostics.Process from Cli.Utils

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
+++ b/src/Microsoft.DotNet.Cli.Utils/Microsoft.DotNet.Cli.Utils.csproj
@@ -29,7 +29,6 @@
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETStandard' ">
     <PackageReference Include="NETStandard.Library" Version="2.0.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">


### PR DESCRIPTION
Removing the explicit dependency on System.Diagnostics.Process from Cli.Utils. Use the assembly from netstandard.

@rohit21agrawal @mmitche this should unblock prodcon once the NuGet changes are checked in on their side as well.
