### PR TITLE
Fix incorrect default VSTest verbosity level.

### DIFF
--- a/src/dotnet/ArgumentForwardingExtensions.cs
+++ b/src/dotnet/ArgumentForwardingExtensions.cs
@@ -35,6 +35,9 @@ namespace Microsoft.DotNet.Cli
                    .OfType<ForwardedArgument>()
                    .SelectMany(o => o.Values);
 
+        public static IEnumerable<string> ForwardedOptionValues(this AppliedOption command, string alias) =>
+            (command.ValueOrDefault<ForwardedArgument>(alias)?.Values ?? Array.Empty<string>());
+
         private class ForwardedArgument
         {
             public ForwardedArgument(params string[] values)

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -60,11 +60,10 @@ namespace Microsoft.DotNet.Tools.Test
                 msbuildArgs.Add($"-property:VSTestCLIRunSettings=\"{runSettingsArg}\"");
             }
 
-            var verbosityArg = msbuildArgs.LastOrDefault(arg => arg.StartsWith("-verbosity"));
-
-            if (!string.IsNullOrEmpty(verbosityArg))
+            var verbosityArg = parsedTest.ForwardedOptionValues("verbosity").SingleOrDefault();
+            if (verbosityArg != null)
             {
-                var verbosity = verbosityArg.Split(':');
+                var verbosity = verbosityArg.Split(':', 2);
                 if (verbosity.Length == 2)
                 {
                     msbuildArgs.Add($"-property:VSTestVerbosity={verbosity[1]}");

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -111,6 +111,27 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [Fact]
+        public void GivenAFailingTestItDisplaysFailureDetails()
+        {
+            var testInstance = TestAssets.Get("XunitCore")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            var result = new DotnetTestCommand()
+                .WithWorkingDirectory(testInstance.Root.FullName)
+                .ExecuteWithCapturedOutput();
+
+            result.ExitCode.Should().Be(1);
+
+            if (!DotnetUnderTest.IsLocalized())
+            {
+                result.StdOut.Should().Contain("Failed   TestNamespace.VSTestXunitTests.VSTestXunitFailTest");
+                result.StdOut.Should().Contain("Assert.Equal() Failure");
+                result.StdOut.Should().Contain("Total tests: 2. Passed: 1. Failed: 1. Skipped: 0.");
+            }
+        }
+
+        [Fact]
         public void TestWillNotBuildTheProjectIfNoBuildArgsIsGiven()
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests


### PR DESCRIPTION
Commit 10289504a8aeb5fab7c1c9f8e0e7602e9c14250a changed the default verbosity
option used for MSBuild from `-v:quiet` to `-verbosity:quiet`.  This triggered a
match that was being done against arguments starting with `-verbosity` to
forward the value to VSTest via the `VSTestVerbosity` property.  The result is
that VSTest is using a default verbosity of `quiet`, suppressing error output
that users expect to see.

The fix is to change the check to only match against user-supplied options.
The default level the command uses for MSBuild is not forwarded to VSTest.

Fixes #9229.
