### PR TITLE
[release/2.2.1xx] Add --disable-parallel to dotnet-new.Tests

### DIFF
--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.New.Tests
 
             new TestCommand("dotnet")
                 .WithWorkingDirectory(rootPath)
-                .Execute($"restore")
+                .Execute($"restore --disable-parallel")
                 .Should().Pass();
 
             var buildResult = new TestCommand("dotnet")


### PR DESCRIPTION
Added to a "restore" executed via string literal. `--disable-parallel` is present in `RestoreCommand` used by the other tests already.

This should fix restore timeouts seem in the official builds (https://github.com/dotnet/core-eng/issues/4076). This is a workaround for a NuGet issue https://github.com/NuGet/Home/issues/6742.

Let me know if there's a better branch to target this to: I'm using `release/2.2.1xx` because the official build break happened here.

FYI @mmitche 