### PR TITLE
Fix test break

### DIFF
--- a/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewAppWithSpecifiedType.cs
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.New.Tests
 
             new TestCommand("dotnet")
                 .WithWorkingDirectory(rootPath)
-                .Execute($"restore")
+                .Execute($"restore --disable-parallel")
                 .Should().Pass();
 
             var buildResult = new TestCommand("dotnet")


### PR DESCRIPTION
Porting back fix from https://github.com/dotnet/cli/pull/9854/files to 2.1.4xx

  - Back porting a change to allow package restore to succeed in some high-load test scenarios.
  - Build failure issue: https://github.com/dotnet/core-eng/issues/4088
   
