### PR TITLE
deploy microsoft.build.nugetsdkresolver assemblies next to nuget DLLs in CLI dir

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -45,6 +45,7 @@
     <NuGetPackagingPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetPackagingPackageVersion>
     <NuGetProjectModelPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetProjectModelPackageVersion>
     <NuGetVersioningPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetVersioningPackageVersion>
+    <MicrosoftBuildNuGetSdkResolverVersion>$(NuGetBuildTasksPackageVersion)</MicrosoftBuildNuGetSdkResolverVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0-preview-20180510-03</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -46,7 +46,6 @@
     <NuGetProjectModelPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetProjectModelPackageVersion>
     <NuGetVersioningPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetVersioningPackageVersion>
     <MicrosoftBuildNuGetSdkResolverVersion>$(NuGetBuildTasksPackageVersion)</MicrosoftBuildNuGetSdkResolverVersion>
-    <MicrosoftBuildFrameworkVersion>15.6.85</MicrosoftBuildFrameworkVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0-preview-20180510-03</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -46,6 +46,7 @@
     <NuGetProjectModelPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetProjectModelPackageVersion>
     <NuGetVersioningPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetVersioningPackageVersion>
     <MicrosoftBuildNuGetSdkResolverVersion>$(NuGetBuildTasksPackageVersion)</MicrosoftBuildNuGetSdkResolverVersion>
+    <MicrosoftBuildFrameworkVersion>15.6.85</MicrosoftBuildFrameworkVersion>
     <MicrosoftNETTestSdkPackageVersion>15.8.0-preview-20180510-03</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>

--- a/src/tool_nuget/tool_nuget.csproj
+++ b/src/tool_nuget/tool_nuget.csproj
@@ -10,5 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppPackageVersion)" />
     <PackageReference Include="NuGet.CommandLine.XPlat" Version="$(NuGetCommandLineXPlatPackageVersion)" />
+    <PackageReference Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverVersion)" />
   </ItemGroup>
 </Project>

--- a/src/tool_nuget/tool_nuget.csproj
+++ b/src/tool_nuget/tool_nuget.csproj
@@ -11,5 +11,6 @@
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppPackageVersion)" />
     <PackageReference Include="NuGet.CommandLine.XPlat" Version="$(NuGetCommandLineXPlatPackageVersion)" />
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverVersion)" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
   </ItemGroup>
 </Project>

--- a/src/tool_nuget/tool_nuget.csproj
+++ b/src/tool_nuget/tool_nuget.csproj
@@ -11,6 +11,5 @@
     <PackageReference Include="Microsoft.NETCore.App" Version="$(MicrosoftNETCoreAppPackageVersion)" />
     <PackageReference Include="NuGet.CommandLine.XPlat" Version="$(NuGetCommandLineXPlatPackageVersion)" />
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverVersion)" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
this PR deploys the resolver DLL next to NuGet DLLs as discussed on email.

CC: @AndyGerlicher @livarcocc 

My build fails locally, is there a way to see what the CI build is producing?