### PR TITLE
Always store absolute full path in directory and file path

### DIFF
--- a/src/Microsoft.DotNet.InternalAbstractions/DirectoryPath.cs
+++ b/src/Microsoft.DotNet.InternalAbstractions/DirectoryPath.cs
@@ -10,8 +10,17 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
     {
         public string Value { get; }
 
+        /// <summary>
+        /// Create DirectoryPath to repesent a absolute directory path. Note it may not exist.
+        /// </summary>
+        /// <param name="value">If the value is not rooted. Path.GetFullPath will be called during the consturctor.</param>
         public DirectoryPath(string value)
         {
+            if (!Path.IsPathRooted(value))
+            {
+                value = Path.GetFullPath(value);
+            }
+
             Value = value;
         }
 
@@ -46,7 +55,7 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
 
         public DirectoryPath GetParentPath()
         {
-            return new DirectoryPath(Directory.GetParent(Path.GetFullPath(Value)).FullName);
+            return new DirectoryPath(Path.GetDirectoryName(Path.GetFullPath(Value)));
         }
     }
 }

--- a/src/Microsoft.DotNet.InternalAbstractions/DirectoryPath.cs
+++ b/src/Microsoft.DotNet.InternalAbstractions/DirectoryPath.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
 
         public DirectoryPath GetParentPath()
         {
-            return new DirectoryPath(Path.GetDirectoryName(Path.GetFullPath(Value)));
+            return new DirectoryPath(Path.GetDirectoryName(Value));
         }
     }
 }

--- a/src/Microsoft.DotNet.InternalAbstractions/FilePath.cs
+++ b/src/Microsoft.DotNet.InternalAbstractions/FilePath.cs
@@ -9,8 +9,17 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
     {
         public string Value { get; }
 
+        /// <summary>
+        /// Create FilePath to repesent a absolute file path. Note it may not exist.
+        /// </summary>
+        /// <param name="value">If the value is not rooted. Path.GetFullPath will be called during the consturctor.</param>
         public FilePath(string value)
         {
+            if (!Path.IsPathRooted(value))
+            {
+                value = Path.GetFullPath(value);
+            }
+
             Value = value;
         }
 

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Mock/FileSystemMockBuilder.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Mock/FileSystemMockBuilder.cs
@@ -39,6 +39,17 @@ namespace Microsoft.Extensions.DependencyModel.Tests
             return this;
         }
 
+        /// <summary>
+        /// Just a "home" means different path on Windows and Unix.
+        /// Create a platform dependent Temporary directory path and use it to avoid further mis interpretation in
+        /// later tests. Like "c:/home vs /home". Instead always use Path.Combine(TempraryDirectory, "home")
+        /// </summary>
+        internal FileSystemMockBuilder UseCurrentSystemTemporaryDirectory()
+        {
+            TemporaryFolder = Path.GetTempPath();
+            return this;
+        }
+
         internal IFileSystem Build()
         {
             return new FileSystemMock(_files, TemporaryFolder);

--- a/test/dotnet.Tests/BuildServerTests/RazorServerTests.cs
+++ b/test/dotnet.Tests/BuildServerTests/RazorServerTests.cs
@@ -24,7 +24,6 @@ namespace Microsoft.DotNet.Tests.BuildServerTests
         public void GivenAFailedShutdownCommandItThrows()
         {
             const int ProcessId = 1234;
-            const string ServerPath = "path/to/rzc.dll";
             const string PipeName = "some-pipe-name";
             const string ErrorMessage = "error!";
 
@@ -33,17 +32,20 @@ namespace Microsoft.DotNet.Tests.BuildServerTests
 
             var fileSystemMock = new FileSystemMockBuilder()
                 .AddFile(pidFilePath, "")
+                .UseCurrentSystemTemporaryDirectory()
                 .Build();
 
             fileSystemMock.File.Exists(pidFilePath).Should().BeTrue();
+
+            var serverPath = Path.Combine(fileSystemMock.Directory.CreateTemporaryDirectory().DirectoryPath, "path/to/rzc.dll");
 
             var server = new RazorServer(
                 pidFile: new RazorPidFile(
                     path: new FilePath(pidFilePath),
                     processId: ProcessId,
-                    serverPath: new FilePath(ServerPath),
+                    serverPath: new FilePath(serverPath),
                     pipeName: PipeName),
-                commandFactory: CreateCommandFactoryMock(ServerPath, PipeName, exitCode: 1, stdErr: ErrorMessage).Object,
+                commandFactory: CreateCommandFactoryMock(serverPath, PipeName, exitCode: 1, stdErr: ErrorMessage).Object,
                 fileSystem: fileSystemMock);
 
             Action a = () => server.Shutdown();
@@ -60,7 +62,6 @@ namespace Microsoft.DotNet.Tests.BuildServerTests
         public void GivenASuccessfulShutdownItDoesNotThrow()
         {
             const int ProcessId = 1234;
-            const string ServerPath = "path/to/rzc.dll";
             const string PipeName = "some-pipe-name";
 
             string pidDirectory = Path.GetFullPath("var/pids/build");
@@ -68,17 +69,20 @@ namespace Microsoft.DotNet.Tests.BuildServerTests
 
             var fileSystemMock = new FileSystemMockBuilder()
                 .AddFile(pidFilePath, "")
+                .UseCurrentSystemTemporaryDirectory()
                 .Build();
 
             fileSystemMock.File.Exists(pidFilePath).Should().BeTrue();
+
+            var serverPath = Path.Combine(fileSystemMock.Directory.CreateTemporaryDirectory().DirectoryPath, "path/to/rzc.dll");
 
             var server = new RazorServer(
                 pidFile: new RazorPidFile(
                     path: new FilePath(pidFilePath),
                     processId: ProcessId,
-                    serverPath: new FilePath(ServerPath),
+                    serverPath: new FilePath(serverPath),
                     pipeName: PipeName),
-                commandFactory: CreateCommandFactoryMock(ServerPath, PipeName).Object,
+                commandFactory: CreateCommandFactoryMock(serverPath, PipeName).Object,
                 fileSystem: fileSystemMock);
 
             server.Shutdown();

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -35,24 +35,28 @@ namespace Microsoft.DotNet.Tests.Commands
         private readonly AppliedOption _appliedCommand;
         private readonly ParseResult _parseResult;
         private readonly BufferedReporter _reporter;
-        private const string PathToPlaceShim = "pathToPlace";
-        private const string PathToPlacePackages = PathToPlaceShim + "pkg";
+        private readonly string _temporaryDirectory;
+        private readonly string _pathToPlaceShim;
+        private readonly string _pathToPlacePackages;
         private const string PackageId = "global.tool.console.demo";
         private const string PackageVersion = "1.0.4";
 
         public ToolInstallCommandTests()
         {
             _reporter = new BufferedReporter();
-            _fileSystem = new FileSystemMockBuilder().Build();
-            _toolPackageStore = new ToolPackageStoreMock(new DirectoryPath(PathToPlacePackages), _fileSystem);
+            _fileSystem = new FileSystemMockBuilder().UseCurrentSystemTemporaryDirectory().Build();
+            _temporaryDirectory =  _fileSystem.Directory.CreateTemporaryDirectory().DirectoryPath;
+            _pathToPlaceShim = Path.Combine(_temporaryDirectory, "pathToPlace");
+            _pathToPlacePackages = _pathToPlaceShim + "Packages";
+            _toolPackageStore = new ToolPackageStoreMock(new DirectoryPath(_pathToPlacePackages), _fileSystem);
             _createShellShimRepository =
                 (nonGlobalLocation) => new ShellShimRepository(
-                    new DirectoryPath(PathToPlaceShim),
+                    new DirectoryPath(_pathToPlaceShim),
                     fileSystem: _fileSystem,
                     appHostShellShimMaker: new AppHostShellShimMakerMock(_fileSystem),
                     filePermissionSetter: new NoOpFilePermissionSetter());
             _environmentPathInstructionMock =
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim);
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim);
             _createToolPackageStoreAndInstaller = (_) => (_toolPackageStore, CreateToolPackageInstaller());
 
             ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {PackageId}");
@@ -197,7 +201,7 @@ namespace Microsoft.DotNet.Tests.Commands
                     Environment.NewLine +
                     string.Format(LocalizableStrings.ToolInstallationFailedWithRestoreGuidance, PackageId));
 
-            _fileSystem.Directory.Exists(Path.Combine(PathToPlacePackages, PackageId)).Should().BeFalse();
+            _fileSystem.Directory.Exists(Path.Combine(_pathToPlacePackages, PackageId)).Should().BeFalse();
         }
 
         [Fact]
@@ -220,7 +224,7 @@ namespace Microsoft.DotNet.Tests.Commands
                     CommonLocalizableStrings.ShellShimConflict,
                     ProjectRestorerMock.FakeCommandName));
 
-            _fileSystem.Directory.Exists(Path.Combine(PathToPlacePackages, PackageId)).Should().BeFalse();
+            _fileSystem.Directory.Exists(Path.Combine(_pathToPlacePackages, PackageId)).Should().BeFalse();
         }
 
         [Fact]
@@ -257,7 +261,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 _parseResult,
                 _createToolPackageStoreAndInstaller,
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim, true),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
                 _reporter);
 
             installCommand.Execute().Should().Be(0);
@@ -284,7 +288,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 result,
                 _createToolPackageStoreAndInstaller,
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim, true),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
                 _reporter);
 
             Action action = () => installCommand.Execute();
@@ -307,7 +311,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 result,
                 _createToolPackageStoreAndInstaller,
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim, true),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
                 _reporter);
 
             installCommand.Execute().Should().Be(0);
@@ -333,7 +337,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 result,
                 _createToolPackageStoreAndInstaller,
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim, true),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
                 _reporter);
 
             installCommand.Execute().Should().Be(0);
@@ -359,7 +363,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 result,
                 _createToolPackageStoreAndInstaller,
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim, true),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
                 _reporter);
 
             Action a = () => installCommand.Execute();
@@ -369,7 +373,7 @@ namespace Microsoft.DotNet.Tests.Commands
                     LocalizableStrings.ToolInstallationRestoreFailed +
                     Environment.NewLine + string.Format(LocalizableStrings.ToolInstallationFailedWithRestoreGuidance, PackageId));
 
-            _fileSystem.Directory.Exists(Path.Combine(PathToPlacePackages, PackageId)).Should().BeFalse();
+            _fileSystem.Directory.Exists(Path.Combine(_pathToPlacePackages, PackageId)).Should().BeFalse();
         }
 
          [Fact]
@@ -383,7 +387,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 result,
                 _createToolPackageStoreAndInstaller,
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim, true),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
                 _reporter);
 
             installCommand.Execute().Should().Be(0);
@@ -411,7 +415,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 parseResult,
                 _createToolPackageStoreAndInstaller,
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim, true),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
                 _reporter);
 
             Action a = () => installCommand.Execute();
@@ -433,7 +437,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 parseResult,
                 _createToolPackageStoreAndInstaller,
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim, true),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim, true),
                 _reporter);
 
             Action a = () => installCommand.Execute();
@@ -454,7 +458,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 parseResult,
                 _createToolPackageStoreAndInstaller,
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim),
                 _reporter);
 
             installCommand.Execute().Should().Be(0);
@@ -466,7 +470,7 @@ namespace Microsoft.DotNet.Tests.Commands
         public void AndPackagedShimIsProvidedWhenRunWithPackageIdItCreateShimUsingPackagedShim()
         {
             var extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty;
-            var prepackagedShimPath = "packagedShimDirectory/" + ProjectRestorerMock.FakeCommandName + extension;
+            var prepackagedShimPath = Path.Combine (_temporaryDirectory, ProjectRestorerMock.FakeCommandName + extension);
             var tokenToIdentifyPackagedShim = "packagedShim";
             _fileSystem.File.WriteAllText(prepackagedShimPath, tokenToIdentifyPackagedShim);
 
@@ -490,7 +494,7 @@ namespace Microsoft.DotNet.Tests.Commands
                         fileSystem: _fileSystem,
                         reporter: _reporter))),
                 _createShellShimRepository,
-                new EnvironmentPathInstructionMock(_reporter, PathToPlaceShim),
+                new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim),
                 _reporter);
 
             installCommand.Execute().Should().Be(0);
@@ -512,11 +516,11 @@ namespace Microsoft.DotNet.Tests.Commands
                 installCallback: installCallback);
         }
 
-        private static string ExpectedCommandPath()
+        private string ExpectedCommandPath()
         {
             var extension = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ".exe" : string.Empty;
             return Path.Combine(
-                "pathToPlace",
+                _pathToPlaceShim,
                 ProjectRestorerMock.FakeCommandName + extension);
         }
 


### PR DESCRIPTION
There is no need to store relative path today. But some part of the system does not accept relative path and there is no indication if it is storing full path or not. This is the root cause of https://github.com/dotnet/cli/issues/9319

“someplace” means different full path for Path class on unix and Windows. And the mock file system uses real Path class. Change tests' setup to use essentially “TEMPATH/someplace” instead of  “someplace”

