### PR TITLE
MSBuild 15.7.172 (2xx)

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,7 +4,7 @@
 
     <MicrosoftNETCoreAppPackageVersion>2.0.7</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.7.0-preview-000163</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.7.0-preview-000172</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>


### PR DESCRIPTION
Internal VS PR (approved & merged): https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/118540

Note we know of at least one more MSBuild version before 15.7 RTM: https://github.com/Microsoft/msbuild/pull/3222 to drop the "preview" version numbering.