### PR TITLE
Fix dotnet sln add for multitargeted C# and VB projects.

### DIFF
--- a/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedCS/MultitargetedCS.csproj
+++ b/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedCS/MultitargetedCS.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedCS/Program.cs
+++ b/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedCS/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace MultitargetedCS
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedFS/MultitargetedFS.fsproj
+++ b/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedFS/MultitargetedFS.fsproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedFS/Program.fs
+++ b/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedFS/Program.fs
@@ -1,0 +1,8 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+
+[<EntryPoint>]
+let main argv =
+    printfn "Hello World from F#!"
+    0 // return an integer exit code

--- a/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedVB/MultitargetedVB.vbproj
+++ b/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedVB/MultitargetedVB.vbproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MultitargetedVB</RootNamespace>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedVB/Program.vb
+++ b/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/MultitargetedVB/Program.vb
@@ -1,0 +1,7 @@
+Imports System
+
+Module Program
+    Sub Main(args As String())
+        Console.WriteLine("Hello World!")
+    End Sub
+End Module

--- a/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/TestAppsWithSlnAndMultitargetedProjects.sln
+++ b/TestAssets/TestProjects/TestAppsWithSlnAndMultitargetedProjects/TestAppsWithSlnAndMultitargetedProjects.sln
@@ -1,0 +1,18 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -23,7 +23,7 @@
     <MicrosoftNETCoreCompilersPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNETCoreCompilersPackageVersion>
     <MicrosoftCodeAnalysisBuildTasksPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisBuildTasksPackageVersion>
     <MicrosoftNetCompilersNetcorePackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNetCompilersNetcorePackageVersion>
-    <MicrosoftNETSdkPackageVersion>2.1.400-preview-63126-05</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>2.1.400-preview-63130-06</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>2.1.1</MicrosoftNETSdkRazorPackageVersion>
     <MicrosoftNETSdkWebPackageVersion>2.1.400-preview1-20180705-1834985</MicrosoftNETSdkWebPackageVersion>

--- a/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
+++ b/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
@@ -1012,6 +1012,72 @@ EndGlobal
                 .Should().BeVisuallyEquivalentTo(ExpectedSlnFileAfterAddingProjectWithAdditionalConfigs);
         }
 
+        [Fact]
+        public void ItAddsACSharpProjectThatIsMultitargeted()
+        {
+            var solutionDirectory = TestAssets
+                .Get("TestAppsWithSlnAndMultitargetedProjects")
+                .CreateInstance()
+                .WithSourceFiles()
+                .Root
+                .FullName;
+
+            var slnFullPath = Path.Combine(solutionDirectory, "App.sln");
+            var projectToAdd = Path.Combine("MultitargetedCS", "MultitargetedCS.csproj");
+
+            new DotnetCommand()
+                .WithWorkingDirectory(solutionDirectory)
+                .ExecuteWithCapturedOutput($"sln add {projectToAdd}")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(string.Format(CommonLocalizableStrings.ProjectAddedToTheSolution, projectToAdd));
+        }
+
+        [Fact]
+        public void ItAddsAVisualBasicProjectThatIsMultitargeted()
+        {
+            var solutionDirectory = TestAssets
+                .Get("TestAppsWithSlnAndMultitargetedProjects")
+                .CreateInstance()
+                .WithSourceFiles()
+                .Root
+                .FullName;
+
+            var slnFullPath = Path.Combine(solutionDirectory, "App.sln");
+            var projectToAdd = Path.Combine("MultitargetedVB", "MultitargetedVB.vbproj");
+
+            new DotnetCommand()
+                .WithWorkingDirectory(solutionDirectory)
+                .ExecuteWithCapturedOutput($"sln add {projectToAdd}")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(string.Format(CommonLocalizableStrings.ProjectAddedToTheSolution, projectToAdd));
+        }
+
+        [Fact]
+        public void ItAddsAnFSharpProjectThatIsMultitargeted()
+        {
+            var solutionDirectory = TestAssets
+                .Get("TestAppsWithSlnAndMultitargetedProjects")
+                .CreateInstance()
+                .WithSourceFiles()
+                .Root
+                .FullName;
+
+            var slnFullPath = Path.Combine(solutionDirectory, "App.sln");
+            var projectToAdd = Path.Combine("MultitargetedFS", "MultitargetedFS.fsproj");
+
+            new DotnetCommand()
+                .WithWorkingDirectory(solutionDirectory)
+                .ExecuteWithCapturedOutput($"sln add {projectToAdd}")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining(string.Format(CommonLocalizableStrings.ProjectAddedToTheSolution, projectToAdd));
+        }
+
         private string GetExpectedSlnContents(
             string slnPath,
             string slnTemplate,


### PR DESCRIPTION
This commit integrates a fix from the SDK repo that sets
`DefaultProjectTypeGuid` for VB and C# projects when the projects are
multitargeting.  This property is used by `dotnet sln add` to determine the
project type guid to map in the solution file.

Adding additional tests that cover the multitargeting scenario for `dotnet sln
add`.

Fixes #9477.
