### PR TITLE
Don't add the ReleaseSuffix to the branding on the CLI

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -8,7 +8,8 @@
     <MajorMinorVersion>$(VersionMajor).$(VersionMinor)</MajorMinorVersion>
     <CliVersionNoSuffix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</CliVersionNoSuffix>
     <CliVersionPrefix>$(CliVersionNoSuffix)-$(ReleaseSuffix)</CliVersionPrefix>
-    <CliBrandingVersion>$(CliVersionNoSuffix) - $(ReleaseSuffix)</CliBrandingVersion>
+    <CliBrandingVersion Condition=" '$(DropSuffix)' != 'true' ">$(CliVersionNoSuffix) - $(ReleaseSuffix)</CliBrandingVersion>
+    <CliBrandingVersion Condition=" '$(DropSuffix)' == 'true' ">$(CliVersionNoSuffix)</CliBrandingVersion>
     <SimpleVersion Condition=" '$(DropSuffix)' != 'true' ">$(CliVersionNoSuffix).$(CommitCount)</SimpleVersion>
     <SimpleVersion Condition=" '$(SimpleVersion)' == '' ">$(CliVersionNoSuffix)</SimpleVersion>
 


### PR DESCRIPTION
Don't add the ReleaseSuffix to the branding on the CLI when DropSuffix is set to true.

Fixes https://github.com/dotnet/cli/issues/9328
