### PR TITLE
Conditionally install the 1.1.2 runtime when building from source

### DIFF
--- a/run-build.ps1
+++ b/run-build.ps1
@@ -111,7 +111,11 @@ if ($LastExitCode -ne 0)
     Copy-Item -Recurse -Force $env:DOTNET_TOOL_DIR $env:DOTNET_INSTALL_DIR
 }
 
-Invoke-Expression "$dotnetInstallPath -Version ""1.1.2"" -Runtime ""dotnet"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+# This install is used to test 1.x scenarios
+# Don't install in source build.
+if ($env:DotNetBuildFromSource -ne "true") {
+    Invoke-Expression "$dotnetInstallPath -Version ""1.1.2"" -Runtime ""dotnet"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$Architecture"""
+}
 
 # Put the stage0 on the path
 $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"

--- a/run-build.sh
+++ b/run-build.sh
@@ -180,8 +180,12 @@ if [ $EXIT_CODE != 0 ]; then
     exit $EXIT_CODE
 fi
 
-#ignore 1.1.2 install failure, as it is not present on all platforms
-(set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --version "1.1.2" --runtime "dotnet" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$ARCHITECTURE" || true)
+# This install is used to test 1.x scenarios
+# Don't install in source build.
+if [[ "$DotNetBuildFromSource" != "true" ]]; then
+    #ignore 1.1.2 install failure, as it is not present on all platforms
+    (set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --version "1.1.2" --runtime "dotnet" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$ARCHITECTURE" || true)
+fi
 
 # Put stage 0 on the PATH (for this shell only)
 PATH="$DOTNET_INSTALL_DIR:$PATH"


### PR DESCRIPTION
Conditionally install the 1.1.2 runtime when building from source since this is used for testing only.

Fixes #9651