### PR TITLE
do not set BaseIntermediateOutputPath in temp project of dotnet install

### DIFF
--- a/src/dotnet/ToolPackage/IProjectRestorer.cs
+++ b/src/dotnet/ToolPackage/IProjectRestorer.cs
@@ -9,7 +9,6 @@ namespace Microsoft.DotNet.ToolPackage
     internal interface IProjectRestorer
     {
         void Restore(FilePath project,
-            DirectoryPath assetJsonOutput,
             FilePath? nugetConfig = null,
             string verbosity = null);
     }

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -27,7 +27,6 @@ namespace Microsoft.DotNet.Tools.Tool.Install
         }
 
         public void Restore(FilePath project,
-            DirectoryPath assetJsonOutput,
             FilePath? nugetConfig = null,
             string verbosity = null)
         {
@@ -43,8 +42,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             argsToPassToRestore.AddRange(new List<string>
             {
                 "--runtime",
-                AnyRid,
-                $"-property:BaseIntermediateOutputPath={assetJsonOutput.ToXmlEncodeString()}"
+                AnyRid
             });
 
             argsToPassToRestore.Add($"-verbosity:{verbosity ?? "quiet"}");

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
@@ -57,19 +57,19 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
         }
 
         public void Restore(FilePath project,
-            DirectoryPath assetJsonOutput,
             FilePath? nugetConfig = null,
             string verbosity = null)
         {
             string packageId;
             VersionRange versionRange;
             string targetFramework;
+            DirectoryPath assetJsonOutput;
             try
             {
-                // The mock installer wrote a mock project file containing id:version:framework
+                // The mock installer wrote a mock project file containing id;version;framework;stageDirectory
                 var contents = _fileSystem.File.ReadAllText(project.Value);
-                var tokens = contents.Split(':');
-                if (tokens.Length != 3)
+                var tokens = contents.Split(';');
+                if (tokens.Length != 4)
                 {
                     throw new ToolPackageException(LocalizableStrings.ToolInstallationRestoreFailed);
                 }
@@ -77,6 +77,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                 packageId = tokens[0];
                 versionRange = VersionRange.Parse(tokens[1]);
                 targetFramework = tokens[2];
+                assetJsonOutput = new DirectoryPath(tokens[3]);
             }
             catch (IOException)
             {

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
@@ -63,12 +63,11 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                     // Write a fake project with the requested package id, version, and framework
                     _fileSystem.File.WriteAllText(
                         tempProject.Value,
-                        $"{packageId}:{versionRange?.ToString("S", new VersionRangeFormatter()) ?? "*"}:{targetFramework}");
+                        $"{packageId};{versionRange?.ToString("S", new VersionRangeFormatter()) ?? "*"};{targetFramework};{stageDirectory.Value}");
 
                     // Perform a restore on the fake project
                     _projectRestorer.Restore(
                         tempProject,
-                        stageDirectory,
                         nugetConfig,
                         verbosity);
 


### PR DESCRIPTION
Should use MsBuildProjectExtensionsPath instead.

- Change the property passin by project file instead of command line. It is more reliable passing path in xml and also the timing of MsBuildProjectExtensionsPath is controlled. (Before loading SDK)
- Change mock fake project to use “;” instead, since c:\path contains “:”.