### PR TITLE
Fix --source-feed option for tool install and update commands.

### DIFF
--- a/src/dotnet/ToolPackage/ToolPackageInstaller.cs
+++ b/src/dotnet/ToolPackage/ToolPackageInstaller.cs
@@ -161,7 +161,17 @@ namespace Microsoft.DotNet.ToolPackage
             var feeds = new List<string>();
             if (additionalFeeds != null)
             {
-                feeds.AddRange(additionalFeeds);
+                foreach (var feed in additionalFeeds)
+                {
+                    if (Uri.IsWellFormedUriString(feed, UriKind.Absolute))
+                    {
+                        feeds.Add(feed);
+                    }
+                    else
+                    {
+                        feeds.Add(Path.GetFullPath(feed));
+                    }
+                }
             }
 
             // use fallbackfolder as feed to enable offline

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -262,6 +262,50 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public void GivenARelativeSourcePathInstallSucceeds(bool testMockBehaviorIsInSync)
+        {
+            var source = GetTestLocalFeedPath();
+
+            var (store, installer, reporter, fileSystem) = Setup(
+                useMock: testMockBehaviorIsInSync,
+                feeds: GetMockFeedsForSource(source));
+
+            var package = installer.InstallPackage(
+                packageId: TestPackageId,
+                versionRange: VersionRange.Parse(TestPackageVersion),
+                targetFramework: _testTargetframework,
+                additionalFeeds: new[] { Path.GetRelativePath(Directory.GetCurrentDirectory(), source) });
+
+            AssertPackageInstall(reporter, fileSystem, package, store);
+
+            package.Uninstall();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GivenAUriSourceInstallSucceeds(bool testMockBehaviorIsInSync)
+        {
+            var source = GetTestLocalFeedPath();
+
+            var (store, installer, reporter, fileSystem) = Setup(
+                useMock: testMockBehaviorIsInSync,
+                feeds: GetMockFeedsForSource(source));
+
+            var package = installer.InstallPackage(
+                packageId: TestPackageId,
+                versionRange: VersionRange.Parse(TestPackageVersion),
+                targetFramework: _testTargetframework,
+                additionalFeeds: new[] { new Uri(source).AbsoluteUri });
+
+            AssertPackageInstall(reporter, fileSystem, package, store);
+
+            package.Uninstall();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public void GivenAEmptySourceAndNugetConfigInstallSucceeds(bool testMockBehaviorIsInSync)
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();


### PR DESCRIPTION
Commit 9cc2b7c regressed the `--source-feed`
option so that it no longer accepted relative paths.  Because the option is now
saved to the temp project file, any relative paths specified by the
`--source-feed` option were made relative to the temp project path and not from
the current working directory of where dotnet was run.

The fix is to use `Path.GetFullPath` of the `--source-feed` option, provided
the option specified was not an absolute URI.

Fixes #9132.