### PR TITLE
Set DOTNET_ROOT from the CLI to ensure any child processes launched use same root

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/EnvironmentProvider.cs
@@ -35,6 +35,8 @@ namespace Microsoft.DotNet.Cli.Utils
             }
         }
 
+        public bool Is64BitProcess => Environment.Is64BitProcess;
+
         private IEnumerable<string> SearchPaths
         {
             get

--- a/src/Microsoft.DotNet.Cli.Utils/IEnvironmentProvider.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/IEnvironmentProvider.cs
@@ -23,5 +23,7 @@ namespace Microsoft.DotNet.Cli.Utils
         string GetEnvironmentVariable(string variable, EnvironmentVariableTarget target);
 
         void SetEnvironmentVariable(string variable, string value, EnvironmentVariableTarget target);
+
+        bool Is64BitProcess { get; }
     }
 }

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -37,6 +37,8 @@ namespace Microsoft.DotNet.Cli
                 PerfTrace.Enabled = true;
             }
 
+            InitializeEnvironment();
+
             InitializeProcess();
 
             try
@@ -250,6 +252,27 @@ namespace Microsoft.DotNet.Cli
                     environmentPath);
 
                 dotnetConfigurer.Configure();
+            }
+        }
+
+        internal static void InitializeEnvironment()
+            => InitializeEnvironment(new EnvironmentProvider());
+
+        internal static void InitializeEnvironment(IEnvironmentProvider env)
+        {
+            var dotnetRootEnv = env.Is64BitProcess
+                ? "DOTNET_ROOT"
+                : "DOTNET_ROOT(x86)";
+
+            try
+            {
+                var rootPath = Path.GetDirectoryName(new Muxer().MuxerPath);
+                env.SetEnvironmentVariable(dotnetRootEnv, rootPath, EnvironmentVariableTarget.Process);
+            }
+            catch
+            {
+                // swallow and ignore in the event MuxerPath throws because it cannot find dotnet.exe
+                return;
             }
         }
 

--- a/test/dotnet.Tests/RootEnvironmentTests.cs
+++ b/test/dotnet.Tests/RootEnvironmentTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Tests
+{
+    public class RootEnvironmentTests
+    {
+        [Theory]
+        [InlineData(true, "DOTNET_ROOT")]
+        [InlineData(false, "DOTNET_ROOT(x86)")]
+        public void ItSetsDotnetRootToMuxerPath(bool is64Bit, string varName)
+        {
+            var expectedPath = Path.GetDirectoryName(new Muxer().MuxerPath);
+            var mockEnv = new Mock<IEnvironmentProvider>();
+            mockEnv.SetupGet(e => e.Is64BitProcess).Returns(is64Bit);
+            mockEnv.Setup(e => e.SetEnvironmentVariable(varName, expectedPath, EnvironmentVariableTarget.Process));
+
+            Program.InitializeEnvironment(mockEnv.Object);
+
+            mockEnv.VerifyAll();
+        }
+    }
+}


### PR DESCRIPTION
Partial solution to https://github.com/dotnet/cli/issues/9114.

This sets DOTNET_ROOT (or DOTNET_ROOT(x86)) at the beginning of the dotnet.dll process. This should help ensure any child processes launched by the SDK via apphost will run on the same installation of .NET Core as the dotnet SDK. These child processes may include `dotnet run`, bundled tools, global tools, processes launched through MSBuild, and more.
