### PR TITLE
Complete configurations based on project file if present.

### DIFF
--- a/src/dotnet/CommonOptions.cs
+++ b/src/dotnet/CommonOptions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli
                 description,
                 Accept.ExactlyOneArgument()
                     .With(name: CommonLocalizableStrings.ConfigurationArgumentName)
-                    .WithSuggestionsFrom("Debug", "Release")
+                    .WithSuggestionsFrom(_ => Suggest.ConfigurationsFromProjectFileOrDefaults())
                     .ForwardAsSingle(o => $"-property:Configuration={o.Arguments.Single()}"));
 
         public static Option VersionSuffixOption() =>

--- a/src/dotnet/MsbuildProject.cs
+++ b/src/dotnet/MsbuildProject.cs
@@ -25,6 +25,7 @@ namespace Microsoft.DotNet.Tools
         private ProjectCollection _projects;
         private List<NuGetFramework> _cachedTfms = null;
         private IEnumerable<string> cachedRuntimeIdentifiers;
+        private IEnumerable<string> cachedConfigurations;
 
         private MsbuildProject(ProjectCollection projects, ProjectRootElement project)
         {
@@ -166,6 +167,12 @@ namespace Microsoft.DotNet.Tools
             var project = GetEvaluatedProject();
             _cachedTfms = project.GetTargetFrameworks().ToList();
             return _cachedTfms;
+        }
+
+        public IEnumerable<string> GetConfigurations()
+        {
+            return cachedConfigurations ??
+                   (cachedConfigurations = GetEvaluatedProject().GetConfigurations());
         }
 
         public bool CanWorkOnFramework(NuGetFramework framework)

--- a/src/dotnet/ProjectExtensions.cs
+++ b/src/dotnet/ProjectExtensions.cs
@@ -32,6 +32,11 @@ namespace Microsoft.DotNet.Tools.ProjectExtensions
                 .Select((frameworkString) => NuGetFramework.Parse(frameworkString));
         }
 
+        public static IEnumerable<string> GetConfigurations(this Project project)
+        {
+            return project.GetPropertyCommaSeparatedValues("Configurations");
+        }
+
         public static IEnumerable<string> GetPropertyCommaSeparatedValues(this Project project, string propertyName)
         {
             return project.GetPropertyValue(propertyName)

--- a/src/dotnet/commands/dotnet-complete/Suggest.cs
+++ b/src/dotnet/commands/dotnet-complete/Suggest.cs
@@ -40,6 +40,11 @@ namespace Microsoft.DotNet.Cli
                 .Select(r => r.Include) ??
             Empty<string>();
 
+        public static IEnumerable<string> ConfigurationsFromProjectFileOrDefaults() =>
+            GetMSBuildProject()
+                ?.GetConfigurations() ??
+            new[] { "Debug", "Release" };
+
         private static MsbuildProject GetMSBuildProject()
         {
             try


### PR DESCRIPTION
based on the discussion in https://github.com/dotnet/cli/issues/9351

This completes `-c` using suggestions from a project file if present similar to the RIDs ad TFMs.