### PR TITLE
Revert version change for ASP.NET bundled templates.

### DIFF
--- a/build/BundledTemplates.props
+++ b/build/BundledTemplates.props
@@ -4,8 +4,8 @@
     <BundledTemplate Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" Version="$(MicrosoftDotNetCommonProjectTemplates20PackageVersion)" />
     <BundledTemplate Include="Microsoft.DotNet.Test.ProjectTemplates.2.1" Version="$(MicrosoftDotNetTestProjectTemplates20PackageVersion)" />
 
-    <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(MicrosoftNETWebItemTemplatesPackageVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="$(MicrosoftNETWebProjectTemplates21PackageVersion)" />
-    <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(MicrosoftNETWebSpaProjectTemplatesPackageVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.ItemTemplates" Version="$(AspNetCoreVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="$(AspNetCoreVersion)" />
+    <BundledTemplate Include="Microsoft.DotNet.Web.Spa.ProjectTemplates" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -26,9 +26,6 @@
     <MicrosoftNETSdkPackageVersion>2.1.301</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>2.1.1</MicrosoftNETSdkRazorPackageVersion>
-    <MicrosoftNETWebItemTemplatesPackageVersion>2.1.1</MicrosoftNETWebItemTemplatesPackageVersion>
-    <MicrosoftNETWebProjectTemplates21PackageVersion>2.1.1</MicrosoftNETWebProjectTemplates21PackageVersion>
-    <MicrosoftNETWebSpaProjectTemplatesPackageVersion>2.1.1</MicrosoftNETWebSpaProjectTemplatesPackageVersion>
     <MicrosoftNETSdkWebPackageVersion>2.1.301</MicrosoftNETSdkWebPackageVersion>
     <MicrosoftNETSdkPublishPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkPublishPackageVersion>
     <MicrosoftNETSdkWebProjectSystemPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWebProjectSystemPackageVersion>


### PR DESCRIPTION
The bundled ASP.NET templates should match the ASP.NET version.

Confusion over versions and missing packages caused a previous commit
to keep the bundled template versions the same while reving the ASP.NET version
from the private branch.

This commit reverts those changes.
