### PR TITLE
Simplified combining dictionaries in Telemetry

### DIFF
--- a/src/dotnet/Telemetry/Telemetry.cs
+++ b/src/dotnet/Telemetry/Telemetry.cs
@@ -141,14 +141,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
             {
                 foreach (KeyValuePair<string, double> measurement in measurements)
                 {
-                    if (eventMeasurements.ContainsKey(measurement.Key))
-                    {
-                        eventMeasurements[measurement.Key] = measurement.Value;
-                    }
-                    else
-                    {
-                        eventMeasurements.Add(measurement.Key, measurement.Value);
-                    }
+                    eventMeasurements[measurement.Key] = measurement.Value;
                 }
             }
             return eventMeasurements;
@@ -161,14 +154,7 @@ namespace Microsoft.DotNet.Cli.Telemetry
                 var eventProperties = new Dictionary<string, string>(_commonProperties);
                 foreach (KeyValuePair<string, string> property in properties)
                 {
-                    if (eventProperties.ContainsKey(property.Key))
-                    {
-                        eventProperties[property.Key] = property.Value;
-                    }
-                    else
-                    {
-                        eventProperties.Add(property.Key, property.Value);
-                    }
+                    eventProperties[property.Key] = property.Value;
                 }
                 return eventProperties;
             }


### PR DESCRIPTION
[According to the documentation](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.item?view=netcore-2.1#remarks), when a key does not exist in the dictionary, using the indexer setter will add a new element to the dictionary. This means the indexer can be used here for both cases, making the code simpler.