### PR TITLE
Use NuGet autocomplete API for add-package suggestions

### DIFF
--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Cli
             try
             {
                 var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-                var response = httpClient.GetAsync($"https://api-v2v3search-0.nuget.org/query?q={match}&skip=0&take=100&prerelease=true", cancellation.Token)
+                var response = httpClient.GetAsync($"https://api-v2v3search-0.nuget.org/autocomplete?q={match}&skip=0&take=100", cancellation.Token)
                                          .Result;
 
                 result = response.Content.ReadAsStreamAsync().Result;
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Cli
 
             foreach (var id in json["data"])
             {
-                yield return id["id"].Value<string>();
+                yield return id.Value<string>();
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/cli/issues/9128.

Since `dotnet add package` doesn't work by default with prerelease packages, and since autcompletion is a convenience feature to make common use easier, I have also removed `prerelease=true`.

Output from `dotnet complete` for my examples from https://github.com/dotnet/cli/issues/9128 is [here](https://gist.github.com/svick/a29fda60d5923da0a3aa3b067ec1c556). Notice that `dotnet complete "dotnet add package Microsoft.CodeA"` now doesn't output anything, I have opened an issue for that: https://github.com/NuGet/NuGetGallery/issues/5858.