### PR TITLE
Fix adding tools directory to PATH for native installers.

### DIFF
--- a/src/Microsoft.DotNet.Configurer/NoOpFileSentinel.cs
+++ b/src/Microsoft.DotNet.Configurer/NoOpFileSentinel.cs
@@ -7,9 +7,16 @@ namespace Microsoft.DotNet.Configurer
 {
     public class NoOpFileSentinel : IFileSentinel
     {
+        private bool _exists;
+
+        public NoOpFileSentinel(bool exists)
+        {
+            _exists = exists;
+        }
+
         public bool Exists()
         {
-            return true;
+            return _exists;
         }
 
         public void Create()

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -147,7 +147,7 @@ namespace Microsoft.DotNet.Cli
                         {
                             aspNetCertificateSentinel = new NoOpAspNetCertificateSentinel();
                             firstTimeUseNoticeSentinel = new NoOpFirstTimeUseNoticeSentinel();
-                            toolPathSentinel = new NoOpFileSentinel();
+                            toolPathSentinel = new NoOpFileSentinel(exists: false);
                             hasSuperUserAccess = true;
                         }
 


### PR DESCRIPTION
This commit fixes adding the tools directory to the user's PATH for the native
installers.

The issue was a regression caused by #8886.  The change used a "no-op" sentinel
file that reported it existed.  This "no-op" sentinel was used for the native
installers.  Unlike the other "no-op" sentinels used by the native installer,
we do want PATH to be modified by the native installer.

The fix is to change the "no-op" sentinel to report the file doesn't exist, but
also to not to attempt to create the file.

This fixes #9208.
