### PR TITLE
Simplify completions scripts

### DIFF
--- a/scripts/register-completions.bash
+++ b/scripts/register-completions.bash
@@ -1,10 +1,8 @@
-#!/bin/bash
 # bash parameter completion for the dotnet CLI
 
 _dotnet_bash_complete()
 {
   local word=${COMP_WORDS[COMP_CWORD]}
-  local dotnetPath=${COMP_WORDS[1]}
 
   local completions=("$(dotnet complete --position ${COMP_POINT} "${COMP_LINE}")")
 

--- a/scripts/register-completions.zsh
+++ b/scripts/register-completions.zsh
@@ -2,8 +2,6 @@
 
 _dotnet_zsh_complete() 
 {
-  local dotnetPath=$words[1]
-
   local completions=("$(dotnet complete "$words")")
 
   reply=( "${(ps:\n:)completions}" )


### PR DESCRIPTION
Simplified completions scripts for bash and zsh by:

* removing unused variables
* removing shebang, since the script is meant to be copied, not executed on its own