### PR TITLE
Add a property to disable bundling ASP.NET Core tools and runtimes

### DIFF
--- a/build/BundledDotnetTools.props
+++ b/build/BundledDotnetTools.props
@@ -1,5 +1,5 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
+  <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' != 'false' ">
     <BundledDotnetTools Include="dotnet-dev-certs" Version="$(AspNetCoreVersion)" />
     <BundledDotnetTools Include="dotnet-ef" Version="$(AspNetCoreVersion)" ObsoletesCliTool="Microsoft.EntityFrameworkCore.Tools.DotNet" />
     <BundledDotnetTools Include="dotnet-sql-cache" Version="$(AspNetCoreVersion)" ObsoletesCliTool="Microsoft.Extensions.Caching.SqlConfig.Tools" />

--- a/build/BundledRuntimes.props
+++ b/build/BundledRuntimes.props
@@ -55,13 +55,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <_DownloadAndExtractItem Include="AspNetCoreSharedFxArchiveFile"
-                             Condition="!Exists('$(AspNetCoreSharedFxArchiveFile)') And ( '$(AspNetCoreSharedFxArchiveRid)' == 'linux-arm' OR !$(Architecture.StartsWith('arm')) )">
-      <Url>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreVersion)/$(AspNetCoreSharedFxArchiveFileName)$(CoreSetupBlobAccessTokenParam)</Url>
-      <DownloadFileName>$(AspNetCoreSharedFxArchiveFile)</DownloadFileName>
-      <ExtractDestination>$(AspNetCoreSharedFxPublishDirectory)</ExtractDestination>
-    </_DownloadAndExtractItem>
-
     <_DownloadAndExtractItem Include="CombinedSharedHostAndFrameworkArchive"
                              Condition="!Exists('$(CombinedSharedHostAndFrameworkArchive)')">
       <Url>$(CoreSetupRootUrl)$(MicrosoftNETCoreAppPackageVersion)/$(CombinedFrameworkHostCompressedFileName)$(CoreSetupBlobAccessTokenParam)</Url>
@@ -95,6 +88,15 @@
       <Url>$(CoreSetupRootUrl)$(HostFxrVersion)/$(DownloadedHostFxrInstallerFileName)$(CoreSetupBlobAccessTokenParam)</Url>
       <DownloadFileName>$(DownloadedHostFxrInstallerFile)</DownloadFileName>
       <ExtractDestination></ExtractDestination>
+    </_DownloadAndExtractItem>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' != 'false' ">
+    <_DownloadAndExtractItem Include="AspNetCoreSharedFxArchiveFile"
+                             Condition="!Exists('$(AspNetCoreSharedFxArchiveFile)') And ( '$(AspNetCoreSharedFxArchiveRid)' == 'linux-arm' OR !$(Architecture.StartsWith('arm')) )">
+      <Url>$(AspNetCoreSharedFxRootUrl)$(AspNetCoreVersion)/$(AspNetCoreSharedFxArchiveFileName)$(CoreSetupBlobAccessTokenParam)</Url>
+      <DownloadFileName>$(AspNetCoreSharedFxArchiveFile)</DownloadFileName>
+      <ExtractDestination>$(AspNetCoreSharedFxPublishDirectory)</ExtractDestination>
     </_DownloadAndExtractItem>
 
     <_DownloadAndExtractItem Include="DownloadedAspNetCoreSharedFxInstallerFile"

--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -3,7 +3,9 @@
     <BundledTemplate Include="Microsoft.DotNet.Common.ItemTemplates" Version="$(MicrosoftDotNetCommonItemTemplatesPackageVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" Version="$(MicrosoftDotNetCommonProjectTemplates20PackageVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="$(MicrosoftDotNetTestProjectTemplates20PackageVersion)" />
+  </ItemGroup>
 
+  <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' != 'false' ">
     <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(AspNetCoreVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="$(AspNetCoreVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(AspNetCoreVersion)" />

--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -3,9 +3,7 @@
     <BundledTemplate Include="Microsoft.DotNet.Common.ItemTemplates" Version="$(MicrosoftDotNetCommonItemTemplatesPackageVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" Version="$(MicrosoftDotNetCommonProjectTemplates20PackageVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="$(MicrosoftDotNetTestProjectTemplates20PackageVersion)" />
-  </ItemGroup>
 
-  <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' != 'false' ">
     <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(AspNetCoreVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="$(AspNetCoreVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(AspNetCoreVersion)" />

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -123,7 +123,29 @@
       <_AspNetCoreAppTargetFrameworkVersion>$(_AspNetCoreAllTargetFrameworkVersion)</_AspNetCoreAppTargetFrameworkVersion>
 
       <_NETCoreSdkIsPreview Condition=" '$(DropSuffix)' == '' ">true</_NETCoreSdkIsPreview>
+    </PropertyGroup>
 
+    <ItemGroup>
+      <BundledVersionsVariable Include="BundledAspNetCoreAllTargetFrameworkVersion" Value="$(_AspNetCoreAllTargetFrameworkVersion)" />
+      <BundledVersionsVariable Include="BundledAspNetCoreAllPackageVersion" Value="$(_AspNetCoreAllPackageVersion)" />
+      <BundledVersionsVariable Include="BundledAspNetCoreAppTargetFrameworkVersion" Value="$(_AspNetCoreAppTargetFrameworkVersion)" />
+      <BundledVersionsVariable Include="BundledAspNetCoreAppPackageVersion" Value="$(_AspNetCoreAppPackageVersion)" />
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' == 'false' ">
+      <!--
+        These properties indicate that the ASP.NET Core shared runtime is not bundled on this platform, so the SDK should not
+        treat these packages as the 'platform' base.
+
+        The bundled aspnet packages versions should still be set, however, so the default, version-less PackageReference
+        still works.
+        See also https://github.com/aspnet/Universe/pull/1130.
+      -->
+      <BundledVersionsVariable Include="_AspNetCoreAppSharedFxIsEnabled" Value="false" />
+      <BundledVersionsVariable Include="_AspNetCoreAllSharedFxIsEnabled" Value="false" />
+    </ItemGroup>
+
+    <PropertyGroup>
       <BundledVersionsPropsContent>
 <![CDATA[
 <!--
@@ -144,10 +166,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <BundledNETStandardTargetFrameworkVersion>$(_NETStandardTargetFrameworkVersion)</BundledNETStandardTargetFrameworkVersion>
     <BundledNETStandardPackageVersion>$(_NETStandardLibraryPackageVersion)</BundledNETStandardPackageVersion>
     <BundledNETCorePlatformsPackageVersion>$(_NETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
-    <BundledAspNetCoreAllTargetFrameworkVersion>$(_AspNetCoreAllTargetFrameworkVersion)</BundledAspNetCoreAllTargetFrameworkVersion>
-    <BundledAspNetCoreAllPackageVersion>$(_AspNetCoreAllPackageVersion)</BundledAspNetCoreAllPackageVersion>
-    <BundledAspNetCoreAppTargetFrameworkVersion>$(_AspNetCoreAppTargetFrameworkVersion)</BundledAspNetCoreAppTargetFrameworkVersion>
-    <BundledAspNetCoreAppPackageVersion>$(_AspNetCoreAppPackageVersion)</BundledAspNetCoreAppPackageVersion>
+    @(BundledVersionsVariable->'<%(Identity)>%(Value)</%(Identity)>', '%0A    ')
     <NETCoreSdkVersion>$(SdkVersion)</NETCoreSdkVersion>
     <_NETCoreSdkIsPreview>$(_NETCoreSdkIsPreview)</_NETCoreSdkIsPreview>
 

--- a/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -90,12 +90,16 @@ namespace Microsoft.DotNet.Configurer
 
         private bool ShouldGenerateAspNetCertificate()
         {
+#if EXCLUDE_ASPNETCORE
+            return false;
+#else
             var generateAspNetCertificate =
                 _environmentProvider.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true);
 
             return ShouldRunFirstRunExperience() &&
                 generateAspNetCertificate &&
                 !_aspNetCertificateSentinel.Exists();
+#endif
         }
 
         private bool ShouldAddPackageExecutablePath()
@@ -153,7 +157,7 @@ namespace Microsoft.DotNet.Configurer
 
         private bool ShouldRunFirstRunExperience()
         {
-            var skipFirstTimeExperience = 
+            var skipFirstTimeExperience =
                 _environmentProvider.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false);
 
             return !skipFirstTimeExperience;

--- a/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj
+++ b/src/Microsoft.DotNet.Configurer/Microsoft.DotNet.Configurer.csproj
@@ -9,6 +9,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/dotnet/cli</RepositoryUrl>
+    <DefineConstants Condition="'$(IncludeAspNetCoreRuntime)' == 'false'">$(DefineConstants);EXCLUDE_ASPNETCORE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/AspNetCoreCertificateGenerator.cs
+++ b/src/dotnet/AspNetCoreCertificateGenerator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.AspNetCore.DeveloperCertificates.XPlat;
 using Microsoft.DotNet.Configurer;
 
 namespace Microsoft.DotNet.Cli
@@ -10,7 +9,9 @@ namespace Microsoft.DotNet.Cli
     {
         public void GenerateAspNetCoreDevelopmentCertificate()
         {
-            CertificateGenerator.GenerateAspNetHttpsCertificate();
+#if !EXCLUDE_ASPNET
+            Microsoft.AspNetCore.DeveloperCertificates.XPlat.CertificateGenerator.GenerateAspNetHttpsCertificate();
+#endif
         }
     }
 }

--- a/src/dotnet/AspNetCoreCertificateGenerator.cs
+++ b/src/dotnet/AspNetCoreCertificateGenerator.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Cli
     {
         public void GenerateAspNetCoreDevelopmentCertificate()
         {
-#if !EXCLUDE_ASPNET
+#if !EXCLUDE_ASPNETCORE
             Microsoft.AspNetCore.DeveloperCertificates.XPlat.CertificateGenerator.GenerateAspNetHttpsCertificate();
 #endif
         }

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -9,6 +9,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssetTargetFallback>dotnet5.4</AssetTargetFallback>
     <RootNamespace>Microsoft.DotNet.Cli</RootNamespace>
+    <DefineConstants Condition="'$(IncludeAspNetCoreRuntime)' == 'false'">$(DefineConstants);EXCLUDE_ASPNETCORE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="commands\dotnet-new\**" />
@@ -60,7 +61,6 @@
     <PackageReference Include="System.Diagnostics.TextWriterTraceListener" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Private.DataContractSerialization" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.3.0" />
     <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
@@ -75,6 +75,11 @@
     <PackageReference Include="Microsoft.DotNet.Archive" Version="$(MicrosoftDotNetArchivePackageVersion)" />
     <PackageReference Include="XliffTasks" Version="$(XliffTasksPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' != 'false' ">
+    <PackageReference Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="$(AspNetCoreVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <Folder Include="commands\dotnet-migrate\xlf" />
     <Folder Include="dotnet-complete\commands\" />


### PR DESCRIPTION
Part of https://github.com/dotnet/source-build/issues/456

Changes:
 - add a property `IncludeAspNetCoreRuntime` which can be set to `false` to disable bundling ASP.NET Core tools, ~~templates~~, and runtimes
 - set properties that align with https://github.com/aspnet/Universe/pull/1130 to prevent shared runtime trimming against aspnet in a source-built CLI
 - includes some changes currently applied in source-build via https://github.com/dotnet/source-build/tree/dev/release/2.1/patches/cli (cc @dseefeld)

~~Marking as WIP because I need to clarify if aspnet templates should be excluded or not.~~
Update: keep templates