### PR TITLE
Clear disabled package sources in generated NuGet.config

### DIFF
--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -32,6 +32,9 @@
       <NugetConfigSuffix>
         <![CDATA[
 </packageSources>
+<disabledPackageSources>
+   <clear/>
+</disabledPackageSources>
 </configuration>
         ]]>
       </NugetConfigSuffix>


### PR DESCRIPTION
This will help prevent the repo being broken if you have the same feeds set up in your global NuGet.config but have them disabled