### PR TITLE
Adding NuGet project lock file options for dotnet restore command

### DIFF
--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
@@ -172,4 +172,19 @@ This is equivalent to deleting project.assets.json.</value>
   <data name="CmdInteractiveRestoreOptionDescription" xml:space="preserve">
     <value>Allows the command to stop and wait for user input or action (for example to complete authentication).</value>
   </data>
+  <data name="CmdLockedModeOptionDescription" xml:space="preserve">
+    <value>Do not allow updating project lock file.</value>
+  </data>
+  <data name="CmdLockFilePathOption" xml:space="preserve">
+    <value>ProjectLockFile_Path</value>
+  </data>
+  <data name="CmdLockFilePathOptionDescription" xml:space="preserve">
+    <value>Project lock file path to be used to write lock file.</value>
+  </data>
+  <data name="CmdReevaluateOptionDescription" xml:space="preserve">
+    <value>Force restore to reevaluate all dependencies even if a lock file already exists.</value>
+  </data>
+  <data name="CmdUseLockFileOptionDescription" xml:space="preserve">
+    <value>Enables project lock file to be generate/ used with restore.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-restore/LocalizableStrings.resx
@@ -173,18 +173,18 @@ This is equivalent to deleting project.assets.json.</value>
     <value>Allows the command to stop and wait for user input or action (for example to complete authentication).</value>
   </data>
   <data name="CmdLockedModeOptionDescription" xml:space="preserve">
-    <value>Do not allow updating project lock file.</value>
+    <value>Don't allow updating project lock file.</value>
   </data>
   <data name="CmdLockFilePathOption" xml:space="preserve">
-    <value>ProjectLockFile_Path</value>
+    <value>LOCK_FILE_PATH</value>
   </data>
   <data name="CmdLockFilePathOptionDescription" xml:space="preserve">
-    <value>Project lock file path to be used to write lock file.</value>
+    <value>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</value>
   </data>
   <data name="CmdReevaluateOptionDescription" xml:space="preserve">
-    <value>Force restore to reevaluate all dependencies even if a lock file already exists.</value>
+    <value>Forces restore to reevaluate all dependencies even if a lock file already exists.</value>
   </data>
   <data name="CmdUseLockFileOptionDescription" xml:space="preserve">
-    <value>Enables project lock file to be generate/ used with restore.</value>
+    <value>Enables project lock file to be generated and used with restore.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.Cli
                         "--reevaluate",
                         LocalizableStrings.CmdReevaluateOptionDescription,
                         Accept.NoArguments()
-                            .ForwardAs("-property:ReevaluateNuGetLockFile=true")) }).ToArray();
+                            .ForwardAs("-property:ReevaluateRestoreGraph=true")) }).ToArray();
         }
 
         public static Option[] AddImplicitRestoreOptions(

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -49,10 +49,10 @@ namespace Microsoft.DotNet.Cli
                             .With(name: LocalizableStrings.CmdLockFilePathOption)
                             .ForwardAsSingle(o => $"-property:NuGetLockFilePath={o.Arguments.Single()}")),
                     Create.Option(
-                        "--reevaluate",
+                        "--force-evaluate",
                         LocalizableStrings.CmdReevaluateOptionDescription,
                         Accept.NoArguments()
-                            .ForwardAs("-property:ReevaluateRestoreGraph=true")) }).ToArray();
+                            .ForwardAs("-property:RestoreForceEvaluate=true")) }).ToArray();
         }
 
         public static Option[] AddImplicitRestoreOptions(

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -31,7 +31,28 @@ namespace Microsoft.DotNet.Cli
                         "--interactive",
                         LocalizableStrings.CmdInteractiveRestoreOptionDescription,
                         Accept.NoArguments()
-                              .ForwardAs("-property:NuGetInteractive=true")) }).ToArray();
+                            .ForwardAs("-property:NuGetInteractive=true")),
+                    Create.Option(
+                        "--use-lock-file",
+                        LocalizableStrings.CmdUseLockFileOptionDescription,
+                        Accept.NoArguments()
+                            .ForwardAs("-property:RestorePackagesWithLockFile=true")),
+                    Create.Option(
+                        "--locked-mode",
+                        LocalizableStrings.CmdLockedModeOptionDescription,
+                        Accept.NoArguments()
+                            .ForwardAs("-property:RestoreLockedMode=true")),
+                    Create.Option(
+                        "--lock-file-path",
+                        LocalizableStrings.CmdLockFilePathOptionDescription,
+                        Accept.ExactlyOneArgument()
+                            .With(name: LocalizableStrings.CmdLockFilePathOption)
+                            .ForwardAsSingle(o => $"-property:NuGetLockFilePath={o.Arguments.Single()}")),
+                    Create.Option(
+                        "--reevaluate",
+                        LocalizableStrings.CmdReevaluateOptionDescription,
+                        Accept.NoArguments()
+                            .ForwardAs("-property:ReevaluateNuGetLockFile=true")) }).ToArray();
         }
 
         public static Option[] AddImplicitRestoreOptions(

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
@@ -95,28 +95,28 @@ Jedná se o ekvivalent odstranění project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.cs.xlf
@@ -94,6 +94,31 @@ Jedná se o ekvivalent odstranění project.assets.json.</target>
         <target state="translated">Umožňuje, aby se příkaz zastavil a počkal na vstup nebo akci uživatele (například na dokončení ověření).</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
@@ -95,28 +95,28 @@ Dies entspricht dem Löschen von "project.assets.json".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.de.xlf
@@ -94,6 +94,31 @@ Dies entspricht dem Löschen von "project.assets.json".</target>
         <target state="translated">Hiermit wird zugelassen, dass der Befehl anhält und auf eine Benutzereingabe oder Aktion wartet (beispielsweise auf den Abschluss der Authentifizierung).</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
@@ -95,28 +95,28 @@ Esta acción es equivalente a eliminar project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.es.xlf
@@ -94,6 +94,31 @@ Esta acción es equivalente a eliminar project.assets.json.</target>
         <target state="translated">Permite que el comando se detenga y espere la entrada o acción del usuario (por ejemplo, para autenticarse).</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
@@ -95,28 +95,28 @@ Cela équivaut à supprimer project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.fr.xlf
@@ -94,6 +94,31 @@ Cela équivaut à supprimer project.assets.json.</target>
         <target state="translated">Permet à la commande de s'arrêter et d'attendre une entrée ou une action de l'utilisateur (par exemple pour effectuer une authentification).</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
@@ -94,6 +94,31 @@ Equivale a eliminare project.assets.json.</target>
         <target state="translated">Consente al comando di arrestare l'esecuzione e attendere l'input o l'azione dell'utente, ad esempio per completare l'autenticazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.it.xlf
@@ -95,28 +95,28 @@ Equivale a eliminare project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
@@ -95,28 +95,28 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ja.xlf
@@ -94,6 +94,31 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">コマンドを停止して、ユーザーの入力またはアクション (認証の完了など) を待機できるようにします。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
@@ -95,28 +95,28 @@ project.assets.json을 삭제하는 것과 동일합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ko.xlf
@@ -94,6 +94,31 @@ project.assets.json을 삭제하는 것과 동일합니다.</target>
         <target state="translated">명령을 중지하고 사용자 입력 또는 작업을 기다리도록 허용합니다(예: 인증 완료).</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
@@ -95,28 +95,28 @@ Jest to równoważne usunięciu pliku project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pl.xlf
@@ -94,6 +94,31 @@ Jest to równoważne usunięciu pliku project.assets.json.</target>
         <target state="translated">Zezwala poleceniu na zatrzymanie działania i zaczekanie na wprowadzenie danych lub wykonanie akcji przez użytkownika (na przykład ukończenie uwierzytelniania).</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -94,6 +94,31 @@ Isso equivale a excluir o project.assets.json.</target>
         <target state="translated">Permite que o comando seja interrompido e aguarde a ação ou entrada do usuário (por exemplo, para concluir a autenticação).</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -95,28 +95,28 @@ Isso equivale a excluir o project.assets.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
@@ -95,28 +95,28 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.ru.xlf
@@ -94,6 +94,31 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">Позволяет остановить команду и ожидать ввода или действия пользователя (например, для проверки подлинности).</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
@@ -95,28 +95,28 @@ project.assets.json öğesini silmeyle eşdeğerdir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.tr.xlf
@@ -94,6 +94,31 @@ project.assets.json öğesini silmeyle eşdeğerdir.</target>
         <target state="translated">Komutun durup kullanıcı girişini veya eylemini (örneğin, kimlik doğrulamasının tamamlanmasını) beklemesine izin verir .</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -95,28 +95,28 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -94,6 +94,31 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">允许命令停止和等待用户输入或操作(例如，用以完成身份验证)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -95,28 +95,28 @@ This is equivalent to deleting project.assets.json.</source>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockedModeOptionDescription">
-        <source>Do not allow updating project lock file.</source>
-        <target state="new">Do not allow updating project lock file.</target>
+        <source>Don't allow updating project lock file.</source>
+        <target state="new">Don't allow updating project lock file.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOption">
-        <source>ProjectLockFile_Path</source>
-        <target state="new">ProjectLockFile_Path</target>
+        <source>LOCK_FILE_PATH</source>
+        <target state="new">LOCK_FILE_PATH</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdLockFilePathOptionDescription">
-        <source>Project lock file path to be used to write lock file.</source>
-        <target state="new">Project lock file path to be used to write lock file.</target>
+        <source>Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</source>
+        <target state="new">Output location where project lock file is written. By default, this is 'PROJECT_ROOT\packages.lock.json'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdReevaluateOptionDescription">
-        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
-        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <source>Forces restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Forces restore to reevaluate all dependencies even if a lock file already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdUseLockFileOptionDescription">
-        <source>Enables project lock file to be generate/ used with restore.</source>
-        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <source>Enables project lock file to be generated and used with restore.</source>
+        <target state="new">Enables project lock file to be generated and used with restore.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -94,6 +94,31 @@ This is equivalent to deleting project.assets.json.</source>
         <target state="translated">允許命令停止並等候使用者輸入或動作 (例如: 完成驗證)。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdLockedModeOptionDescription">
+        <source>Do not allow updating project lock file.</source>
+        <target state="new">Do not allow updating project lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOption">
+        <source>ProjectLockFile_Path</source>
+        <target state="new">ProjectLockFile_Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdLockFilePathOptionDescription">
+        <source>Project lock file path to be used to write lock file.</source>
+        <target state="new">Project lock file path to be used to write lock file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdReevaluateOptionDescription">
+        <source>Force restore to reevaluate all dependencies even if a lock file already exists.</source>
+        <target state="new">Force restore to reevaluate all dependencies even if a lock file already exists.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CmdUseLockFileOptionDescription">
+        <source>Enables project lock file to be generate/ used with restore.</source>
+        <target state="new">Enables project lock file to be generate/ used with restore.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -29,6 +29,10 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--no-dependencies" }, "-property:RestoreRecursive=false")]
         [InlineData(new string[] { "-v", "minimal" }, @"-verbosity:minimal")]
         [InlineData(new string[] { "--verbosity", "minimal" }, @"-verbosity:minimal")]
+        [InlineData(new string[] { "--use-lock-file" }, "-property:RestorePackagesWithLockFile=true")]
+        [InlineData(new string[] { "--locked-mode" }, "-property:RestoreLockedMode=true")]
+        [InlineData(new string[] { "--reevaluate" }, "-property:ReevaluateNuGetLockFile=true")]
+        [InlineData(new string[] { "--lock-file-path", "<lockFilePath>" }, "-property:NuGetLockFilePath=<lockFilePath>")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--verbosity", "minimal" }, @"-verbosity:minimal")]
         [InlineData(new string[] { "--use-lock-file" }, "-property:RestorePackagesWithLockFile=true")]
         [InlineData(new string[] { "--locked-mode" }, "-property:RestoreLockedMode=true")]
-        [InlineData(new string[] { "--reevaluate" }, "-property:ReevaluateRestoreGraph=true")]
+        [InlineData(new string[] { "--force-evaluate" }, "-property:RestoreForceEvaluate=true")]
         [InlineData(new string[] { "--lock-file-path", "<lockFilePath>" }, "-property:NuGetLockFilePath=<lockFilePath>")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--verbosity", "minimal" }, @"-verbosity:minimal")]
         [InlineData(new string[] { "--use-lock-file" }, "-property:RestorePackagesWithLockFile=true")]
         [InlineData(new string[] { "--locked-mode" }, "-property:RestoreLockedMode=true")]
-        [InlineData(new string[] { "--reevaluate" }, "-property:ReevaluateNuGetLockFile=true")]
+        [InlineData(new string[] { "--reevaluate" }, "-property:ReevaluateRestoreGraph=true")]
         [InlineData(new string[] { "--lock-file-path", "<lockFilePath>" }, "-property:NuGetLockFilePath=<lockFilePath>")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {


### PR DESCRIPTION
Since We (NuGet) is working on enabling NuGet project lock file for VS 15.9, this PR is to add lock file options to `dotnet restore` command.

Feature Spec - https://github.com/NuGet/Home/wiki/Enable-repeatable-package-restore-using-lock-file#extensibility

Let me know if this isn't the right branch to target 15.9. Also, the feature is already approved for 15.9.