### PR TITLE
Follow XDG spec

### DIFF
--- a/src/dotnet/MulticoreJitProfilePathCalculator.cs
+++ b/src/dotnet/MulticoreJitProfilePathCalculator.cs
@@ -51,7 +51,12 @@ namespace Microsoft.DotNet.Cli
 
         private static string GetNonWindowsRuntimeDataRoot()
         {
-            return $"{(Environment.GetEnvironmentVariable("HOME"))}/.dotnet/";
+            var XDG_DATA_HOME = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+
+            if(string.IsNullOrEmpty(XDG_DATA_HOME))
+                XDG_DATA_HOME = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".local/share");
+            
+            return Path.Combine(XDG_DATA_HOME, "dotnet");
         }
     }
 }

--- a/src/dotnet/MulticoreJitProfilePathCalculator.cs
+++ b/src/dotnet/MulticoreJitProfilePathCalculator.cs
@@ -39,9 +39,14 @@ namespace Microsoft.DotNet.Cli
 
         private string GetRuntimeDataRootPathString()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? GetWindowsRuntimeDataRoot()
-                : GetNonWindowsRuntimeDataRoot();
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return GetWindowsRuntimeDataRoot();
+
+            else if(RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return GetOSXRuntimeDataRoot();
+            
+            else
+                return GetUnixRuntimeDataRoot();
         }
 
         private static string GetWindowsRuntimeDataRoot()
@@ -49,7 +54,12 @@ namespace Microsoft.DotNet.Cli
             return $@"{(Environment.GetEnvironmentVariable("LocalAppData"))}\Microsoft\dotnet\";
         }
 
-        private static string GetNonWindowsRuntimeDataRoot()
+        private static string GetOSXRuntimeDataRoot()
+        {
+            return Path.Combine(Environment.GetEnvironmentVariable("HOME"), "Library/dotnet");
+        }
+
+        private static string GetUnixRuntimeDataRoot()
         {
             var XDG_DATA_HOME = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
 

--- a/test/dotnet.Tests/GivenThatIWantToManageMulticoreJIT.cs
+++ b/test/dotnet.Tests/GivenThatIWantToManageMulticoreJIT.cs
@@ -92,9 +92,14 @@ namespace Microsoft.DotNet.Tests
         {
             var rid = PlatformAbstractions.RuntimeEnvironment.GetRuntimeIdentifier();
             
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? $@"Microsoft\dotnet\optimizationdata\{version}\{rid}" 
-                : $@".dotnet/optimizationdata/{version}/{rid}";
+            if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return $@"Microsoft\dotnet\optimizationdata\{version}\{rid}";
+            
+            else if(RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return $@"Library/dotnet/optimizationdata/{version}/{rid}";
+
+            else
+                return $@".local/share/dotnet/optimizationdata/{version}/{rid}";
         }
 
         private static string GetDotnetVersion()


### PR DESCRIPTION
This change allows the dotnet cli to follow the XDG spec on linux
and changes the OSX path to `$HOME/Library/dotnet`

sources: 
https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
https://stackoverflow.com/questions/3373948/equivalents-of-xdg-config-home-and-xdg-data-home-on-mac-os-x