### PR TITLE
Add NoWarn=NU5104 when packaging Cli.Utils for tests.

### DIFF
--- a/build/test/TestPackageProjects.targets
+++ b/build/test/TestPackageProjects.targets
@@ -39,7 +39,7 @@
         <VersionPrefix>$(CliVersionPrefix)</VersionPrefix>
         <VersionSuffix>$(VersionSuffix)</VersionSuffix>
         <Clean>False</Clean>
-        <MsbuildArgs>/p:TargetFramework=netstandard2.0</MsbuildArgs>
+        <MsbuildArgs>/p:TargetFramework=netstandard2.0 /p:NoWarn=NU5104</MsbuildArgs>
       </BaseTestPackageProject>
       <BaseTestPackageProject Include="src/Microsoft.DotNet.InternalAbstractions">
         <Name>Microsoft.DotNet.InternalAbstractions</Name>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -86,7 +86,7 @@
 
     <DotNetPublish ToolPath="$(PreviousStageDirectory)"
                    Configuration="$(Configuration)"
-                   ProjectPath="$(SrcDirectory)/tool_fsharp/tool_fsc.csproj" />
+                   ProjectPath="$(SrcDirectory)/tool_fsharp/tool_fsc.csproj" MSBuildArgs="/p:PublishDir=$(FSharpDirectory)" />
   </Target>
 
   <Target Name="GenerateCliRuntimeConfigurationFiles"

--- a/src/tool_fsharp/tool_fsc.csproj
+++ b/src/tool_fsharp/tool_fsc.csproj
@@ -2,11 +2,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.tasks))\dir.tasks" />
 
   <PropertyGroup>
-    <VersionPrefix>$(CliVersionPrefix)</VersionPrefix>
     <TargetFramework>$(CliTargetFramework)</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PublishDir>$(FSharpDirectory)</PublishDir>
-    <VersionSuffix>$(CommitCount)</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Add NoWarn for the stable package depending on non-stable package when packaging Cli.Utils for tests.

This should unblock prodcon to produce stable builds with tests turned on.
