### PR TITLE
Fix relative path tool path

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/PathUtility.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/PathUtility.cs
@@ -119,6 +119,11 @@ namespace Microsoft.DotNet.Tools.Common
         /// </summary>
         public static string GetRelativePath(string path1, string path2)
         {
+            if (!Path.IsPathRooted(path1) || !Path.IsPathRooted(path2))
+            {
+                throw new ArgumentException("both paths need to be rooted/full path");
+            }
+
             return GetRelativePath(path1, path2, Path.DirectorySeparatorChar, true);
         }
 

--- a/src/dotnet/ShellShim/AppHostShimMaker.cs
+++ b/src/dotnet/ShellShim/AppHostShimMaker.cs
@@ -39,8 +39,8 @@ namespace Microsoft.DotNet.ShellShim
                 appHostSourcePath = Path.Combine(_appHostSourceDirectory, ApphostNameWithoutExtension);
             }
 
-            var appHostDestinationFilePath = shimPath.Value;
-            var appBinaryFilePath = PathUtility.GetRelativePath(appHostDestinationFilePath, entryPoint.Value);
+            var appHostDestinationFilePath = Path.GetFullPath(shimPath.Value);
+            var appBinaryFilePath = Path.GetRelativePath(Path.GetDirectoryName(appHostDestinationFilePath), Path.GetFullPath(entryPoint.Value));
 
             EmbedAppNameInHost.EmbedAndReturnModifiedAppHostPath(
                 appHostSourceFilePath: appHostSourcePath,


### PR DESCRIPTION
fix https://github.com/dotnet/cli/issues/9319

Replace PathUtility with new Path.GetRelativePath corefx api

Pass pull path to such api

--------------------

It would like to have a next step later that enforces DirectoryPath and FilePath always store full path. The problem I have is Path behaves differently in windows and mac. For example, /home means different thing in windows and unix. So if I store full path currently, a lot of test will fail. But I think it worth to do the proper fix to eliminate the whole class of bugs