### PR TITLE
Rename buildserver command.

### DIFF
--- a/src/dotnet/BuiltInCommandsCatalog.cs
+++ b/src/dotnet/BuiltInCommandsCatalog.cs
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Cli
                 Command = ToolCommand.Run,
                 DocLink = "https://aka.ms/dotnet-tool"
             },
-            ["buildserver"] = new BuiltInCommandMetadata
+            ["build-server"] = new BuiltInCommandMetadata
             {
                 Command = BuildServerCommand.Run,
                 DocLink = "https://aka.ms/dotnet-build-server"

--- a/src/dotnet/commands/dotnet-buildserver/BuildServerCommand.cs
+++ b/src/dotnet/commands/dotnet-buildserver/BuildServerCommand.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Tools.BuildServer
 {
     public class BuildServerCommand : DotNetTopLevelCommandBase
     {
-        protected override string CommandName => "buildserver";
+        protected override string CommandName => "build-server";
         protected override string FullCommandNameLocalized => LocalizableStrings.BuildServerCommandName;
         protected override string ArgumentName => "";
         protected override string ArgumentDescriptionLocalized => "";

--- a/src/dotnet/commands/dotnet-buildserver/BuildServerCommandParser.cs
+++ b/src/dotnet/commands/dotnet-buildserver/BuildServerCommandParser.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Cli
         public static Command CreateCommand()
         {
             return Create.Command(
-                "buildserver",
+                "build-server",
                 LocalizableStrings.CommandDescription,
                 Accept.NoArguments(),
                 CommonOptions.HelpOption(),

--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -29,7 +29,7 @@ path-to-application:
   vstest           {LocalizableStrings.VsTestDefinition}
   store            {LocalizableStrings.StoreDefinition}
   tool             {LocalizableStrings.ToolDefinition}
-  buildserver      {LocalizableStrings.BuildServerDefinition}
+  build-server     {LocalizableStrings.BuildServerDefinition}
   help             {LocalizableStrings.HelpDefinition}
 
 {LocalizableStrings.CommonOptions}:

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -40,7 +40,7 @@ SDK commands:
   vstest           Runs Microsoft Test Execution Command Line Tool.
   store            Stores the specified assemblies in the runtime store.
   tool             Install or work with tools that extend the .NET experience.
-  buildserver      Interact with servers started by a build.
+  build-server     Interact with servers started by a build.
   help             Show help.
 
 Common options:

--- a/test/dotnet.Tests/CommandTests/BuildServerShutdownCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/BuildServerShutdownCommandTests.cs
@@ -172,9 +172,9 @@ namespace Microsoft.DotNet.Tests.Commands
 
         private BuildServerShutdownCommand CreateCommand(string options = "", IEnumerable<IBuildServerManager> managers = null)
         {
-            ParseResult result = Parser.Instance.Parse("dotnet buildserver shutdown " + options);
+            ParseResult result = Parser.Instance.Parse("dotnet build-server shutdown " + options);
             return new BuildServerShutdownCommand(
-                options: result["dotnet"]["buildserver"]["shutdown"],
+                options: result["dotnet"]["build-server"]["shutdown"],
                 result: result,
                 managers: managers,
                 useOrderedWait: true,

--- a/test/dotnet.Tests/ParserTests/BuildServerShutdownParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/BuildServerShutdownParserTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.DotNet.Tests.ParserTests
         [Fact]
         public void GivenNoOptionsAllFlagsAreFalse()
         {
-            var result = Parser.Instance.Parse("dotnet buildserver shutdown");
+            var result = Parser.Instance.Parse("dotnet build-server shutdown");
 
-            var options = result["dotnet"]["buildserver"]["shutdown"];
+            var options = result["dotnet"]["build-server"]["shutdown"];
             options.ValueOrDefault<bool>("msbuild").Should().Be(false);
             options.ValueOrDefault<bool>("vbcscompiler").Should().Be(false);
             options.ValueOrDefault<bool>("razor").Should().Be(false);
@@ -34,9 +34,9 @@ namespace Microsoft.DotNet.Tests.ParserTests
         [Fact]
         public void GivenMSBuildOptionIsItTrue()
         {
-            var result = Parser.Instance.Parse("dotnet buildserver shutdown --msbuild");
+            var result = Parser.Instance.Parse("dotnet build-server shutdown --msbuild");
 
-            var options = result["dotnet"]["buildserver"]["shutdown"];
+            var options = result["dotnet"]["build-server"]["shutdown"];
             options.ValueOrDefault<bool>("msbuild").Should().Be(true);
             options.ValueOrDefault<bool>("vbcscompiler").Should().Be(false);
             options.ValueOrDefault<bool>("razor").Should().Be(false);
@@ -45,9 +45,9 @@ namespace Microsoft.DotNet.Tests.ParserTests
         [Fact]
         public void GivenVBCSCompilerOptionIsItTrue()
         {
-            var result = Parser.Instance.Parse("dotnet buildserver shutdown --vbcscompiler");
+            var result = Parser.Instance.Parse("dotnet build-server shutdown --vbcscompiler");
 
-            var options = result["dotnet"]["buildserver"]["shutdown"];
+            var options = result["dotnet"]["build-server"]["shutdown"];
             options.ValueOrDefault<bool>("msbuild").Should().Be(false);
             options.ValueOrDefault<bool>("vbcscompiler").Should().Be(true);
             options.ValueOrDefault<bool>("razor").Should().Be(false);
@@ -56,9 +56,9 @@ namespace Microsoft.DotNet.Tests.ParserTests
         [Fact]
         public void GivenRazorOptionIsItTrue()
         {
-            var result = Parser.Instance.Parse("dotnet buildserver shutdown --razor");
+            var result = Parser.Instance.Parse("dotnet build-server shutdown --razor");
 
-            var options = result["dotnet"]["buildserver"]["shutdown"];
+            var options = result["dotnet"]["build-server"]["shutdown"];
             options.ValueOrDefault<bool>("msbuild").Should().Be(false);
             options.ValueOrDefault<bool>("vbcscompiler").Should().Be(false);
             options.ValueOrDefault<bool>("razor").Should().Be(true);
@@ -67,9 +67,9 @@ namespace Microsoft.DotNet.Tests.ParserTests
         [Fact]
         public void GivenMultipleOptionsThoseAreTrue()
         {
-            var result = Parser.Instance.Parse("dotnet buildserver shutdown --razor --msbuild");
+            var result = Parser.Instance.Parse("dotnet build-server shutdown --razor --msbuild");
 
-            var options = result["dotnet"]["buildserver"]["shutdown"];
+            var options = result["dotnet"]["build-server"]["shutdown"];
             options.ValueOrDefault<bool>("msbuild").Should().Be(true);
             options.ValueOrDefault<bool>("vbcscompiler").Should().Be(false);
             options.ValueOrDefault<bool>("razor").Should().Be(true);


### PR DESCRIPTION
This commit renames the `buildserver` command to `build-server`.

Fixes #9075.
