### PR TITLE
Log a verbose message when DOTNET_CLI_HOME is being used.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
@@ -276,4 +276,7 @@
 
 dotnet tool install --global {1}</value>
   </data>
+  <data name="DotnetCliHomeUsed" xml:space="preserve">
+    <value>Using home directory '{0}' set by the '{1}' environment variable.</value>
+  </data>
 </root>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet 도구를 설치하세요. install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet 工具安装 -- 全局 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
@@ -268,6 +268,11 @@ dotnet tool install --global {1}</source>
 dotnet tool install --global {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="DotnetCliHomeUsed">
+        <source>Using home directory '{0}' set by the '{1}' environment variable.</source>
+        <target state="new">Using home directory '{0}' set by the '{1}' environment variable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -149,6 +149,8 @@ namespace Microsoft.DotNet.Cli
                         bool skipFirstRunExperience =
                             environmentProvider.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false);
 
+                        ReportDotnetHomeUsage(environmentProvider);
+
                         topLevelCommandParserResult = new TopLevelCommandParserResult(command);
                         var hasSuperUserAccess = false;
                         if (IsDotnetBeingInvokedFromNativeInstaller(topLevelCommandParserResult))
@@ -227,6 +229,21 @@ namespace Microsoft.DotNet.Cli
                 exitCode = result.ExitCode;
             }
             return exitCode;
+        }
+
+        private static void ReportDotnetHomeUsage(IEnvironmentProvider provider)
+        {
+            var home = provider.GetEnvironmentVariable(CliFolderPathCalculator.DotnetHomeVariableName);
+            if (string.IsNullOrEmpty(home))
+            {
+                return;
+            }
+
+            Reporter.Verbose.WriteLine(
+                string.Format(
+                    LocalizableStrings.DotnetCliHomeUsed,
+                    home,
+                    CliFolderPathCalculator.DotnetHomeVariableName));
         }
 
         private static bool IsDotnetBeingInvokedFromNativeInstaller(TopLevelCommandParserResult parseResult)

--- a/test/dotnet.Tests/GivenThatDotNetRunsCommands.cs
+++ b/test/dotnet.Tests/GivenThatDotNetRunsCommands.cs
@@ -49,5 +49,23 @@ namespace Microsoft.DotNet.Tests
                 .And
                 .HaveStdErrContaining(CliFolderPathCalculator.DotnetHomeVariableName);
         }
+
+        [Fact]
+        public void GivenASpecifiedDotnetCliHomeVariableItPrintsUsageMessage()
+        {
+            var home = Path.Combine(TempRoot.Root, Path.GetRandomFileName());
+
+            new TestCommand("dotnet")
+                .WithEnvironmentVariable(CliFolderPathCalculator.DotnetHomeVariableName, home)
+                .ExecuteWithCapturedOutput("-d help")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(
+                    string.Format(
+                        LocalizableStrings.DotnetCliHomeUsed,
+                        home,
+                        CliFolderPathCalculator.DotnetHomeVariableName));
+        }
     }
 }


### PR DESCRIPTION
This commit logs a diagnostic message when the `DOTNET_CLI_HOME` variable is
used.  This enables users to determine where first-run-experience and global
tool files are being written to.

Fixes #9510.
