### PR TITLE
Removing the word please from the ASP.NET first run message.

### DIFF
--- a/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
@@ -151,7 +151,7 @@ Here are some options to fix this error:
     <value>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</value>
   </data>
 </root>

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
@@ -62,9 +62,9 @@ Tuto chybu můžete opravit pomocí některé z těchto možností:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Úspěšně se podařilo nainstalovat certifikát pro vývoj ASP.NET Core HTTPS Development Certificate.
 Pokud chcete certifikátu důvěřovat (platí jenom pro Windows a macOS), nainstalujte nejprve nástroj dev-certs. To uděláte tak, že spustíte dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final a potom dotnet-dev-certs https --trust.

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
@@ -62,9 +62,9 @@ Im Folgenden finden Sie einige Optionen, um diesen Fehler zu beheben:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Das ASP.NET Core-HTTPS-Entwicklungszertifikat wurde erfolgreich installiert.
 Um dem Zertifikat zu vertrauen (nur Windows und macOS), installieren Sie zuerst das Tool "dev-certs", indem Sie "dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final" und anschließend "dotnet-dev-certs https --trust" ausführen.

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
@@ -61,9 +61,9 @@ Estas son algunas opciones para corregir este error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 El certificado de desarrollo HTTPS de ASP.NET Core se ha instalado correctamente.
 Para confiar en el certificado (solo Windows y macOS), instale primero la herramienta dev-certs ejecutando "dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final" y, después, ejecute "dotnet-dev-certs https --trust".

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
@@ -62,9 +62,9 @@ Voici quelques options pour corriger cette erreur :
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Installation réussie du certificat de développement HTTPS ASP.NET Core.
 Pour approuver le certificat (Windows et macOS uniquement), installez d'abord l'outil dev-certs en exécutant 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final', puis exécutez 'dotnet-dev-certs https --trust'.

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
@@ -62,9 +62,9 @@ Ecco alcune opzioni per correggere questo errore:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Il certificato di sviluppo HTTPS di ASP.NET Core è stato installato.
 Per considerare attendibile il certificato (solo Windows e macOS), installare prima lo strumento dev-certs eseguendo 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' e quindi eseguire 'dotnet-dev-certs https --trust'.

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
@@ -62,9 +62,9 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 ASP.NET Core HTTPS 開発証明書が正常にインストールされました。
 証明書を信頼する (Windows および macOS のみ) には、まず 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' を実行して dev-certs ツールをインストールし、次に 'dotnet-dev-certs https --trust' を実行します。

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
@@ -62,9 +62,9 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 ASP.NET Core HTTPS 개발 인증서를 설치했습니다.
 인증서를 신뢰하려면(Windows 및 macOS만 해당) 먼저 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final'을 실행하여 dev-certs 도구를 설치한 다음, 'dotnet-dev-certs https --trust'를 실행하세요.

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
@@ -62,9 +62,9 @@ Oto kilka opcji naprawiania tego błędu:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Pomyślnie zainstalowano certyfikat deweloperski protokołu HTTPS programu ASP.NET Core.
 Aby ufać temu certyfikatowi (dotyczy tylko systemów Windows i macOS), najpierw zainstaluj narzędzie dev-certs, uruchamiając polecenie „dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final”, a następnie uruchom polecenie „dotnet-dev-certs https --trust”.

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
@@ -62,9 +62,9 @@ Aqui estão algumas opções para corrigir este erro:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Certificado de Desenvolvimento HTTPS ASP.NET Core instalado com êxito.
 Para confiar no certificado (apenas Windows e macOS), primeiramente instale a ferramenta dev-certs executando 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' e, em seguida, execute 'dotnet-dev-certs https --trust'.

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
@@ -62,9 +62,9 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 Сертификат разработки HTTPS для ASP.NET Core установлен.
 Чтобы сделать сертификат доверенным (только Windows и macOS), сначала установите инструмент dev-certs, выполнив команду "dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final", а затем выполните "dotnet-dev-certs https --trust".

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
@@ -62,9 +62,9 @@ Bu hatayı düzeltmek için bazı seçenekler:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 ASP.NET Core HTTPS Geliştirme Sertifikası başarıyla yüklendi.
 Sertifikaya güvenmek için (yalnızca Windows ve macOS) önce 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final', sonra 'dotnet-dev-certs https --trust' komutlarını çalıştırarak dev-certs aracını yükleyin.

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
@@ -62,9 +62,9 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 已成功安装 ASP.NET Core HTTPS 开发证书。
 要信任证书(仅限 Windows 和 macOS)，请首先通过运行 "dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final" 安装 dev-certs 工具，然后运行 "dotnet-dev-certs https --trust"。

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
@@ -62,9 +62,9 @@ Here are some options to fix this error:
         <source>ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
-To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms please refer to the platform specific documentation.
+To trust the certificate run 'dotnet dev-certs https --trust' (Windows and macOS only). For establishing trust on other platforms refer to the platform specific documentation.
 For more information on configuring HTTPS see https://go.microsoft.com/fwlink/?linkid=848054.</source>
-        <target state="translated">ASP.NET Core
+        <target state="needs-review-translation">ASP.NET Core
 ------------
 已成功安裝 ASP.NET Core HTTPS 開發憑證。
 若要信任此憑證 (僅限 Windows 與 macOS)，請先執行 'dotnet tool install dotnet-dev-certs -g --version 2.1.0-preview1-final' 來安裝 dev-certs 工具，然後再執行 'dotnet-dev-certs https --trust'。


### PR DESCRIPTION
@MattGertz for approval to take to ship room for RTM

**Issues fixed**

https://github.com/dotnet/cli/issues/9195

**Description of Issue**

We have the word please in one of our messages in a situation where MS guidance asks us not to use it. We are just removing that message.

**Customer Impact**

We are violating MS guidance.

**Risk**

Low - Just a small text change.

**Testing**

CLI CI.