### PR TITLE
Add CLI side of "latest patch for 2.1" in roll-forward logic

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -196,6 +196,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <LatestPatchVersionForNetCore1_0 Condition="'%24(LatestPatchVersionForNetCore1_0)' == ''">1.0.12</LatestPatchVersionForNetCore1_0>
     <LatestPatchVersionForNetCore1_1 Condition="'%24(LatestPatchVersionForNetCore1_1)' == ''">1.1.9</LatestPatchVersionForNetCore1_1>
     <LatestPatchVersionForNetCore2_0 Condition="'%24(LatestPatchVersionForNetCore2_0)' == ''">2.0.9</LatestPatchVersionForNetCore2_0>
+    <LatestPatchVersionForNetCore2_1 Condition="'%24(LatestPatchVersionForNetCore2_1)' == ''">2.1.2</LatestPatchVersionForNetCore2_1>
   </PropertyGroup>
 </Project>
 ]]>

--- a/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
+++ b/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
@@ -21,8 +21,9 @@ namespace EndToEnd
         [ClassData(typeof(SupportedNetCoreAppVersions))]
         public void ItRollsForwardToTheLatestVersion(string minorVersion)
         {
-            // https://github.com/dotnet/cli/issues/9661: remove this once the ASP.NET version bump
-            // merges from 2.1.3xx -> 2.1.4xx -> 2.2.1xx
+            // https://github.com/dotnet/cli/issues/9661
+            // https://github.com/dotnet/sdk/issues/2446
+            // dotnet/sdk is missing handling for 2.1 when it isn't the latest runtime
             if (minorVersion == "2.1")
             {
                 return;


### PR DESCRIPTION
Also adjust comment with real reason for skipping test, pointing to dotnet/sdk bug.

See https://github.com/dotnet/sdk/issues/2446, which is still needed to fully fix the issue.


