### PR TITLE
Adding a workaround for the sockets issue when restoring with many nuget feeds.

### DIFF
--- a/run-build.ps1
+++ b/run-build.ps1
@@ -76,6 +76,9 @@ $env:DOTNET_MULTILEVEL_LOOKUP=0
 # Turn off MSBuild Node re-use
 $env:MSBUILDDISABLENODEREUSE=1
 
+# Workaround for the sockets issue when restoring with many nuget feeds.
+$env:DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=0
+
 # Enable vs test console logging
 $env:VSTEST_BUILD_TRACE=1
 $env:VSTEST_TRACE_BUILD=1

--- a/run-build.sh
+++ b/run-build.sh
@@ -154,6 +154,9 @@ export DOTNET_MULTILEVEL_LOOKUP=0
 # Turn off MSBuild Node re-use
 export MSBUILDDISABLENODEREUSE=1
 
+# Workaround for the sockets issue when restoring with many nuget feeds.
+export DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=0
+
 # Install a stage 0
 INSTALL_ARCHITECTURE=$ARCHITECTURE
 archlower="$(echo $ARCHITECTURE | awk '{print tolower($0)}')"


### PR DESCRIPTION
This is the one in 2.2.1xx.