### PR TITLE
Remove xml encoding

### DIFF
--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             {
                 "--runtime",
                 AnyRid,
-                $"-property:BaseIntermediateOutputPath={assetJsonOutput.ToXmlEncodeString()}"
+                $"-property:BaseIntermediateOutputPath={assetJsonOutput.Value}"
             });
 
             argsToPassToRestore.Add($"-verbosity:{verbosity ?? "quiet"}");

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -617,7 +617,9 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            string nonAscii = "ab Ṱ̺̺̕o 田中さん åä";
+            var surrogate = Char.ConvertFromUtf32(Int32.Parse("0301", NumberStyles.HexNumber));
+            string nonAscii = "ab Ṱ̺̺̕o 田中さん åä" + surrogate;
+
             var root = new DirectoryPath(Path.Combine(TempRoot.Root, nonAscii, Path.GetRandomFileName()));
             var reporter = new BufferedReporter();
             var fileSystem = new FileSystemWrapper();
@@ -635,6 +637,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 nugetConfig: nugetConfigPath);
 
             AssertPackageInstall(reporter, fileSystem, package, store);
+            Char.IsSurrogate(surrogate).Should().BeTrue();
 
             package.Uninstall();
         }

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -606,6 +606,33 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             reporter.Lines.Should().Contain(l => l.Contains("warning"));
             reporter.Lines.Should().NotContain(l => l.Contains(tempProject.Value));
             reporter.Lines.Clear();
+
+            AssertPackageInstall(reporter, fileSystem, package, store);
+
+            package.Uninstall();
+        }
+
+        [Fact]
+        public void GivenARootWithNonAsciiCharactorInstallSucceeds()
+        {
+            var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
+
+            string nonAscii = "ab Ṱ̺̺̕o 田中さん åä";
+            var root = new DirectoryPath(Path.Combine(TempRoot.Root, nonAscii, Path.GetRandomFileName()));
+            var reporter = new BufferedReporter();
+            var fileSystem = new FileSystemWrapper();
+            var store = new ToolPackageStore(root);
+            var installer = new ToolPackageInstaller(
+                store: store,
+                projectRestorer: new ProjectRestorer(reporter),
+                tempProject: GetUniqueTempProjectPathEachTest(),
+                offlineFeed: new DirectoryPath("does not exist"));
+
+            var package = installer.InstallPackage(
+                packageId: TestPackageId,
+                versionRange: VersionRange.Parse(TestPackageVersion),
+                targetFramework: _testTargetframework,
+                nugetConfig: nugetConfigPath);
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 


### PR DESCRIPTION
fix https://github.com/dotnet/cli/issues/9413
Rely on CommandSpecFactory for the quoting

This fix can resolve the problem when the user has Non ASCII character in their $HOME directory. However, it will **not** resolve all the case when there is control character in folder name like “alexander, the great”. It will keep the “same level” with `dotnet build -o` which should be acceptable. Please see the detail in the issue. Since this goes to 2.1.3xx. I try to keep the change minimal. The existing escaping is far from ideal. I hope to keep investigating into this issue and find a general solution for 2.1.4xx.