### PR TITLE
Fix validation of tool-path option for tool list and uninstall commands.

### DIFF
--- a/src/dotnet/commands/dotnet-tool/list/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/list/LocalizableStrings.resx
@@ -144,4 +144,7 @@
   <data name="CommandsColumn" xml:space="preserve">
     <value>Commands</value>
   </data>
+  <data name="InvalidToolPathOption" xml:space="preserve">
+    <value>Tool path '{0}' does not exist.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/list/ToolListCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/list/ToolListCommand.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
@@ -44,6 +45,14 @@ namespace Microsoft.DotNet.Tools.Tool.List
             DirectoryPath? toolPath = null;
             if (!string.IsNullOrWhiteSpace(toolPathOption))
             {
+                if (!Directory.Exists(toolPathOption))
+                {
+                    throw new GracefulException(
+                        string.Format(
+                            LocalizableStrings.InvalidToolPathOption,
+                            toolPathOption));
+                }
+
                 toolPath = new DirectoryPath(toolPathOption);
             }
 

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.cs.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.de.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.es.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.fr.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.it.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ja.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ko.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pl.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ru.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.tr.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="new">(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
@@ -153,4 +153,7 @@
   <data name="UninstallToolCommandInvalidGlobalAndToolPath" xml:space="preserve">
     <value>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</value>
   </data>
+  <data name="InvalidToolPathOption" xml:space="preserve">
+    <value>Tool path '{0}' does not exist.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/uninstall/ToolUninstallCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/uninstall/ToolUninstallCommand.cs
@@ -49,20 +49,28 @@ namespace Microsoft.DotNet.Tools.Tool.Uninstall
             var global = _options.ValueOrDefault<bool>("global");
             var toolPath = _options.SingleArgumentOrDefault("tool-path");
 
-            if (string.IsNullOrWhiteSpace(toolPath) && !global)
+            DirectoryPath? toolDirectoryPath = null;
+            if (!string.IsNullOrWhiteSpace(toolPath))
+            {
+                if (!Directory.Exists(toolPath))
+                {
+                    throw new GracefulException(
+                        string.Format(
+                            LocalizableStrings.InvalidToolPathOption,
+                            toolPath));
+                }
+
+                toolDirectoryPath = new DirectoryPath(toolPath);
+            }
+
+            if (toolDirectoryPath == null && !global)
             {
                 throw new GracefulException(LocalizableStrings.UninstallToolCommandNeedGlobalOrToolPath);
             }
 
-            if (!string.IsNullOrWhiteSpace(toolPath) && global)
+            if (toolDirectoryPath != null && global)
             {
                 throw new GracefulException(LocalizableStrings.UninstallToolCommandInvalidGlobalAndToolPath);
-            }
-
-            DirectoryPath? toolDirectoryPath = null;
-            if (!string.IsNullOrWhiteSpace(toolPath))
-            {
-                toolDirectoryPath = new DirectoryPath(toolPath);
             }
 
             IToolPackageStore toolPackageStore = _createToolPackageStore(toolDirectoryPath);

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Globální cesta a cesta k nástroji nemůžou být zadané současně.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Die gleichzeitige Angabe von "global" und "tool-path" ist nicht möglich.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">No puede tener una ruta global y de herramienta como opinión al mismo tiempo."</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Impossible d'avoir une propriété opinion avec les paramètres global et tool-path en même temps."</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Non è possibile specificare contemporaneamente global e tool-path come opzione."</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">global と tool-path を意見として同時に指定することはできません。"</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">전역 및 도구 경로를 의견으로 동시에 사용할 수 없습니다."</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Nie można jednocześnie używać ścieżki globalnej i ścieżki narzędzia jako opinii.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Não é possível ter o caminho de ferramenta e o global como opinião ao mesmo tempo."</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Невозможно указать глобальный параметр и параметр tool-path в качестве оценки одновременно.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Fikir olarak aynı anda hem genel yol hem de araç yolu kullanılamaz.”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">无法同时主张全局和工具路径。”</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">無法同時將全域與工具路徑作為選項。」</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidToolPathOption">
+        <source>Tool path '{0}' does not exist.</source>
+        <target state="new">Tool path '{0}' does not exist.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/dotnet.Tests/CommandTests/ToolListCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolListCommandTests.cs
@@ -55,7 +55,8 @@ namespace Microsoft.DotNet.Tests.Commands
         {
             var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
 
-            var command = CreateCommand(store.Object, "-g --tool-path /tools", "/tools");
+            var toolPath = Path.GetTempPath();
+            var command = CreateCommand(store.Object, $"-g --tool-path {toolPath}", toolPath);
 
             Action a = () => {
                 command.Execute();
@@ -84,6 +85,26 @@ namespace Microsoft.DotNet.Tests.Commands
         }
 
         [Fact]
+        public void GivenAnInvalidToolPathItThrowsException()
+        {
+            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            store
+                .Setup(s => s.EnumeratePackages())
+                .Returns(new IToolPackage[0]);
+
+            var toolPath = "tool-path-does-not-exist";
+            var command = CreateCommand(store.Object, $"--tool-path {toolPath}", toolPath);
+
+            Action a = () => command.Execute();
+
+            a.ShouldThrow<GracefulException>()
+             .And
+             .Message
+             .Should()
+             .Be(string.Format(LocalizableStrings.InvalidToolPathOption, toolPath));
+        }
+
+        [Fact]
         public void GivenAToolPathItPassesToolPathToStoreFactory()
         {
             var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
@@ -91,7 +112,8 @@ namespace Microsoft.DotNet.Tests.Commands
                 .Setup(s => s.EnumeratePackages())
                 .Returns(new IToolPackage[0]);
 
-            var command = CreateCommand(store.Object, "--tool-path /tools", "/tools");
+            var toolPath = Path.GetTempPath();
+            var command = CreateCommand(store.Object, $"--tool-path {toolPath}", toolPath);
 
             command.Execute().Should().Be(0);
 

--- a/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
@@ -51,11 +51,11 @@ namespace Microsoft.DotNet.Tests.Commands
 
             Action a = () => command.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
-                .Should().Contain(
-                    string.Format(
-                    LocalizableStrings.ToolNotInstalled,
-                    packageId));
+            a.ShouldThrow<GracefulException>()
+                .And
+                .Message
+                .Should()
+                .Be(string.Format(LocalizableStrings.ToolNotInstalled, packageId));
         }
 
         [Fact]
@@ -131,9 +131,10 @@ namespace Microsoft.DotNet.Tests.Commands
                 .Execute();
 
             a.ShouldThrow<GracefulException>()
-                .And.Message
-                .Should().Contain(
-                    string.Format(
+                .And
+                .Message
+                .Should()
+                .Be(string.Format(
                     CommonLocalizableStrings.FailedToUninstallToolPackage,
                     PackageId,
                     "simulated error"));
@@ -145,12 +146,31 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void WhenRunWithBothGlobalAndToolPathShowErrorMessage()
         {
-            var uninstallCommand = CreateUninstallCommand($"-g --tool-path /tmp/folder {PackageId}");
+            var uninstallCommand = CreateUninstallCommand($"-g --tool-path {Path.GetTempPath()} {PackageId}");
 
             Action a = () => uninstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
-                .Should().Contain(LocalizableStrings.UninstallToolCommandInvalidGlobalAndToolPath);
+            a.ShouldThrow<GracefulException>()
+                .And
+                .Message
+                .Should()
+                .Be(LocalizableStrings.UninstallToolCommandInvalidGlobalAndToolPath);
+        }
+
+        [Fact]
+        public void GivenAnInvalidToolPathItThrowsException()
+        {
+            var toolPath = "tool-path-does-not-exist";
+
+            var uninstallCommand = CreateUninstallCommand($"--tool-path {toolPath} {PackageId}");
+
+            Action a = () => uninstallCommand.Execute();
+
+            a.ShouldThrow<GracefulException>()
+                .And
+                .Message
+                .Should()
+                .Be(string.Format(LocalizableStrings.InvalidToolPathOption, toolPath));
         }
 
         [Fact]
@@ -160,8 +180,11 @@ namespace Microsoft.DotNet.Tests.Commands
 
             Action a = () => uninstallCommand.Execute();
 
-            a.ShouldThrow<GracefulException>().And.Message
-                .Should().Contain(LocalizableStrings.UninstallToolCommandNeedGlobalOrToolPath);
+            a.ShouldThrow<GracefulException>()
+                .And
+                .Message
+                .Should()
+                .Be(LocalizableStrings.UninstallToolCommandNeedGlobalOrToolPath);
         }
 
         private ToolInstallCommand CreateInstallCommand(string options)


### PR DESCRIPTION
This PR checks that the `--tool-path` option for the `tool list` and `tool
uninstall` commands is a directory that exists.

If the directory does not exist, an error and the command help is displayed.

Fixes #8931.