### PR TITLE
Add Fed28 and Deb9 to 2.1.3xx dotnet-install script

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -75,16 +75,24 @@ get_legacy_os_name_from_platform() {
             echo "debian"
             return 0
             ;;
+        "debian.9")
+            echo "linux"
+            return 0
+            ;;
         "fedora.23")
             echo "fedora.23"
+            return 0
+            ;;
+        "fedora.24")
+            echo "fedora.24"
             return 0
             ;;
         "fedora.27")
             echo "fedora.27"
             return 0
             ;;
-        "fedora.24")
-            echo "fedora.24"
+        "fedora.28")
+            echo "linux"
             return 0
             ;;
         "opensuse.13.2")


### PR DESCRIPTION
Add Fed28 and Deb9 to 2.1.3xx dotnet-install script

Continuation of https://github.com/dotnet/cli/pull/8902
Unblocks https://github.com/dotnet/core-setup/pull/4043

PTAL: @johnbeisner or @livarcocc 