### PR TITLE
Add flag to skip download from the CDN, and support installing from a local file share

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -648,6 +648,11 @@ download() {
     local remote_path="$1"
     local out_path="${2:-}"
 
+    if [[ "$remote_path" != "http"* ]]; then
+        cp "$remote_path" "$out_path"
+        return $?
+    fi
+
     local failed=false
     if machine_has "curl"; then
         downloadcurl "$remote_path" "$out_path" || failed=true
@@ -811,6 +816,7 @@ install_dir="<auto>"
 architecture="<auto>"
 dry_run=false
 no_path=false
+no_cdn=false
 azure_feed="https://dotnetcli.azureedge.net/dotnet"
 uncached_feed="https://dotnetcli.blob.core.windows.net/dotnet"
 feed_credential=""
@@ -861,6 +867,9 @@ do
             ;;
         --verbose|-[Vv]erbose)
             verbose=true
+            ;;
+        --no-cdn|-[Nn]o[Cc]dn)
+            no_cdn=true
             ;;
         --azure-feed|-[Aa]zure[Ff]eed)
             shift
@@ -924,6 +933,7 @@ do
             echo "  --verbose,-Verbose                 Display diagnostics information."
             echo "  --azure-feed,-AzureFeed            Azure feed location. Defaults to $azure_feed, This parameter typically is not changed by the user."
             echo "  --uncached-feed,-UncachedFeed      Uncached feed location. This parameter typically is not changed by the user."
+            echo "  --no-cdn,-NoCdn                    Disable downloading from the Azure CDN, and use the uncached feed directly."
             echo "  --feed-credential,-FeedCredential  Azure feed shared access token. This parameter typically is not specified."
             echo "  --runtime-id                       Installs the .NET Tools for the given platform (use linux-x64 for portable linux)."
             echo "      -RuntimeId"
@@ -948,6 +958,10 @@ do
 
     shift
 done
+
+if [ "$no_cdn" = true ]; then
+    azure_feed="$uncached_feed"
+fi
 
 check_min_reqs
 calculate_vars


### PR DESCRIPTION
Adding two improvements from changes we made to the script to support building/testing aspnetcore.

* Support for installing from a local file share. This let's us test `dotnet-install.sh/ps1` when building the aspnetcore shared framework without needing to first upload it to a remote blob store
* Add `-Nocdn` to disable fetching from `dotnetcli.azureedge.net`. (workaround for https://github.com/dotnet/cli/issues/9143)