### PR TITLE
Fix extraction of folders

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -628,7 +628,7 @@ extract_dotnet_package() {
     tar -xzf "$zip_path" -C "$temp_out_path" > /dev/null || failed=true
 
     local folders_with_version_regex='^.*/[0-9]+\.[0-9]+[^/]+/'
-    find "$temp_out_path" -type f | grep -Eo "$folders_with_version_regex" | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" false
+    find "$temp_out_path" -type f | grep -Eo "$folders_with_version_regex" | sort | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" false
     find "$temp_out_path" -type f | grep -Ev "$folders_with_version_regex" | copy_files_or_dirs_from_list "$temp_out_path" "$out_path" "$override_non_versioned_files"
 
     rm -rf "$temp_out_path"


### PR DESCRIPTION
## Steps to reproduce
- Create an Azure Container Instance Container with [this docker image](https://hub.docker.com/r/arodus/docker-jenkins-slave-mono/). (May also be reproducible with every other linux host, but didn't happen on local windows machine.) 
Set the environment variable `JENKINS_SLAVE_SSH_PUBKEY` to a valid ssh public key.
- Connect to the container via ssh.
- Download the [the dotnet install script](https://github.com/dotnet/cli/blob/master/scripts/obtain/dotnet-install.sh).
- Run `./dotnet-install.sh --install-dir test --version 2.1.300-rc1-008673 --no-path`
- Run `./temp/dotnet --version`

## Expected  behavior
The version of dotnet is printed to the console.

## Actual behavior
The execution fails with the message: 
`Found dotnet SDK, but did not find dotnet.dll at [temp/sdk/2.1.300-rc1-008673/dotnet.dll]`
The directory `temp/sdk/2.1.300-rc1-008673/` is empty besides the folder `DotNetTools`.

## Reason
It's possible that `find` returns the results in an order where the subdirectory is before the parent directory. As a result the parent folder already exists [when the override check happens](https://github.com/dotnet/cli/blob/master/scripts/obtain/dotnet-install.sh#L609) and the content of the directory won't get copied.

## Solution
Sorting the result of `find` to ensure the parent directory is always copied before its sub directories.








