### PR TITLE
Add restore passthrough 

### DIFF
--- a/src/Microsoft.DotNet.InternalAbstractions/FilePath.cs
+++ b/src/Microsoft.DotNet.InternalAbstractions/FilePath.cs
@@ -23,6 +23,16 @@ namespace Microsoft.Extensions.EnvironmentAbstractions
             Value = value;
         }
 
+        public static FilePath? CreateOrReturnNullWhenValueIsNull(string value)
+        {
+            if (value != null)
+            {
+                return new FilePath(value);
+            }
+
+            return null;
+        }
+
         public string ToQuotedString()
         {
             return $"\"{Value}\"";

--- a/src/dotnet/ToolPackage/PackageLocation.cs
+++ b/src/dotnet/ToolPackage/PackageLocation.cs
@@ -1,5 +1,7 @@
 ﻿
 using System;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.ToolPackage
@@ -14,6 +16,12 @@ namespace Microsoft.DotNet.ToolPackage
             NugetConfig = nugetConfig;
             RootConfigDirectory = rootConfigDirectory;
             AdditionalFeeds = additionalFeeds ?? Array.Empty<string>();
+        }
+
+        public PackageLocation(AppliedOption appliedOption)
+        {
+            NugetConfig = FilePath.CreateOrReturnNullWhenValueIsNull(appliedOption.ValueOrDefault<string>("configfile"));
+            AdditionalFeeds  = appliedOption.ValueOrDefault<string[]>("add-source");
         }
 
         public FilePath? NugetConfig { get; }

--- a/src/dotnet/ToolPackage/PackageLocation.cs
+++ b/src/dotnet/ToolPackage/PackageLocation.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotNet.ToolPackage
     {
         public PackageLocation(
             FilePath? nugetConfig = null,
-            DirectoryPath? rootConfigDirectory = null, 
+            DirectoryPath? rootConfigDirectory = null,
             string[] additionalFeeds = null)
         {
             NugetConfig = nugetConfig;

--- a/src/dotnet/ToolPackage/PackageLocation.cs
+++ b/src/dotnet/ToolPackage/PackageLocation.cs
@@ -11,21 +11,25 @@ namespace Microsoft.DotNet.ToolPackage
         public PackageLocation(
             FilePath? nugetConfig = null,
             DirectoryPath? rootConfigDirectory = null,
-            string[] additionalFeeds = null)
+            string[] additionalFeeds = null,
+            bool disableParallel = false)
         {
             NugetConfig = nugetConfig;
             RootConfigDirectory = rootConfigDirectory;
             AdditionalFeeds = additionalFeeds ?? Array.Empty<string>();
+            DisableParallel = disableParallel;
         }
 
         public PackageLocation(AppliedOption appliedOption)
         {
             NugetConfig = FilePath.CreateOrReturnNullWhenValueIsNull(appliedOption.ValueOrDefault<string>("configfile"));
             AdditionalFeeds  = appliedOption.ValueOrDefault<string[]>("add-source");
+            DisableParallel = appliedOption.ValueOrDefault<bool>("disable-parallel");
         }
 
         public FilePath? NugetConfig { get; }
         public DirectoryPath? RootConfigDirectory { get; }
         public string[] AdditionalFeeds { get; }
+        public bool DisableParallel { get; }
     }
 }

--- a/src/dotnet/ToolPackage/PackageLocation.cs
+++ b/src/dotnet/ToolPackage/PackageLocation.cs
@@ -12,12 +12,15 @@ namespace Microsoft.DotNet.ToolPackage
             FilePath? nugetConfig = null,
             DirectoryPath? rootConfigDirectory = null,
             string[] additionalFeeds = null,
-            bool disableParallel = false)
+            bool disableParallel = false,
+            bool NoCache = false,
+            bool ignoreFailedSources = false)
         {
             NugetConfig = nugetConfig;
             RootConfigDirectory = rootConfigDirectory;
             AdditionalFeeds = additionalFeeds ?? Array.Empty<string>();
             DisableParallel = disableParallel;
+            IgnoreFailedSources = IgnoreFailedSources;
         }
 
         public PackageLocation(AppliedOption appliedOption)
@@ -25,11 +28,15 @@ namespace Microsoft.DotNet.ToolPackage
             NugetConfig = FilePath.CreateOrReturnNullWhenValueIsNull(appliedOption.ValueOrDefault<string>("configfile"));
             AdditionalFeeds  = appliedOption.ValueOrDefault<string[]>("add-source");
             DisableParallel = appliedOption.ValueOrDefault<bool>("disable-parallel");
+            NoCache = appliedOption.ValueOrDefault<bool>("no-cache");
+            IgnoreFailedSources = appliedOption.ValueOrDefault<bool>("ignore-failed-sources");
         }
 
         public FilePath? NugetConfig { get; }
         public DirectoryPath? RootConfigDirectory { get; }
         public string[] AdditionalFeeds { get; }
         public bool DisableParallel { get; }
+        public bool NoCache { get; }
+        public bool IgnoreFailedSources { get; }
     }
 }

--- a/src/dotnet/commands/dotnet-tool/ToolCommandRestorePassThroughOptions.cs
+++ b/src/dotnet/commands/dotnet-tool/ToolCommandRestorePassThroughOptions.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.CommandLine;
+using LocalizableStrings = Microsoft.DotNet.Tools.Restore.LocalizableStrings;
+
+namespace Microsoft.DotNet.Cli
+{
+    internal static class ToolCommandRestorePassThroughOptions
+    {
+        public static Option DisableParallelOption()
+        {
+            return Create.Option(
+                "--disable-parallel",
+                LocalizableStrings.CmdDisableParallelOptionDescription,
+                Accept.NoArguments());
+        }
+
+        public static Option ConfigfileOption()
+        {
+            return Create.Option(
+                    "--configfile",
+                    LocalizableStrings.CmdConfigFileOptionDescription,
+                    Accept.ExactlyOneArgument()
+                          .With(name: LocalizableStrings.CmdConfigFileOption));
+        }
+
+        public static Option NoCacheOption()
+        {
+            return Create.Option(
+                    "--no-cache",
+                    LocalizableStrings.CmdNoCacheOptionDescription,
+                    Accept.NoArguments());
+        }
+
+        public static Option IgnoreFailedSourcesOption()
+        {
+            return Create.Option(
+                    "--ignore-failed-sources",
+                    LocalizableStrings.CmdIgnoreFailedSourcesOptionDescription,
+                    Accept.NoArguments());
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -64,6 +64,11 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             }
         }
 
+        public List<string> ToRestoreArguments(PackageLocation packageLocation)
+        {
+            throw new NotImplementedException();
+        }
+
         private static void WriteLine(IReporter reporter, string line, FilePath project)
         {
             line = line ?? "";

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -71,6 +71,11 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                 args.Add(packageLocation.NugetConfig.Value.Value);
             }
 
+            if (packageLocation.DisableParallel)
+            {
+                args.Add("--disable-parallel");
+            }
+
             return args;
         }
 

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -33,17 +33,14 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             var argsToPassToRestore = new List<string>();
 
             argsToPassToRestore.Add(project.Value);
-            if (packageLocation.NugetConfig != null)
-            {
-                argsToPassToRestore.Add("--configfile");
-                argsToPassToRestore.Add(packageLocation.NugetConfig.Value.Value);
-            }
 
             argsToPassToRestore.AddRange(new List<string>
             {
                 "--runtime",
                 AnyRid
             });
+
+            argsToPassToRestore.AddRange(ToRestoreArguments(packageLocation));
 
             argsToPassToRestore.Add($"-verbosity:{verbosity ?? "quiet"}");
 
@@ -64,9 +61,17 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             }
         }
 
-        public List<string> ToRestoreArguments(PackageLocation packageLocation)
+        public static List<string> ToRestoreArguments(PackageLocation packageLocation)
         {
-            throw new NotImplementedException();
+            var args = new List<string>();
+
+            if (packageLocation.NugetConfig != null)
+            {
+                args.Add("--configfile");
+                args.Add(packageLocation.NugetConfig.Value.Value);
+            }
+
+            return args;
         }
 
         private static void WriteLine(IReporter reporter, string line, FilePath project)

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -76,6 +76,16 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                 args.Add("--disable-parallel");
             }
 
+            if (packageLocation.NoCache)
+            {
+                args.Add("--no-cache");
+            }
+
+            if (packageLocation.IgnoreFailedSources)
+            {
+                args.Add("--ignore-failed-sources");
+            }
+
             return args;
         }
 

--- a/src/dotnet/commands/dotnet-tool/install/ToolInstallCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ToolInstallCommand.cs
@@ -52,9 +52,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 
             _packageId = new PackageId(appliedCommand.Arguments.Single());
             _packageVersion = appliedCommand.ValueOrDefault<string>("version");
-            _packageLocation = new PackageLocation(
-                nugetConfig: FilePath.CreateOrReturnNullWhenValueIsNull(appliedCommand.ValueOrDefault<string>("configfile")),
-                additionalFeeds: appliedCommand.ValueOrDefault<string[]>("add-source"));
+            _packageLocation = new PackageLocation(appliedCommand);
             _framework = appliedCommand.ValueOrDefault<string>("framework");
             _global = appliedCommand.ValueOrDefault<bool>("global");
             _verbosity = appliedCommand.SingleArgumentOrDefault("verbosity");

--- a/src/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
@@ -30,11 +30,6 @@ namespace Microsoft.DotNet.Cli
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.VersionOptionName)),
                 Create.Option(
-                    "--configfile",
-                    LocalizableStrings.ConfigFileOptionDescription,
-                    Accept.ExactlyOneArgument()
-                          .With(name: LocalizableStrings.ConfigFileOptionName)),
-                Create.Option(
                     "--add-source",
                     LocalizableStrings.AddSourceOptionDescription,
                     Accept.OneOrMoreArguments()
@@ -44,6 +39,10 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.FrameworkOptionDescription,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.FrameworkOptionName)),
+                ToolCommandRestorePassThroughOptions.ConfigfileOption(),
+                ToolCommandRestorePassThroughOptions.DisableParallelOption(),
+                ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption(),
+                ToolCommandRestorePassThroughOptions.NoCacheOption(),
                 CommonOptions.HelpOption(),
                 CommonOptions.VerbosityOption());
         }

--- a/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommandParser.cs
+++ b/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommandParser.cs
@@ -25,11 +25,6 @@ namespace Microsoft.DotNet.Cli
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.ToolPathOptionName)),
                 Create.Option(
-                    "--configfile",
-                    LocalizableStrings.ConfigFileOptionDescription,
-                    Accept.ExactlyOneArgument()
-                          .With(name: LocalizableStrings.ConfigFileOptionName)),
-                Create.Option(
                     "--add-source",
                     LocalizableStrings.AddSourceOptionDescription,
                     Accept.OneOrMoreArguments()
@@ -39,6 +34,10 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.FrameworkOptionDescription,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.FrameworkOptionName)),
+                ToolCommandRestorePassThroughOptions.ConfigfileOption(),
+                ToolCommandRestorePassThroughOptions.DisableParallelOption(),
+                ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption(),
+                ToolCommandRestorePassThroughOptions.NoCacheOption(),
                 CommonOptions.HelpOption(),
                 CommonOptions.VerbosityOption());
         }

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ProjectRestorerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ProjectRestorerTests.cs
@@ -52,6 +52,45 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             restoreAppliedCommand.HasOption("--disable-parallel").Should().BeFalse();
         }
 
+        [Fact]
+        void ItCreatesValidArgumentsToRestoreForwardingNoCache()
+        {
+            PackageLocation packageLocation = CreatePackageLocationByInstallCommand($"dotnet tool install -g console.test.app --no-cache");
+
+            List<string> args = ProjectRestorer.ToRestoreArguments(packageLocation);
+
+            AppliedOption restoreAppliedCommand = CreateRestoreCommandParseResultUsingToRestoreArguments(args);
+            restoreAppliedCommand.HasOption("--no-cache").Should().BeTrue();
+        }
+
+        [Fact]
+        void ItCreatesValidArgumentsToRestoreForwardingIgnoreFailedSources()
+        {
+            PackageLocation packageLocation = CreatePackageLocationByInstallCommand($"dotnet tool install -g console.test.app --ignore-failed-sources");
+
+            List<string> args = ProjectRestorer.ToRestoreArguments(packageLocation);
+
+            AppliedOption restoreAppliedCommand = CreateRestoreCommandParseResultUsingToRestoreArguments(args);
+            restoreAppliedCommand.HasOption("--ignore-failed-sources").Should().BeTrue();
+        }
+
+        [Fact]
+        void ItCreatesValidArgumentsToRestoreForwardingMixArguments()
+        {
+            const string configPath = "c:\\nuget.config";
+            PackageLocation packageLocation = CreatePackageLocationByInstallCommand($"dotnet tool install -g console.test.app --configfile {configPath} --ignore-failed-sources");
+
+            List<string> args = ProjectRestorer.ToRestoreArguments(packageLocation);
+
+            AppliedOption restoreAppliedCommand = CreateRestoreCommandParseResultUsingToRestoreArguments(args);
+            restoreAppliedCommand.HasOption("--no-cache").Should().BeFalse();
+            restoreAppliedCommand.HasOption("--disable-parallel").Should().BeFalse();
+            restoreAppliedCommand.HasOption("--ignore-failed-sources").Should().BeTrue();
+            restoreAppliedCommand["--configfile"].Arguments.Single()
+                .Should()
+                .Be(configPath);
+        }
+
         private static AppliedOption CreateRestoreCommandParseResultUsingToRestoreArguments(List<string> args)
         {
             args.Insert(0, "restore");

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ProjectRestorerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ProjectRestorerTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Tools.Tool.Install;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Xunit;
+using System.Linq;
+using Microsoft.DotNet.Cli.CommandLine;
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.ToolPackage.Tests
+{
+    public class ProjectRestorerTests : TestBase
+    {
+        [Fact]
+        void ToRestoreArgumentsNugetConfigTests()
+        {
+            const string configPath = "c:\\nuget.config";
+            var packageLocation = new PackageLocation(nugetConfig: new FilePath(configPath));
+            System.Collections.Generic.List<string> args = ProjectRestorer.ToRestoreArguments(packageLocation);
+            args.Insert(0, "restore");
+            args.Insert(0, "dotnet");
+
+            AppliedOption appliedCommand = Parser.Instance.Parse(args.ToArray()).AppliedCommand();
+
+            appliedCommand["--configfile"].Arguments.Single()
+                .Should()
+                .Be(configPath);
+        }
+    }
+}

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -85,31 +85,11 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             package.Uninstall();
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void GivenNugetConfigInstallSucceeds(bool testMockBehaviorIsInSync)
-        {
-            var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
-
-            var (store, installer, reporter, fileSystem) = Setup(
-                useMock: testMockBehaviorIsInSync,
-                feeds: GetMockFeedsForConfigFile(nugetConfigPath));
-
-            var package = installer.InstallPackage(new PackageLocation(nugetConfig: nugetConfigPath),
-                packageId: TestPackageId,
-                versionRange: VersionRange.Parse(TestPackageVersion),
-                targetFramework: _testTargetframework);
-
-            AssertPackageInstall(reporter, fileSystem, package, store);
-
-            package.Uninstall();
-        }
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void GivenNugetConfigInstallSucceedsInTransaction(bool testMockBehaviorIsInSync)
+        public void GivenNugetInstallSucceedsInTransaction(bool testMockBehaviorIsInSync)
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
@@ -138,7 +118,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void GivenNugetConfigInstallCreatesAnAssetFile(bool testMockBehaviorIsInSync)
+        public void GivenNugetInstallCreatesAnAssetFile(bool testMockBehaviorIsInSync)
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
             var package = installer.InstallPackage(
-                new PackageLocation(nugetConfig: nugetConfigPath), 
+                new PackageLocation(nugetConfig: nugetConfigPath),
                 packageId: TestPackageId,
                 targetFramework: _testTargetframework);
 

--- a/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
@@ -108,5 +108,35 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var appliedOptions = result["dotnet"]["tool"]["install"];
             appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\Tools");
         }
+
+        [Fact]
+        public void InstallToolParserCanParseNoCacheOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool install -g console.test.app --no-cache");
+
+            var appliedOptions = result["dotnet"]["tool"]["install"];
+            appliedOptions.ValueOrDefault<bool>("no-cache").Should().Be(true);
+        }
+
+        [Fact]
+        public void InstallToolParserCanParseIgnoreFailedSourcesOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool install -g console.test.app --ignore-failed-sources");
+
+            var appliedOptions = result["dotnet"]["tool"]["install"];
+            appliedOptions.ValueOrDefault<bool>("ignore-failed-sources").Should().Be(true);
+        }
+
+        [Fact]
+        public void InstallToolParserCanParseDisableParallelOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool install -g console.test.app --disable-parallel");
+
+            var appliedOptions = result["dotnet"]["tool"]["install"];
+            appliedOptions.ValueOrDefault<bool>("disable-parallel").Should().Be(true);
+        }
     }
 }

--- a/test/dotnet.Tests/ParserTests/UpdateToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/UpdateToolParserTests.cs
@@ -107,5 +107,35 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var appliedOptions = result["dotnet"]["tool"]["update"];
             appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\TestAssetLocalNugetFeed");
         }
+
+        [Fact]
+        public void UpdateToolParserCanParseNoCacheOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool update -g console.test.app --no-cache");
+
+            var appliedOptions = result["dotnet"]["tool"]["update"];
+            appliedOptions.ValueOrDefault<bool>("no-cache").Should().Be(true);
+        }
+
+        [Fact]
+        public void UpdateToolParserCanParseIgnoreFailedSourcesOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool update -g console.test.app --ignore-failed-sources");
+
+            var appliedOptions = result["dotnet"]["tool"]["update"];
+            appliedOptions.ValueOrDefault<bool>("ignore-failed-sources").Should().Be(true);
+        }
+
+        [Fact]
+        public void UpdateToolParserCanParseDisableParallelOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool update -g console.test.app --disable-parallel");
+
+            var appliedOptions = result["dotnet"]["tool"]["update"];
+            appliedOptions.ValueOrDefault<bool>("disable-parallel").Should().Be(true);
+        }
     }
 }


### PR DESCRIPTION
Allow disable-parallel, no-cache, ignore-failed-sources to pass through dotnet tool install

And refactor –-configfile to use the new way handling pass through.
Only few restore option make sense to dotnet tool install. So we need to handle it case by case. And it requires much more code than just pass the rest as string. And option like -–source is not directly pass through, since tool install will make it “additional” and also pass it via xml. Only disable-parallel, no-cache, ignore-failed-sources, configfile have no difference between restore and tool install.
I test it by make sure PackageLocation can get correct option from parse result and when feed argument generator’s result back to restore parser. Verify it can be understand by restore parser. We could further abstract the idea of pass through (less code). But so far only these 4 options are qualified to this concept.
