### PR TITLE
[Arm64] Enable crossgen

### DIFF
--- a/build/CrossGen.props
+++ b/build/CrossGen.props
@@ -1,8 +1,11 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <RuntimeNETCoreAppPackageName>runtime.$(SharedFrameworkRid).microsoft.netcore.app</RuntimeNETCoreAppPackageName>
-    <CrossgenPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppPackageVersion)/tools/crossgen$(ExeExtension)</CrossgenPath>
-    <LibCLRJitPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppPackageVersion)/runtimes/$(SharedFrameworkRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
+    <_crossDir Condition="'$(Architecture)' == 'arm64'">/x64_arm64</_crossDir>
+    <CrossgenPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppPackageVersion)/tools$(_crossDir)/crossgen$(ExeExtension)</CrossgenPath>
+    <LibCLRJitRid Condition="'$(Architecture)' != 'arm64'">$(SharedFrameworkRid)</LibCLRJitRid>
+    <LibCLRJitRid Condition="'$(Architecture)' == 'arm64'">x64_arm64</LibCLRJitRid>
+    <LibCLRJitPath>$(NuGetPackagesDir)/$(RuntimeNETCoreAppPackageName)/$(MicrosoftNETCoreAppPackageVersion)/runtimes/$(LibCLRJitRid)/native/$(DynamicLibPrefix)clrjit$(DynamicLibExtension)</LibCLRJitPath>
     <SharedFrameworkNameVersionPath>$(OutputDirectory)/shared/$(SharedFrameworkName)/$(MicrosoftNETCoreAppPackageVersion)</SharedFrameworkNameVersionPath>
   </PropertyGroup>
 </Project>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -257,7 +257,7 @@
   </Target>
 
   <Target Name="CrossgenPublishDir"
-          Condition=" '$(DISABLE_CROSSGEN)' == '' And !$(Architecture.StartsWith('arm')) "
+          Condition=" '$(DISABLE_CROSSGEN)' == '' And '$(Architecture)' != 'arm' "
           AfterTargets="PublishSdks">
     <ItemGroup>
       <RoslynFiles Include="$(PublishDir)Roslyn\bincore\**\*" />


### PR DESCRIPTION
Enable Arm64 Crossgen 

Fixes for arm64 #8998 

Depends on dotnet/core-setup#3987 ++

Works if I manually copy crossgen dependencies from core-setup

```bash
# Copy x64_arm64 crossgen
 cp -r \
    ../core-setup/packages/transport.runtime.linux-arm64.microsoft.netcore.runtime.coreclr/2.1.0-preview3-26404-06/tools/x64_arm64 \
    ./.nuget/packages/runtime.linux-arm64.microsoft.netcore.app/2.1.0-preview3-26404-01/tools

# Copy x64_arm64 libclrjit.so
cp -r \
    ../core-setup/packages/transport.runtime.linux-arm64.microsoft.netcore.jit/2.1.0-preview3-26404-06/runtimes/x64_arm64 \
    ./.nuget/packages/runtime.linux-arm64.microsoft.netcore.app/2.1.0-preview3-26404-01/runtimes/

```

@eerhardt 
Contains #8896 which I hope/expect will merge before dotnet/core-setup#3987 is ready