### PR TITLE
Add `--runtime` option to `dotnet test`.

### DIFF
--- a/src/dotnet/CommonOptions.cs
+++ b/src/dotnet/CommonOptions.cs
@@ -37,9 +37,9 @@ namespace Microsoft.DotNet.Cli
                     .With(name: CommonLocalizableStrings.FrameworkArgumentName)
                     .ForwardAsSingle(o => $"-property:TargetFramework={o.Arguments.Single()}"));
         
-        public static Option RuntimeOption(string description) =>
+        public static Option RuntimeOption(string description, bool withShortOption = true) =>
             Create.Option(
-                "-r|--runtime",
+                withShortOption ? "-r|--runtime" : "--runtime",
                 description,
                 Accept.ExactlyOneArgument()
                     .WithSuggestionsFrom(_ => Suggest.RunTimesFromProjectFile())

--- a/src/dotnet/commands/dotnet-test/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-test/LocalizableStrings.resx
@@ -205,6 +205,9 @@ Outputs a 'Sequence.xml' file in the current directory that captures the order o
   <data name="FrameworkOptionDescription" xml:space="preserve">
     <value>The target framework to run tests for. The target framework must also be specified in the project file.</value>
   </data>
+  <data name="RuntimeOptionDescription" xml:space="preserve">
+    <value>The target runtime to test for.</value>
+  </data>
   <data name="ConfigurationOptionDescription" xml:space="preserve">
     <value>The configuration to use for running tests. The default for most projects is 'Debug'.</value>
   </data>

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -56,6 +56,7 @@ namespace Microsoft.DotNet.Cli
                                     })),
                   CommonOptions.ConfigurationOption(LocalizableStrings.ConfigurationOptionDescription),
                   CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription),
+                  CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription, withShortOption: false),
                   Create.Option(
                         "-o|--output",
                         LocalizableStrings.CmdOutputDescription,

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.cs.xlf
@@ -160,6 +160,11 @@ Výstupem je soubor Sequence.xml v aktuálním adresáři, do kterého se zaznam
         <target state="translated">Konfigurace, která se má použít pro spuštění testů. Výchozí možností pro většinu projektů je Debug.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.de.xlf
@@ -160,6 +160,11 @@ Im aktuellen Verzeichnis wird eine Datei namens "Sequence.xml" ausgegeben, in de
         <target state="translated">Die für die Testausführung zu verwendende Konfiguration. Standard für die meisten Projekte ist "Debug".</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.es.xlf
@@ -160,6 +160,11 @@ Crea un archivo de salida en el directorio actual como "Sequence.xml" que captur
         <target state="translated">La configuración que se usará para ejecutar pruebas. El valor predeterminado para la mayoría de los proyectos es "Debug".</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.fr.xlf
@@ -160,6 +160,11 @@ Elle génère dans le répertoire actif un fichier de sortie nommé 'Sequence.xm
         <target state="translated">Configuration à utiliser pour l'exécution des tests. La valeur par défaut pour la plupart des projets est 'Debug'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.it.xlf
@@ -160,6 +160,11 @@ Crea nella directory corrente un file di output denominato "Sequence.xml", in cu
         <target state="translated">Configurazione da usare per eseguire i test. L'impostazione predefinita per la maggior parte dei progetti è 'Debug'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ja.xlf
@@ -160,6 +160,11 @@ Outputs a 'Sequence.xml' file in the current directory that captures the order o
         <target state="translated">テストの実行に使用する構成。ほとんどのプロジェクトで、既定値は 'Debug' です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ko.xlf
@@ -160,6 +160,11 @@ Outputs a 'Sequence.xml' file in the current directory that captures the order o
         <target state="translated">테스트 실행에 사용할 구성입니다. 대부분의 프로젝트에서 기본값은 'Debug'입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pl.xlf
@@ -160,6 +160,11 @@ Tworzy w bieżącym katalogu plik wyjściowy „Sequence.xml”, który przechwy
         <target state="translated">Konfiguracja do użycia na potrzeby uruchamiania testów. W przypadku większości projektów ustawienie domyślne to „Debugowanie”.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.pt-BR.xlf
@@ -160,6 +160,11 @@ Emite um arquivo 'Sequence.xml' no diretório atual que captura a ordem de execu
         <target state="translated">A configuração a ser usada para executar testes. O padrão para a maioria dos projetos é 'Debug'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.ru.xlf
@@ -160,6 +160,11 @@ Outputs a 'Sequence.xml' file in the current directory that captures the order o
         <target state="translated">Конфигурация для выполнения тестов. По умолчанию для большинства проектов используется "Debug".</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.tr.xlf
@@ -160,6 +160,11 @@ Geçerli dizinde testin kilitlenmeden önceki test yürütme sırasını yakalay
         <target state="translated">Testleri çalıştırmak için kullanılacak yapılandırma. Çoğu proje için varsayılan, ‘Hata Ayıklama’ seçeneğidir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hans.xlf
@@ -160,6 +160,11 @@ Outputs a 'Sequence.xml' file in the current directory that captures the order o
         <target state="translated">用于运行测试的配置。大多数项目的默认值是 "Debug"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-test/xlf/LocalizableStrings.zh-Hant.xlf
@@ -160,6 +160,11 @@ Outputs a 'Sequence.xml' file in the current directory that captures the order o
         <target state="translated">要用於執行測試的組態。大部分的專案預設為「偵錯」。</target>
         <note />
       </trans-unit>
+      <trans-unit id="RuntimeOptionDescription">
+        <source>The target runtime to test for.</source>
+        <target state="new">The target runtime to test for.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
This commit adds a `--runtime` option to the `dotnet test` command for
consistency with other commands.

The option does not have a short form of `-r`, however, because `dotnet test`
already uses the short form for another option (results directory).

Fixes #9583.