### PR TITLE
Add the NoWarn option when producing Cli.Utils for full framework as well

### DIFF
--- a/build/test/TestPackageProjects.targets
+++ b/build/test/TestPackageProjects.targets
@@ -29,6 +29,7 @@
         <VersionPrefix>$(CliVersionPrefix)</VersionPrefix>
         <VersionSuffix>$(VersionSuffix)</VersionSuffix>
         <Clean>False</Clean>
+        <MsbuildArgs>/p:NoWarn=NU5104</MsbuildArgs>
       </BaseTestPackageProject>
       <BaseTestPackageProject Include="src/Microsoft.DotNet.Cli.Utils"
                               Condition=" '$(IsDesktopAvailable)' == 'False' " >


### PR DESCRIPTION
Add the NoWarn option when producing Cli.Utils for full framework as well.
