### PR TITLE
MSBuild 15.7.177 (2xx)

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -4,7 +4,7 @@
 
     <MicrosoftNETCoreAppPackageVersion>2.0.7</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.7.0-preview-000163</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.7.177</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>


### PR DESCRIPTION
This is based on top of #9133 because that's the version of NuGet we have a compile-time reference to and which will ship with Preview 6. I think it caused an issue last time the assembly version changed.

Internal PR: https://devdiv.visualstudio.com/DevDiv/MSBuild/_git/VS/pullrequest/119072