### PR TITLE
Fix .deb and .rpm dependency on the aspnetcore-store package 

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -73,7 +73,6 @@
     <CurrentAspNetCoreRuntimeVersion Condition="'$(AspNetCoreRuntimePackageFlavor)'!='notimestamp'">$(AspNetCoreVersion)-$(AspNetCoreRelease)-$(AspNetCoreRuntimePackageTimestamp)</CurrentAspNetCoreRuntimeVersion>
 
     <AspNetCoreRuntimePackageBrandName>aspnetcore-store</AspNetCoreRuntimePackageBrandName>
-    <AspNetCoreVersionAndRelease>$(AspNetCoreVersion)-$(AspNetCoreRelease)</AspNetCoreVersionAndRelease>
     <AspNetCoreRuntimeAzureblobStoresSubfolderName>$(AspNetCoreBranchName)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimeAzureblobStoresSubfolderName>
   </PropertyGroup>
 

--- a/build/package/Installer.DEB.targets
+++ b/build/package/Installer.DEB.targets
@@ -109,6 +109,7 @@
 
     <ItemGroup>
       <TestSdkDebTaskEnvironmentVariables Include="PATH=$(DebianInstalledDirectory)$(PathListSeparator)$(PATH)" />
+      <TestSdkDebTaskEnvironmentVariables Include="SDK_INSTALLER_FILE=$(SdkInstallerFile)" />
 
       <!-- Consumed By Publish -->
       <GeneratedInstallers Include="$(SdkInstallerFile)" />

--- a/build/package/Installer.DEB.targets
+++ b/build/package/Installer.DEB.targets
@@ -35,6 +35,7 @@
       <HostFxrDebianPackageName>dotnet-hostfxr-$(HostFxrDebianPackageVersion)</HostFxrDebianPackageName>
       <HostFxrDebianPackageName>$(HostFxrDebianPackageName.ToLower())</HostFxrDebianPackageName>
       <HostDebianPackageName>dotnet-host</HostDebianPackageName>
+      <AspNetCoreRuntimeDebPackageName>$(AspNetCoreRuntimePackageBrandName)-$(CurrentAspNetCoreRuntimeVersion)</AspNetCoreRuntimeDebPackageName>
     </PropertyGroup>
 
     <!-- Inputs -->
@@ -84,7 +85,7 @@
         <ReplacementString>$(SharedFxDebianPackageName)</ReplacementString>
       </DebianConfigTokenValues>
       <DebianConfigTokenValues Include="%ASPNETCOREPACKAGESTORE_DEBIAN_PACKAGE_NAME%">
-        <ReplacementString>$(AspNetCoreRuntimePackageName)</ReplacementString>
+        <ReplacementString>$(AspNetCoreRuntimeDebPackageName)</ReplacementString>
       </DebianConfigTokenValues>
       <DebianConfigTokenValues Include="%SHARED_FRAMEWORK_DEBIAN_PACKAGE_ADDITIONAL_DEPENDENCY%"
                                Condition="'$(IncludeAdditionalSharedFrameworks)' == 'true'">

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -137,6 +137,7 @@
 
     <ItemGroup>
       <TestSdkRpmTaskEnvironmentVariables Include="PATH=$(RpmInstalledDirectory)$(PathListSeparator)$(PATH)" />
+      <TestSdkRpmTaskEnvironmentVariables Include="SDK_INSTALLER_FILE=$(SdkInstallerFile)" />
       <GeneratedInstallers Include="$(SdkInstallerFile)" />
     </ItemGroup>
 
@@ -238,7 +239,7 @@
                    ToolPath="$(RpmInstalledDirectory)" />
 
     <DotNetTest ProjectPath="$(EndToEndTestProject)"
-                EnvironmentVariables="@(TestSdkDebTaskEnvironmentVariables)"
+                EnvironmentVariables="@(TestSdkRpmTaskEnvironmentVariables)"
                 ToolPath="$(RpmInstalledDirectory)" />
 
     <!-- Clean up Packages -->

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -50,10 +50,8 @@
       <HostFxrRpmPackageName>dotnet-hostfxr-$(HostFxrRpmPackageVersion)</HostFxrRpmPackageName>
       <HostFxrRpmPackageName>$(HostFxrRpmPackageName.ToLower())</HostFxrRpmPackageName>
       <HostRpmPackageName>dotnet-host</HostRpmPackageName>
-      <AspNetCoreRuntimePackageName>$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersionAndRelease)-$(AspNetCoreRuntimePackageTimestamp)</AspNetCoreRuntimePackageName>
-      <AspNetCoreRuntimePackageName Condition="'$(AspNetCoreRuntimePackageFlavor)' == 'notimestamp'">$(AspNetCoreRuntimePackageBrandName)-$(AspNetCoreVersion)</AspNetCoreRuntimePackageName>
-      <AspNetCoreRuntimePackageName200>$(AspNetCoreRuntimePackageBrandName)-2.0.0</AspNetCoreRuntimePackageName200>
-      <AspNetCoreRuntimePackageName203>$(AspNetCoreRuntimePackageBrandName)-2.0.3</AspNetCoreRuntimePackageName203>
+      <AspNetCoreRuntimeRpmPackageName>$(AspNetCoreRuntimePackageBrandName)-$(CurrentAspNetCoreRuntimeVersion)</AspNetCoreRuntimeRpmPackageName>
+      <AspNetCoreRuntimeRpmPackageVersion>$(CurrentAspNetCoreRuntimeVersion)</AspNetCoreRuntimeRpmPackageVersion>
       <AfterInstallHostScriptTemplateFile>$(ScriptsDir)/$(AfterInstallHostScriptName)</AfterInstallHostScriptTemplateFile>
       <AfterInstallHostScriptDestinationFile>$(RpmLayoutScripts)/$(AfterInstallHostScriptName)</AfterInstallHostScriptDestinationFile>
     </PropertyGroup>
@@ -112,10 +110,10 @@
         <ReplacementString>$(SharedFrameworkVersion)</ReplacementString>
       </SDKTokenValue>
       <SDKTokenValue Include="%ASPNETCOREPACKAGESTORE_RPM_PACKAGE_NAME%">
-        <ReplacementString>$(AspNetCoreRuntimePackageName)</ReplacementString>
+        <ReplacementString>$(AspNetCoreRuntimeRpmPackageName)</ReplacementString>
       </SDKTokenValue>
       <SDKTokenValue Include="%ASPNETCOREPACKAGESTORE_RPM_PACKAGE_VERSION%">
-        <ReplacementString>$(AspNetCoreRuntimePackageVersion)</ReplacementString>
+        <ReplacementString>$(AspNetCoreRuntimeRpmPackageVersion)</ReplacementString>
       </SDKTokenValue>
       <SDKTokenValue Include="%SHARED_HOST_RPM_NAME%">
         <ReplacementString>$(SharedFxRpmPackageName)</ReplacementString>

--- a/test/EndToEnd/GivenDotNetLinuxInstallers.cs
+++ b/test/EndToEnd/GivenDotNetLinuxInstallers.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.DotNet.Tests.EndToEnd
+{
+    public class GivenDotNetLinuxInstallers
+    {
+        [Fact]
+        public void ItHasExpectedDependencies()
+        {
+            var installerFile = Environment.GetEnvironmentVariable("SDK_INSTALLER_FILE");
+            if (string.IsNullOrEmpty(installerFile))
+            {
+                return;
+            }
+
+            var ext = Path.GetExtension(installerFile);
+            switch (ext)
+            {
+                case ".deb":
+                    DebianPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(installerFile);
+                    return;
+                case ".rpm":
+                    RpmPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(installerFile);
+                    return;
+            }
+        }
+
+        private void DebianPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(string installerFile)
+        {
+            // Example output:
+
+            // $ dpkg --info dotnet-sdk-2.1.105-ubuntu-x64.deb
+
+            // new debian package, version 2.0.
+            // size 75660448 bytes: control archive=29107 bytes.
+            //     717 bytes,    11 lines      control              
+            // 123707 bytes,  1004 lines      md5sums              
+            //     1710 bytes,    28 lines   *  postinst             #!/usr/bin/env
+            // Package: dotnet-sdk-2.1.104
+            // Version: 2.1.104-1
+            // Architecture: amd64
+            // Maintainer: Microsoft <dotnetcore@microsoft.com>
+            // Installed-Size: 201119
+            // Depends: dotnet-runtime-2.0.6, aspnetcore-store-2.0.6
+            // Section: devel
+            // Priority: standard
+            // Homepage: https://dotnet.github.io/core
+            // Description: Microsoft .NET Core SDK - 2.1.104
+
+            new TestCommand("dpkg")
+                .ExecuteWithCapturedOutput($"--info {installerFile}")
+                .Should().Pass()
+                    .And.HaveStdOutMatching(@"Depends:.*\s?dotnet-runtime-\d+(\.\d+){2}")
+                    .And.HaveStdOutMatching(@"Depends:.*\s?aspnetcore-store-\d+(\.\d+){2}");
+        }
+
+        private void RpmPackageHasDependencyOnAspNetCoreStoreAndDotnetRuntime(string installerFile)
+        {
+            // Example output:
+
+            // $ rpm -qpR dotnet-sdk-2.1.105-rhel-x64.rpm
+
+            // dotnet-runtime-2.0.7 >= 2.0.7
+            // aspnetcore-store-2.0.7 >= 2.0.7
+            // /bin/sh
+            // /bin/sh
+            // rpmlib(PayloadFilesHavePrefix) <= 4.0-1
+            // rpmlib(CompressedFileNames) <= 3.0.4-1
+
+            new TestCommand("rpm")
+                .ExecuteWithCapturedOutput($"-qpR {installerFile}")
+                .Should().Pass()
+                    .And.HaveStdOutMatching(@"dotnet-runtime-\d+(\.\d+){2} >= \d+(\.\d+){2}")
+                    .And.HaveStdOutMatching(@"aspnetcore-store-\d+(\.\d+){2} >= \d+(\.\d+){2}");
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/9095

In cleaning up some targets for 2.1.105, I missed that the <AspNetCoreRuntimePackageName> property needed to be set in both Installer.RPM.targets _and_ Installer.DEB.targets.

Changes:
 - add tests that would have caught this error in the first place
 - fix the targets to include correctly a dependency on aspnetcore-store for 2.1.1xx builds