### PR TITLE
MSBuild 15.8.61

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -45,6 +45,7 @@
     <NuGetPackagingPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetPackagingPackageVersion>
     <NuGetProjectModelPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetProjectModelPackageVersion>
     <NuGetVersioningPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetVersioningPackageVersion>
+    <NuGetSdkResolverPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetSdkResolverPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0-preview-20180510-03</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -5,7 +5,7 @@
     <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-rtm-26515-03</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.7.179</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.8.0-preview-000061</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -283,6 +283,9 @@
       <RemainingFiles Remove="$(PublishDir)**\*.resources.dll" />
 
       <DiasymReaderPath Include="$(SharedFrameworkNameVersionPath)/Microsoft.DiaSymReader.Native.*.dll" />
+
+      <!-- MSBuild includes reference assemblies to compile in-memory tasks. Don't try to crossgen. -->
+      <RemainingFiles Remove="$(PublishDir)ref\*.dll" />
     </ItemGroup>
 
     <AddMetadataIsPE Items="@(RoslynFiles)">

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppPackageVersion)" />
     <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.NuGetSdkResolver" Version="$(NuGetSdkResolverPackageVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)" />
     <PackageReference Include="Microsoft.TestPlatform.Build" Version="$(MicrosoftTestPlatformBuildPackageVersion)" />
     <PackageReference Condition=" '$(DotNetBuildFromSource)' != 'true' " Include="NuGet.Localization" Version="$(NuGetProjectModelPackageVersion)" />

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/GivenAnMSBuildSdkResolver.cs
@@ -334,19 +334,34 @@ namespace Microsoft.DotNet.Cli.Utils.Tests
         private sealed class MockFactory : SdkResultFactory
         {
             public override SdkResult IndicateFailure(IEnumerable<string> errors, IEnumerable<string> warnings = null)
-                => new MockResult { Success = false, Errors = errors, Warnings = warnings  };
+                => new MockResult(success: false, path: null, version: null, warnings: warnings, errors: errors);
 
             public override SdkResult IndicateSuccess(string path, string version, IEnumerable<string> warnings = null)
-                => new MockResult { Success = true, Path = path, Version = version, Warnings = warnings };
+                => new MockResult(success: true, path: path, version: version, warnings: warnings);
         }
 
         private sealed class MockResult : SdkResult
         {
-            public new bool Success { get => base.Success; set => base.Success = value; }
-            public string Version { get; set; }
-            public string Path { get; set; }
-            public IEnumerable<string> Errors { get; set; }
-            public IEnumerable<string> Warnings { get; set; }
+            public MockResult(bool success, string path, string version, IEnumerable<string> warnings = null,
+                IEnumerable<string> errors = null)
+            {
+                Success = success;
+                Path = path;
+                Version = version;
+                Warnings = warnings;
+                Errors = errors;
+            }
+
+            public new bool Success
+            {
+                get => base.Success;
+                private set => base.Success = value;
+            }
+
+            public override string Version { get; protected set; }
+            public override string Path { get; protected set; }
+            public IEnumerable<string> Errors { get; }
+            public IEnumerable<string> Warnings { get; }
         }
     }
 }


### PR DESCRIPTION
This change removes our NuGet resolver in favor of an xml file manifest (in `Microsoft.Build.Runtime`) pointing to `Microsoft.Build.NuGetSdkResolver.dll` (next to `MSBuild.dll`) which is included with NuGet now. Removes the only direct compile-time dependency MSBuild had on NuGet.