### PR TITLE
Fix OrchestratedPackageVersionProps for source-build.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,9 @@ tools\TestAssetsDependencies\TestAssetsDependencies.csproj
 
   <PropertyGroup>
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+    <RelativeGeneratedPropsDir>bin/obj</RelativeGeneratedPropsDir>
+    <GeneratedPropsDir>$(RepoRoot)/$(RelativeGeneratedPropsDir)</GeneratedPropsDir>
+    <OrchestratedPackageVersionsProps>$(GeneratedPropsDir)/OrchestratedPackageVersionsProps.props</OrchestratedPackageVersionsProps>
 
     <NuGetPackagesDir>$(NUGET_PACKAGES)</NuGetPackagesDir>
     <NuGetPackagesDir Condition=" '$(NuGetPackagesDir)' == '' ">$(RepoRoot)/.nuget/packages</NuGetPackagesDir>

--- a/build/Prepare.targets
+++ b/build/Prepare.targets
@@ -7,6 +7,7 @@
 
   <Target Name="Init"
           DependsOnTargets="SetTelemetryProfile;
+                            DownloadPackageVersionsProps;
                             BuildDotnetCliBuildFramework;">
   </Target>
 


### PR DESCRIPTION
When InitRepo was removed, the call to DownloadPackageVersionProps did not get moved elsewhere.  This change restores it and the properties that the target depends on.

Fixes #9680.
