### PR TITLE
Allow ExternalRestoreSources in offline build (remove source-build patch 0003)

### DIFF
--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -41,7 +41,7 @@
                       Lines="$(NugetConfigHeader)"
                       Overwrite="true" />
 
-    <WriteLinesToFile Condition="'$(ExternalRestoreSources)' != '' and '$(DotNetBuildOffline)' != 'true'"
+    <WriteLinesToFile Condition="'$(ExternalRestoreSources)' != ''"
                       File="$(GeneratedNuGetConfig)"
                       Lines="&lt;add key=&quot;PrivateBlobFeed%(NugetConfigPrivateFeeds.Filename)&quot; value=&quot;%(NugetConfigPrivateFeeds.Identity)&quot; /&gt;"
                       Overwrite="false" />


### PR DESCRIPTION
Allow the caller to provide ExternalRestoreSources while DotnetBuildOffline = true. Any logic to block passing ExternalRestoreSources belongs in the caller.

Fixes source-build offline build: it passes in filesystem NuGet sources for prebuilt and source-built packages.

---

Lets us remove `0003-Use-Repo-API-restore-sources-dependency-upgrade.patch` from source-build (https://github.com/dotnet/source-build/issues/496). Most of the changes aren't needed if we use existing properties from ProdCon instead of the source-build repo API.

To test this out I produced a tarball and built the tarball offline: works, and smoke-test is good.

/cc @dleeapho