### PR TITLE
Passing the right BundledNETCoreAppPackageVersion

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -137,7 +137,7 @@
         So that we don't need to manually update the version selection logic between when we ship a final release and when we ship the first patch
       -->
     <GetUseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion
-      BundledNETCoreAppPackageVersion="$(BundledNETCoreAppPackageVersion)">
+      BundledNETCoreAppPackageVersion="$(_NETCoreAppPackageVersion)">
       <Output TaskParameter="UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion"
               PropertyName="_UseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion" />
     </GetUseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>


### PR DESCRIPTION
…pPackageVersion version

this is a face palm. $(BundledNETCoreAppPackageVersion) is stage0's BundledNETCoreAppPackageVersion. We want to use stage2's. Which is $(_NETCoreAppPackageVersion) since 

`<BundledNETCoreAppPackageVersion>$(_NETCoreAppPackageVersion)</BundledNETCoreAppPackageVersion>`

fixes https://github.com/dotnet/cli/issues/9701

no test caught it since we don't have a good way to assert preview version(it keeps changing). But we would caught it if it is non preview