### PR TITLE
Removing some patches for source build.

### DIFF
--- a/build/GitCommitInfo.targets
+++ b/build/GitCommitInfo.targets
@@ -1,12 +1,14 @@
 <Project ToolsVersion="15.0">
   <Target Name="WriteGitCommitInfoProps">
     <Exec Command="git rev-list --count HEAD" 
-          ConsoleToMSBuild="true">
+          ConsoleToMSBuild="true"
+          Condition=" '$(GitInfoCommitCount)' == '' ">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitInfoCommitCount" />
     </Exec>
 
     <Exec Command="git rev-parse HEAD" 
-          ConsoleToMSBuild="true">
+          ConsoleToMSBuild="true"
+          Condition=" '$(GitInfoCommitHash)' == '' ">
       <Output TaskParameter="ConsoleOutput" PropertyName="GitInfoCommitHash" />
     </Exec>
 

--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -43,7 +43,7 @@
 
     <WriteLinesToFile Condition="'$(ExternalRestoreSources)' != '' and '$(DotNetBuildOffline)' != 'true'"
                       File="$(GeneratedNuGetConfig)"
-                      Lines="&lt;add key=&quot;PrivateBlobFeed%(NugetConfigPrivateFeeds.Filename)&quot; value=&quot;%(NugetConfigPrivateFeeds.Identity)&quot; /&gt;"
+                      Lines="&lt;add key=&quot;PrivateBlobFeed%(NugetConfigPrivateFeeds.Identity)&quot; value=&quot;%(NugetConfigPrivateFeeds.Identity)&quot; /&gt;"
                       Overwrite="false" />
 
     <WriteLinesToFile Condition="'$(DotNetBuildOffline)' != 'true'"

--- a/run-build.sh
+++ b/run-build.sh
@@ -189,7 +189,7 @@ fi
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
 if [ $BUILD -eq 1 ]; then
-    dotnet msbuild build.proj /p:Architecture=$ARCHITECTURE $CUSTOM_BUILD_ARGS /p:GeneratePropsFile=true /t:WriteDynamicPropsToStaticPropsFiles $argsnotargets
+    dotnet msbuild build.proj /p:Architecture=$ARCHITECTURE $CUSTOM_BUILD_ARGS /p:GeneratePropsFile=true /t:WriteDynamicPropsToStaticPropsFiles ${argsnotargets[@]}
     dotnet msbuild build.proj /m /v:normal /fl /flp:v=diag /p:Architecture=$ARCHITECTURE $CUSTOM_BUILD_ARGS $args
 else
     echo "Not building due to --nobuild"

--- a/src/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -5,7 +5,7 @@
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(OS)' == 'Windows_NT'">win-x86;win-x64</RuntimeIdentifiers>
     <WarningsAsErrors>true</WarningsAsErrors>
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.Build" Version="$(MicrosoftTestPlatformBuildPackageVersion)" />
-    <PackageReference Include="NuGet.Localization" Version="$(NuGetProjectModelPackageVersion)" />
+    <PackageReference Condition=" '$(DotNetBuildFromSource)' != 'true' " Include="NuGet.Localization" Version="$(NuGetProjectModelPackageVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelPackageVersion)" />
     <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersPackageVersion)">
       <ExcludeAssets>All</ExcludeAssets>


### PR DESCRIPTION
Addresses patches 04, 07, 08, 09 and 12 from https://github.com/dotnet/cli/issues/9176.

01, 02, 06 and 11 are not needed or have already been addressed.

Which leaves 03, 05 and 10, that are being investigated.