### PR TITLE
Multiple Logger/TestAdapter inputs from dotnet CLI

### DIFF
--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -40,19 +40,19 @@ namespace Microsoft.DotNet.Cli
                   Create.Option(
                         "-a|--test-adapter-path",
                         LocalizableStrings.CmdTestAdapterPathDescription,
-                        Accept.ExactlyOneArgument()
+                        Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.CmdTestAdapterPath)
-                              .ForwardAsSingle(o => $"-property:VSTestTestAdapterPath={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:VSTestTestAdapterPath=\"{string.Join(";", o.Arguments)}\"")),
                   Create.Option(
                         "-l|--logger",
                         LocalizableStrings.CmdLoggerDescription,
-                        Accept.ExactlyOneArgument()
+                        Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.CmdLoggerOption)
                               .ForwardAsSingle(o =>
                                     {
                                           var loggersString = string.Join(";", GetSemiColonEscapedArgs(o.Arguments));
 
-                                          return $"-property:VSTestLogger={loggersString}";
+                                          return $"-property:VSTestLogger=\"{loggersString}\"";
                                     })),
                   CommonOptions.ConfigurationOption(),
                   CommonOptions.FrameworkOption(),

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -132,6 +132,39 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [Fact]
+        public void ItAcceptsMultipleLoggersAsCliArguments()
+        {
+            // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests
+            var testProjectDirectory = this.CopyAndRestoreVSTestDotNetCoreTestApp("10");
+
+            string trxLoggerDirectory = Path.Combine(testProjectDirectory, "RD");
+
+            // Delete trxLoggerDirectory if it exist
+            if (Directory.Exists(trxLoggerDirectory))
+            {
+                Directory.Delete(trxLoggerDirectory, true);
+            }
+
+            // Call test with logger enable
+            CommandResult result = new DotnetTestCommand()
+                                       .WithWorkingDirectory(testProjectDirectory)
+                                       .ExecuteWithCapturedOutput("--logger \"trx;logfilename=custom.trx\" --logger console;verbosity=normal -- RunConfiguration.ResultsDirectory=" + trxLoggerDirectory);
+
+            // Verify
+            var trxFilePath = Path.Combine(trxLoggerDirectory, "custom.trx");
+            Assert.True(File.Exists(trxFilePath));
+            result.StdOut.Should().Contain(trxFilePath);
+            result.StdOut.Should().Contain("Passed   VSTestPassTest");
+            result.StdOut.Should().Contain("Failed   VSTestFailTest");
+
+            // Cleanup trxLoggerDirectory if it exist
+            if (Directory.Exists(trxLoggerDirectory))
+            {
+                Directory.Delete(trxLoggerDirectory, true);
+            }
+        }
+
+        [Fact]
         public void TestWillNotBuildTheProjectIfNoBuildArgsIsGiven()
         {
             // Copy and restore VSTestCore project in output directory of project dotnet-vstest.Tests


### PR DESCRIPTION
- Allow dotnet CLI to take multiple inputs for logger, & TAP
- Complete PR: https://github.com/Microsoft/vstest/pull/1574 , then update dotnet sdk here

Fixes: https://github.com/Microsoft/vstest/issues/1319