### PR TITLE
Fix build warnings and treat msbuild warnings as errors

### DIFF
--- a/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-tool-invoker/dotnet-dependency-tool-invoker.csproj
@@ -1,8 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project>
 
   <!-- This test asset needs to import the general dir.props in order to get the SdkNugetVersion property.
       This is why it also needs to explicitly set DisableImplicitFrameworkReferences to false. -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
 
   <PropertyGroup>
     <VersionPrefix>1.0.0-rc</VersionPrefix>
@@ -23,4 +24,5 @@
     <PackageReference Include="System.Linq" Version="4.3.0" />
   </ItemGroup>
 
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 </Project>

--- a/build/BuildDefaults.props
+++ b/build/BuildDefaults.props
@@ -33,5 +33,6 @@
     <NoWarn>NU1701;NU5104</NoWarn>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -78,7 +78,7 @@
   <PropertyGroup>
     <BuildTasksFeedToolVersion>2.1.0-prerelease-02430-04</BuildTasksFeedToolVersion>
     <VersionToolsVersion>$(BuildTasksFeedToolVersion)</VersionToolsVersion>
-    <DotnetDebToolVersion>2.0.0-preview2-25331-01</DotnetDebToolVersion>
+    <DotnetDebToolVersion>2.0.0</DotnetDebToolVersion>
   </PropertyGroup>
 
 </Project>

--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -94,12 +94,12 @@
         UseHardlinksIfPossible="False" />
 
       <!-- Remove Shared Framework and Debian Packages -->
-      <Exec Command="sudo dpkg -r $(SdkDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreSharedFxDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(SharedFxDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(HostFxrDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(HostDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(RuntimeDepsPackageName)" />
+      <Exec Command="sudo dpkg -r $(SdkDebianPackageName)" IgnoreStandardErrorWarningFormat="true"  />
+      <Exec Command="sudo dpkg -r $(AspNetCoreSharedFxDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
+      <Exec Command="sudo dpkg -r $(SharedFxDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
+      <Exec Command="sudo dpkg -r $(HostFxrDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
+      <Exec Command="sudo dpkg -r $(HostDebianPackageName)" IgnoreStandardErrorWarningFormat="true"/>
+      <Exec Command="sudo dpkg -r $(RuntimeDepsPackageName)" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Target Name="TestSdkDeb"
@@ -129,12 +129,12 @@
                   ToolPath="$(DebianInstalledDirectory)" />
 
       <!-- Clean up Packages -->
-      <Exec Command="sudo dpkg -r $(SdkDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(AspNetCoreSharedFxDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(SharedFxDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(HostFxrDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(HostDebianPackageName)" />
-      <Exec Command="sudo dpkg -r $(RuntimeDepsPackageName)" />
+      <Exec Command="sudo dpkg -r $(SdkDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
+      <Exec Command="sudo dpkg -r $(AspNetCoreSharedFxDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
+      <Exec Command="sudo dpkg -r $(SharedFxDebianPackageName)" IgnoreStandardErrorWarningFormat="true"  />
+      <Exec Command="sudo dpkg -r $(HostFxrDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
+      <Exec Command="sudo dpkg -r $(HostDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
+      <Exec Command="sudo dpkg -r $(RuntimeDepsPackageName)" IgnoreStandardErrorWarningFormat="true" />
   </Target>
 
   <Target Name="PrepareDotnetDebDirectories">
@@ -174,8 +174,9 @@
   <Target Name="TestDebuild">
       <Message Text="Don't remove this" />
 
-      <!-- run Debuild -->
-      <Exec Command="/usr/bin/env debuild -h" ContinueOnError="true">
+      <!-- run Debuild  -->
+      <!-- NB: IgnoreExitCode prevents Exec from failing, but does not prevent us from retrieving the exit code. -->
+      <Exec Command="/usr/bin/env debuild -h > /dev/null 2>&amp;1" IgnoreExitCode="true">
           <Output TaskParameter="ExitCode" PropertyName="DebuildExitCode" />
       </Exec>
 

--- a/build/package/Installer.RPM.targets
+++ b/build/package/Installer.RPM.targets
@@ -196,7 +196,8 @@
   <Target Name="TestFPMTool">
 
     <!-- run FPM  -->
-    <Exec Command="fpm --help > /dev/null" ContinueOnError="True">
+    <!-- NB: IgnoreExitCode prevents Exec from failing, but does not prevent us from retrieving the exit code. -->
+    <Exec Command="fpm --help > /dev/null 2>&amp;1" IgnoreExitCode="True">
       <Output TaskParameter="ExitCode" PropertyName="FPMExitCode"/>
     </Exec>
 


### PR DESCRIPTION
We were getting the warning that we set BaseIntermediateOutputPath to late because in this special case, we did it after SDK props and not via Directory.Build.props.

Also, preventing more warnings like this from creeping in by treating MSBuild warnings as errors, same as compiler warnings.