### PR TITLE
Add retry when Directory.Move

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/FileAccessRetryer.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/FileAccessRetryer.cs
@@ -50,13 +50,14 @@ namespace Microsoft.DotNet.Cli.Utils
         }
 
         /// <summary>
-        /// Run Directory.Move and File.Move in Windows has a chance to get IOException with HResult 0x80070005. But this error is transient.
+        /// Run Directory.Move and File.Move in Windows has a chance to get IOException with
+        /// HResult 0x80070005 due to Indexer. But this error is transient.
         /// </summary>
         internal static void RetryOnMoveAccessFailure(Action action)
         {
             const int ERROR_HRESULT_ACCESS_DENIED = unchecked((int)0x80070005);
-            int nextWaitTime = 1000;
-            int remainRetry = 3;
+            int nextWaitTime = 10;
+            int remainRetry = 10;
 
             while (true)
             {
@@ -68,7 +69,7 @@ namespace Microsoft.DotNet.Cli.Utils
                 catch (IOException e) when (e.HResult == ERROR_HRESULT_ACCESS_DENIED)
                 {
                     Thread.Sleep(nextWaitTime);
-                    nextWaitTime *= 10;
+                    nextWaitTime *= 2;
                     remainRetry--;
                     if (remainRetry == 0)
                     {

--- a/src/dotnet/ShellShim/ShellShimRepository.cs
+++ b/src/dotnet/ShellShim/ShellShimRepository.cs
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.ShellShim
                         foreach (var file in GetShimFiles(commandName).Where(f => _fileSystem.File.Exists(f.Value)))
                         {
                             var tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-                            _fileSystem.File.Move(file.Value, tempPath);
+                            FileAccessRetrier.RetryOnMoveAccessFailure(() => _fileSystem.File.Move(file.Value, tempPath));
                             files[file.Value] = tempPath;
                         }
                     }
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.ShellShim
                 rollback: () => {
                     foreach (var kvp in files)
                     {
-                        _fileSystem.File.Move(kvp.Value, kvp.Key);
+                        FileAccessRetrier.RetryOnMoveAccessFailure(() => _fileSystem.File.Move(kvp.Value, kvp.Key));
                     }
                 });
         }

--- a/src/dotnet/ToolPackage/ToolPackageInstaller.cs
+++ b/src/dotnet/ToolPackage/ToolPackageInstaller.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.Tools;
 using Microsoft.Extensions.EnvironmentAbstractions;
@@ -82,7 +83,7 @@ namespace Microsoft.DotNet.ToolPackage
                         }
 
                         Directory.CreateDirectory(packageRootDirectory.Value);
-                        Directory.Move(stageDirectory.Value, packageDirectory.Value);
+                        FileAccessRetrier.RetryOnMoveAccessFailure(() => Directory.Move(stageDirectory.Value, packageDirectory.Value));
                         rollbackDirectory = packageDirectory.Value;
 
                         return new ToolPackageInstance(_store, packageId, version, packageDirectory);

--- a/src/dotnet/ToolPackage/ToolPackageInstance.cs
+++ b/src/dotnet/ToolPackage/ToolPackageInstance.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.ProjectModel;
 using NuGet.Versioning;
 using Microsoft.DotNet.Cli.Utils;
+using System.Threading;
 
 namespace Microsoft.DotNet.ToolPackage
 {
@@ -79,7 +80,7 @@ namespace Microsoft.DotNet.ToolPackage
                             // Use the staging directory for uninstall
                             // This prevents cross-device moves when temp is mounted to a different device
                             var tempPath = _store.GetRandomStagingDirectory().Value;
-                            Directory.Move(PackageDirectory.Value, tempPath);
+                            FileAccessRetrier.RetryOnMoveAccessFailure(() => Directory.Move(PackageDirectory.Value, tempPath));
                             tempPackageDirectory = tempPath;
                         }
 
@@ -111,7 +112,7 @@ namespace Microsoft.DotNet.ToolPackage
                     if (tempPackageDirectory != null)
                     {
                         Directory.CreateDirectory(rootDirectory.Value);
-                        Directory.Move(tempPackageDirectory, PackageDirectory.Value);
+                        FileAccessRetrier.RetryOnMoveAccessFailure(() => Directory.Move(tempPackageDirectory, PackageDirectory.Value));
                     }
                 });
         }


### PR DESCRIPTION
> Link to GitHub issue for open source changes  

https://github.com/dotnet/cli/issues/9289

> Link to GitHub dotnet:release/[version] pull request (see Git Prepping a PR from the Release Branch) 

https://github.com/dotnet/cli/pull/9313

> ProjectK TFS bug and changeset for closed source changes (security fix, package authoring, etc) 

N/A 

> Describe the issue and how it manifests to the customer. 

When running uninstall and then install on Windows. Due to global tools use Directory.Move underneath, there is a chance the indexer or the antivirus collided (had a handle still open on the prior name). And the installation/uninstalling will fail with access denied error.

> What is the impact on the customer?
 
This impact the producers most. During producer’s test, it is likely they will uninstall and install their tools several times. And the frequency of seeing this error varies machine by machine.

> Are there changes that cannot be made in GitHub? (security fixes, etc) 

No

> Characterize potential risks introduced by the fix. 

Low risk. Try action on failure. And Directory.Move, File.Move is atomic. Once it fails it can be retired.

> Does the change alter existing behaviors? (return values or types, error messages or exceptions, etc. In 
other words, is this a build-to-build breaking change?) 

No

 >> What changed?
>> What will teams need to do to respond?
>> Once check-in is approved send breaking change mail to netcorebreak

> Code reviewers:

> What testing has been completed? 

manual test

> Which platforms are impacted? (Linux | Mac | Windows) 

Windows

> Effected binaries and packages (exact name)

dotnet.dll, Microsoft.DotNet.Cli.Utils.dll


------------

Why check 0x80070005 on IOException
This error is the exact error thrown. It is just an IOException. The only way to detect that is by HResult.

Why don’t use the function above -- RetryOnFileAccessFailure?
RetryOnFileAccessFailure is async. And also in this case, it is awaiting a void. There is some gotcha around it. Since it is so close to release, I choose the safer way. And RetryOnFileAccessFailure ‘s exception is not specific. UnauthorizedAccessException is likely a real error for user to handle for –-tool-path.
 
Tested with 100 times tight loop. No error
