### PR TITLE
Allows .NET Core apps to be optionally run using the Mono runtime

### DIFF
--- a/src/dotnet/commands/dotnet-run/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-run/LocalizableStrings.resx
@@ -144,6 +144,12 @@
   <data name="FrameworkOptionDescription" xml:space="preserve">
     <value>The target framework to run for. The target framework must also be specified in the project file.</value>
   </data>
+  <data name="CommandOptionCLRDescription" xml:space="preserve">
+    <value>The execution runtime to run the .NET application with.</value>
+  </data>
+  <data name="CommandOptionCLRName" xml:space="preserve">
+    <value>RUNTIME</value>
+  </data>
   <data name="RunCommandException" xml:space="preserve">
     <value>The build failed. Please fix the build errors and run again.</value>
   </data>

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -31,6 +31,8 @@ namespace Microsoft.DotNet.Tools.Run
         public bool NoLaunchProfile { get; private set; }
         private bool UseLaunchProfile => !NoLaunchProfile;
 
+        public string ExecutingRuntime { get; private set; }
+
         public int Start()
         {
             Initialize();
@@ -69,6 +71,7 @@ namespace Microsoft.DotNet.Tools.Run
             string launchProfile,
             bool noLaunchProfile,
             bool noRestore,
+            string executingRuntime,
             IEnumerable<string> restoreArgs,
             IReadOnlyCollection<string> args)
         {
@@ -81,6 +84,7 @@ namespace Microsoft.DotNet.Tools.Run
             Args = args;
             RestoreArgs = restoreArgs;
             NoRestore = noRestore;
+            ExecutingRuntime = executingRuntime;
         }
 
         public RunCommand MakeNewWithReplaced(string configuration = null,
@@ -90,6 +94,7 @@ namespace Microsoft.DotNet.Tools.Run
             string launchProfile = null,
             bool? noLaunchProfile = null,
             bool? noRestore = null,
+            string executingRuntime = null,
             IEnumerable<string> restoreArgs = null,
             IReadOnlyCollection<string> args = null)
         {
@@ -101,6 +106,7 @@ namespace Microsoft.DotNet.Tools.Run
                 launchProfile ?? this.LaunchProfile,
                 noLaunchProfile ?? this.NoLaunchProfile,
                 noRestore ?? this.NoRestore,
+                executingRuntime ?? this.ExecutingRuntime,
                 restoreArgs ?? this.RestoreArgs,
                 args ?? this.Args
             );
@@ -198,6 +204,11 @@ namespace Microsoft.DotNet.Tools.Run
             if (!string.IsNullOrWhiteSpace(Framework))
             {
                 globalProperties.Add("TargetFramework", Framework);
+            }
+
+            if (!string.IsNullOrWhiteSpace(ExecutingRuntime))
+            {
+                globalProperties.Add("ExecutingRuntime", ExecutingRuntime);
             }
 
             var project = new ProjectInstance(Project, globalProperties, null);

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -28,6 +28,7 @@ namespace Microsoft.DotNet.Cli
                         noLaunchProfile: o.HasOption("--no-launch-profile"),
                         noRestore: o.HasOption("--no-restore") || o.HasOption("--no-build"),
                         restoreArgs: o.OptionValuesToBeForwarded(),
+                        executingRuntime: GetRuntimeName(o.SingleArgumentOrDefault("--clr")),
                         args: o.Arguments
                     )),
                 options: new[]
@@ -52,7 +53,24 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CommandOptionNoBuildDescription,
                         Accept.NoArguments()),
                     CommonOptions.NoRestoreOption(),
-                    CommonOptions.VerbosityOption()
+                    CommonOptions.VerbosityOption(),
+                    Create.Option(
+                        "--clr",
+                        LocalizableStrings.CommandOptionCLRDescription,
+                        Accept.AnyOneOf("coreclr", "mono").With(name: LocalizableStrings.CommandOptionCLRName))
                 });
+
+        static string GetRuntimeName(string option)
+        {
+            switch (option)
+            {
+                case "mono":
+                    return "mono";
+                case "coreclr":
+                    return "dotnet";
+                default:
+                    return "";
+            }
+        }
     }
 }

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.cs.xlf
@@ -144,6 +144,14 @@ Aktuální {1} je {2}.</target>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.de.xlf
@@ -144,6 +144,14 @@ Ein ausführbares Projekt sollte ein ausführbares TFM (z.B. netcoreapp2.0) verw
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.es.xlf
@@ -144,6 +144,14 @@ El actual {1} es "{2}".</target>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.fr.xlf
@@ -144,6 +144,14 @@ Le {1} actuel est '{2}'.</target>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.it.xlf
@@ -144,6 +144,14 @@ Il valore corrente di {1} è '{2}'.</target>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ja.xlf
@@ -144,6 +144,14 @@ The current {1} is '{2}'.</source>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ko.xlf
@@ -144,6 +144,14 @@ The current {1} is '{2}'.</source>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pl.xlf
@@ -144,6 +144,14 @@ Bieżący element {1}: „{2}”.</target>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.pt-BR.xlf
@@ -144,6 +144,14 @@ O {1} atual é '{2}'.</target>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.ru.xlf
@@ -144,6 +144,14 @@ The current {1} is '{2}'.</source>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.tr.xlf
@@ -144,6 +144,14 @@ Geçerli {1}: '{2}'.</target>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hans.xlf
@@ -144,6 +144,14 @@ The current {1} is '{2}'.</source>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-run/xlf/LocalizableStrings.zh-Hant.xlf
@@ -144,6 +144,14 @@ The current {1} is '{2}'.</source>
       <trans-unit id="FrameworkOptionDescription">
         <source>The target framework to run for. The target framework must also be specified in the project file.</source>
         <target state="new">The target framework to run for. The target framework must also be specified in the project file.</target>
+      <trans-unit id="CommandOptionCLRDescription">
+        <source>The execution runtime to run the .NET application with.</source>
+        <target state="new">The execution runtime to run the .NET application with.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CommandOptionCLRName">
+        <source>RUNTIME</source>
+        <target state="new">RUNTIME</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fixes #6043

Requires https://github.com/dotnet/sdk/pull/2260
