### PR TITLE
Fix broken samples link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ You can also use our Docker base images found on https://hub.docker.com/r/micros
 Basic usage
 -----------
 
-When you have the .NET Command Line Interface installed on your OS of choice, you can try it out using some of the samples on the [dotnet/core repo](https://github.com/dotnet/core/tree/release/2.2.1xx/samples). You can download the sample in a directory, and then you can kick the tires of the CLI.
+When you have the .NET Command Line Interface installed on your OS of choice, you can try it out using some of the samples on the [dotnet/core repo](https://github.com/dotnet/core/tree/master/samples). You can download the sample in a directory, and then you can kick the tires of the CLI.
 
 
 First, you will need to restore the packages:


### PR DESCRIPTION
Looks like a branch search and replace mistake.

skip ci please
