### PR TITLE
Remove mac mark all 755

### DIFF
--- a/packaging/osx/clisdk/scripts/postinstall
+++ b/packaging/osx/clisdk/scripts/postinstall
@@ -8,9 +8,6 @@ PACKAGE=$1
 INSTALL_DESTINATION=$2
 INSTALL_TEMP_HOME=/tmp/dotnet-installer
 
-# A temporary fix for the permissions issue(s)
-chmod -R 755 $INSTALL_DESTINATION
-
 first_run() {
     $INSTALL_DESTINATION/dotnet exec $INSTALL_DESTINATION/sdk/%SDK_VERSION%/dotnet.dll internal-reportinstallsuccess "$1" > /dev/null 2>&1 || true
 }


### PR DESCRIPTION
fix https://github.com/dotnet/cli/issues/7618

This temporary fix is added in https://github.com/dotnet/cli/pull/517 There was no core-setup at that time. And mark `dotnet` as executable should be enough. It is changing the whole folder as executable.

Today, it is covered by core-setup https://github.com/dotnet/core-setup/blob/master/src/pkg/packaging/osx/hostfxr/scripts/postinstall#L11
