### PR TITLE
MSBuild 15.8.101

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -11,7 +11,7 @@
     <DotnetWatchPackageVersion>2.1.0</DotnetWatchPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.1.0</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>$(MicrosoftNETCoreAppPackageVersion)</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>15.8.0-preview-000086</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>15.8.0-preview-000101</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>


### PR DESCRIPTION
This would be in favor of #9468, but I left the old one open since it seemed to have issues that I'm not clear of the cause yet.

This insertion contains https://github.com/Microsoft/msbuild/pull/3376 which revs the version of `System.Collections.Immutable` and `System.Reflection.Metadata` to `1.5.0` and `1.6.0`. This is part of a large coordinated change for all of VS.