### PR TITLE
Avoid GenerateAssemblyInfo for dotnet migrate tests

### DIFF
--- a/test/dotnet-migrate.Tests/GivenThatIWantToMigrateSolutions.cs
+++ b/test/dotnet-migrate.Tests/GivenThatIWantToMigrateSolutions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.DotNet.Migration.Tests
 
             new DotnetCommand()
                 .WithWorkingDirectory(projectDirectory)
-                .Execute($"build \"{solutionRelPath}\"")
+                .Execute($"build \"{solutionRelPath}\" -p:GenerateAssemblyInfo=false") // https://github.com/dotnet/sdk/issues/2278"
                 .Should().Pass();
 
             SlnFile slnFile = SlnFile.Read(Path.Combine(projectDirectory.FullName, solutionRelPath));


### PR DESCRIPTION
This test is the only remaining test for cli-migrate to ensure cli-migrate is connected correctly. But it has the same test issue. Porting https://github.com/dotnet/cli-migrate/commit/21c69705d58b47fdfc834fd975f1d5ef4f44931c