### PR TITLE
Vstest args for dotnet cli

### DIFF
--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Tools.Test
             var msbuildArgs = new List<string>()
             {
                 "-target:VSTest",
-                "-verbosity:minimal",
+                "-verbosity:quiet",
                 "-nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
                 "-nologo"
             };

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Tools.Test
             var msbuildArgs = new List<string>()
             {
                 "-target:VSTest",
-                "-verbosity:quiet",
+                "-verbosity:minimal",
                 "-nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
                 "-nologo"
             };

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -40,19 +40,19 @@ namespace Microsoft.DotNet.Cli
                   Create.Option(
                         "-a|--test-adapter-path",
                         LocalizableStrings.CmdTestAdapterPathDescription,
-                        Accept.ExactlyOneArgument()
+                        Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.CmdTestAdapterPath)
-                              .ForwardAsSingle(o => $"-property:VSTestTestAdapterPath={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"/p:VSTestTestAdapterPath=\"{string.Join(";", o.Arguments)}\"")),
                   Create.Option(
                         "-l|--logger",
                         LocalizableStrings.CmdLoggerDescription,
-                        Accept.ExactlyOneArgument()
+                        Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.CmdLoggerOption)
                               .ForwardAsSingle(o =>
                                     {
                                           var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
 
-                                          return $"-property:VSTestLogger={loggersString}";
+                                        return $"/p:VSTestLogger=\"{loggersString}\"";
                                     })),
                   CommonOptions.ConfigurationOption(),
                   CommonOptions.FrameworkOption(),

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdTestAdapterPathDescription,
                         Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.CmdTestAdapterPath)
-                              .ForwardAsSingle(o => $"/p:VSTestTestAdapterPath=\"{string.Join(";", o.Arguments)}\"")),
+                              .ForwardAsSingle(o => $"-property:VSTestTestAdapterPath=\"{string.Join(";", o.Arguments)}\"")),
                   Create.Option(
                         "-l|--logger",
                         LocalizableStrings.CmdLoggerDescription,
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli
                                     {
                                           var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
 
-                                        return $"/p:VSTestLogger=\"{loggersString}\"";
+                                        return $"-property:VSTestLogger=\"{loggersString}\"";
                                     })),
                   CommonOptions.ConfigurationOption(),
                   CommonOptions.FrameworkOption(),

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -295,7 +295,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             // Call test with logger enable
             CommandResult result = new DotnetTestCommand()
                                        .WithWorkingDirectory(testProjectDirectory)
-                                       .ExecuteWithCapturedOutput("--logger \"trx;logfilename=custom.trx\" --logger console -- RunConfiguration.ResultsDirectory=" + trxLoggerDirectory);
+                                       .ExecuteWithCapturedOutput("--logger \"trx;logfilename=custom.trx\" --logger console;verbosity=normal -- RunConfiguration.ResultsDirectory=" + trxLoggerDirectory);
 
             // Verify
             var trxFilePath = Path.Combine(trxLoggerDirectory, "custom.trx");

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -278,6 +278,39 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(1);
         }
 
+        [Fact]
+        public void ItAcceptsMultipleLoggersAsCliArguments()
+        {
+            // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
+            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("10");
+
+            string trxLoggerDirectory = Path.Combine(testProjectDirectory, "RD");
+
+            // Delete trxLoggerDirectory if it exist
+            if (Directory.Exists(trxLoggerDirectory))
+            {
+                Directory.Delete(trxLoggerDirectory, true);
+            }
+
+            // Call test with logger enable
+            CommandResult result = new DotnetTestCommand()
+                                       .WithWorkingDirectory(testProjectDirectory)
+                                       .ExecuteWithCapturedOutput("--logger \"trx;logfilename=custom.trx\" --logger console -- RunConfiguration.ResultsDirectory=" + trxLoggerDirectory);
+
+            // Verify
+            var trxFilePath = Path.Combine(trxLoggerDirectory, "custom.trx");
+            Assert.True(File.Exists(trxFilePath));
+            result.StdOut.Should().Contain(trxFilePath);
+            result.StdOut.Should().Contain("Passed   VSTestPassTest");
+            result.StdOut.Should().Contain("Failed   VSTestFailTest");
+
+            // Cleanup trxLoggerDirectory if it exist
+            if (Directory.Exists(trxLoggerDirectory))
+            {
+                Directory.Delete(trxLoggerDirectory, true);
+            }
+        }
+
         private string CopyAndRestoreVSTestDotNetCoreTestApp([CallerMemberName] string callingMethod = "")
         {
             // Copy VSTestCore project in output directory of project dotnet-vstest.Tests

--- a/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
+++ b/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
                 .ExecuteWithCapturedOutput("test");
 
             cmd.Should().Pass();
-            cmd.StdOut.Should().Contain("Message with normal importance");
+            cmd.StdOut.Should().Contain("Message with high importance");
         }
 
         [Fact]

--- a/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
+++ b/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
         }
 
         [Fact]
-        public void When_dotnet_test_invokes_msbuild_with_no_args_verbosity_is_set_to_quiet()
+        public void When_dotnet_test_invokes_msbuild_with_no_args_verbosity_is_set_to_mininal()
         {
             var testInstance = TestAssets.Get("MSBuildIntegration")
                 .CreateInstance()
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
                 .ExecuteWithCapturedOutput("test");
 
             cmd.Should().Pass();
-            cmd.StdOut.Should().NotContain("Message with high importance");
+            cmd.StdOut.Should().Contain("Message with normal importance");
         }
 
         [Fact]

--- a/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
+++ b/test/msbuild.IntegrationTests/GivenDotnetInvokesMSBuild.cs
@@ -75,7 +75,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
         }
 
         [Fact]
-        public void When_dotnet_test_invokes_msbuild_with_no_args_verbosity_is_set_to_mininal()
+        public void When_dotnet_test_invokes_msbuild_with_no_args_verbosity_is_set_to_quiet()
         {
             var testInstance = TestAssets.Get("MSBuildIntegration")
                 .CreateInstance()
@@ -86,7 +86,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.IntegrationTests
                 .ExecuteWithCapturedOutput("test");
 
             cmd.Should().Pass();
-            cmd.StdOut.Should().Contain("Message with high importance");
+            cmd.StdOut.Should().NotContain("Message with high importance");
         }
 
         [Fact]


### PR DESCRIPTION
- Allow dotnet CLI to take multiple inputs for logger, & TAP
- Complete PR: https://github.com/Microsoft/vstest/pull/1574 , then update dotnet sdk here

Fixes: https://github.com/Microsoft/vstest/issues/1319