### PR TITLE
Pass BaseIntermediateOutputPath via xml

### DIFF
--- a/src/dotnet/ToolPackage/IProjectRestorer.cs
+++ b/src/dotnet/ToolPackage/IProjectRestorer.cs
@@ -9,7 +9,6 @@ namespace Microsoft.DotNet.ToolPackage
     internal interface IProjectRestorer
     {
         void Restore(FilePath project,
-            DirectoryPath assetJsonOutput,
             FilePath? nugetConfig = null,
             string verbosity = null);
     }

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -27,7 +27,6 @@ namespace Microsoft.DotNet.Tools.Tool.Install
         }
 
         public void Restore(FilePath project,
-            DirectoryPath assetJsonOutput,
             FilePath? nugetConfig = null,
             string verbosity = null)
         {
@@ -43,8 +42,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             argsToPassToRestore.AddRange(new List<string>
             {
                 "--runtime",
-                AnyRid,
-                $"-property:BaseIntermediateOutputPath={assetJsonOutput.ToXmlEncodeString()}"
+                AnyRid
             });
 
             argsToPassToRestore.Add($"-verbosity:{verbosity ?? "quiet"}");

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -1,8 +1,9 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -16,8 +17,10 @@ using Microsoft.DotNet.Tools.Tool.Install;
 using Microsoft.DotNet.Tools.Tests.ComponentMocks;
 using Microsoft.Extensions.DependencyModel.Tests;
 using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.TemplateEngine.Cli;
 using NuGet.Versioning;
 using Xunit;
+using LocalizableStrings = Microsoft.DotNet.Tools.Tool.Install.LocalizableStrings;
 
 namespace Microsoft.DotNet.ToolPackage.Tests
 {
@@ -606,6 +609,35 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             reporter.Lines.Should().Contain(l => l.Contains("warning"));
             reporter.Lines.Should().NotContain(l => l.Contains(tempProject.Value));
             reporter.Lines.Clear();
+
+            AssertPackageInstall(reporter, fileSystem, package, store);
+
+            package.Uninstall();
+        }
+
+        [Fact]
+        public void GivenARootWithNonAsciiCharactorInstallSucceeds()
+        {
+            var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
+
+            var surrogate = char.ConvertFromUtf32(int.Parse("2A601", NumberStyles.HexNumber));
+            string nonAscii = "ab Ṱ̺̺̕o 田中さん åä," + surrogate;
+
+            var root = new DirectoryPath(Path.Combine(TempRoot.Root, nonAscii, Path.GetRandomFileName()));
+            var reporter = new BufferedReporter();
+            var fileSystem = new FileSystemWrapper();
+            var store = new ToolPackageStore(root);
+            var installer = new ToolPackageInstaller(
+                store: store,
+                projectRestorer: new ProjectRestorer(reporter),
+                tempProject: GetUniqueTempProjectPathEachTest(),
+                offlineFeed: new DirectoryPath("does not exist"));
+
+            var package = installer.InstallPackage(
+                packageId: TestPackageId,
+                versionRange: VersionRange.Parse(TestPackageVersion),
+                targetFramework: _testTargetframework,
+                nugetConfig: nugetConfigPath);
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
@@ -57,19 +57,19 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
         }
 
         public void Restore(FilePath project,
-            DirectoryPath assetJsonOutput,
             FilePath? nugetConfig = null,
             string verbosity = null)
         {
             string packageId;
             VersionRange versionRange;
             string targetFramework;
+            DirectoryPath assetJsonOutput;
             try
             {
-                // The mock installer wrote a mock project file containing id:version:framework
+                // The mock installer wrote a mock project file containing id;version;framework;stageDirectory
                 var contents = _fileSystem.File.ReadAllText(project.Value);
-                var tokens = contents.Split(':');
-                if (tokens.Length != 3)
+                var tokens = contents.Split(';');
+                if (tokens.Length != 4)
                 {
                     throw new ToolPackageException(LocalizableStrings.ToolInstallationRestoreFailed);
                 }
@@ -77,6 +77,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                 packageId = tokens[0];
                 versionRange = VersionRange.Parse(tokens[1]);
                 targetFramework = tokens[2];
+                assetJsonOutput = new DirectoryPath(tokens[3]);
             }
             catch (IOException)
             {

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
@@ -63,12 +63,11 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                     // Write a fake project with the requested package id, version, and framework
                     _fileSystem.File.WriteAllText(
                         tempProject.Value,
-                        $"{packageId}:{versionRange?.ToString("S", new VersionRangeFormatter()) ?? "*"}:{targetFramework}");
+                        $"{packageId};{versionRange?.ToString("S", new VersionRangeFormatter()) ?? "*"};{targetFramework};{stageDirectory.Value}");
 
                     // Perform a restore on the fake project
                     _projectRestorer.Restore(
                         tempProject,
-                        stageDirectory,
                         nugetConfig,
                         verbosity);
 


### PR DESCRIPTION
Fix https://github.com/dotnet/cli/issues/9413

Instead of command line to avoid escaping problem.

It can support most of the character including surrogate char. It cannot
support semicolon. However, semicolon is not allow to be part of the
user name.

Port 2.1.4xx fix 0251f677ede571b61a47ca24f38df8e09038277d while keep
BaseIntermediateOutputPath instead of MsBuildProjectExtensionsPath to
minimize the change.

