### PR TITLE
Fix alpine file ownership issues with newer docker

### DIFF
--- a/scripts/docker/alpine.3.6/Dockerfile
+++ b/scripts/docker/alpine.3.6/Dockerfile
@@ -9,6 +9,15 @@ FROM microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156
 # This Dockerfile doesn't use the USER_ID, but the parameter needs to be declared to prevent docker
 # from issuing a warning
 ARG USER_ID=0
+RUN adduser code_executor -u ${USER_ID} -G root -D
+RUN echo 'code_executor ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# With the User Change, we need to change permssions on these directories
+RUN chmod -R a+rwx /usr/local
+RUN chmod -R a+rwx /home
+
+# Set user to the one we just created
+USER ${USER_ID}
 
 # Set working directory
 WORKDIR /opt/code


### PR DESCRIPTION
Upgrades to a newer docker version (18.03.1-ce) caused files created inside to be owned by root on alpine.  It appears that the logic to set up the user in the container so that this doesn't happen was missing from alpine.  While it's not clear why it worked before at all, the logic has been duplicated (tweaked for the alpine base image).
