### PR TITLE
Test and automatic Update default package version

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -132,6 +132,13 @@
       <_NETCoreSdkIsPreview Condition=" '$(DropSuffix)' != 'true' ">true</_NETCoreSdkIsPreview>
     </PropertyGroup>
 
+
+    <GetUseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion
+      BundledNETCoreAppPackageVersion="$(BundledNETCoreAppPackageVersion)">
+      <Output TaskParameter="UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion"
+              PropertyName="_UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion" />
+    </GetUseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>
+
     <ItemGroup>
       <BundledVersionsVariable Include="BundledAspNetCoreAllTargetFrameworkVersion" Value="$(_AspNetCoreAllTargetFrameworkVersion)" />
       <BundledVersionsVariable Include="BundledAspNetCoreAllPackageVersion" Value="$(_AspNetCoreAllPackageVersion)" />
@@ -180,6 +187,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Default patch versions for each minor version of ASP.NET Core -->
     <DefaultPatchVersionForAspNetCoreAll2_1>$(_DefaultPatchVersionForAspNetCoreAll2_1)</DefaultPatchVersionForAspNetCoreAll2_1>
     <DefaultPatchVersionForAspNetCoreApp2_1>$(_DefaultPatchVersionForAspNetCoreApp2_1)</DefaultPatchVersionForAspNetCoreApp2_1>
+    <UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>$(_UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion)</UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>
 
     <!-- Latest patch versions for each minor version of .NET Core -->
     <LatestPatchVersionForNetCore1_0 Condition="'$(LatestPatchVersionForNetCore1_0)' == ''">1.0.11</LatestPatchVersionForNetCore1_0>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -193,8 +193,8 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultPatchVersionForAspNetCoreApp2_1>$(_DefaultPatchVersionForAspNetCoreApp2_1)</DefaultPatchVersionForAspNetCoreApp2_1>
 
     <!-- Latest patch versions for each minor version of .NET Core -->
-    <LatestPatchVersionForNetCore1_0 Condition="'%24(LatestPatchVersionForNetCore1_0)' == ''">1.0.11</LatestPatchVersionForNetCore1_0>
-    <LatestPatchVersionForNetCore1_1 Condition="'%24(LatestPatchVersionForNetCore1_1)' == ''">1.1.8</LatestPatchVersionForNetCore1_1>
+    <LatestPatchVersionForNetCore1_0 Condition="'%24(LatestPatchVersionForNetCore1_0)' == ''">1.0.12</LatestPatchVersionForNetCore1_0>
+    <LatestPatchVersionForNetCore1_1 Condition="'%24(LatestPatchVersionForNetCore1_1)' == ''">1.1.9</LatestPatchVersionForNetCore1_1>
     <LatestPatchVersionForNetCore2_0 Condition="'%24(LatestPatchVersionForNetCore2_0)' == ''">2.0.9</LatestPatchVersionForNetCore2_0>
   </PropertyGroup>
 </Project>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -132,7 +132,10 @@
       <_NETCoreSdkIsPreview Condition=" '$(DropSuffix)' != 'true' ">true</_NETCoreSdkIsPreview>
     </PropertyGroup>
 
-
+    <!--
+        Setting the property to true if patch == 0 and preview == true. SDK will set DefaultNetCorePatchVersion according to this flag.
+        So that we don't need to manually update the version selection logic between when we ship a final release and when we ship the first patch
+      -->
     <GetUseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion
       BundledNETCoreAppPackageVersion="$(BundledNETCoreAppPackageVersion)">
       <Output TaskParameter="UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion"
@@ -177,6 +180,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   <PropertyGroup>
     <BundledNETCoreAppTargetFrameworkVersion>$(_NETCoreAppTargetFrameworkVersion)</BundledNETCoreAppTargetFrameworkVersion>
     <BundledNETCoreAppPackageVersion>$(_NETCoreAppPackageVersion)</BundledNETCoreAppPackageVersion>
+    <UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>$(_UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion)</UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>
     <BundledNETStandardTargetFrameworkVersion>$(_NETStandardTargetFrameworkVersion)</BundledNETStandardTargetFrameworkVersion>
     <BundledNETStandardPackageVersion>$(_NETStandardLibraryPackageVersion)</BundledNETStandardPackageVersion>
     <BundledNETCorePlatformsPackageVersion>$(_NETCorePlatformsPackageVersion)</BundledNETCorePlatformsPackageVersion>
@@ -187,7 +191,6 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Default patch versions for each minor version of ASP.NET Core -->
     <DefaultPatchVersionForAspNetCoreAll2_1>$(_DefaultPatchVersionForAspNetCoreAll2_1)</DefaultPatchVersionForAspNetCoreAll2_1>
     <DefaultPatchVersionForAspNetCoreApp2_1>$(_DefaultPatchVersionForAspNetCoreApp2_1)</DefaultPatchVersionForAspNetCoreApp2_1>
-    <UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>$(_UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion)</UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>
 
     <!-- Latest patch versions for each minor version of .NET Core -->
     <LatestPatchVersionForNetCore1_0 Condition="'%24(LatestPatchVersionForNetCore1_0)' == ''">1.0.11</LatestPatchVersionForNetCore1_0>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -190,9 +190,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>$(_UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion)</UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>
 
     <!-- Latest patch versions for each minor version of .NET Core -->
-    <LatestPatchVersionForNetCore1_0 Condition="'$(LatestPatchVersionForNetCore1_0)' == ''">1.0.11</LatestPatchVersionForNetCore1_0>
-    <LatestPatchVersionForNetCore1_1 Condition="'$(LatestPatchVersionForNetCore1_1)' == ''">1.1.8</LatestPatchVersionForNetCore1_1>
-    <LatestPatchVersionForNetCore2_0 Condition="'$(LatestPatchVersionForNetCore2_0)' == ''">2.0.7</LatestPatchVersionForNetCore2_0>
+    <LatestPatchVersionForNetCore1_0 Condition="'%24(LatestPatchVersionForNetCore1_0)' == ''">1.0.11</LatestPatchVersionForNetCore1_0>
+    <LatestPatchVersionForNetCore1_1 Condition="'%24(LatestPatchVersionForNetCore1_1)' == ''">1.1.8</LatestPatchVersionForNetCore1_1>
+    <LatestPatchVersionForNetCore2_0 Condition="'%24(LatestPatchVersionForNetCore2_0)' == ''">2.0.7</LatestPatchVersionForNetCore2_0>
   </PropertyGroup>
 </Project>
 ]]>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -195,7 +195,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <!-- Latest patch versions for each minor version of .NET Core -->
     <LatestPatchVersionForNetCore1_0 Condition="'%24(LatestPatchVersionForNetCore1_0)' == ''">1.0.11</LatestPatchVersionForNetCore1_0>
     <LatestPatchVersionForNetCore1_1 Condition="'%24(LatestPatchVersionForNetCore1_1)' == ''">1.1.8</LatestPatchVersionForNetCore1_1>
-    <LatestPatchVersionForNetCore2_0 Condition="'%24(LatestPatchVersionForNetCore2_0)' == ''">2.0.7</LatestPatchVersionForNetCore2_0>
+    <LatestPatchVersionForNetCore2_0 Condition="'%24(LatestPatchVersionForNetCore2_0)' == ''">2.0.9</LatestPatchVersionForNetCore2_0>
   </PropertyGroup>
 </Project>
 ]]>

--- a/build/Microsoft.DotNet.Cli.tasks
+++ b/build/Microsoft.DotNet.Cli.tasks
@@ -23,6 +23,7 @@
   <UsingTask TaskName="GenerateMsiVersion" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="GenerateNuGetPackagesArchiveVersion" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="GetCurrentRuntimeInformation" AssemblyFile="$(CLIBuildDll)" />
+  <UsingTask TaskName="GetUseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion" AssemblyFile="$(CLIBuildDll)"/>
   <UsingTask TaskName="MakeRelative" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="RemoveAssetFromDepsPackages" AssemblyFile="$(CLIBuildDll)" />
   <UsingTask TaskName="ReplaceFileContents" AssemblyFile="$(CLIBuildDll)" />

--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -5,6 +5,7 @@
         <NugetConfigPrivateFeeds Include="$(ExternalRestoreSources.Split(';'))" />
       </ItemGroup>
 
+    <!-- dotnet-core is needed since no old (like 1.1) runtime package will be published to relatively new BlobFeed -->
     <PropertyGroup>
       <NugetConfigHeader>
         <![CDATA[
@@ -26,6 +27,7 @@
     <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
     <add key="linux-musl-bootstrap-feed" value="https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180420-03/aspnet-inputs/index.json" />
     <add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
         ]]>
       </NugetConfigCLIFeeds>
 

--- a/build_projects/dotnet-cli-build/GetUseBundledVersionAsDefaultVersion.cs
+++ b/build_projects/dotnet-cli-build/GetUseBundledVersionAsDefaultVersion.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
+using Microsoft.DotNet.Cli.Build.Framework;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Cli.Build
+{
+    public class GetUseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion : Task
+    {
+        [Required]
+        public string BundledNETCoreAppPackageVersion { get; set; }
+
+        [Output]
+        public string UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion { get; set; }
+
+        public override bool Execute()
+        {
+            var parsedVersion = NuGetVersion.Parse(BundledNETCoreAppPackageVersion);
+            UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion =
+                (parsedVersion.Patch == 0) && parsedVersion.IsPrerelease ? "true" : "false";
+
+            return true;
+        }
+    }
+}

--- a/test/EndToEnd/GivenFrameworkDependentApps.cs
+++ b/test/EndToEnd/GivenFrameworkDependentApps.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using FluentAssertions;
+using Microsoft.DotNet.PlatformAbstractions;
 using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using NuGet.ProjectModel;
@@ -20,6 +21,8 @@ namespace EndToEnd
         {
             var _testInstance = TestAssets.Get("TestAppSimple")
                 .CreateInstance(identifier: minorVersion)
+                // scope the feed to only dotnet-core feed to avoid flaky when different feed has a newer / lower version
+                .WithNuGetConfig(new RepoDirectoriesProvider().TestPackages)
                 .WithSourceFiles();
 
             string projectDirectory = _testInstance.Root.FullName;

--- a/test/EndToEnd/GivenFrameworkDependentApps.cs
+++ b/test/EndToEnd/GivenFrameworkDependentApps.cs
@@ -12,11 +12,11 @@ using Xunit;
 
 namespace EndToEnd
 {
-    public class GivenPortableApps : TestBase
+    public class GivenFrameworkDependentApps : TestBase
     {
         [Theory]
         [ClassData(typeof(SupportedNetCoreAppVersions))]
-        public void ItDoesNotRollsForwardToTheLatestVersion(string minorVersion)
+        public void ItDoesNotRollForwardToTheLatestVersion(string minorVersion)
         {
             var _testInstance = TestAssets.Get("TestAppSimple")
                 .CreateInstance(identifier: minorVersion)
@@ -36,7 +36,7 @@ namespace EndToEnd
 
             project.Save(projectPath);
 
-            //  Get the version rolled forward to
+            //  Get the resolved version of .NET Core
             new RestoreCommand()
                     .WithWorkingDirectory(projectDirectory)
                     .Execute()
@@ -48,11 +48,11 @@ namespace EndToEnd
             var versionInAssertsJson = GetNetCoreAppVersion(assetsFile);
             versionInAssertsJson.Should().NotBeNull();
 
-            if (versionInAssertsJson.IsPrerelease)
+            if (versionInAssertsJson.IsPrerelease && versionInAssertsJson.Patch == 0)
             {
-                //  If this version of .NET Core is still prerelease, then:
-                //  - There aren't any patches to roll-forward to, so we skip testing this until the version
-                //    leaves prerelease.
+                // if the bundled version is, for example, a prerelease of
+                // .NET Core 2.1.1, that we don't roll forward to that prerelease
+                // version for framework-dependent deployments.
                 return;
             }
 

--- a/test/EndToEnd/GivenPortableApps.cs
+++ b/test/EndToEnd/GivenPortableApps.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using NuGet.ProjectModel;
+using NuGet.Versioning;
+using Xunit;
+
+namespace EndToEnd
+{
+    public class GivenPortableApps : TestBase
+    {
+        [Theory]
+        [ClassData(typeof(SupportedNetCoreAppVersions))]
+        public void ItDoesNotRollsForwardToTheLatestVersion(string minorVersion)
+        {
+            var _testInstance = TestAssets.Get("TestAppSimple")
+                .CreateInstance(identifier: minorVersion)
+                .WithSourceFiles();
+
+            string projectDirectory = _testInstance.Root.FullName;
+
+            string projectPath = Path.Combine(projectDirectory, "TestAppSimple.csproj");
+
+            var project = XDocument.Load(projectPath);
+            var ns = project.Root.Name.Namespace;
+
+            //  Update TargetFramework to the right version of .NET Core
+            project.Root.Element(ns + "PropertyGroup")
+                .Element(ns + "TargetFramework")
+                .Value = "netcoreapp" + minorVersion;
+
+            project.Save(projectPath);
+
+            //  Get the version rolled forward to
+            new RestoreCommand()
+                    .WithWorkingDirectory(projectDirectory)
+                    .Execute()
+                    .Should().Pass();
+
+            string assetsFilePath = Path.Combine(projectDirectory, "obj", "project.assets.json");
+            var assetsFile = new LockFileFormat().Read(assetsFilePath);
+
+            var versionInAssertsJson = GetNetCoreAppVersion(assetsFile);
+            versionInAssertsJson.Should().NotBeNull();
+
+            if (versionInAssertsJson.IsPrerelease)
+            {
+                //  If this version of .NET Core is still prerelease, then:
+                //  - There aren't any patches to roll-forward to, so we skip testing this until the version
+                //    leaves prerelease.
+                return;
+            }
+
+            versionInAssertsJson.ToNormalizedString().Should().BeEquivalentTo(GetExpectedVersion(minorVersion));
+        }
+
+        private NuGetVersion GetNetCoreAppVersion(LockFile lockFile)
+        {
+            return lockFile?.Targets?.SingleOrDefault(t => t.RuntimeIdentifier == null)
+                ?.Libraries?.SingleOrDefault(l =>
+                    string.Compare(l.Name, "Microsoft.NETCore.App", StringComparison.CurrentCultureIgnoreCase) == 0)
+                ?.Version;
+        }
+
+        public string GetExpectedVersion(string minorVersion)
+        {
+            if (minorVersion.StartsWith("1.0"))
+            {
+                return "1.0.5";  // special case for 1.0
+            }
+            else if (minorVersion.StartsWith("1.1"))
+            {
+                return "1.1.2";  // special case for 1.1
+            }
+            else
+            {
+                var parsed = NuGetVersion.Parse(minorVersion);
+                return new NuGetVersion(parsed.Major, parsed.Minor, 0).ToNormalizedString();
+            }
+        }
+    }
+}

--- a/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
+++ b/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
@@ -16,7 +16,7 @@ namespace EndToEnd
     public class GivenSelfContainedAppsRollForward : TestBase
     {
 
-        [Theory(Skip = "Runtime 1.1 support for openSUSE and Fedora 27 needed")]
+        [Theory]
         //  MemberData is used instead of InlineData here so we can access it in another test to
         //  verify that we are covering the latest release of .NET Core
         [MemberData(nameof(SupportedNetCoreAppVersions))]

--- a/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
+++ b/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -13,13 +12,13 @@ using Xunit;
 
 namespace EndToEnd
 {
-    public class GivenSelfContainedAppsRollForward : TestBase
+    public partial class GivenSelfContainedAppsRollForward : TestBase
     {
 
         [Theory]
         //  MemberData is used instead of InlineData here so we can access it in another test to
         //  verify that we are covering the latest release of .NET Core
-        [MemberData(nameof(SupportedNetCoreAppVersions))]
+        [ClassData(typeof(SupportedNetCoreAppVersions))]
         public void ItRollsForwardToTheLatestVersion(string minorVersion)
         {
             var _testInstance = TestAssets.Get("TestAppSimple")
@@ -118,24 +117,10 @@ namespace EndToEnd
                     .Element(ns + "TargetFramework")
                     .Value;
 
-                SupportedNetCoreAppVersions.Select(v => $"netcoreapp{v[0]}")
+                SupportedNetCoreAppVersions.Versions.Select(v => $"netcoreapp{v[0]}")
                     .Should().Contain(targetFramework, $"the {nameof(SupportedNetCoreAppVersions)} property should include the default version " +
                     "of .NET Core created by \"dotnet new\"");
                 
-            }
-        }
-
-        public static IEnumerable<object[]> SupportedNetCoreAppVersions
-        {
-            get
-            {
-                return new[]
-                {
-                    "1.0",
-                    "1.1",
-                    "2.0",
-                    "2.1"
-                }.Select(version => new object[] { version });
             }
         }
     }

--- a/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
+++ b/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
@@ -118,7 +118,7 @@ namespace EndToEnd
                     .Value;
 
                 SupportedNetCoreAppVersions.Versions.Select(v => $"netcoreapp{v[0]}")
-                    .Should().Contain(targetFramework, $"the {nameof(SupportedNetCoreAppVersions)} property should include the default version " +
+                    .Should().Contain(targetFramework, $"the {nameof(SupportedNetCoreAppVersions)}.{nameof(SupportedNetCoreAppVersions.Versions)} property should include the default version " +
                     "of .NET Core created by \"dotnet new\"");
                 
             }

--- a/test/EndToEnd/SupportedNetCoreAppVersions.cs
+++ b/test/EndToEnd/SupportedNetCoreAppVersions.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace EndToEnd
+{
+    public class SupportedNetCoreAppVersions : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator() => Versions.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        public static IEnumerable<object[]> Versions
+        {
+            get
+            {
+                return new[]
+                {
+                    "1.0",
+                    "1.1",
+                    "2.0",
+                    "2.1"
+                }.Select(version => new object[] { version });
+            }
+        }
+    }
+}


### PR DESCRIPTION
partial https://github.com/dotnet/sdk/issues/2275

-  Add test to CLI that will catch portable not move forward that is similar to dotnet/cli#8919
-   CLI sets UseBundledVersionAsDefaultVersion based on patch version == 0 and is preview == true
