### PR TITLE
Pin stage0 used for update-dependencies to stable 2.1 build

### DIFF
--- a/build_projects/update-dependencies/update-dependencies.ps1
+++ b/build_projects/update-dependencies/update-dependencies.ps1
@@ -38,7 +38,7 @@ $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
 # Install a stage 0
 Write-Output "Installing .NET Core CLI Stage 0"
-& "$RepoRoot\scripts\obtain\dotnet-install.ps1" -Channel "master" -Architecture $Architecture
+& "$RepoRoot\scripts\obtain\dotnet-install.ps1" -Version 2.1.302 -Architecture $Architecture
 if($LASTEXITCODE -ne 0) { throw "Failed to install stage0" }
 
 # Put the stage0 on the path

--- a/build_projects/update-dependencies/update-dependencies.sh
+++ b/build_projects/update-dependencies/update-dependencies.sh
@@ -34,7 +34,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
 # Install a stage 0
 echo "Installing .NET Core CLI Stage 0"
-$REPO_ROOT/scripts/obtain/dotnet-install.sh -Channel master -Architecture x64
+$REPO_ROOT/scripts/obtain/dotnet-install.sh -Version 2.1.302 -Architecture x64
 
 if [ $? -ne 0 ]; then
     echo "Failed to install stage 0"


### PR DESCRIPTION
@dagood @eerhardt 

We're getting builds from master and then trying to run on 2.1 tooling on 3.0. The builds from master aren't in great shape right now and I don't like having 3.0 dependent projects in 2.1.x branches. It seems to me that we can just use a stable build and stable TFM for the update-dependencies, but maybe I've misunderstood something about how this works.

This should fix the issue identified here: https://github.com/dotnet/versions/pull/331#issuecomment-405972675