### PR TITLE
Removing the publish lzma from the CLI

### DIFF
--- a/build/Publish.targets
+++ b/build/Publish.targets
@@ -28,8 +28,6 @@
                      Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' "/>
       <ForPublishing Include="$(PackagesDirectory)/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.*"
                      Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' "/>
-      <ForPublishing Include="$(PackagesDirectory)/nuGetPackagesArchive.lzma"
-                     Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' "/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We no longer have the lzma in the CLI. It comes in in the core-sdk layer. Removing the publish lzma from the CLI as it is breaking the official build.
