### PR TITLE
Fix header output by `dotnet sln list`.

### DIFF
--- a/src/dotnet/commands/dotnet-sln/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-sln/LocalizableStrings.resx
@@ -150,4 +150,7 @@
   <data name="CreateSubcommandHelpText" xml:space="preserve">
     <value>Create a solution file.</value>
   </data>
+  <data name="ProjectsHeader" xml:space="preserve">
+    <value>Project(s)</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-sln/list/Program.cs
+++ b/src/dotnet/commands/dotnet-sln/list/Program.cs
@@ -36,9 +36,9 @@ namespace Microsoft.DotNet.Tools.Sln.List
             }
             else
             {
-                Reporter.Output.WriteLine($"{CommonLocalizableStrings.ProjectReferenceOneOrMore}");
-                Reporter.Output.WriteLine(new string('-', CommonLocalizableStrings.ProjectReferenceOneOrMore.Length));
-                foreach (var slnProject in slnFile.Projects)
+                Reporter.Output.WriteLine($"{LocalizableStrings.ProjectsHeader}");
+                Reporter.Output.WriteLine(new string('-', LocalizableStrings.ProjectsHeader.Length));
+                foreach (var slnProject in slnFile.Projects.Where(p => p.TypeGuid != ProjectTypeGuids.SolutionFolderGuid))
                 {
                     Reporter.Output.WriteLine(slnProject.FilePath);
                 }

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Vytvoří soubor řešení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Erstellt eine Projektmappendatei.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Cree un archivo de la solución.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Créez un fichier solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Consente di creare un file di soluzione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">ソリューション ファイルを作成します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">솔루션 파일을 만듭니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Utwórz plik rozwiązania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Criar um arquivo de solução.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Создает файл решения.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Bir çözüm dosyası oluşturun.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">创建解决方案文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-sln/xlf/LocalizableStrings.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">建立方案檔。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProjectsHeader">
+        <source>Project(s)</source>
+        <target state="new">Project(s)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/dotnet-sln-list.Tests/GivenDotnetSlnList.cs
+++ b/test/dotnet-sln-list.Tests/GivenDotnetSlnList.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Xunit;
+using CommandLocalizableStrings = Microsoft.DotNet.Tools.Sln.LocalizableStrings;
 
 namespace Microsoft.DotNet.Cli.Sln.List.Tests
 {
@@ -160,7 +161,7 @@ Commands:
         }
 
         [Fact]
-        public void WhenNoProjectReferencesArePresentInTheSolutionItPrintsANoProjectMessage()
+        public void WhenNoProjectsArePresentInTheSolutionItPrintsANoProjectMessage()
         {
             var projectDirectory = TestAssets
                 .Get("TestAppWithEmptySln")
@@ -177,11 +178,10 @@ Commands:
         }
 
         [Fact]
-        public void WhenProjectReferencesArePresentInTheSolutionItListsThem()
+        public void WhenProjectsPresentInTheSolutionItListsThem()
         {
-            string OutputText = CommonLocalizableStrings.ProjectReferenceOneOrMore;
-            OutputText += $@"
-{new string('-', OutputText.Length)}
+            var expectedOutput = $@"{CommandLocalizableStrings.ProjectsHeader}
+{new string('-', CommandLocalizableStrings.ProjectsHeader.Length)}
 {Path.Combine("App", "App.csproj")}
 {Path.Combine("Lib", "Lib.csproj")}";
 
@@ -196,7 +196,7 @@ Commands:
                 .WithWorkingDirectory(projectDirectory)
                 .ExecuteWithCapturedOutput("sln list");
             cmd.Should().Pass();
-            cmd.StdOut.Should().BeVisuallyEquivalentTo(OutputText);
+            cmd.StdOut.Should().BeVisuallyEquivalentTo(expectedOutput);
         }
     }
 }


### PR DESCRIPTION
The `dotnet sln list` command uses `Project reference(s)` as the header for the
output instead of `Project(s)`. To be consistent with Visual Studio, the header
should refer to these as projects rather than project references as users can't
add "project references" to a solution.

This commit changes the header to `Project(s)`.

Additionally, the command now filters out solution folders and only shows
projects.

Fixes #9246.
