### PR TITLE
Change configuration completion suggestion to standard capitalization

### DIFF
--- a/src/dotnet/CommonOptions.cs
+++ b/src/dotnet/CommonOptions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli
                 description,
                 Accept.ExactlyOneArgument()
                     .With(name: CommonLocalizableStrings.ConfigurationArgumentName)
-                    .WithSuggestionsFrom("DEBUG", "RELEASE")
+                    .WithSuggestionsFrom("Debug", "Release")
                     .ForwardAsSingle(o => $"-property:Configuration={o.Arguments.Single()}"));
 
         public static Option VersionSuffixOption() =>


### PR DESCRIPTION
Changes completion suggestions for `-c` to standard capitalisation to prevent against issues with case sensitivity.

Tentatively against 2.1.4xx, but should be a clean merge into master as well.