### PR TITLE
Add a restore and add pkg commands interactive flag

### DIFF
--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
@@ -49,7 +49,9 @@ namespace Microsoft.DotNet.Cli
                                     .With(name: LocalizableStrings.CmdPackageDirectory)
                                     .ForwardAsSingle(o => $"--package-directory {o.Arguments.Single()}")),
                 Create.Option("--interactive",
-                              LocalizableStrings.CmdInteractiveRestoreDescription));
+                              LocalizableStrings.CmdInteractiveRestoreDescription,
+                              Accept.NoArguments()
+                                    .ForwardAs("--interactive")));
         }
 
         public static IEnumerable<string> QueryNuGet(string match)

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/AddPackageParser.cs
@@ -47,7 +47,9 @@ namespace Microsoft.DotNet.Cli
                               LocalizableStrings.CmdPackageDirectoryDescription,
                               Accept.ExactlyOneArgument()
                                     .With(name: LocalizableStrings.CmdPackageDirectory)
-                                    .ForwardAsSingle(o => $"--package-directory {o.Arguments.Single()}")));
+                                    .ForwardAsSingle(o => $"--package-directory {o.Arguments.Single()}")),
+                Create.Option("--interactive",
+                              LocalizableStrings.CmdInteractiveRestoreDescription));
         }
 
         public static IEnumerable<string> QueryNuGet(string match)

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
@@ -165,4 +165,7 @@
   <data name="CmdDGFileIOException" xml:space="preserve">
     <value>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</value>
   </data>
+  <data name="CmdInteractiveRestoreDescription" xml:space="preserve">
+    <value>Allow the command to block and require manual action to proceed.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
@@ -166,6 +166,6 @@
     <value>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</value>
   </data>
   <data name="CmdInteractiveRestoreDescription" xml:space="preserve">
-    <value>Allows the command to stop and wait for user input or action (for example to complete authentication)</value>
+    <value>Allows the command to stop and wait for user input or action (for example to complete authentication).</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/LocalizableStrings.resx
@@ -166,6 +166,6 @@
     <value>Unable to generate a temporary file for project '{0}'. Cannot add package reference. Please clear the temp directory and try again.</value>
   </data>
   <data name="CmdInteractiveRestoreDescription" xml:space="preserve">
-    <value>Allow the command to block and require manual action to proceed.</value>
+    <value>Allows the command to stop and wait for user input or action (for example to complete authentication)</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Nejde generovat dočasný soubor pro projekt {0}. Není možné přidat odkaz na balíček. Vyprázdněte prosím dočasný adresář a zkuste to znovu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.cs.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Für das Projekt "{0}" kann keine temporäre Datei generiert werden. Ein Paketverweis kann nicht hinzugefügt werden. Löschen Sie das temporäre Verzeichnis, und versuchen Sie es noch mal.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.de.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">No se puede generar un archivo temporal para el proyecto "{0}". No se puede agregar la referencia del paquete. Borre el directorio temporal e inténtelo de nuevo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.es.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Impossible de générer un fichier temporaire pour le projet '{0}'. Impossible d'ajouter une référence de package. Effacez le répertoire temporaire et réessayez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Non è possibile generare un file temporaneo per il progetto '{0}'. Non è possibile aggiungere il riferimento al pacchetto. Cancellare la directory temp e riprovare.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.it.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">プロジェクト '{0}' の一時ファイルを生成できません。パッケージ参照を追加できません。一時ディレクトリをクリアして、もう一度お試しください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ja.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">'{0}' 프로젝트에 대한 임시 파일을 생성할 수 없습니다. 패키지 참조를 추가할 수 없습니다. 임시 디렉터리를 지우고 다시 시도하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ko.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Nie można wygenerować pliku tymczasowego dla projektu „{0}”. Nie można dodać odwołania do pakietu. Wyczyść katalog tymczasowy i spróbuj ponownie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Não é possível gerar um arquivo temporário para o projeto '{0}'. Não é possível adicionar a referência do pacote. Limpe i diretório temporário e tente novamente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Не удалось создать временный файл для проекта "{0}". Невозможно добавить ссылку на пакет. Очистите временный каталог и повторите попытку.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.ru.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">'{0}' projesi için bir geçici dosya oluşturulamıyor. Paket başvurusu eklenemiyor. Lütfen geçici dizini temizleyin ve yeniden deneyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.tr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">未能为项目“{0}”生成临时文件。无法添加包引用。请清除临时目录，再重试。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">無法產生專案 '{0}' 的暫存檔案。無法新增套件參考。請清除暫存目錄並再試一次。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreDescription">
+        <source>Allow the command to block and require manual action to proceed.</source>
+        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allow the command to block and require manual action to proceed.</source>
-        <target state="new">Allow the command to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-add/dotnet-add-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-nuget/Program.cs
+++ b/src/dotnet/commands/dotnet-nuget/Program.cs
@@ -35,9 +35,14 @@ namespace Microsoft.DotNet.Tools.NuGet
             public int Run(string[] args)
             {
                 var nugetApp = new NuGetForwardingApp(args);
-
+                nugetApp.WithEnvironmentVariable("DOTNET_HOST_PATH", GetDotnetPath());
                 return nugetApp.Execute();
             }
+        }
+
+        private static string GetDotnetPath()
+        {
+            return new Muxer().MuxerPath;
         }
     }
 }

--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
@@ -169,4 +169,7 @@
     <value>Force all dependencies to be resolved even if the last restore was successful.
 This is equivalent to deleting project.assets.json.</value>
   </data>
+  <data name="CmdInteractiveRestoreOptionDescription" xml:space="preserve">
+    <value>Allow restore to block and require manual action to proceed.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
@@ -170,6 +170,6 @@
 This is equivalent to deleting project.assets.json.</value>
   </data>
   <data name="CmdInteractiveRestoreOptionDescription" xml:space="preserve">
-    <value>Allow restore to block and require manual action to proceed.</value>
+    <value>Allows the command to stop and wait for user input or action (for example to complete authentication)</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
@@ -170,6 +170,6 @@
 This is equivalent to deleting project.assets.json.</value>
   </data>
   <data name="CmdInteractiveRestoreOptionDescription" xml:space="preserve">
-    <value>Allows the command to stop and wait for user input or action (for example to complete authentication)</value>
+    <value>Allows the command to stop and wait for user input or action (for example to complete authentication).</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -24,7 +24,14 @@ namespace Microsoft.DotNet.Cli
         {
             var fullRestoreOptions = AddImplicitRestoreOptions(new Option[] { CommonOptions.HelpOption() }, true, true);
 
-            return fullRestoreOptions.Concat(new Option[] { CommonOptions.VerbosityOption() }).ToArray();
+            return fullRestoreOptions.Concat(
+                new Option[] {
+                    CommonOptions.VerbosityOption(),
+                    Create.Option(
+                        "--interactive",
+                        LocalizableStrings.CmdInteractiveRestoreOptionDescription,
+                        Accept.NoArguments()
+                              .ForwardAs("-property:NuGetInteractive=true")) }).ToArray();
         }
 
         public static Option[] AddImplicitRestoreOptions(
@@ -94,12 +101,7 @@ namespace Microsoft.DotNet.Cli
                     useShortOptions ? "-f|--force" : "--force",
                     LocalizableStrings.CmdForceRestoreOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("-property:RestoreForce=true")),
-                 Create.Option(
-                    "--interactive",
-                    showHelp ? LocalizableStrings.CmdInteractiveRestoreOptionDescription : string.Empty,
-                    Accept.NoArguments()
-                          .ForwardAs("-property:NuGetInteractive=true"))
+                          .ForwardAs("-property:RestoreForce=true"))
             };
         }
     }

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -94,7 +94,12 @@ namespace Microsoft.DotNet.Cli
                     useShortOptions ? "-f|--force" : "--force",
                     LocalizableStrings.CmdForceRestoreOptionDescription,
                     Accept.NoArguments()
-                          .ForwardAs("-property:RestoreForce=true"))
+                          .ForwardAs("-property:RestoreForce=true")),
+                 Create.Option(
+                    "--interactive",
+                    showHelp ? LocalizableStrings.CmdInteractiveRestoreOptionDescription : string.Empty,
+                    Accept.NoArguments()
+                          .ForwardAs("-property:NuGetInteractive=true"))
             };
         }
     }

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">Tento příznak nastavte, pokud chcete vynutit vyřešení všech závislostí, i když poslední obnovení proběhlo úspěšně. Jedná se o ekvivalent odstranění project.assets.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">Legen Sie dieses Flag fest, damit alle Abhängigkeiten aufgelöst werden, auch wenn die letzte Wiederherstellung erfolgreich war. Dies entspricht dem Löschen von "project.assets.json".</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">Establezca este indicador para forzar la resolución de todas las dependencias aunque la última restauración se haya realizado correctamente. Esta acción es equivalente a eliminar project.assets.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">Définissez cet indicateur pour forcer la résolution de toutes les dépendances même si la dernière restauration a réussi. Cela équivaut à supprimer project.assets.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">Impostare questo flag per forzare la risoluzione di tutte le dipendenze anche se l'ultimo ripristino è riuscito. Equivale a eliminare project.assets.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">このフラグを設定すると、最後に行われた復元が成功した場合でも強制的にすべての依存関係を解決します。これは、project.assets.json を削除することと同じです。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">마지막 복원이 성공적인 경우에도 이 플래그를 설정하여 모든 종속성을 확인합니다. project.assets.json을 삭제하는 것과 동일합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">Ustaw tę flagę, aby wymusić rozstrzygnięcie wszystkich zależności nawet w przypadku, gdy ostatnie przywracanie się powiodło. Jest to równoważne usunięciu pliku project.assets.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">Defina este sinalizador para forçar todas as dependências a serem resolvidas, mesmo que a última restauração tenha tido êxito. Isso equivale a excluir o project.assets.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">Задайте этот флаг, чтобы принудительно разрешать все зависимости даже в случае успеха последнего восстановления. Это эквивалентно удалению project.assets.json.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">Son geri yükleme başarılı olsa bile tüm bağımlılıkların çözümlenmesini zorlamak için bu bayrağı ayarlayın. Bu, project.assets.json öğesini silmeyle eşdeğerdir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">设置此标志以强制解析所有依赖项，即使最后一次还原已经成功。这等效于删除 project.assets.json。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
-        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -89,8 +89,8 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdInteractiveRestoreOptionDescription">
-        <source>Allow restore to block and require manual action to proceed.</source>
-        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <source>Allows the command to stop and wait for user input or action (for example to complete authentication)</source>
+        <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication)</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -88,6 +88,11 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="needs-review-translation">設定此旗標可在即使上次還原已成功的情況下，仍然強制解決所有相依性。如此等同於刪除 project.assets.json。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdInteractiveRestoreOptionDescription">
+        <source>Allow restore to block and require manual action to proceed.</source>
+        <target state="new">Allow restore to block and require manual action to proceed.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
This change is dependent on https://github.com/NuGet/NuGet.Client/pull/2288. 
Ideally it should be merged when an insertion that contains the above PR happens. 

Fixes https://github.com/NuGet/Home/issues/7017

Part of https://github.com/NuGet/Home/issues/6642. 

Per https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin, we agreed to use the
`--interactive` option in the dotnet restore and add package ref commands to allow the action to be blocked. 

Let me know if I should be targetting a different branch. The change should make it 2.1.4xx in the end. 

//cc
@livarcocc @nguerrera @dsplaisted @peterhuene @wli3 