### PR TITLE
Fix archiving to .zip.

### DIFF
--- a/build/package/Archive.targets
+++ b/build/package/Archive.targets
@@ -17,14 +17,6 @@
     </PropertyGroup>
 
     <ZipFileCreateFromDirectory
-        Condition=" '$(OS)' == 'Windows_NT' "
-        SourceDirectory="%(GenerateArchivesInputsOutputs.InputDirectory)"
-        DestinationArchive="$(GenerateArchivesDestinationArchive)"
-        OverwriteDestination="true"
-        ExcludePatterns="%(GenerateArchivesInputsOutputs.ExcludePatterns)" />
-
-    <TarGzFileCreateFromDirectory
-        Condition=" '$(OS)' != 'Windows_NT' "
         SourceDirectory="%(GenerateArchivesInputsOutputs.InputDirectory)"
         DestinationArchive="$(GenerateArchivesDestinationArchive)"
         OverwriteDestination="true"


### PR DESCRIPTION
From [here](https://github.com/dotnet/cli/blob/5632ca0714f18e188228104849e52eb011461ae0/build/FileExtensions.props#L3), we are now always using zip files instead of tarballs on Linux.  This change makes it so that we do not generate tarballs with a .zip extension, which confuses some downstream repos.