### PR TITLE
Replace alpine with linux-musl builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Build Status
 [rhel6-build-badge]: https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/7392/badge
 [rhel6-build]: https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=7392
 
-[linux-musl-build-badge]: https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/8168/badge
-[linux-musl-build]: https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=8168
+[linux-musl-build-badge]: https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/9036/badge
+[linux-musl-build]: https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=9036
 
 Installers and Binaries
 -----------------------

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This project has adopted the code of conduct defined by the [Contributor Covenan
 Build Status
 ------------
 
-|Windows x64|Windows x86|macOS|Linux x64 Archive|Linux arm Archive|Linux arm64 Archive|Linux Native Installers|RHEL 6 Archive|Alpine 3.6 Archive|
+|Windows x64|Windows x86|macOS|Linux x64 Archive|Linux arm Archive|Linux arm64 Archive|Linux Native Installers|RHEL 6 Archive|Linux-musl Archive|
 |:------:|:------:|:------:|:------:|:------:|:------:|:------:|:------:|:------:|
-|[![][win-x64-build-badge]][win-x64-build]|[![][win-x86-build-badge]][win-x86-build]|[![][osx-build-badge]][osx-build]|[![][linux-build-badge]][linux-build]|[![][linux-arm-build-badge]][linux-arm-build]|[![][linux-arm64-build-badge]][linux-arm64-build]|[![][linuxnative-build-badge]][linuxnative-build]|[![][rhel6-build-badge]][rhel6-build]|[![][alpine3.6-build-badge]][alpine3.6-build]|
+|[![][win-x64-build-badge]][win-x64-build]|[![][win-x86-build-badge]][win-x86-build]|[![][osx-build-badge]][osx-build]|[![][linux-build-badge]][linux-build]|[![][linux-arm-build-badge]][linux-arm-build]|[![][linux-arm64-build-badge]][linux-arm64-build]|[![][linuxnative-build-badge]][linuxnative-build]|[![][rhel6-build-badge]][rhel6-build]|[![][linux-musl-build-badge]][linux-musl-build]|
 
 [win-x64-build-badge]: https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/6902/badge
 [win-x64-build]: https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=6902
@@ -51,8 +51,8 @@ Build Status
 [rhel6-build-badge]: https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/7392/badge
 [rhel6-build]: https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=7392
 
-[alpine3.6-build-badge]: https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/8168/badge
-[alpine3.6-build]: https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=8168
+[linux-musl-build-badge]: https://devdiv.visualstudio.com/_apis/public/build/definitions/0bdbc590-a062-4c3f-b0f6-9383f67865ee/8168/badge
+[linux-musl-build]: https://devdiv.visualstudio.com/DevDiv/_build?_a=completed&definitionId=8168
 
 Installers and Binaries
 -----------------------
@@ -74,7 +74,7 @@ To download the .NET Core runtime **without** the SDK, visit https://github.com/
 | **Linux arm** | [tar.gz][linux-arm-targz] - [Checksum][linux-arm-targz-checksum] |
 | **Linux arm64** | [tar.gz][linux-arm64-targz] - [Checksum][linux-arm64-targz-checksum] |
 | **RHEL 6** | [tar.gz][rhel-6-targz] - [Checksum][rhel-6-targz-checksum] |
-| **Alpine 3.6** | [tar.gz][alpine-3.6-targz] - [Checksum][alpine-3.6-targz-checksum] |
+| **Linux-musl** | [tar.gz][linux-musl-targz] - [Checksum][linux-musl-targz-checksum] |
 
 | Latest Coherent Build<sup>2</sup><br>*master* |
 |:------:|
@@ -123,8 +123,8 @@ Reference notes:
 [rhel-6-targz]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-rhel.6-x64.tar.gz
 [rhel-6-targz-checksum]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-rhel.6-x64.tar.gz.sha
 
-[alpine-3.6-targz]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-alpine.3.6-x64.tar.gz
-[alpine-3.6-targz-checksum]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-alpine.3.6-x64.tar.gz.sha
+[linux-musl-targz]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-musl-x64.tar.gz
+[linux-musl-targz-checksum]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/master/dotnet-sdk-latest-linux-musl-x64.tar.gz.sha
 
 # Debian daily feed
 
@@ -173,7 +173,7 @@ apt-cache search dotnet-sdk | grep 2.0.0
 Docker
 ------
 
-You can also use our Docker base images found on https://hub.docker.com/r/microsoft/dotnet to set up your dev or testing environment for usage.  
+You can also use our Docker base images found on https://hub.docker.com/r/microsoft/dotnet to set up your dev or testing environment for usage.
 
 Basic usage
 -----------

--- a/TestAssets/TestProjects/AppWithCorruptedLaunchSettings/AppWithCorruptedLaunchSettings.csproj
+++ b/TestAssets/TestProjects/AppWithCorruptedLaunchSettings/AppWithCorruptedLaunchSettings.csproj
@@ -4,6 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-musl-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithLaunchSettings/AppWithLaunchSettings.csproj
+++ b/TestAssets/TestProjects/AppWithLaunchSettings/AppWithLaunchSettings.csproj
@@ -4,6 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-musl-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/AppWithLaunchSettingsNoDefault/AppWithLaunchSettingsNoDefault.csproj
+++ b/TestAssets/TestProjects/AppWithLaunchSettingsNoDefault/AppWithLaunchSettingsNoDefault.csproj
@@ -4,6 +4,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-musl-x64</RuntimeIdentifiers>
   </PropertyGroup>
 </Project>

--- a/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
+++ b/TestAssets/TestProjects/MSBuildTestApp/MSBuildTestApp.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;alpine.3.6-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.12-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;rhel.6-x64;centos.7-x64;rhel.7-x64;debian.8-x64;fedora.24-x64;opensuse.42.1-x64;linux-musl-x64</RuntimeIdentifiers>
     <RestoreAdditionalProjectSources Condition="'$(TEST_PACKAGES)' != ''">$(TEST_PACKAGES)</RestoreAdditionalProjectSources>
   </PropertyGroup>
 

--- a/build/Branding.props
+++ b/build/Branding.props
@@ -13,19 +13,19 @@
     <ProductMonikerRid Condition=" '$(Rid)' == 'ubuntu.16.04-x64' OR
                                    '$(Rid)' == 'fedora.24-x64' OR
                                    '$(Rid)' == 'rhel.6-x64' OR
-                                   '$(Rid)' == 'alpine.3.6-x64' OR
+                                   '$(Rid)' == 'linux-musl-x64' OR
                                    '$(Rid)' == 'opensuse.42.1-x64' ">$(Rid)</ProductMonikerRid>
     <ProductMonikerRid Condition=" '$(ProductMonikerRid)' == '' ">$(OSName)-$(Architecture)</ProductMonikerRid>
 
     <HostMonikerRid Condition=" '$(HostRid)' == 'ubuntu.16.04-x64' OR
                                 '$(HostRid)' == 'fedora.24-x64' OR
                                 '$(HostRid)' == 'rhel.6-x64' OR
-                                '$(HostRid)' == 'alpine.3.6-x64' OR
+                                '$(HostRid)' == 'linux-musl-x64' OR
                                 '$(HostRid)' == 'opensuse.42.1-x64' ">$(HostRid)</HostMonikerRid>
     <HostMonikerRid Condition=" '$(HostMonikerRid)' == '' ">$(HostOSName)-$(Architecture)</HostMonikerRid>
     <HostMonikerRidForFileName>$(HostMonikerRid)</HostMonikerRidForFileName>
     <HostMonikerRidForFileName Condition=" '$(IsDebianBaseDistro)' == 'true' OR '$(IsRPMBasedDistro)' == 'true' ">$(Architecture)</HostMonikerRidForFileName>
-    
+
     <ArtifactNameSdk>dotnet-sdk-internal</ArtifactNameSdk>
     <ArtifactNameCombinedHostHostFxrFrameworkSdk>dotnet-sdk</ArtifactNameCombinedHostHostFxrFrameworkSdk>
     <ArtifactNameSdkLanguagePack>$(ArtifactNameCombinedHostHostFxrFrameworkSdk)-langpack</ArtifactNameSdkLanguagePack>

--- a/build/BuildDefaults.props
+++ b/build/BuildDefaults.props
@@ -6,10 +6,10 @@
     <!-- https://github.com/dotnet/cli/issues/8800 -->
     <IncludeNuGetPackageArchive Condition=" $(Architecture.StartsWith('arm')) ">false</IncludeNuGetPackageArchive>
     <IncludeNuGetPackageArchive Condition=" '$(IncludeNuGetPackageArchive)' == '' ">true</IncludeNuGetPackageArchive>
-    <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND ($(Rid.StartsWith('rhel.6')) OR $(Rid.StartsWith('alpine.3.6')))">true</SkipBuildingInstallers>
+    <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' AND ($(Rid.StartsWith('rhel.6')) OR $(Rid.StartsWith('linux-musl')))">true</SkipBuildingInstallers>
     <SkipBuildingInstallers Condition=" '$(SkipBuildingInstallers)' == '' ">false</SkipBuildingInstallers>
-    <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(OSPlatform)' == 'linux' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'alpine.3.6-x64' ">true</UsePortableLinuxSharedFramework>
-    <IncludeSharedFrameworksForBackwardsCompatibilityTests Condition=" $(IncludeSharedFrameworksForBackwardsCompatibilityTests) == '' AND '$(Rid)' != 'linux-x64' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'alpine.3.6-x64'">true</IncludeSharedFrameworksForBackwardsCompatibilityTests>
+    <UsePortableLinuxSharedFramework Condition=" '$(UsePortableLinuxSharedFramework)' == '' AND '$(OSPlatform)' == 'linux' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'linux-musl-x64' ">true</UsePortableLinuxSharedFramework>
+    <IncludeSharedFrameworksForBackwardsCompatibilityTests Condition=" $(IncludeSharedFrameworksForBackwardsCompatibilityTests) == '' AND '$(Rid)' != 'linux-x64' AND '$(Rid)' != 'rhel.6-x64' AND '$(Rid)' != 'linux-musl-x64'">true</IncludeSharedFrameworksForBackwardsCompatibilityTests>
     <HighEntropyVA>true</HighEntropyVA>
 
     <!-- Only use asset target fallback that we set (not implicit one to net461). -->

--- a/build/DerivedHostMachineInfo.props
+++ b/build/DerivedHostMachineInfo.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsDebianBaseDistro Condition=" '$(HostOSName)' == 'ubuntu' OR '$(HostOSName)' == 'debian' ">true</IsDebianBaseDistro>
     <IsRPMBasedDistro Condition=" $(HostRid.StartsWith('rhel')) AND '$(HostRid)' != 'rhel.6-x64' ">true</IsRPMBasedDistro>
-    <PublishNativeInstallers Condition=" '$(IslinuxPortable)' != 'true' AND '$(HostRid)' != 'rhel.6-x64' AND '$(HostRid)' != 'alpine.3.6-x64'">true</PublishNativeInstallers>
+    <PublishNativeInstallers Condition=" '$(IslinuxPortable)' != 'true' AND '$(HostRid)' != 'rhel.6-x64' AND '$(HostRid)' != 'linux-musl-x64'">true</PublishNativeInstallers>
     <PublishArchives Condition=" '$(IslinuxPortable)' == 'true' OR ('$(IsDebianBaseDistro)' != 'true' AND '$(IsRPMBasedDistro)' != 'true') ">true</PublishArchives>
   </PropertyGroup>
 </Project>

--- a/build/publish/Badge.targets
+++ b/build/publish/Badge.targets
@@ -31,7 +31,7 @@
     <PropertyGroup>
       <VersionBadgeMoniker>$(OSName)_$(Architecture)</VersionBadgeMoniker>
       <VersionBadgeMoniker Condition=" '$(Rid)' == 'rhel.6-x64' ">rhel.6_x64</VersionBadgeMoniker>
-      <VersionBadgeMoniker Condition=" '$(Rid)' == 'alpine.3.6-x64' ">alpine.3.6_x64</VersionBadgeMoniker>
+      <VersionBadgeMoniker Condition=" '$(Rid)' == 'linux-musl-x64' ">linux_musl_x64</VersionBadgeMoniker>
       <VersionBadgeMoniker Condition=" '$(IslinuxPortable)' == 'true' ">linux_$(Architecture)</VersionBadgeMoniker>
       <VersionBadgeMoniker Condition=" '$(IsBuildingAndPublishingAllLinuxDistrosNativeInstallers)' == 'true' ">all_linux_distros_native_installer</VersionBadgeMoniker>
 

--- a/build_projects/dotnet-cli-build/CheckIfAllBuildsHavePublished.cs
+++ b/build_projects/dotnet-cli-build/CheckIfAllBuildsHavePublished.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Cli.Build
                 { "osx_x64", false },
                 { "linux_x64", false },
                 { "rhel.6_x64", false },
-                { "alpine.3.6_x64", false },
+                { "linux_musl_x64", false },
                 { "all_linux_distros_native_installer", false },
                 { "linux_arm", false },
                 { "linux_arm64", false }

--- a/netci.groovy
+++ b/netci.groovy
@@ -9,7 +9,7 @@ def project = GithubProject
 def branch = GithubBranchName
 def isPR = true
 
-def platformList = ['Linux:x64:Release', 'Debian8.2:x64:Debug', 'Ubuntu:x64:Release', 'Ubuntu16.04:x64:Debug', 'OSX10.12:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT_ES:x64:Debug', 'RHEL7.2:x64:Release', 'CentOS7.1:x64:Debug', 'RHEL6:x64:Debug', 'Alpine3.6:x64:Debug', 'Linux:arm:Debug', 'Linux:arm64:Debug']
+def platformList = ['Linux:x64:Release', 'Debian8.2:x64:Debug', 'Ubuntu:x64:Release', 'Ubuntu16.04:x64:Debug', 'OSX10.12:x64:Release', 'Windows_NT:x64:Release', 'Windows_NT:x86:Debug', 'Windows_NT_ES:x64:Debug', 'RHEL7.2:x64:Release', 'CentOS7.1:x64:Debug', 'RHEL6:x64:Debug', 'Linux-musl:x64:Debug', 'Linux:arm:Debug', 'Linux:arm64:Debug']
 
 def static getBuildJobName(def configuration, def os, def architecture) {
     return configuration.toLowerCase() + '_' + os.toLowerCase() + '_' + architecture.toLowerCase()
@@ -55,9 +55,9 @@ set DOTNET_CLI_UI_LANGUAGE=es
         osUsedForMachineAffinity = 'Ubuntu16.04';
         buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --runtime-id rhel.6-x64 --docker rhel.6 --targets Default"
     }
-    else if (os == 'Alpine3.6') {
+    else if (os == 'Linux-musl') {
         osUsedForMachineAffinity = 'Ubuntu16.04';
-        buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --runtime-id alpine.3.6-x64 --docker alpine.3.6 --targets Default"
+        buildCommand = "./build.sh --skip-prereqs --configuration ${configuration} --runtime-id linux-musl-x64 --docker alpine.3.6 --targets Default"
     }
     else {
         // Jenkins non-Ubuntu CI machines don't have docker

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -136,10 +136,6 @@ get_linux_platform_name() {
     else
         if [ -e /etc/os-release ]; then
             . /etc/os-release
-            if [[ $ID == "alpine" ]]; then
-                # remove the last version digit
-                VERSION_ID=${VERSION_ID%.*}
-            fi
             echo "$ID.$VERSION_ID"
             return 0
         elif [ -e /etc/redhat-release ]; then
@@ -166,8 +162,11 @@ get_current_os_name() {
         local linux_platform_name
         linux_platform_name="$(get_linux_platform_name)" || { echo "linux" && return 0 ; }
 
-        if [[ $linux_platform_name == "rhel.6" || $linux_platform_name == "alpine.3.6" ]]; then
+        if [[ $linux_platform_name == "rhel.6" ]]; then
             echo $linux_platform_name
+            return 0
+        elif [[ $linux_platform_name == alpine* ]]; then
+            echo "linux-musl"
             return 0
         else
             echo "linux"
@@ -597,7 +596,7 @@ copy_files_or_dirs_from_list() {
     local osname="$(get_current_os_name)"
     local override_switch=$(
         if [ "$override" = false ]; then
-            if [[ "$osname" == 'alpine'* ]]; then 
+            if [[ "$osname" == 'alpine'* ]]; then
                 printf -- "-u";
             else
                 printf -- "-n";

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
     <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
-    <PackageReference Include="runtime.alpine.3.6-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
+    <PackageReference Include="runtime.linux-musl-x64.Microsoft.NETCore.DotNetHostResolver" Version="$(MicrosoftNETCoreDotNetHostResolverPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/EnvironmentInfo.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/EnvironmentInfo.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 {
                     case "fedora.24-x64":
                     case "rhel.6-x64":
-                    case "alpine.3.6-x64":
+                    case "linux-musl-x64":
                     case "opensuse.42.1-x64":
                     case "ubuntu.16.10-x64":
                     case "linux-x64":
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 {
                     case "linux-x64":
                     case "rhel.6-x64":
-                    case "alpine.3.6-x64":
+                    case "linux-musl-x64":
                         return false;
                 }
             }
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 switch (rid)
                 {
                     case "rhel.6-x64":
-                    case "alpine.3.6-x64":
+                    case "linux-musl-x64":
                         return false;
                 }
             }


### PR DESCRIPTION
We still build linux-musl on the alpine OS but we no longer
produce a alpine installer/tar file instead we just have the
linux-musl version.

cc @eerhardt @johnbeisner @livarcocc @janvorli 

This is pretty close to a find-release of alpine3.6 with linux-musl. I suspect we also need to make changes to the official build definitions which I will do once this merges. 