### PR TITLE
MSBuild 15.8.78 (4xx)

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -5,7 +5,7 @@
     <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0-rtm-26515-03</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.8.0-preview-000061</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.8.0-preview-000078</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>


### PR DESCRIPTION
MSBuild 15.8.78

PR #9279 accidentally clobbered a fix for Microsoft/msbuild#3346 pulled in with #3317.

This version of MSBuild is in VS d15.8stg now.

@livarcocc : @YunWeiaa found this failed on master, but it should be failing on 4xx, too. Do you want the change merged to both (here to 4xx, #9398 to master) or just let codeflow take it from here to master?