### PR TITLE
Always execute cache expansion on native installers.

### DIFF
--- a/src/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
+++ b/src/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
@@ -1,0 +1,14 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Configurer
+{
+    public class DotnetFirstRunConfiguration
+    {
+        public bool GenerateAspNetCertificate { get; set; }
+
+        public bool PrintTelemetryMessage { get; set; }
+
+        public bool SkipFirstRunExperience { get; set; }
+    }
+}

--- a/src/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
+++ b/src/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
@@ -5,10 +5,20 @@ namespace Microsoft.DotNet.Configurer
 {
     public class DotnetFirstRunConfiguration
     {
-        public bool GenerateAspNetCertificate { get; set; }
+        public bool GenerateAspNetCertificate { get; }
 
-        public bool PrintTelemetryMessage { get; set; }
+        public bool PrintTelemetryMessage { get; }
 
-        public bool SkipFirstRunExperience { get; set; }
+        public bool SkipFirstRunExperience { get; }
+
+        public DotnetFirstRunConfiguration(
+            bool generateAspNetCertificate,
+            bool printTelemetryMessage,
+            bool skipFirstRunExperience)
+        {
+            GenerateAspNetCertificate = generateAspNetCertificate;
+            PrintTelemetryMessage = printTelemetryMessage;
+            SkipFirstRunExperience = skipFirstRunExperience;
+        }
     }
 }

--- a/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Configurer
     public class DotnetFirstTimeUseConfigurer
     {
         private IReporter _reporter;
-        private IEnvironmentProvider _environmentProvider;
+        private DotnetFirstRunConfiguration _dotnetFirstRunConfiguration;
         private INuGetCachePrimer _nugetCachePrimer;
         private INuGetCacheSentinel _nugetCacheSentinel;
         private IFirstTimeUseNoticeSentinel _firstTimeUseNoticeSentinel;
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Configurer
             IAspNetCertificateSentinel aspNetCertificateSentinel,
             IAspNetCoreCertificateGenerator aspNetCoreCertificateGenerator,
             IFileSentinel toolPathSentinel,
-            IEnvironmentProvider environmentProvider,
+            DotnetFirstRunConfiguration dotnetFirstRunConfiguration,
             IReporter reporter,
             string cliFallbackFolderPath,
             IEnvironmentPath pathAdder)
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Configurer
             _aspNetCertificateSentinel = aspNetCertificateSentinel;
             _aspNetCoreCertificateGenerator = aspNetCoreCertificateGenerator;
             _toolPathSentinel = toolPathSentinel;
-            _environmentProvider = environmentProvider;
+            _dotnetFirstRunConfiguration = dotnetFirstRunConfiguration;
             _reporter = reporter;
             _cliFallbackFolderPath = cliFallbackFolderPath;
             _pathAdder = pathAdder ?? throw new ArgumentNullException(nameof(pathAdder));
@@ -93,11 +93,8 @@ namespace Microsoft.DotNet.Configurer
 #if EXCLUDE_ASPNETCORE
             return false;
 #else
-            var generateAspNetCertificate =
-                _environmentProvider.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true);
-
             return ShouldRunFirstRunExperience() &&
-                generateAspNetCertificate &&
+                _dotnetFirstRunConfiguration.GenerateAspNetCertificate &&
                 !_aspNetCertificateSentinel.Exists();
 #endif
         }
@@ -116,11 +113,8 @@ namespace Microsoft.DotNet.Configurer
 
         private bool ShouldPrintFirstTimeUseNotice()
         {
-            var showFirstTimeUseNotice =
-                _environmentProvider.GetEnvironmentVariableAsBool("DOTNET_PRINT_TELEMETRY_MESSAGE", true);
-
             return ShouldRunFirstRunExperience() &&
-                showFirstTimeUseNotice &&
+                _dotnetFirstRunConfiguration.PrintTelemetryMessage &&
                 !_firstTimeUseNoticeSentinel.Exists();
         }
 
@@ -157,10 +151,7 @@ namespace Microsoft.DotNet.Configurer
 
         private bool ShouldRunFirstRunExperience()
         {
-            var skipFirstTimeExperience =
-                _environmentProvider.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false);
-
-            return !skipFirstTimeExperience;
+            return !_dotnetFirstRunConfiguration.SkipFirstRunExperience;
         }
     }
 }

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -164,12 +164,10 @@ namespace Microsoft.DotNet.Cli
                             skipFirstRunExperience = false;
                         }
 
-                        var dotnetFirstRunConfiguration = new DotnetFirstRunConfiguration
-                        {
-                            GenerateAspNetCertificate = generateAspNetCertificate,
-                            PrintTelemetryMessage = printTelemetryMessage,
-                            SkipFirstRunExperience = skipFirstRunExperience
-                        };
+                        var dotnetFirstRunConfiguration = new DotnetFirstRunConfiguration(
+                            generateAspNetCertificate,
+                            printTelemetryMessage,
+                            skipFirstRunExperience);
 
                         ConfigureDotNetForFirstTimeUse(
                             nugetCacheSentinel,

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         private Mock<IAspNetCertificateSentinel> _aspNetCertificateSentinelMock;
         private Mock<IAspNetCoreCertificateGenerator> _aspNetCoreCertificateGeneratorMock;
         private Mock<IFileSentinel> _toolPathSentinelMock;
-        private Mock<IEnvironmentProvider> _environmentProviderMock;
         private Mock<IReporter> _reporterMock;
         private Mock<IEnvironmentPath> _pathAdderMock;
 
@@ -33,16 +32,8 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             _aspNetCertificateSentinelMock = new Mock<IAspNetCertificateSentinel>();
             _aspNetCoreCertificateGeneratorMock = new Mock<IAspNetCoreCertificateGenerator>();
             _toolPathSentinelMock = new Mock<IFileSentinel>();
-            _environmentProviderMock = new Mock<IEnvironmentProvider>();
             _reporterMock = new Mock<IReporter>();
             _pathAdderMock = new Mock<IEnvironmentPath>();
-
-            _environmentProviderMock
-                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false))
-                .Returns(false);
-            _environmentProviderMock
-                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_PRINT_TELEMETRY_MESSAGE", true))
-                .Returns(true);
         }
 
         [Fact]
@@ -57,7 +48,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -72,9 +67,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         public void It_does_not_print_the_first_time_use_notice_when_the_user_has_set_the_DOTNET_SKIP_FIRST_TIME_EXPERIENCE_environemnt_variable()
         {
             _firstTimeUseNoticeSentinelMock.Setup(n => n.Exists()).Returns(false);
-            _environmentProviderMock
-                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false))
-                .Returns(true);
 
             var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
                 _nugetCachePrimerMock.Object,
@@ -83,7 +75,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = true,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -98,9 +94,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         public void It_does_not_print_the_first_time_use_notice_when_the_user_has_set_the_DOTNET_PRINT_TELEMETRY_MESSAGE_environemnt_variable()
         {
             _firstTimeUseNoticeSentinelMock.Setup(n => n.Exists()).Returns(false);
-            _environmentProviderMock
-                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_PRINT_TELEMETRY_MESSAGE", true))
-                .Returns(false);
 
             var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
                 _nugetCachePrimerMock.Object,
@@ -109,7 +102,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = false
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -132,7 +129,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -155,7 +156,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -177,7 +182,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -199,7 +208,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -210,12 +223,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Fact]
-        public void It_does_not_prime_the_cache_if_the_sentinel_exists_but_the_user_has_set_the_DOTNET_SKIP_FIRST_TIME_EXPERIENCE_environemnt_variable()
+        public void It_does_not_prime_the_cache_if_the_sentinel_does_not_exist_but_the_user_has_set_the_DOTNET_SKIP_FIRST_TIME_EXPERIENCE_environment_variable()
         {
             _nugetCacheSentinelMock.Setup(n => n.Exists()).Returns(false);
-            _environmentProviderMock
-                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false))
-                .Returns(true);
 
             var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
                 _nugetCachePrimerMock.Object,
@@ -224,7 +234,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = true,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -246,7 +260,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -269,7 +287,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -295,7 +317,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -322,7 +348,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -345,7 +375,12 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true,
+                    GenerateAspNetCertificate = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -368,7 +403,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -398,7 +437,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -420,7 +463,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -435,9 +482,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         public void It_does_not_generate_the_aspnet_https_development_certificate_when_the_user_has_set_the_DOTNET_SKIP_FIRST_TIME_EXPERIENCE_environment_variable()
         {
             _aspNetCertificateSentinelMock.Setup(n => n.Exists()).Returns(false);
-            _environmentProviderMock
-                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false))
-                .Returns(true);
 
             var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
                 _nugetCachePrimerMock.Object,
@@ -446,7 +490,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -461,9 +509,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         public void It_does_not_generate_the_aspnet_https_development_certificate_when_the_user_has_set_the_DOTNET_GENERATE_ASPNET_CERTIFICATE_environment_variable()
         {
             _aspNetCertificateSentinelMock.Setup(n => n.Exists()).Returns(false);
-            _environmentProviderMock
-                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true))
-                .Returns(false);
 
             var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
                 _nugetCachePrimerMock.Object,
@@ -472,7 +517,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -487,8 +536,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         public void It_generates_the_aspnet_https_development_certificate_if_the_sentinel_does_not_exist()
         {
             _aspNetCertificateSentinelMock.Setup(n => n.Exists()).Returns(false);
-            _environmentProviderMock.Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true))
-                .Returns(true);
 
             var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
                 _nugetCachePrimerMock.Object,
@@ -497,7 +544,12 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true,
+                    GenerateAspNetCertificate = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -520,7 +572,12 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = false,
+                    PrintTelemetryMessage = true,
+                    GenerateAspNetCertificate = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -533,10 +590,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         [Fact]
         public void It_does_not_add_the_tool_path_to_the_environment_if_the_first_run_experience_is_skipped()
         {
-            _environmentProviderMock
-                .Setup(e => e.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false))
-                .Returns(true);
-
             var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
                 _nugetCachePrimerMock.Object,
                 _nugetCacheSentinelMock.Object,
@@ -544,7 +597,12 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCertificateSentinelMock.Object,
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
-                _environmentProviderMock.Object,
+                new DotnetFirstRunConfiguration
+                {
+                    SkipFirstRunExperience = true,
+                    PrintTelemetryMessage = true,
+                    GenerateAspNetCertificate = true
+                },
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
@@ -49,10 +49,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -76,10 +77,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = true,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: true
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -103,10 +105,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = false
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: false,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -130,10 +133,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -157,10 +161,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -183,10 +188,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -209,10 +215,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -235,10 +242,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = true,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: true
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -261,10 +269,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -288,10 +297,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -318,10 +328,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -349,10 +360,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -376,11 +388,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true,
-                    GenerateAspNetCertificate = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -404,10 +416,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -438,10 +451,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -464,10 +478,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -491,10 +506,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: true
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -518,10 +534,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true
-                },
+                (
+                    generateAspNetCertificate: false,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -545,11 +562,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true,
-                    GenerateAspNetCertificate = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -573,11 +590,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = false,
-                    PrintTelemetryMessage = true,
-                    GenerateAspNetCertificate = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: false
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);
@@ -598,11 +615,11 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 _aspNetCoreCertificateGeneratorMock.Object,
                 _toolPathSentinelMock.Object,
                 new DotnetFirstRunConfiguration
-                {
-                    SkipFirstRunExperience = true,
-                    PrintTelemetryMessage = true,
-                    GenerateAspNetCertificate = true
-                },
+                (
+                    generateAspNetCertificate: true,
+                    printTelemetryMessage: true,
+                    skipFirstRunExperience: true
+                ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
                 _pathAdderMock.Object);

--- a/test/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.csproj
+++ b/test/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.csproj
@@ -13,9 +13,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="2.0.0" />
-  </ItemGroup>
-
+  
 </Project>


### PR DESCRIPTION
Introduced a DotnetFirstRunConfiguration that holds the values that were usually passed around as environment variables. This concentrates the place where we need access to the Environment Provider and allows us to set our own controls values when necessary.

The Configuration is then used and set whenever the report-installsuccess verb is invoked (meaning this is a native installer) and we set the skip first run value to false, guaranteeing cache expansion will happen if necessary.

Minor fix, also took the opportunity to remove the direct dependency of TestFramework to Netstandard.Library, fixing one of the warnings we have been getting in our builds. Can't let these proliferate.
