### PR TITLE
Fix warnings

### DIFF
--- a/build/BuildDefaults.props
+++ b/build/BuildDefaults.props
@@ -33,7 +33,6 @@
     <NoWarn>NU1701;NU5104</NoWarn>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- https://github.com/dotnet/cli/issues/9834 - re-enable the flag below once warnings are cleared up -->
-    <!-- <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors> -->
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 </Project>

--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -128,6 +128,9 @@
                   ToolPath="$(DebianInstalledDirectory)" />
 
       <!-- Clean up Packages -->
+      <!-- The following line is needed. So it won't warning dotnet folder is not empty after uninstall -->
+      <Exec Command="sudo rm -rf /usr/share/dotnet/sdk/NuGetFallbackFolder" />
+
       <Exec Command="sudo dpkg -r $(SdkDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
       <Exec Command="sudo dpkg -r $(AspNetCoreSharedFxDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
       <Exec Command="sudo dpkg -r $(SharedFxDebianPackageName)" IgnoreStandardErrorWarningFormat="true"  />

--- a/build/package/Installer.DEB.proj
+++ b/build/package/Installer.DEB.proj
@@ -94,7 +94,6 @@
         UseHardlinksIfPossible="False" />
 
       <!-- Remove Shared Framework and Debian Packages -->
-      <Exec Command="sudo dpkg -r $(SdkDebianPackageName)" IgnoreStandardErrorWarningFormat="true"  />
       <Exec Command="sudo dpkg -r $(AspNetCoreSharedFxDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
       <Exec Command="sudo dpkg -r $(SharedFxDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />
       <Exec Command="sudo dpkg -r $(HostFxrDebianPackageName)" IgnoreStandardErrorWarningFormat="true" />

--- a/scripts/docker/debian/Dockerfile
+++ b/scripts/docker/debian/Dockerfile
@@ -7,7 +7,8 @@
 FROM microsoft/dotnet-buildtools-prereqs:debian-8.2-debpkg-d770b8b-20180628122423
 
 # Misc Dependencies for build
-RUN apt-get update && \
+RUN rm -rf /var/lib/apt/lists/* && \
+    apt-get update && \
     apt-get -qqy install \
         sudo && \
     apt-get clean && \

--- a/scripts/docker/debian/Dockerfile
+++ b/scripts/docker/debian/Dockerfile
@@ -4,46 +4,14 @@
 #
 
 # Dockerfile that creates a container suitable to build dotnet-cli
-FROM debian:jessie
+FROM microsoft/dotnet-buildtools-prereqs:debian-8.2-debpkg-d770b8b-20180628122423
 
 # Misc Dependencies for build
 RUN apt-get update && \
     apt-get -qqy install \
-        curl \
-        unzip \
-        gettext \
         sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-# This could become a "microsoft/coreclr" image, since it just installs the dependencies for CoreCLR (and stdlib)
-RUN apt-get update &&\
-    apt-get -qqy install \
-        libunwind8 \
-        libkrb5-3 \
-        libicu52 \
-        liblttng-ust0 \
-        libssl1.0.0 \
-        zlib1g \
-        libuuid1 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install Build Prereqs
-RUN apt-get update && \
-    apt-get -qqy install \
-        debhelper \
-        build-essential \
-        devscripts \
-        git \
-        cmake \
-        clang-3.5 && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Use clang as c++ compiler
-RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-3.5 100
-RUN update-alternatives --set c++ /usr/bin/clang++-3.5
 
 # Setup User to match Host User, and give superuser permissions
 ARG USER_ID=0


### PR DESCRIPTION
Using prebuild docker image eliminate warning during apt-get install build packages like python. There are warnings due to redundant remove dotnet-sdk when there is no dotnet-sdk before the test. And add delete fallback folder to prevent error on remove dotnet-sdk package from apt after the test