### PR TITLE
Insert 15.8 Roslyn into CLI 2.1.400

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -18,7 +18,7 @@
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftFSharpCompilerPackageVersion>10.2.0-rtm-180620-0</MicrosoftFSharpCompilerPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>2.8.1-beta6-62915-07</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>2.9.0-beta8-63115-02</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisBuildTasksPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisBuildTasksPackageVersion>
     <MicrosoftNETCoreCompilersPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNETCoreCompilersPackageVersion>
     <MicrosoftCodeAnalysisBuildTasksPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisBuildTasksPackageVersion>


### PR DESCRIPTION
I've added a Maestro trigger to automatically insert from dev/15.8 to release/2.1.4xx in the future.

However, adding a trigger doesn't create an initial PR, so this first 15.8 insertion of Roslyn into CLI 2.1.400 was manual.

Version obtained from https://github.com/dotnet/versions/blob/master/build-info/dotnet/roslyn/dev15.8/Latest_Packages.txt

Please confirm that this build is OK to insert @Shyam-Gupta @jasonmalinowski @jaredpar 


