### PR TITLE
Fix build warning about duplicate msbuild import

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -1,5 +1,4 @@
 <Project>
-  <Import Project="BundledDotnetTools.props" />
 
   <Target Name="GenerateMSBuildExtensions"
           DependsOnTargets="GenerateBundledVersionsProps;GenerateBundledCliToolsProps;RestoreMSBuildExtensionsPackages">


### PR DESCRIPTION
Fixing this:
```
D:\Src\cli\build\MSBuildExtensions.targets(2,3): 
warning MSB4011: "D:\Src\cli\build\BundledDotnetTools.props" cannot be imported again. 
It was already imported at "D:\Src\cli\Directory.Build.props (60,5)". 
This is most likely a build authoring error. 
This subsequent import will be ignored.
```