### PR TITLE
Suppress output from `dotnet run` when using quiet verbosity level.

### DIFF
--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -26,6 +26,10 @@ namespace Microsoft.DotNet.Tools.Run
 
         private List<string> _args;
         private bool ShouldBuild => !NoBuild;
+        private bool HasQuietVerbosity =>
+            RestoreArgs.All(arg => !arg.StartsWith("-verbosity:", StringComparison.Ordinal) ||
+                                    arg.Equals("-verbosity:q", StringComparison.Ordinal) ||
+                                    arg.Equals("-verbosity:quiet", StringComparison.Ordinal));
 
         public string LaunchProfile { get; private set; }
         public bool NoLaunchProfile { get; private set; }
@@ -114,7 +118,10 @@ namespace Microsoft.DotNet.Tools.Run
                 var launchSettingsPath = Path.Combine(buildPathContainer, "Properties", "launchSettings.json");
                 if (File.Exists(launchSettingsPath))
                 {
-                    Reporter.Output.WriteLine(string.Format(LocalizableStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
+                    if (!HasQuietVerbosity) {
+                        Reporter.Output.WriteLine(string.Format(LocalizableStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
+                    }
+
                     string profileName = string.IsNullOrEmpty(LaunchProfile) ? LocalizableStrings.DefaultLaunchProfileDisplayName : LaunchProfile;
 
                     try

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -343,6 +343,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                             .WithSourceFiles();
 
             var testProjectDirectory = testInstance.Root.FullName;
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
 
             new RestoreCommand()
                 .WithWorkingDirectory(testProjectDirectory)
@@ -359,8 +360,30 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 .ExecuteWithCapturedOutput();
 
             cmd.Should().Pass()
+                .And.NotHaveStdOutContaining(string.Format(LocalizableStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
                 .And.HaveStdOutContaining("First");
                          
+            cmd.StdErr.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItPrintsUsingLaunchSettingsMessageWhenNotQuiet()
+        {
+            var testInstance = TestAssets.Get("AppWithLaunchSettings")
+                            .CreateInstance()
+                            .WithSourceFiles();
+
+            var testProjectDirectory = testInstance.Root.FullName;
+            var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
+
+            var cmd = new RunCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("-v:m");
+
+            cmd.Should().Pass()
+                .And.HaveStdOutContaining(string.Format(LocalizableStrings.UsingLaunchSettingsFromMessage, launchSettingsPath))
+                .And.HaveStdOutContaining("First");
+
             cmd.StdErr.Should().BeEmpty();
         }
 


### PR DESCRIPTION
This commit suppresses the output that is displayed by the `dotnet run` command
when launch settings are being used, unless the verbosity level is above
"quiet".

Fixes #9545.
