### PR TITLE
Select forward arguments to restore

### DIFF
--- a/src/dotnet/ToolPackage/ToolPackageFactory.cs
+++ b/src/dotnet/ToolPackage/ToolPackageFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.Tools.Tool.Install;
@@ -11,12 +12,13 @@ namespace Microsoft.DotNet.ToolPackage
     internal static class ToolPackageFactory
     {
         public static (IToolPackageStore, IToolPackageInstaller) CreateToolPackageStoreAndInstaller(
-            DirectoryPath? nonGlobalLocation = null)
+            DirectoryPath? nonGlobalLocation = null,
+            IEnumerable<string> alwaysForwardArguments = null)
         {
             IToolPackageStore toolPackageStore = CreateToolPackageStore(nonGlobalLocation);
             var toolPackageInstaller = new ToolPackageInstaller(
                 toolPackageStore,
-                new ProjectRestorer());
+                new ProjectRestorer(alwaysForwardArguments: alwaysForwardArguments));
 
             return (toolPackageStore, toolPackageInstaller);
         }

--- a/src/dotnet/ToolPackage/ToolPackageFactory.cs
+++ b/src/dotnet/ToolPackage/ToolPackageFactory.cs
@@ -13,12 +13,12 @@ namespace Microsoft.DotNet.ToolPackage
     {
         public static (IToolPackageStore, IToolPackageInstaller) CreateToolPackageStoreAndInstaller(
             DirectoryPath? nonGlobalLocation = null,
-            IEnumerable<string> alwaysForwardArguments = null)
+            IEnumerable<string> additionalRestoreArguments = null)
         {
             IToolPackageStore toolPackageStore = CreateToolPackageStore(nonGlobalLocation);
             var toolPackageInstaller = new ToolPackageInstaller(
                 toolPackageStore,
-                new ProjectRestorer(alwaysForwardArguments: alwaysForwardArguments));
+                new ProjectRestorer(additionalRestoreArguments: additionalRestoreArguments));
 
             return (toolPackageStore, toolPackageInstaller);
         }

--- a/src/dotnet/commands/dotnet-tool/ToolCommandRestorePassThroughOptions.cs
+++ b/src/dotnet/commands/dotnet-tool/ToolCommandRestorePassThroughOptions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.DotNet.Cli.CommandLine;
+using LocalizableStrings = Microsoft.DotNet.Tools.Restore.LocalizableStrings;
+
+
+namespace Microsoft.DotNet.Cli
+{
+    internal static class ToolCommandRestorePassThroughOptions
+    {
+        public static Option DisableParallelOption()
+        {
+            return Create.Option(
+                "--disable-parallel",
+                LocalizableStrings.CmdDisableParallelOptionDescription,
+                Accept.NoArguments().ForwardAs("--disable-parallel"));
+        }
+
+        public static Option NoCacheOption()
+        {
+            return Create.Option(
+                "--no-cache",
+                LocalizableStrings.CmdNoCacheOptionDescription,
+                Accept.NoArguments().ForwardAs("--no-cache"));
+        }
+
+        public static Option IgnoreFailedSourcesOption()
+        {
+            return Create.Option(
+                "--ignore-failed-sources",
+                LocalizableStrings.CmdIgnoreFailedSourcesOptionDescription,
+                Accept.NoArguments().ForwardAs("--ignore-failed-sources"));
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Tools;
@@ -18,9 +19,11 @@ namespace Microsoft.DotNet.Tools.Tool.Install
         private readonly IReporter _reporter;
         private readonly IReporter _errorReporter;
         private readonly bool _forceOutputRedirection;
+        private readonly IEnumerable<string> _alwaysForwardArguments;
 
-        public ProjectRestorer(IReporter reporter = null)
+        public ProjectRestorer(IReporter reporter = null, IEnumerable<string> alwaysForwardArguments = null)
         {
+            _alwaysForwardArguments = alwaysForwardArguments;
             _reporter = reporter ?? Reporter.Output;
             _errorReporter = reporter ?? Reporter.Error;
             _forceOutputRedirection = reporter != null;
@@ -46,6 +49,11 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             });
 
             argsToPassToRestore.Add($"-verbosity:{verbosity ?? "quiet"}");
+
+            if (_alwaysForwardArguments != null && _alwaysForwardArguments.Any())
+            {
+                argsToPassToRestore.AddRange(_alwaysForwardArguments);
+            }
 
             var command = new DotNetCommandFactory(alwaysRunOutOfProc: true)
                 .Create("restore", argsToPassToRestore);

--- a/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ProjectRestorer.cs
@@ -19,11 +19,12 @@ namespace Microsoft.DotNet.Tools.Tool.Install
         private readonly IReporter _reporter;
         private readonly IReporter _errorReporter;
         private readonly bool _forceOutputRedirection;
-        private readonly IEnumerable<string> _alwaysForwardArguments;
+        private readonly IEnumerable<string> _additionalRestoreArguments;
 
-        public ProjectRestorer(IReporter reporter = null, IEnumerable<string> alwaysForwardArguments = null)
+        public ProjectRestorer(IReporter reporter = null,
+            IEnumerable<string> additionalRestoreArguments = null)
         {
-            _alwaysForwardArguments = alwaysForwardArguments;
+            _additionalRestoreArguments = additionalRestoreArguments;
             _reporter = reporter ?? Reporter.Output;
             _errorReporter = reporter ?? Reporter.Error;
             _forceOutputRedirection = reporter != null;
@@ -50,9 +51,9 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 
             argsToPassToRestore.Add($"-verbosity:{verbosity ?? "quiet"}");
 
-            if (_alwaysForwardArguments != null && _alwaysForwardArguments.Any())
+            if (_additionalRestoreArguments != null)
             {
-                argsToPassToRestore.AddRange(_alwaysForwardArguments);
+                argsToPassToRestore.AddRange(_additionalRestoreArguments);
             }
 
             var command = new DotNetCommandFactory(alwaysRunOutOfProc: true)

--- a/src/dotnet/commands/dotnet-tool/install/ToolInstallCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ToolInstallCommand.cs
@@ -18,7 +18,10 @@ using NuGet.Versioning;
 namespace Microsoft.DotNet.Tools.Tool.Install
 {
     internal delegate IShellShimRepository CreateShellShimRepository(DirectoryPath? nonGlobalLocation = null);
-    internal delegate (IToolPackageStore, IToolPackageInstaller) CreateToolPackageStoreAndInstaller(DirectoryPath? nonGlobalLocation = null);
+
+    internal delegate (IToolPackageStore, IToolPackageInstaller) CreateToolPackageStoreAndInstaller(
+        DirectoryPath? nonGlobalLocation = null,
+        IEnumerable<string> forwardRestoreArgument = null);
 
     internal class ToolInstallCommand : CommandBase
     {
@@ -36,6 +39,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
         private readonly bool _global;
         private readonly string _verbosity;
         private readonly string _toolPath;
+        private IEnumerable<string> _forwardRestoreArguments;
 
         public ToolInstallCommand(
             AppliedOption appliedCommand,
@@ -61,6 +65,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             _toolPath = appliedCommand.SingleArgumentOrDefault("tool-path");
 
             _createToolPackageStoreAndInstaller = createToolPackageStoreAndInstaller ?? ToolPackageFactory.CreateToolPackageStoreAndInstaller;
+            _forwardRestoreArguments = appliedCommand.OptionValuesToBeForwarded();
 
             _environmentPathInstruction = environmentPathInstruction
                 ?? EnvironmentPathFactory.CreateEnvironmentPathInstruction();
@@ -107,7 +112,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
             }
 
             (IToolPackageStore toolPackageStore, IToolPackageInstaller toolPackageInstaller) =
-                _createToolPackageStoreAndInstaller(toolPath);
+                _createToolPackageStoreAndInstaller(toolPath, _forwardRestoreArguments);
             IShellShimRepository shellShimRepository = _createShellShimRepository(toolPath);
 
             // Prevent installation if any version of the package is installed

--- a/src/dotnet/commands/dotnet-tool/install/ToolInstallCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ToolInstallCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 
     internal delegate (IToolPackageStore, IToolPackageInstaller) CreateToolPackageStoreAndInstaller(
         DirectoryPath? nonGlobalLocation = null,
-        IEnumerable<string> forwardRestoreArgument = null);
+        IEnumerable<string> forwardRestoreArguments = null);
 
     internal class ToolInstallCommand : CommandBase
     {

--- a/src/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ToolInstallCommandParser.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Cli
                     "--configfile",
                     LocalizableStrings.ConfigFileOptionDescription,
                     Accept.ExactlyOneArgument()
-                          .With(name: LocalizableStrings.ConfigFileOptionName)),
+                        .With(name: LocalizableStrings.ConfigFileOptionName)),
                 Create.Option(
                     "--add-source",
                     LocalizableStrings.AddSourceOptionDescription,
@@ -44,6 +44,9 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.FrameworkOptionDescription,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.FrameworkOptionName)),
+                ToolCommandRestorePassThroughOptions.DisableParallelOption(),
+                ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption(),
+                ToolCommandRestorePassThroughOptions.NoCacheOption(),
                 CommonOptions.HelpOption(),
                 CommonOptions.VerbosityOption());
         }

--- a/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
@@ -20,7 +20,8 @@ namespace Microsoft.DotNet.Tools.Tool.Update
     internal delegate IShellShimRepository CreateShellShimRepository(DirectoryPath? nonGlobalLocation = null);
 
     internal delegate (IToolPackageStore, IToolPackageInstaller) CreateToolPackageStoreAndInstaller(
-        DirectoryPath? nonGlobalLocation = null);
+        DirectoryPath? nonGlobalLocation = null,
+        IEnumerable<string> alwaysForwardArguments = null);
 
     internal class ToolUpdateCommand : CommandBase
     {

--- a/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Tool.Update
 
     internal delegate (IToolPackageStore, IToolPackageInstaller) CreateToolPackageStoreAndInstaller(
         DirectoryPath? nonGlobalLocation = null,
-        IEnumerable<string> alwaysForwardArguments = null);
+        IEnumerable<string> additionalRestoreArguments = null);
 
     internal class ToolUpdateCommand : CommandBase
     {

--- a/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommandParser.cs
+++ b/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommandParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using LocalizableStrings = Microsoft.DotNet.Tools.Tool.Update.LocalizableStrings;
 
@@ -28,7 +29,7 @@ namespace Microsoft.DotNet.Cli
                     "--configfile",
                     LocalizableStrings.ConfigFileOptionDescription,
                     Accept.ExactlyOneArgument()
-                          .With(name: LocalizableStrings.ConfigFileOptionName)),
+                        .With(name: LocalizableStrings.ConfigFileOptionName)),
                 Create.Option(
                     "--add-source",
                     LocalizableStrings.AddSourceOptionDescription,
@@ -39,6 +40,9 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.FrameworkOptionDescription,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.FrameworkOptionName)),
+                ToolCommandRestorePassThroughOptions.DisableParallelOption(),
+                ToolCommandRestorePassThroughOptions.IgnoreFailedSourcesOption(),
+                ToolCommandRestorePassThroughOptions.NoCacheOption(),
                 CommonOptions.HelpOption(),
                 CommonOptions.VerbosityOption());
         }

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -57,7 +57,8 @@ namespace Microsoft.DotNet.Tests.Commands
                     filePermissionSetter: new NoOpFilePermissionSetter());
             _environmentPathInstructionMock =
                 new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim);
-            _createToolPackageStoreAndInstaller = (_) => (_toolPackageStore, CreateToolPackageInstaller());
+            _createToolPackageStoreAndInstaller =
+                (location, forwardArguement) => (_toolPackageStore, CreateToolPackageInstaller());
 
             ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {PackageId}");
             _appliedCommand = result["dotnet"]["tool"]["install"];
@@ -114,7 +115,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             var installCommand = new ToolInstallCommand(appliedCommand,
                 parseResult,
-                (_) => (_toolPackageStore, toolToolPackageInstaller),
+                (location, forwardArguement) => (_toolPackageStore, toolToolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -165,7 +166,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var installToolCommand = new ToolInstallCommand(
                 _appliedCommand,
                 _parseResult,
-                (_) => (_toolPackageStore, toolPackageInstaller),
+                (location, forwardArguement) => (_toolPackageStore, toolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -188,7 +189,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var installCommand = new ToolInstallCommand(
                 _appliedCommand,
                 _parseResult,
-                (_) => (_toolPackageStore, toolPackageInstaller),
+                (location, forwardArguement) => (_toolPackageStore, toolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -237,7 +238,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var installCommand = new ToolInstallCommand(
                 _appliedCommand,
                 _parseResult,
-                (_) => (_toolPackageStore, toolPackageInstaller),
+                (location, forwardArguement) => (_toolPackageStore, toolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -486,7 +487,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             var installCommand = new ToolInstallCommand(appliedCommand,
                 parseResult,
-                (_) => (_toolPackageStore, new ToolPackageInstallerMock(
+                (location, forwardArguement) => (_toolPackageStore, new ToolPackageInstallerMock(
                     fileSystem: _fileSystem,
                     store: _toolPackageStore,
                     packagedShimsMap: packagedShimsMap,

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.DotNet.Tests.Commands
             _environmentPathInstructionMock =
                 new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim);
             _createToolPackageStoreAndInstaller =
-                (location, forwardArguement) => (_toolPackageStore, CreateToolPackageInstaller());
+                (location, forwardArguments) => (_toolPackageStore, CreateToolPackageInstaller());
 
             ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {PackageId}");
             _appliedCommand = result["dotnet"]["tool"]["install"];
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             var installCommand = new ToolInstallCommand(appliedCommand,
                 parseResult,
-                (location, forwardArguement) => (_toolPackageStore, toolToolPackageInstaller),
+                (location, forwardArguments) => (_toolPackageStore, toolToolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -166,7 +166,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var installToolCommand = new ToolInstallCommand(
                 _appliedCommand,
                 _parseResult,
-                (location, forwardArguement) => (_toolPackageStore, toolPackageInstaller),
+                (location, forwardArguments) => (_toolPackageStore, toolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -189,7 +189,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var installCommand = new ToolInstallCommand(
                 _appliedCommand,
                 _parseResult,
-                (location, forwardArguement) => (_toolPackageStore, toolPackageInstaller),
+                (location, forwardArguments) => (_toolPackageStore, toolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -238,7 +238,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var installCommand = new ToolInstallCommand(
                 _appliedCommand,
                 _parseResult,
-                (location, forwardArguement) => (_toolPackageStore, toolPackageInstaller),
+                (location, forwardArguments) => (_toolPackageStore, toolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -487,7 +487,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             var installCommand = new ToolInstallCommand(appliedCommand,
                 parseResult,
-                (location, forwardArguement) => (_toolPackageStore, new ToolPackageInstallerMock(
+                (location, forwardArguments) => (_toolPackageStore, new ToolPackageInstallerMock(
                     fileSystem: _fileSystem,
                     store: _toolPackageStore,
                     packagedShimsMap: packagedShimsMap,

--- a/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return new ToolInstallCommand(
                 result["dotnet"]["tool"]["install"],
                 result,
-                (_) => (store, packageInstallerMock),
+                (location, forwardArguement) => (store, packageInstallerMock),
                 (_) => new ShellShimRepository(
                     new DirectoryPath(_shimsDirectory),
                     fileSystem: _fileSystem,

--- a/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return new ToolInstallCommand(
                 result["dotnet"]["tool"]["install"],
                 result,
-                (location, forwardArguement) => (store, packageInstallerMock),
+                (location, forwardArguments) => (store, packageInstallerMock),
                 (_) => new ShellShimRepository(
                     new DirectoryPath(_shimsDirectory),
                     fileSystem: _fileSystem,

--- a/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var command = new ToolUpdateCommand(
                 result["dotnet"]["tool"]["update"],
                 result,
-                _ => (_store,
+                (location, forwardArguement) => (_store,
                     new ToolPackageInstallerMock(
                         _fileSystem,
                         _store,
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var command = new ToolUpdateCommand(
                 result["dotnet"]["tool"]["update"],
                 result,
-                _ => (_store,
+                (location, forwardArguement) => (_store,
                     new ToolPackageInstallerMock(
                         _fileSystem,
                         _store,
@@ -213,7 +213,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return new ToolInstallCommand(
                 result["dotnet"]["tool"]["install"],
                 result,
-                (_) => (_store, new ToolPackageInstallerMock(
+                (location, forwardArguement) => (_store, new ToolPackageInstallerMock(
                     _fileSystem,
                     _store,
                     new ProjectRestorerMock(
@@ -233,7 +233,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return new ToolUpdateCommand(
                 result["dotnet"]["tool"]["update"],
                 result,
-                (_) => (_store, new ToolPackageInstallerMock(
+                (location, forwardArguement) => (_store, new ToolPackageInstallerMock(
                     _fileSystem,
                     _store,
                     new ProjectRestorerMock(

--- a/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var command = new ToolUpdateCommand(
                 result["dotnet"]["tool"]["update"],
                 result,
-                (location, forwardArguement) => (_store,
+                (location, forwardArguments) => (_store,
                     new ToolPackageInstallerMock(
                         _fileSystem,
                         _store,
@@ -163,7 +163,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var command = new ToolUpdateCommand(
                 result["dotnet"]["tool"]["update"],
                 result,
-                (location, forwardArguement) => (_store,
+                (location, forwardArguments) => (_store,
                     new ToolPackageInstallerMock(
                         _fileSystem,
                         _store,
@@ -213,7 +213,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return new ToolInstallCommand(
                 result["dotnet"]["tool"]["install"],
                 result,
-                (location, forwardArguement) => (_store, new ToolPackageInstallerMock(
+                (location, forwardArguments) => (_store, new ToolPackageInstallerMock(
                     _fileSystem,
                     _store,
                     new ProjectRestorerMock(
@@ -233,7 +233,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return new ToolUpdateCommand(
                 result["dotnet"]["tool"]["update"],
                 result,
-                (location, forwardArguement) => (_store, new ToolPackageInstallerMock(
+                (location, forwardArguments) => (_store, new ToolPackageInstallerMock(
                     _fileSystem,
                     _store,
                     new ProjectRestorerMock(

--- a/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/InstallToolParserTests.cs
@@ -108,5 +108,35 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var appliedOptions = result["dotnet"]["tool"]["install"];
             appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\Tools");
         }
+
+        [Fact]
+        public void InstallToolParserCanParseNoCacheOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool install -g console.test.app --no-cache");
+
+            var appliedOptions = result["dotnet"]["tool"]["install"];
+            appliedOptions.OptionValuesToBeForwarded().Should().ContainSingle("--no-cache");
+        }
+
+        [Fact]
+        public void InstallToolParserCanParseIgnoreFailedSourcesOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool install -g console.test.app --ignore-failed-sources");
+
+            var appliedOptions = result["dotnet"]["tool"]["install"];
+            appliedOptions.OptionValuesToBeForwarded().Should().ContainSingle("--ignore-failed-sources");
+        }
+
+        [Fact]
+        public void InstallToolParserCanParseDisableParallelOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool install -g console.test.app --disable-parallel");
+
+            var appliedOptions = result["dotnet"]["tool"]["install"];
+            appliedOptions.OptionValuesToBeForwarded().Should().ContainSingle("--disable-parallel");
+        }
     }
 }

--- a/test/dotnet.Tests/ParserTests/UpdateToolParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/UpdateToolParserTests.cs
@@ -107,5 +107,35 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var appliedOptions = result["dotnet"]["tool"]["update"];
             appliedOptions.SingleArgumentOrDefault("tool-path").Should().Be(@"C:\TestAssetLocalNugetFeed");
         }
+
+        [Fact]
+        public void UpdateToolParserCanParseNoCacheOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool update -g console.test.app --no-cache");
+
+            var appliedOptions = result["dotnet"]["tool"]["update"];
+            appliedOptions.OptionValuesToBeForwarded().Should().ContainSingle("--no-cache");
+        }
+
+        [Fact]
+        public void UpdateToolParserCanParseIgnoreFailedSourcesOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool update -g console.test.app --ignore-failed-sources");
+
+            var appliedOptions = result["dotnet"]["tool"]["update"];
+            appliedOptions.OptionValuesToBeForwarded().Should().ContainSingle("--ignore-failed-sources");
+        }
+
+        [Fact]
+        public void UpdateToolParserCanParseDisableParallelOption()
+        {
+            var result =
+                Parser.Instance.Parse(@"dotnet tool update -g console.test.app --disable-parallel");
+
+            var appliedOptions = result["dotnet"]["tool"]["update"];
+            appliedOptions.OptionValuesToBeForwarded().Should().ContainSingle("--disable-parallel");
+        }
     }
 }


### PR DESCRIPTION
previous discussion
https://github.com/dotnet/cli/pull/9819

There is no test to cover “forward” part like all other forward options. The complex logic like ForwardAs, OptionValuesToBeForwarded are existing. Also, these options are hard to see affect from CLI side.

--Configfile are not completely “just forward it”. 1. We need to check if the files existence and throw accordingly. 2. We need to forward with full path 3. We have bug passing it wrong. And there are several tests around it. So, I didn’t move it to forward command.
