### PR TITLE
Revert implementation of the --mode option for the publish command.

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -23,7 +23,7 @@
     <MicrosoftNETCoreCompilersPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNETCoreCompilersPackageVersion>
     <MicrosoftCodeAnalysisBuildTasksPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisBuildTasksPackageVersion>
     <MicrosoftNetCompilersNetcorePackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNetCompilersNetcorePackageVersion>
-    <MicrosoftNETSdkPackageVersion>2.1.400-preview-63027-01</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>2.1.400-preview-63109-04</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>$(MicrosoftAspNetCoreAppPackageVersion)</MicrosoftNETSdkRazorPackageVersion>
     <MicrosoftNETSdkWebPackageVersion>2.1.400-preview1-20180614-1774926</MicrosoftNETSdkWebPackageVersion>

--- a/src/dotnet/commands/dotnet-publish/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-publish/LocalizableStrings.resx
@@ -135,16 +135,9 @@
   <data name="ManifestOptionDescription" xml:space="preserve">
     <value>The path to a target manifest file that contains the list of packages to be excluded from the publish step.</value>
   </data>
-  <data name="ModeOptionDescription" xml:space="preserve">
-    <value>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</value>
-  </data>
-  <data name="ModeOptionName" xml:space="preserve">
-    <value>MODE</value>
+  <data name="SelfContainedOptionDescription" xml:space="preserve">
+    <value>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</value>
   </data>
   <data name="NoBuildOptionDescription" xml:space="preserve">
     <value>Do not build the project before publishing. Implies --no-restore.</value>
@@ -153,16 +146,10 @@ The default is 'self-contained' when a target runtime is specified.</value>
     <value>The target framework to publish for. The target framework has to be specified in the project file.</value>
   </data>
   <data name="RuntimeOptionDescription" xml:space="preserve">
-    <value>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</value>
+    <value>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</value>
   </data>
   <data name="ConfigurationOptionDescription" xml:space="preserve">
     <value>The configuration to publish for. The default for most projects is 'Debug'.</value>
-  </data>
-  <data name="PublishModeAndSelfContainedOptionsConflict" xml:space="preserve">
-    <value>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</value>
-  </data>
-  <data name="UnsupportedPublishMode" xml:space="preserve">
-    <value>The specified publish mode '{0}' is not supported.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -39,37 +39,6 @@ namespace Microsoft.DotNet.Tools.Publish
 
             var appliedPublishOption = result["dotnet"]["publish"];
 
-            if (appliedPublishOption.HasOption("mode") && appliedPublishOption.HasOption("self-contained"))
-            {
-                throw new GracefulException(LocalizableStrings.PublishModeAndSelfContainedOptionsConflict);
-            }
-
-            var mode = appliedPublishOption.ValueOrDefault<string>("mode");
-            switch (mode)
-            {
-                case null:
-                    break;
-
-                case PublishCommandParser.SelfContainedMode:
-                    msbuildArgs.Add("-p:SelfContained=true");
-                    break;
-
-                case PublishCommandParser.FxDependentMode:
-                    msbuildArgs.Add("-p:SelfContained=false");
-                    break;
-
-                case PublishCommandParser.FxDependentNoExeMode:
-                    msbuildArgs.Add("-p:SelfContained=false");
-                    msbuildArgs.Add("-p:UseAppHost=false");
-                    break;
-
-                default:
-                    throw new GracefulException(
-                        string.Format(
-                            LocalizableStrings.UnsupportedPublishMode,
-                            mode));
-            }
-
             msbuildArgs.AddRange(appliedPublishOption.OptionValuesToBeForwarded());
 
             msbuildArgs.AddRange(appliedPublishOption.Arguments);

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -10,10 +10,6 @@ namespace Microsoft.DotNet.Cli
 {
     internal static class PublishCommandParser
     {
-        public const string SelfContainedMode = "self-contained";
-        public const string FxDependentMode = "fx-dependent";
-        public const string FxDependentNoExeMode = "fx-dependent-no-exe";
-
         public static Command Publish() =>
             CreateWithRestoreOptions.Command(
                 "publish",
@@ -44,7 +40,7 @@ namespace Microsoft.DotNet.Cli
                     Accept.NoArguments().ForwardAs("-property:NoBuild=true")),
                 Create.Option(
                     "--self-contained",
-                    "", // Hidden option for backwards-compatibility (now '--mode self-contained').
+                    LocalizableStrings.SelfContainedOptionDescription,
                     Accept.ZeroOrOneArgument()
                         .WithSuggestionsFrom("true", "false")
                         .ForwardAsSingle(o =>
@@ -52,14 +48,6 @@ namespace Microsoft.DotNet.Cli
                             string value = o.Arguments.Any() ? o.Arguments.Single() : "true";
                             return $"-property:SelfContained={value}";
                         })),
-                Create.Option(
-                    "--mode",
-                    LocalizableStrings.ModeOptionDescription,
-                    Accept.AnyOneOf(
-                        SelfContainedMode,
-                        FxDependentMode,
-                        FxDependentNoExeMode)
-                        .With(name: LocalizableStrings.ModeOptionName)),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());
     }

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.cs.xlf
@@ -37,51 +37,27 @@
         <target state="translated">Cesta k cílovému souboru manifestu obsahujícímu seznam balíčků, které se mají vyloučit z kroku publikování</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">Publikuje spolu s aplikací modul runtime .NET Core, aby se tento modul nemusel instalovat na cílový počítač. Standardně se nastaví na True, pokud je zadaný identifikátor modulu runtime.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">Nesestavujte projekt, dokud ho nepublikujete. Implikuje možnost --no-restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.de.xlf
@@ -37,51 +37,27 @@
         <target state="translated">Der Pfad zu einer Zielmanifestdatei, die die Liste der von der Veröffentlichung auszuschließenden Pakete enthält.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">Veröffentlichen Sie die .NET Core-Runtime mit Ihrer Anwendung, damit die Runtime auf dem Zielcomputer nicht installiert werden muss. Der Standardwert ist "true", wenn ein Runtimebezeichner angegeben ist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">Erstellt das Projekt nicht vor dem Veröffentlichen. Impliziert "--no-restore".</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.es.xlf
@@ -37,51 +37,27 @@
         <target state="translated">La ruta de acceso a un archivo de manifiesto de destino que contiene la lista de paquetes que se excluirán del paso de publicación.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">Publica el tiempo de ejecución de .NET Core con su aplicación para que no sea necesario instalarlo en la máquina de destino. Si se especifica un identificador de tiempo de ejecución, se toma como predeterminado el valor "true".</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">No compile el proyecto antes de publicarlo. Implica --no-restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.fr.xlf
@@ -37,51 +37,27 @@
         <target state="translated">Chemin d'un fichier manifeste cible contenant la liste des packages à exclure de l'étape de publication.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">Publiez le runtime .NET Core avec votre application pour éviter à l'utilisateur de l'installer sur la machine cible. La valeur par défaut est 'true' si un identificateur de runtime est spécifié.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">Ne pas générer le projet avant la publication. Implique --no-restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.it.xlf
@@ -37,51 +37,27 @@
         <target state="translated">Percorso di un file manifesto di destinazione che contiene l'elenco di pacchetti da escludere dal passaggio di pubblicazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">Pubblica il runtime di .NET Core con l'applicazione in modo che non sia necessario installarlo nel computer di destinazione. Se si specifica un identificatore di runtime, l'impostazione predefinita è 'true'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">Non compila il progetto prima della pubblicazione. Implica --no-restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ja.xlf
@@ -37,51 +37,27 @@
         <target state="translated">発行ステップから除外されるパッケージのリストを含むターゲット マニフェスト ファイルへのパス。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">ランタイムをターゲット マシンにインストールしなくてもよいよう、.NET Core ランタイムをアプリケーションと一緒に発行します。ランタイム ID が指定される場合、既定の 'true' になります。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">発行する前にプロジェクトをビルドしないでください。--no-restore を意味します。</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ko.xlf
@@ -37,51 +37,27 @@
         <target state="translated">게시 단계에서 제외할 패키지 목록이 들어 있는 대상 매니페스트 파일의 경로입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">런타임은 대상 컴퓨터에 설치할 필요가 없으므로 응용 프로그램과 함께 .NET Core 런타임을 게시합니다. 런타임 식별자가 지정된 경우 기본값은 'true'입니다.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">게시하기 전에 프로젝트를 빌드하지 않습니다. 복원 없음을 의미합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pl.xlf
@@ -37,51 +37,27 @@
         <target state="translated">Ścieżka do docelowego pliku manifestu zawierającego listę pakietów, które mają zostać wykluczone z kroku publikowania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">Opublikuj środowisko uruchomieniowe programu .NET Core z aplikacją, aby nie trzeba było go instalować na maszynie docelowej. Domyślnie jest ustawiona wartość „true” w przypadku określenia identyfikatora środowiska uruchomieniowego.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">Nie kompiluj tego projektu przed opublikowaniem. Powoduje przyjęcie, że podano parametr --no-restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pt-BR.xlf
@@ -37,51 +37,27 @@
         <target state="translated">O caminho para um arquivo de manifesto de destino que contém a lista de pacotes a serem excluídos da etapa de publicação.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">Publique o tempo de execução .NET Core com seu aplicativo para que o tempo de execução não precise ser instalado no computador de destino. Assumirá 'true' como padrão se um identificador de tempo de execução for especificado.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">Não compile o projeto antes de publicar. Implica em --no-restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ru.xlf
@@ -37,51 +37,27 @@
         <target state="translated">Путь к целевому файлу манифеста, содержащему список пакетов, исключаемых из публикации.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">Опубликуйте среду выполнения .NET Core вместе с приложением, чтобы ее не нужно было устанавливать на целевом компьютере. Если идентификатор среды выполнения указан, значение по умолчанию — true.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">Сборка проекта перед публикацией не выполняется. Подразумевает --no-restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.tr.xlf
@@ -37,51 +37,27 @@
         <target state="translated">Yayımlama adımının dışında tutulacak paketlerin listesini içeren bir hedef bildirim dosyasının yolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">Çalışma zamanının hedef makineye yüklenmesine gerek kalmaması için, .NET Core çalışma zamanını uygulamanızla birlikte yayımlayın. Bir çalışma zamanı tanımlayıcısı belirtilmişse, varsayılan olarak 'true' değerine ayarlanır.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">Yayımlamadan önce projeyi derlemeyin. --no-restore anlamına gelir.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hans.xlf
@@ -37,51 +37,27 @@
         <target state="translated">指向目标清单文件的路径，该文件包含要通过发布步骤执行的包的列表。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">随附应用程序发布 .NET Core 运行时，免除在目标计算机上安装运行时的需求。如果指定了运行时标识符，则默认为 “true”。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">发布之前不要生成项目。Implies --no-restore.</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hant.xlf
@@ -37,51 +37,27 @@
         <target state="translated">目標資訊清單檔案的路徑，其包含要從發行步驟中排除的套件清單。</target>
         <note />
       </trans-unit>
+      <trans-unit id="SelfContainedOptionDescription">
+        <source>Publish the .NET Core runtime with your application so the runtime doesn't need to be installed on the target machine.
+The default is 'true' if a runtime identifier is specified.</source>
+        <target state="needs-review-translation">隨著應用程式一併發行 .NET Core 執行階段，因此不需要在目標電腦上安裝此執行階段。若指定了執行階段識別碼，則預設為 'true'。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoBuildOptionDescription">
         <source>Do not build the project before publishing. Implies --no-restore.</source>
         <target state="translated">請勿在執行之前建置專案。提示：-no-restore。</target>
         <note />
       </trans-unit>
       <trans-unit id="RuntimeOptionDescription">
-        <source>The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</source>
-        <target state="new">The target runtime to publish the application for.
-The default is to publish a framework-dependent application without an executable.</target>
+        <source>The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</source>
+        <target state="new">The target runtime to publish for. This is used when creating a self-contained deployment.
+The default is to publish a framework-dependent application.</target>
         <note />
       </trans-unit>
       <trans-unit id="ConfigurationOptionDescription">
         <source>The configuration to publish for. The default for most projects is 'Debug'.</source>
         <target state="new">The configuration to publish for. The default for most projects is 'Debug'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionDescription">
-        <source>The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</source>
-        <target state="new">The mode to use when publishing the application.
-The 'self-contained' mode publishes the application with the .NET Core runtime.
-The 'fx-dependent' mode publishes the application as framework-dependent. If a target runtime is specified, it is published with an executable.
-The 'fx-dependent-no-exe' mode publishes the application as framework-dependent without an executable.
-The default is 'fx-dependent-no-exe' when a target runtime is not specified.
-The default is 'self-contained' when a target runtime is specified.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ModeOptionName">
-        <source>MODE</source>
-        <target state="new">MODE</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="PublishModeAndSelfContainedOptionsConflict">
-        <source>The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</source>
-        <target state="new">The '--mode' and '--self-contained' options cannot be used together. Specify only one of the options.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UnsupportedPublishMode">
-        <source>The specified publish mode '{0}' is not supported.</source>
-        <target state="new">The specified publish mode '{0}' is not supported.</target>
         <note />
       </trans-unit>
     </body>

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/PublishCommand.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         private string _output;
         private string _runtime;
         private List<string> _targetManifests = new List<string>();
-        private string _mode;
+        private bool? _selfContained;
 
         public PublishCommand WithFramework(string framework)
         {
@@ -44,9 +44,9 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             return this;
         }
 
-        public PublishCommand WithMode(string value)
+        public PublishCommand WithSelfContained(bool value)
         {
-            _mode = value;
+            _selfContained = value;
             return this;
         }
 
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                 OutputOption,
                 TargetOption,
                 RuntimeOption,
-                ModeOption);
+                SelfContainedOption);
         }
 
         private string FrameworkOption => string.IsNullOrEmpty(_framework) ? "" : $"-f {_framework}";
@@ -80,6 +80,6 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         private string TargetOption => string.Join(" ", _targetManifests);
 
-        private string ModeOption => string.IsNullOrEmpty(_mode) ? "" : $"--mode {_mode}";
+        private string SelfContainedOption => _selfContained.HasValue ? $"--self-contained:{_selfContained.Value}" : "";
     }
 }


### PR DESCRIPTION
This commit reverts the implementation of the `--mode` option for the `dotnet
publish` command.  A bug in the apphost prevents this feature from working
properly in some cases and there currently is not a mechanism to service it
with this feature.

The team has decided to move this feature to 2.2.1xx for the .NET Core SDK.

Fixes dotnet/sdk#2380.