### PR TITLE
Use cp -u on linux-musl

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ Reference notes:
 [rhel-6-targz]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/2.1.3xx/dotnet-sdk-latest-rhel.6-x64.tar.gz
 [rhel-6-targz-checksum]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/2.1.3xx/dotnet-sdk-latest-rhel.6-x64.tar.gz.sha
 
-[alpine-3.6-targz]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/2.1.3xx/dotnet-sdk-latest-alpine.3.6-x64.tar.gz
-[alpine-3.6-targz-checksum]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/2.1.3xx/dotnet-sdk-latest-alpine.3.6-x64.tar.gz.sha
+[linux-musl-targz]: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/release/2.1.3xx/dotnet-sdk-latest-linux-musl-x64.tar.gz
+[linux-musl-targz-checksum]: https://dotnetclichecksums.blob.core.windows.net/dotnet/Sdk/release/2.1.3xx/dotnet-sdk-latest-linux-musl-x64.tar.gz.sha
 
 # Debian daily feed
 

--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -596,7 +596,7 @@ copy_files_or_dirs_from_list() {
     local osname="$(get_current_os_name)"
     local override_switch=$(
         if [ "$override" = false ]; then
-            if [[ "$osname" == 'alpine'* ]]; then
+            if [[ "$osname" == "linux-musl" ]]; then
                 printf -- "-u";
             else
                 printf -- "-n";


### PR DESCRIPTION
This actually applies to all busybox based OS. Fixes https://github.com/dotnet/cli/issues/8738.
Also updated readme: alpine-<ver>-targz to musl-targz. Discussion: https://github.com/dotnet/cli/commit/65d5730631ef3cae8435be66b37b6c03b49d5dbf#r28750312

@weshaggard, @johnbeisner 

Follow-up to: https://github.com/dotnet/cli/pull/9104