### PR TITLE
MSBuild 15.7.177 (3xx)

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -5,7 +5,7 @@
     <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-rc1-26423-06</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.7.0-preview-000169</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.7.177</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>


### PR DESCRIPTION
This supersedes #9141

Keeping up to date with prodcon.

This isn't critical, but after RTM we'll need to make a commit like this to prep for servicing. See Microsoft/msbuild#3228 for details.