### PR TITLE
Testplatform 15.8.0-preview-20180605-02

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -46,7 +46,7 @@
     <NuGetProjectModelPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetProjectModelPackageVersion>
     <NuGetVersioningPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetVersioningPackageVersion>
     <NuGetSdkResolverPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetSdkResolverPackageVersion>
-    <MicrosoftNETTestSdkPackageVersion>15.8.0-preview-20180510-03</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>15.8.0-preview-20180605-02</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>
     <XliffTasksPackageVersion>0.2.0-beta-000042</XliffTasksPackageVersion>


### PR DESCRIPTION
Inserting Testplatform 15.8.0-preview-20180605-02 package in dotnet cli

This has already been inserted in VS [15.8.0-preview-20180605-02 Insertion PR](https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/126257?_a=overview)
Here are the [Release Notes](https://github.com/Microsoft/vstest-docs/blob/master/docs/releases.md#1580-preview-20180605-02)

Please push these changes at the earliest.
