### PR TITLE
Add TryGetMostFitRuntimeIdentifier

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/FrameworkDependencyFile.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/FrameworkDependencyFile.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Microsoft.DotNet.PlatformAbstractions;
@@ -43,6 +44,77 @@ namespace Microsoft.DotNet.Cli.Utils
                 .RuntimeLibraries
                 .FirstOrDefault(l => "netstandard.library".Equals(l.Name, StringComparison.OrdinalIgnoreCase))
                 ?.Version;
+        }
+
+        public bool TryGetMostFitRuntimeIdentifier(
+            string alternativeCurrentRuntimeIdentifier,
+            string[] candidateRuntimeIdentifiers,
+            out string mostFitRuntimeIdentifier)
+        {
+            return TryGetMostFitRuntimeIdentifier(
+                RuntimeEnvironment.GetRuntimeIdentifier(),
+                alternativeCurrentRuntimeIdentifier,
+                DependencyContext.RuntimeGraph,
+                candidateRuntimeIdentifiers,
+                out mostFitRuntimeIdentifier);
+        }
+
+        internal static bool TryGetMostFitRuntimeIdentifier(
+            string currentRuntimeIdentifier,
+            string alternativeCurrentRuntimeIdentifier,
+            IReadOnlyList<RuntimeFallbacks> runtimeGraph,
+            string[] candidateRuntimeIdentifiers,
+            out string mostFitRuntimeIdentifier)
+        {
+            mostFitRuntimeIdentifier = null;
+            RuntimeFallbacks[] runtimeFallbacksCandidates;
+
+            if (!string.IsNullOrEmpty(currentRuntimeIdentifier))
+            {
+                runtimeFallbacksCandidates =
+                    runtimeGraph
+                    .Where(g => string.Equals(g.Runtime, currentRuntimeIdentifier, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+            }
+            else
+            {
+                runtimeFallbacksCandidates = new RuntimeFallbacks[0];
+            }
+
+            if (runtimeFallbacksCandidates.Length == 0 && !string.IsNullOrEmpty(alternativeCurrentRuntimeIdentifier))
+            {
+                runtimeFallbacksCandidates =
+                    runtimeGraph
+                    .Where(g => string.Equals(g.Runtime, alternativeCurrentRuntimeIdentifier, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+            }
+
+            if (runtimeFallbacksCandidates.Length == 0)
+            {
+                return false;
+            }
+
+            RuntimeFallbacks runtimeFallbacks = runtimeFallbacksCandidates[0];
+
+            var runtimeFallbacksIncludesRuntime =
+                runtimeFallbacks.Fallbacks.ToList();
+            runtimeFallbacksIncludesRuntime.Insert(0, runtimeFallbacks.Runtime);
+
+            var candidateMap = candidateRuntimeIdentifiers
+                .Distinct(comparer: StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(x => x, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var fallback in runtimeFallbacksIncludesRuntime)
+            {
+                if (candidateMap.TryGetValue(fallback, out string match))
+                {
+                    mostFitRuntimeIdentifier = match;
+
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private DependencyContext CreateDependencyContext()

--- a/src/Microsoft.DotNet.Cli.Utils/FrameworkDependencyFile.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/FrameworkDependencyFile.cs
@@ -78,7 +78,7 @@ namespace Microsoft.DotNet.Cli.Utils
             }
             else
             {
-                runtimeFallbacksCandidates = new RuntimeFallbacks[0];
+                runtimeFallbacksCandidates = Array.Empty<RuntimeFallbacks>();
             }
 
             if (runtimeFallbacksCandidates.Length == 0 && !string.IsNullOrEmpty(alternativeCurrentRuntimeIdentifier))
@@ -96,9 +96,10 @@ namespace Microsoft.DotNet.Cli.Utils
 
             RuntimeFallbacks runtimeFallbacks = runtimeFallbacksCandidates[0];
 
-            var runtimeFallbacksIncludesRuntime =
-                runtimeFallbacks.Fallbacks.ToList();
-            runtimeFallbacksIncludesRuntime.Insert(0, runtimeFallbacks.Runtime);
+            var runtimeFallbacksIncludesRuntime = new List<string>();
+            runtimeFallbacksIncludesRuntime.Add(runtimeFallbacks.Runtime);
+            runtimeFallbacksIncludesRuntime.AddRange(runtimeFallbacks.Fallbacks);
+
 
             var candidateMap = candidateRuntimeIdentifiers
                 .Distinct(comparer: StringComparer.OrdinalIgnoreCase)

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAFrameworkDependencyFile.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAFrameworkDependencyFile.cs
@@ -1,0 +1,147 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.Extensions.DependencyModel;
+using Xunit;
+
+namespace Microsoft.DotNet.Cli.Utils.Tests
+{
+    public class GivenAFrameworkDependencyFile
+    {
+        private readonly IReadOnlyList<RuntimeFallbacks> _testRuntimeGraph;
+
+        public GivenAFrameworkDependencyFile()
+        {
+            _testRuntimeGraph = new List<RuntimeFallbacks>
+            {
+                new RuntimeFallbacks("win-x64", new [] { "win", "any", "base" }),
+                new RuntimeFallbacks("win8", new [] { "win7", "win", "any", "base" }),
+                new RuntimeFallbacks("win7", new [] { "win", "any", "base" }),
+                new RuntimeFallbacks("win", new [] { "any", "base" }),
+            };
+        }
+
+        [Fact]
+        public void WhenPassSeveralCompatibleRuntimeIdentifiersItOutMostFitRid()
+        {
+            FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
+                    currentRuntimeIdentifier: "win7",
+                    alternativeCurrentRuntimeIdentifier : "win",
+                    runtimeGraph : _testRuntimeGraph,
+                    candidateRuntimeIdentifiers : new [] { "win", "any" },
+                    mostFitRuntimeIdentifier : out string mostFitRid)
+                .Should().BeTrue();
+
+            mostFitRid.Should().Be("win");
+        }
+
+        [Fact]
+        public void WhenPassSeveralCompatibleRuntimeIdentifiersItOutMostFitRid2()
+        {
+            FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
+                    currentRuntimeIdentifier: "win",
+                    alternativeCurrentRuntimeIdentifier: null,
+                    runtimeGraph: _testRuntimeGraph,
+                    candidateRuntimeIdentifiers: new[] { "win", "any" },
+                    mostFitRuntimeIdentifier: out string mostFitRid)
+                .Should().BeTrue();
+
+            mostFitRid.Should().Be("win");
+        }
+
+        [Fact]
+        public void WhenPassSeveralCompatibleRuntimeIdentifiersAndCurrentRuntimeIdentifierIsNullReturnsFalse()
+        {
+            FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
+                    currentRuntimeIdentifier: null,
+                    alternativeCurrentRuntimeIdentifier: null,
+                    runtimeGraph: _testRuntimeGraph,
+                    candidateRuntimeIdentifiers: new[] { "win", "any" },
+                    mostFitRuntimeIdentifier: out string mostFitRid)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenPassSeveralCompatibleRuntimeIdentifiersItOutMostFitRidWithCasingPreserved()
+        {
+            FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
+                    currentRuntimeIdentifier: "win7",
+                    alternativeCurrentRuntimeIdentifier : null,
+                    runtimeGraph : _testRuntimeGraph,
+                    candidateRuntimeIdentifiers : new [] { "Win", "any" },
+                    mostFitRuntimeIdentifier : out string mostFitRid)
+                .Should().BeTrue();
+
+            mostFitRid.Should().Be("Win");
+        }
+
+        [Fact]
+        public void WhenPassSeveralCompatibleRuntimeIdentifiersWithDuplicationItOutMostFitRid()
+        {
+            FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
+                    currentRuntimeIdentifier: "win7",
+                    alternativeCurrentRuntimeIdentifier : null,
+                    runtimeGraph : _testRuntimeGraph,
+                    candidateRuntimeIdentifiers : new [] { "win", "win", "any" },
+                    mostFitRuntimeIdentifier : out string mostFitRid)
+                .Should().BeTrue();
+
+            mostFitRid.Should().Be("win");
+        }
+
+        [Fact]
+        public void WhenPassSeveralCompatibleRuntimeIdentifiersAndDuplicationItOutMostFitRidWithCasingPreservedTheFirstIsFavoriated()
+        {
+            FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
+                    currentRuntimeIdentifier: "win7",
+                    alternativeCurrentRuntimeIdentifier: null,
+                    runtimeGraph: _testRuntimeGraph,
+                    candidateRuntimeIdentifiers: new[] { "Win", "win", "win", "any" },
+                    mostFitRuntimeIdentifier: out string mostFitRid)
+                .Should().BeTrue();
+
+            mostFitRid.Should().Be("Win");
+        }
+
+        [Fact]
+        public void WhenPassSeveralNonCompatibleRuntimeIdentifiersItReturnsFalse()
+        {
+            FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
+                    currentRuntimeIdentifier: "win7",
+                    alternativeCurrentRuntimeIdentifier : null,
+                    runtimeGraph : _testRuntimeGraph,
+                    candidateRuntimeIdentifiers : new [] { "centos", "debian" },
+                    mostFitRuntimeIdentifier : out string mostFitRid)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenCurrentRuntimeIdentifierIsNotSupportedItUsesAlternative()
+        {
+            FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
+                    currentRuntimeIdentifier: "win-vnext",
+                    alternativeCurrentRuntimeIdentifier: "win8",
+                    runtimeGraph: _testRuntimeGraph,
+                    candidateRuntimeIdentifiers: new[] { "win", "any" },
+                    mostFitRuntimeIdentifier: out string mostFitRid)
+                .Should().BeTrue();
+
+            mostFitRid.Should().Be("win");
+        }
+
+        [Fact]
+        public void WhenCurrentRuntimeIdentifierIsNotSupportedSoIsTheAlternativeItReturnsFalse()
+        {
+            FrameworkDependencyFile.TryGetMostFitRuntimeIdentifier(
+                    currentRuntimeIdentifier: "osx10.13-x64",
+                    alternativeCurrentRuntimeIdentifier: "osx-x64",
+                    runtimeGraph: _testRuntimeGraph,
+                    candidateRuntimeIdentifiers: new[] { "win", "any" },
+                    mostFitRuntimeIdentifier: out string mostFitRid)
+                .Should().BeFalse();
+        }
+    }
+}


### PR DESCRIPTION
This is the most tricky part of consume bring your own shim. CLI will need to select the most fit RID given the shims folder layout in nupkg. This function is to pick that. 

Say there is folder `win10-x64, win-x64, win, linux`, CLI need to pick the right shim folder to use according to machine RID (say it is windows 10 x64). And this function take these rids as input and return `win10-x64`.