### PR TITLE
Add bundled aspnetcore runtime framework versions

### DIFF
--- a/TestAssets/TestProjects/TestWebAppSimple/Program.cs
+++ b/TestAssets/TestProjects/TestWebAppSimple/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace TestWebAppSimple
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/TestAssets/TestProjects/TestWebAppSimple/Startup.cs
+++ b/TestAssets/TestProjects/TestWebAppSimple/Startup.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TestWebAppSimple
+{
+    public class Startup
+    {
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.Run(async (context) =>
+            {
+                await context.Response.WriteAsync("Hello World!");
+            });
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestWebAppSimple/TestWebAppSimple.csproj
+++ b/TestAssets/TestProjects/TestWebAppSimple/TestWebAppSimple.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Web" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <Target Name="WriteVersionsFile" BeforeTargets="Restore">
+    <WriteLinesToFile
+      File="$(MSBuildThisFileDirectory)/.BundledAspNetCoreVersion"
+      Lines="$(MicrosoftAspNetCoreAppPackageVersion)"
+      Overwrite="true"/>
+  </Target>
+
+</Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MicrosoftAspNetCoreAppPackageVersion>2.1.0-preview2-30475</MicrosoftAspNetCoreAppPackageVersion>
+    <MicrosoftAspNetCoreAllPackageVersion>2.1.0-preview2-30475</MicrosoftAspNetCoreAllPackageVersion>
+    <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-rc1-26420-08</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <MicrosoftBuildPackageVersion>15.7.0-preview-000169</MicrosoftBuildPackageVersion>
@@ -17,7 +18,7 @@
     <MicrosoftNETSdkPackageVersion>2.1.300-preview3-62819-01</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</MicrosoftNETSdkRazorPackageVersion>
-    <MicrosoftNETSdkWebPackageVersion>2.1.300-rc1-20180418-1607241</MicrosoftNETSdkWebPackageVersion>
+    <MicrosoftNETSdkWebPackageVersion>2.1.300-rc1-20180420-1612100</MicrosoftNETSdkWebPackageVersion>
     <MicrosoftNETSdkPublishPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkPublishPackageVersion>
     <MicrosoftNETSdkWebProjectSystemPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWebProjectSystemPackageVersion>
     <MicrosoftDotNetCommonItemTemplatesPackageVersion>1.0.2-beta3-20180418-1607235</MicrosoftDotNetCommonItemTemplatesPackageVersion>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -113,10 +113,14 @@
       <_NETCoreAppPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</_NETCoreAppPackageVersion>
       <_NETStandardLibraryPackageVersion>@(_NETStandardLibraryPackageVersions->Distinct())</_NETStandardLibraryPackageVersion>
       <_NETCorePlatformsPackageVersion>@(_NETCorePlatformsPackageVersions->Distinct())</_NETCorePlatformsPackageVersion>
+      <_AspNetCoreAllPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</_AspNetCoreAllPackageVersion>
+      <_AspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</_AspNetCoreAppPackageVersion>
 
       <!-- Use only major and minor in target framework version -->
       <_NETCoreAppTargetFrameworkVersion>$(_NETCoreAppPackageVersion.Split('.')[0]).$(_NETCoreAppPackageVersion.Split('.')[1])</_NETCoreAppTargetFrameworkVersion>
       <_NETStandardTargetFrameworkVersion>$(_NETStandardLibraryPackageVersion.Split('.')[0]).$(_NETStandardLibraryPackageVersion.Split('.')[1])</_NETStandardTargetFrameworkVersion>
+      <_AspNetCoreAllTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</_AspNetCoreAllTargetFrameworkVersion>
+      <_AspNetCoreAppTargetFrameworkVersion>$(_AspNetCoreAllTargetFrameworkVersion)</_AspNetCoreAppTargetFrameworkVersion>
 
       <_NETCoreSdkIsPreview Condition=" '$(DropSuffix)' == '' ">true</_NETCoreSdkIsPreview>
 
@@ -140,9 +144,13 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledNETStandardTargetFrameworkVersion>$(_NETStandardTargetFrameworkVersion)</BundledNETStandardTargetFrameworkVersion>
     <BundledNETStandardPackageVersion>$(_NETStandardLibraryPackageVersion)</BundledNETStandardPackageVersion>
     <BundledNETCorePlatformsPackageVersion>$(_NETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
+    <BundledAspNetCoreAllTargetFrameworkVersion>$(_AspNetCoreAllTargetFrameworkVersion)</BundledAspNetCoreAllTargetFrameworkVersion>
+    <BundledAspNetCoreAllPackageVersion>$(_AspNetCoreAllPackageVersion)</BundledAspNetCoreAllPackageVersion>
+    <BundledAspNetCoreAppTargetFrameworkVersion>$(_AspNetCoreAppTargetFrameworkVersion)</BundledAspNetCoreAppTargetFrameworkVersion>
+    <BundledAspNetCoreAppPackageVersion>$(_AspNetCoreAppPackageVersion)</BundledAspNetCoreAppPackageVersion>
     <NETCoreSdkVersion>$(SdkVersion)</NETCoreSdkVersion>
     <_NETCoreSdkIsPreview>$(_NETCoreSdkIsPreview)</_NETCoreSdkIsPreview>
-    
+
     <!-- Latest patch versions for each minor version of .NET Core -->
     <LatestPatchVersionForNetCore1_0 Condition="'$(LatestPatchVersionForNetCore1_0)' == ''">1.0.11</LatestPatchVersionForNetCore1_0>
     <LatestPatchVersionForNetCore1_1 Condition="'$(LatestPatchVersionForNetCore1_1)' == ''">1.1.8</LatestPatchVersionForNetCore1_1>

--- a/test/EndToEnd/GivenAspNetAppsResolveImplicitVersions.cs
+++ b/test/EndToEnd/GivenAspNetAppsResolveImplicitVersions.cs
@@ -1,0 +1,222 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using Xunit;
+
+namespace EndToEnd
+{
+    public class GivenAspNetAppsResolveImplicitVersions : TestBase
+    {
+        private const string AspNetTestProject = "TestWebAppSimple";
+
+        [Fact]
+        public void PortablePublishWithLatestTFMUsesBundledAspNetCoreAppVersion()
+        {
+            var _testInstance = TestAssets.Get(AspNetTestProject)
+                .CreateInstance(identifier: LatestSupportedAspNetCoreAppVersion)
+                .WithSourceFiles();
+
+            string projectDirectory = _testInstance.Root.FullName;
+            string projectPath = Path.Combine(projectDirectory, $"{AspNetTestProject}.csproj");
+
+            var project = XDocument.Load(projectPath);
+            var ns = project.Root.Name.Namespace;
+
+            //  Update TargetFramework to the right version of .NET Core
+            project.Root.Element(ns + "PropertyGroup")
+                .Element(ns + "TargetFramework")
+                .Value = "netcoreapp" + LatestSupportedAspNetCoreAppVersion;
+
+            project.Save(projectPath);
+
+            //  Get the implicit version
+            new RestoreCommand()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute()
+                    .Should().Pass();
+
+            var assetsFilePath = Path.Combine(projectDirectory, "obj", "project.assets.json");
+            var assetsFile = new LockFileFormat().Read(assetsFilePath);
+
+            var restoredVersion = GetAspNetCoreAppVersion(assetsFile, portable: true);
+            restoredVersion.Should().NotBeNull();
+
+            var bundledVersionPath = Path.Combine(projectDirectory, ".BundledAspNetCoreVersion");
+            var bundledVersion = File.ReadAllText(bundledVersionPath).Trim();
+
+            restoredVersion.ToNormalizedString().Should().BeEquivalentTo(bundledVersion,
+                "The bundled aspnetcore versions set in Microsoft.NETCoreSdk.BundledVersions.props should be idenitical to the versions set in DependencyVersions.props." +
+                "Please update MSBuildExtensions.targets in this repo so these versions match.");
+        }
+
+        [Fact]
+        public void StandalonePublishWithLatestTFMUsesBundledAspNetCoreAppVersion()
+        {
+            var _testInstance = TestAssets.Get(AspNetTestProject)
+                .CreateInstance(identifier: LatestSupportedAspNetCoreAppVersion)
+                .WithSourceFiles();
+
+            string projectDirectory = _testInstance.Root.FullName;
+            string projectPath = Path.Combine(projectDirectory, $"{AspNetTestProject}.csproj");
+
+            var project = XDocument.Load(projectPath);
+            var ns = project.Root.Name.Namespace;
+
+            //  Update TargetFramework to the right version of .NET Core
+            project.Root.Element(ns + "PropertyGroup")
+                .Element(ns + "TargetFramework")
+                .Value = "netcoreapp" + LatestSupportedAspNetCoreAppVersion;
+
+            var rid = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
+
+            //  Set RuntimeIdentifier to simulate standalone publish
+            project.Root.Element(ns + "PropertyGroup")
+                .Add(new XElement(ns + "RuntimeIdentifier", rid));
+
+            project.Save(projectPath);
+
+            //  Get the implicit version
+            new RestoreCommand()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute()
+                    .Should().Pass();
+
+            var assetsFilePath = Path.Combine(projectDirectory, "obj", "project.assets.json");
+            var assetsFile = new LockFileFormat().Read(assetsFilePath);
+
+            var restoredVersion = GetAspNetCoreAppVersion(assetsFile);
+            restoredVersion.Should().NotBeNull();
+
+            var bundledVersionPath = Path.Combine(projectDirectory, ".BundledAspNetCoreVersion");
+            var bundledVersion = File.ReadAllText(bundledVersionPath).Trim();
+
+            restoredVersion.ToNormalizedString().Should().BeEquivalentTo(bundledVersion,
+                "The bundled aspnetcore versions set in Microsoft.NETCoreSdk.BundledVersions.props should be idenitical to the versions set in DependencyVersions.props." +
+                "Please update MSBuildExtensions.targets in this repo so these versions match.");
+        }
+
+        [Theory]
+        [MemberData(nameof(SupportedAspNetCoreAppVersions))]
+        public void ItRollsForwardToTheLatestVersion(string minorVersion)
+        {
+            var _testInstance = TestAssets.Get(AspNetTestProject)
+                .CreateInstance(identifier: minorVersion)
+                .WithSourceFiles();
+
+            string projectDirectory = _testInstance.Root.FullName;
+
+            string projectPath = Path.Combine(projectDirectory, $"{AspNetTestProject}.csproj");
+
+            var project = XDocument.Load(projectPath);
+            var ns = project.Root.Name.Namespace;
+
+            //  Update TargetFramework to the right version of .NET Core
+            project.Root.Element(ns + "PropertyGroup")
+                .Element(ns + "TargetFramework")
+                .Value = "netcoreapp" + minorVersion;
+
+            var rid = Microsoft.DotNet.PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
+
+            //  Set RuntimeIdentifier to opt in to roll-forward behavior
+            project.Root.Element(ns + "PropertyGroup")
+                .Add(new XElement(ns + "RuntimeIdentifier", rid));
+
+            project.Save(projectPath);
+
+            //  Get the version rolled forward to
+            new RestoreCommand()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute()
+                    .Should().Pass();
+
+            string assetsFilePath = Path.Combine(projectDirectory, "obj", "project.assets.json");
+            var assetsFile = new LockFileFormat().Read(assetsFilePath);
+
+            var rolledForwardVersion = GetAspNetCoreAppVersion(assetsFile);
+            rolledForwardVersion.Should().NotBeNull();
+
+            if (rolledForwardVersion.IsPrerelease)
+            {
+                //  If this version of .NET Core is still prerelease, then:
+                //  - Floating the patch by adding ".*" to the major.minor version won't work, but
+                //  - There aren't any patches to roll-forward to, so we skip testing this until the version
+                //    leaves prerelease.
+                return;
+            }
+
+            //  Float the RuntimeFrameworkVersion to get the latest version of the runtime available from feeds
+            Directory.Delete(Path.Combine(projectDirectory, "obj"), true);
+            project.Root.Element(ns + "PropertyGroup")
+                .Add(new XElement(ns + "RuntimeFrameworkVersion", $"{minorVersion}.*"));
+            project.Save(projectPath);
+
+            new RestoreCommand()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute()
+                    .Should().Pass();
+
+            var floatedAssetsFile = new LockFileFormat().Read(assetsFilePath);
+
+            var floatedVersion = GetAspNetCoreAppVersion(floatedAssetsFile);
+            floatedVersion.Should().NotBeNull();
+
+            rolledForwardVersion.ToNormalizedString().Should().BeEquivalentTo(floatedVersion.ToNormalizedString(),
+                "the latest patch version properties in Microsoft.NETCoreSdk.BundledVersions.props need to be updated " +
+                "(see MSBuildExtensions.targets in this repo)");
+        }
+
+        [Fact]
+        public void WeCoverLatestAspNetCoreAppRollForward()
+        {
+            //  Run "dotnet new web", get TargetFramework property, and make sure it's covered in SupportedAspNetCoreAppVersions
+            using (DisposableDirectory directory = Temp.CreateDirectory())
+            {
+                string projectDirectory = directory.Path;
+
+                new NewCommandShim()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute("web --no-restore")
+                    .Should().Pass();
+
+                string projectPath = Path.Combine(projectDirectory, Path.GetFileName(projectDirectory) + ".csproj");
+
+                var project = XDocument.Load(projectPath);
+                var ns = project.Root.Name.Namespace;
+
+                string targetFramework = project.Root.Element(ns + "PropertyGroup")
+                    .Element(ns + "TargetFramework")
+                    .Value;
+
+                SupportedAspNetCoreAppVersions.Select(v => $"netcoreapp{v[0]}")
+                    .Should().Contain(targetFramework, $"the {nameof(SupportedAspNetCoreAppVersions)} property should include the default version " +
+                    "of Microsoft.AspNetCore.App used by the templates created by \"dotnet new web\"");
+
+            }
+        }
+
+        private NuGetVersion GetAspNetCoreAppVersion(LockFile lockFile, bool portable = false)
+        {
+            return lockFile?.Targets?.SingleOrDefault(t => portable || t.RuntimeIdentifier != null)
+                ?.Libraries?.SingleOrDefault(l =>
+                    string.Compare(l.Name, "Microsoft.AspNetCore.App", StringComparison.CurrentCultureIgnoreCase) == 0)
+                ?.Version;
+        }
+
+        public static string LatestSupportedAspNetCoreAppVersion = "2.1";
+
+        public static IEnumerable<object[]> SupportedAspNetCoreAppVersions
+        {
+            get
+            {
+                yield return new object[] { LatestSupportedAspNetCoreAppVersion };
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add integration test for implicit Microsoft.AspNetCore.App versions

Addresses https://github.com/aspnet/Universe/issues/967. I'm adding the bundled AspNetCore runtime frameworks versions required by the Web SDK. I have run these tests locally but the PR's tests won't pass until we have a build with the Web SDK updates to ingest. We can review the PR but since it's ask mode, please wait for ship-room approval before merging. 