### PR TITLE
Refactor uninstall to a class

### DIFF
--- a/src/dotnet/ToolPackage/IToolPackage.cs
+++ b/src/dotnet/ToolPackage/IToolPackage.cs
@@ -21,7 +21,5 @@ namespace Microsoft.DotNet.ToolPackage
         IEnumerable<string> Warnings { get; }
 
         IReadOnlyList<FilePath> PackagedShims { get; }
-
-        void Uninstall();
     }
 }

--- a/src/dotnet/ToolPackage/IToolPackageStore.cs
+++ b/src/dotnet/ToolPackage/IToolPackageStore.cs
@@ -8,12 +8,16 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ToolPackage
 {
-    internal interface IToolPackageStore: IToolPackageStoreQuery
+    internal interface IToolPackageStore
     {
-        IEnumerable<IToolPackage> EnumeratePackages();
+        DirectoryPath Root { get; }
 
-        IEnumerable<IToolPackage> EnumeratePackageVersions(PackageId packageId);
+        DirectoryPath GetRandomStagingDirectory();
 
-        IToolPackage GetPackage(PackageId packageId, NuGetVersion version);
+        NuGetVersion GetStagedPackageVersion(DirectoryPath stagingDirectory, PackageId packageId);
+
+        DirectoryPath GetRootPackageDirectory(PackageId packageId);
+
+        DirectoryPath GetPackageDirectory(PackageId packageId, NuGetVersion version);
     }
 }

--- a/src/dotnet/ToolPackage/IToolPackageStore.cs
+++ b/src/dotnet/ToolPackage/IToolPackageStore.cs
@@ -8,18 +8,8 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ToolPackage
 {
-    internal interface IToolPackageStore
+    internal interface IToolPackageStore: IToolPackageStoreQuery
     {
-        DirectoryPath Root { get; }
-
-        DirectoryPath GetRandomStagingDirectory();
-
-        NuGetVersion GetStagedPackageVersion(DirectoryPath stagingDirectory, PackageId packageId);
-
-        DirectoryPath GetRootPackageDirectory(PackageId packageId);
-
-        DirectoryPath GetPackageDirectory(PackageId packageId, NuGetVersion version);
-
         IEnumerable<IToolPackage> EnumeratePackages();
 
         IEnumerable<IToolPackage> EnumeratePackageVersions(PackageId packageId);

--- a/src/dotnet/ToolPackage/IToolPackageStoreQuery.cs
+++ b/src/dotnet/ToolPackage/IToolPackageStoreQuery.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.ToolPackage
+{
+    internal interface IToolPackageStoreQuery
+    {
+        DirectoryPath Root { get; }
+
+        DirectoryPath GetRandomStagingDirectory();
+
+        NuGetVersion GetStagedPackageVersion(DirectoryPath stagingDirectory, PackageId packageId);
+
+        DirectoryPath GetRootPackageDirectory(PackageId packageId);
+
+        DirectoryPath GetPackageDirectory(PackageId packageId, NuGetVersion version);
+    }
+}

--- a/src/dotnet/ToolPackage/IToolPackageStoreQuery.cs
+++ b/src/dotnet/ToolPackage/IToolPackageStoreQuery.cs
@@ -10,14 +10,10 @@ namespace Microsoft.DotNet.ToolPackage
 {
     internal interface IToolPackageStoreQuery
     {
-        DirectoryPath Root { get; }
+        IEnumerable<IToolPackage> EnumeratePackages();
 
-        DirectoryPath GetRandomStagingDirectory();
+        IEnumerable<IToolPackage> EnumeratePackageVersions(PackageId packageId);
 
-        NuGetVersion GetStagedPackageVersion(DirectoryPath stagingDirectory, PackageId packageId);
-
-        DirectoryPath GetRootPackageDirectory(PackageId packageId);
-
-        DirectoryPath GetPackageDirectory(PackageId packageId, NuGetVersion version);
+        IToolPackage GetPackage(PackageId packageId, NuGetVersion version);
     }
 }

--- a/src/dotnet/ToolPackage/IToolPackageUninstaller.cs
+++ b/src/dotnet/ToolPackage/IToolPackageUninstaller.cs
@@ -1,0 +1,6 @@
+﻿using Microsoft.Extensions.EnvironmentAbstractions;
+
+internal interface IToolPackageUninstaller
+{
+    void Uninstall(DirectoryPath packageDirectory);
+}

--- a/src/dotnet/ToolPackage/ToolPackageFactory.cs
+++ b/src/dotnet/ToolPackage/ToolPackageFactory.cs
@@ -10,58 +10,65 @@ namespace Microsoft.DotNet.ToolPackage
 {
     internal static class ToolPackageFactory
     {
-        public static (IToolPackageStore, IToolPackageInstaller) CreateToolPackageStoreAndInstaller(
+        public static (IToolPackageStore, IToolPackageStoreQuery, IToolPackageInstaller) CreateToolPackageStoresAndInstaller(
             DirectoryPath? nonGlobalLocation = null)
         {
-            IToolPackageStore toolPackageStore = CreateToolPackageStore(nonGlobalLocation);
+            ToolPackageStoreAndQuery toolPackageStore = CreateConcreteToolPackageStore(nonGlobalLocation);
             var toolPackageInstaller = new ToolPackageInstaller(
                 toolPackageStore,
                 new ProjectRestorer());
 
-            return (toolPackageStore, toolPackageInstaller);
+            return (toolPackageStore, toolPackageStore, toolPackageInstaller);
         }
 
-        public static (IToolPackageStore, IToolPackageUninstaller) CreateToolPackageStoreAndUninstaller(
+        public static (IToolPackageStore, IToolPackageStoreQuery, IToolPackageUninstaller) CreateToolPackageStoresAndUninstaller(
             DirectoryPath? nonGlobalLocation = null)
         {
-            IToolPackageStore toolPackageStore = CreateToolPackageStore(nonGlobalLocation);
+            ToolPackageStoreAndQuery toolPackageStore = CreateConcreteToolPackageStore(nonGlobalLocation);
             var toolPackageUninstaller = new ToolPackageUninstaller(
                 toolPackageStore);
 
-            return (toolPackageStore, toolPackageUninstaller);
+            return (toolPackageStore, toolPackageStore, toolPackageUninstaller);
         }
 
         public static (IToolPackageStore,
+            IToolPackageStoreQuery,
             IToolPackageInstaller,
             IToolPackageUninstaller)
-            CreateToolPackageStoreInstallerUninstaller(
+            CreateToolPackageStoresAndInstallerAndUninstaller(
                 DirectoryPath? nonGlobalLocation = null)
         {
-            IToolPackageStore toolPackageStore = CreateToolPackageStore(nonGlobalLocation);
+            ToolPackageStoreAndQuery toolPackageStore = CreateConcreteToolPackageStore(nonGlobalLocation);
             var toolPackageInstaller = new ToolPackageInstaller(
                 toolPackageStore,
                 new ProjectRestorer());
             var toolPackageUninstaller = new ToolPackageUninstaller(
                 toolPackageStore);
 
-            return (toolPackageStore, toolPackageInstaller, toolPackageUninstaller);
+            return (toolPackageStore, toolPackageStore, toolPackageInstaller, toolPackageUninstaller);
         }
 
-        public static IToolPackageStore CreateToolPackageStore(
+        public static IToolPackageStoreQuery CreateToolPackageStoreQuery(
             DirectoryPath? nonGlobalLocation = null)
         {
-            var toolPackageStore =
-                new ToolPackageStore(nonGlobalLocation.HasValue
-                    ? new DirectoryPath(
-                        ToolPackageFolderPathCalculator.GetToolPackageFolderPath(nonGlobalLocation.Value.Value))
-                    : GetPackageLocation());
-
-            return toolPackageStore;
+            return CreateConcreteToolPackageStore(nonGlobalLocation);
         }
 
         private static DirectoryPath GetPackageLocation()
         {
             return new DirectoryPath(CliFolderPathCalculator.ToolsPackagePath);
+        }
+
+        private static ToolPackageStoreAndQuery CreateConcreteToolPackageStore(
+            DirectoryPath? nonGlobalLocation = null)
+        {
+            var toolPackageStore =
+                new ToolPackageStoreAndQuery(nonGlobalLocation.HasValue
+                    ? new DirectoryPath(
+                        ToolPackageFolderPathCalculator.GetToolPackageFolderPath(nonGlobalLocation.Value.Value))
+                    : GetPackageLocation());
+
+            return toolPackageStore;
         }
     }
 }

--- a/src/dotnet/ToolPackage/ToolPackageFactory.cs
+++ b/src/dotnet/ToolPackage/ToolPackageFactory.cs
@@ -21,13 +21,40 @@ namespace Microsoft.DotNet.ToolPackage
             return (toolPackageStore, toolPackageInstaller);
         }
 
+        public static (IToolPackageStore, IToolPackageUninstaller) CreateToolPackageStoreAndUninstaller(
+            DirectoryPath? nonGlobalLocation = null)
+        {
+            IToolPackageStore toolPackageStore = CreateToolPackageStore(nonGlobalLocation);
+            var toolPackageUninstaller = new ToolPackageUninstaller(
+                toolPackageStore);
+
+            return (toolPackageStore, toolPackageUninstaller);
+        }
+
+        public static (IToolPackageStore,
+            IToolPackageInstaller,
+            IToolPackageUninstaller)
+            CreateToolPackageStoreInstallerUninstaller(
+                DirectoryPath? nonGlobalLocation = null)
+        {
+            IToolPackageStore toolPackageStore = CreateToolPackageStore(nonGlobalLocation);
+            var toolPackageInstaller = new ToolPackageInstaller(
+                toolPackageStore,
+                new ProjectRestorer());
+            var toolPackageUninstaller = new ToolPackageUninstaller(
+                toolPackageStore);
+
+            return (toolPackageStore, toolPackageInstaller, toolPackageUninstaller);
+        }
+
         public static IToolPackageStore CreateToolPackageStore(
             DirectoryPath? nonGlobalLocation = null)
         {
             var toolPackageStore =
                 new ToolPackageStore(nonGlobalLocation.HasValue
-                ? new DirectoryPath(ToolPackageFolderPathCalculator.GetToolPackageFolderPath(nonGlobalLocation.Value.Value))
-                : GetPackageLocation());
+                    ? new DirectoryPath(
+                        ToolPackageFolderPathCalculator.GetToolPackageFolderPath(nonGlobalLocation.Value.Value))
+                    : GetPackageLocation());
 
             return toolPackageStore;
         }

--- a/src/dotnet/ToolPackage/ToolPackageInstaller.cs
+++ b/src/dotnet/ToolPackage/ToolPackageInstaller.cs
@@ -14,13 +14,13 @@ namespace Microsoft.DotNet.ToolPackage
 {
     internal class ToolPackageInstaller : IToolPackageInstaller
     {
-        private readonly IToolPackageStore _store;
+        private readonly IToolPackageStoreQuery _store;
         private readonly IProjectRestorer _projectRestorer;
         private readonly FilePath? _tempProject;
         private readonly DirectoryPath _offlineFeed;
 
         public ToolPackageInstaller(
-            IToolPackageStore store,
+            IToolPackageStoreQuery store,
             IProjectRestorer projectRestorer,
             FilePath? tempProject = null,
             DirectoryPath? offlineFeed = null)
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.ToolPackage
                         FileAccessRetrier.RetryOnMoveAccessFailure(() => Directory.Move(stageDirectory.Value, packageDirectory.Value));
                         rollbackDirectory = packageDirectory.Value;
 
-                        return new ToolPackageInstance(_store, packageId, version, packageDirectory);
+                        return new ToolPackageInstance(packageId, version, packageDirectory);
                     }
                     catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
                     {

--- a/src/dotnet/ToolPackage/ToolPackageInstaller.cs
+++ b/src/dotnet/ToolPackage/ToolPackageInstaller.cs
@@ -14,13 +14,13 @@ namespace Microsoft.DotNet.ToolPackage
 {
     internal class ToolPackageInstaller : IToolPackageInstaller
     {
-        private readonly IToolPackageStoreQuery _store;
+        private readonly IToolPackageStore _store;
         private readonly IProjectRestorer _projectRestorer;
         private readonly FilePath? _tempProject;
         private readonly DirectoryPath _offlineFeed;
 
         public ToolPackageInstaller(
-            IToolPackageStoreQuery store,
+            IToolPackageStore store,
             IProjectRestorer projectRestorer,
             FilePath? tempProject = null,
             DirectoryPath? offlineFeed = null)

--- a/src/dotnet/ToolPackage/ToolPackageStore.cs
+++ b/src/dotnet/ToolPackage/ToolPackageStore.cs
@@ -92,9 +92,7 @@ namespace Microsoft.DotNet.ToolPackage
 
             foreach (var subdirectory in Directory.EnumerateDirectories(packageRootDirectory.Value))
             {
-                yield return new ToolPackageInstance(
-                    this,
-                    packageId,
+                yield return new ToolPackageInstance(packageId,
                     NuGetVersion.Parse(Path.GetFileName(subdirectory)),
                     new DirectoryPath(subdirectory));
             }
@@ -112,7 +110,7 @@ namespace Microsoft.DotNet.ToolPackage
             {
                 return null;
             }
-            return new ToolPackageInstance(this, packageId, version, directory);
+            return new ToolPackageInstance(packageId, version, directory);
         }
     }
 }

--- a/src/dotnet/ToolPackage/ToolPackageStoreAndQuery.cs
+++ b/src/dotnet/ToolPackage/ToolPackageStoreAndQuery.cs
@@ -8,11 +8,11 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ToolPackage
 {
-    internal class ToolPackageStore : IToolPackageStore
+    internal class ToolPackageStoreAndQuery : IToolPackageStoreQuery, IToolPackageStore
     {
         public const string StagingDirectory = ".stage";
 
-        public ToolPackageStore(DirectoryPath root)
+        public ToolPackageStoreAndQuery(DirectoryPath root)
         {
             Root = new DirectoryPath(Path.GetFullPath(root.Value));
         }

--- a/src/dotnet/ToolPackage/ToolPackageUninstaller.cs
+++ b/src/dotnet/ToolPackage/ToolPackageUninstaller.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ToolPackage;
+using Microsoft.Extensions.EnvironmentAbstractions;
+
+internal class ToolPackageUninstaller : IToolPackageUninstaller
+{
+    private readonly IToolPackageStoreQuery _toolPackageStoreQuery;
+
+    public ToolPackageUninstaller(IToolPackageStoreQuery toolPackageStoreQuery)
+    {
+        _toolPackageStoreQuery = toolPackageStoreQuery ?? throw new ArgumentException(nameof(toolPackageStoreQuery));
+    }
+
+    public void Uninstall(DirectoryPath packageDirectory)
+    {
+        var rootDirectory = packageDirectory.GetParentPath();
+        string tempPackageDirectory = null;
+
+        TransactionalAction.Run(
+            action: () =>
+            {
+                try
+                {
+                    if (Directory.Exists(packageDirectory.Value))
+                    {
+                        // Use the staging directory for uninstall
+                        // This prevents cross-device moves when temp is mounted to a different device
+                        var tempPath = _toolPackageStoreQuery.GetRandomStagingDirectory().Value;
+                        FileAccessRetrier.RetryOnMoveAccessFailure(() =>
+                            Directory.Move(packageDirectory.Value, tempPath));
+                        tempPackageDirectory = tempPath;
+                    }
+
+                    if (Directory.Exists(rootDirectory.Value) &&
+                        !Directory.EnumerateFileSystemEntries(rootDirectory.Value).Any())
+                    {
+                        Directory.Delete(rootDirectory.Value, false);
+                    }
+                }
+                catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
+                {
+                    throw new ToolPackageException(ex.Message, ex);
+                }
+            },
+            commit: () =>
+            {
+                if (tempPackageDirectory != null)
+                {
+                    Directory.Delete(tempPackageDirectory, true);
+                }
+            },
+            rollback: () =>
+            {
+                if (tempPackageDirectory != null)
+                {
+                    Directory.CreateDirectory(rootDirectory.Value);
+                    FileAccessRetrier.RetryOnMoveAccessFailure(() =>
+                        Directory.Move(tempPackageDirectory, packageDirectory.Value));
+                }
+            });
+    }
+}

--- a/src/dotnet/ToolPackage/ToolPackageUninstaller.cs
+++ b/src/dotnet/ToolPackage/ToolPackageUninstaller.cs
@@ -8,9 +8,9 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 
 internal class ToolPackageUninstaller : IToolPackageUninstaller
 {
-    private readonly IToolPackageStoreQuery _toolPackageStoreQuery;
+    private readonly IToolPackageStore _toolPackageStoreQuery;
 
-    public ToolPackageUninstaller(IToolPackageStoreQuery toolPackageStoreQuery)
+    public ToolPackageUninstaller(IToolPackageStore toolPackageStoreQuery)
     {
         _toolPackageStoreQuery = toolPackageStoreQuery ?? throw new ArgumentException(nameof(toolPackageStoreQuery));
     }

--- a/src/dotnet/commands/dotnet-tool/list/ToolListCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/list/ToolListCommand.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 
 namespace Microsoft.DotNet.Tools.Tool.List
 {
-    internal delegate IToolPackageStore CreateToolPackageStore(DirectoryPath? nonGlobalLocation = null);
+    internal delegate IToolPackageStoreQuery CreateToolPackageStore(DirectoryPath? nonGlobalLocation = null);
 
     internal class ListToolCommand : CommandBase
     {
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Tools.Tool.List
             _options = options ?? throw new ArgumentNullException(nameof(options));
             _reporter = reporter ?? Reporter.Output;
             _errorReporter = reporter ?? Reporter.Error;
-            _createToolPackageStore = createToolPackageStore ?? ToolPackageFactory.CreateToolPackageStore;
+            _createToolPackageStore = createToolPackageStore ?? ToolPackageFactory.CreateToolPackageStoreQuery;
         }
 
         public override int Execute()

--- a/src/dotnet/commands/dotnet-tool/uninstall/ToolUninstallCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/uninstall/ToolUninstallCommand.cs
@@ -17,19 +17,19 @@ using Microsoft.Extensions.EnvironmentAbstractions;
 namespace Microsoft.DotNet.Tools.Tool.Uninstall
 {
     internal delegate IShellShimRepository CreateShellShimRepository(DirectoryPath? nonGlobalLocation = null);
-    internal delegate IToolPackageStore CreateToolPackageStore(DirectoryPath? nonGlobalLocation = null);
+    internal delegate (IToolPackageStore, IToolPackageUninstaller) CreateToolPackageStoreAndUninstaller(DirectoryPath? nonGlobalLocation = null);
     internal class ToolUninstallCommand : CommandBase
     {
         private readonly AppliedOption _options;
         private readonly IReporter _reporter;
         private readonly IReporter _errorReporter;
         private CreateShellShimRepository _createShellShimRepository;
-        private CreateToolPackageStore _createToolPackageStore;
+        private CreateToolPackageStoreAndUninstaller _createToolPackageStoreAndUninstaller;
 
         public ToolUninstallCommand(
             AppliedOption options,
             ParseResult result,
-            CreateToolPackageStore createToolPackageStore = null,
+            CreateToolPackageStoreAndUninstaller createToolPackageStoreAndUninstaller = null,
             CreateShellShimRepository createShellShimRepository = null,
             IReporter reporter = null)
             : base(result)
@@ -39,7 +39,8 @@ namespace Microsoft.DotNet.Tools.Tool.Uninstall
             _errorReporter = reporter ?? Reporter.Error;
 
             _createShellShimRepository = createShellShimRepository ?? ShellShimRepositoryFactory.CreateShellShimRepository;
-            _createToolPackageStore = createToolPackageStore ?? ToolPackageFactory.CreateToolPackageStore;
+            _createToolPackageStoreAndUninstaller = createToolPackageStoreAndUninstaller ??
+                                                    ToolPackageFactory.CreateToolPackageStoreAndUninstaller;
         }
 
         public override int Execute()
@@ -71,7 +72,8 @@ namespace Microsoft.DotNet.Tools.Tool.Uninstall
                 throw new GracefulException(LocalizableStrings.UninstallToolCommandInvalidGlobalAndToolPath);
             }
 
-            IToolPackageStore toolPackageStore = _createToolPackageStore(toolDirectoryPath);
+            (IToolPackageStore toolPackageStore, IToolPackageUninstaller toolPackageUninstaller)
+                = _createToolPackageStoreAndUninstaller(toolDirectoryPath);
             IShellShimRepository shellShimRepository = _createShellShimRepository(toolDirectoryPath);
 
             var packageId = new PackageId(_options.Arguments.Single());
@@ -114,7 +116,7 @@ namespace Microsoft.DotNet.Tools.Tool.Uninstall
                         shellShimRepository.RemoveShim(command.Name);
                     }
 
-                    package.Uninstall();
+                    toolPackageUninstaller.Uninstall(package.PackageDirectory);
 
                     scope.Complete();
                 }

--- a/src/dotnet/commands/dotnet-tool/uninstall/ToolUninstallCommandLowLevelErrorConverter.cs
+++ b/src/dotnet/commands/dotnet-tool/uninstall/ToolUninstallCommandLowLevelErrorConverter.cs
@@ -17,7 +17,10 @@ namespace Microsoft.DotNet.Tools.Tool.Uninstall
             {
                 userFacingMessages = new[]
                 {
-                    ex.Message
+                    String.Format(
+                        CommonLocalizableStrings.FailedToUninstallToolPackage,
+                        packageId,
+                        ex.Message),
                 };
             }
             else if (ex is ToolConfigurationException || ex is ShellShimException)

--- a/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/update/ToolUpdateCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tools.Tool.Update
 {
     internal delegate IShellShimRepository CreateShellShimRepository(DirectoryPath? nonGlobalLocation = null);
 
-    internal delegate (IToolPackageStore, IToolPackageInstaller) CreateToolPackageStoreAndInstaller(
+    internal delegate (IToolPackageStore, IToolPackageInstaller, IToolPackageUninstaller) CreateToolPackageStoreInstallerUninstaller(
         DirectoryPath? nonGlobalLocation = null);
 
     internal class ToolUpdateCommand : CommandBase
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Tools.Tool.Update
         private readonly IReporter _reporter;
         private readonly IReporter _errorReporter;
         private readonly CreateShellShimRepository _createShellShimRepository;
-        private readonly CreateToolPackageStoreAndInstaller _createToolPackageStoreAndInstaller;
+        private readonly CreateToolPackageStoreInstallerUninstaller _createToolPackageStoreInstallerUninstaller;
 
         private readonly PackageId _packageId;
         private readonly string _configFilePath;
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Tool.Update
 
         public ToolUpdateCommand(AppliedOption appliedCommand,
             ParseResult parseResult,
-            CreateToolPackageStoreAndInstaller createToolPackageStoreAndInstaller = null,
+            CreateToolPackageStoreInstallerUninstaller createToolPackageStoreInstallerUninstaller = null,
             CreateShellShimRepository createShellShimRepository = null,
             IReporter reporter = null)
             : base(parseResult)
@@ -57,8 +57,8 @@ namespace Microsoft.DotNet.Tools.Tool.Update
             _verbosity = appliedCommand.SingleArgumentOrDefault("verbosity");
             _toolPath = appliedCommand.SingleArgumentOrDefault("tool-path");
 
-            _createToolPackageStoreAndInstaller = createToolPackageStoreAndInstaller ??
-                                                  ToolPackageFactory.CreateToolPackageStoreAndInstaller;
+            _createToolPackageStoreInstallerUninstaller = createToolPackageStoreInstallerUninstaller ??
+                                                  ToolPackageFactory.CreateToolPackageStoreInstallerUninstaller;
 
             _createShellShimRepository =
                 createShellShimRepository ?? ShellShimRepositoryFactory.CreateShellShimRepository;
@@ -77,8 +77,8 @@ namespace Microsoft.DotNet.Tools.Tool.Update
                 toolPath = new DirectoryPath(_toolPath);
             }
 
-            (IToolPackageStore toolPackageStore, IToolPackageInstaller toolPackageInstaller) =
-                _createToolPackageStoreAndInstaller(toolPath);
+            (IToolPackageStore toolPackageStore, IToolPackageInstaller toolPackageInstaller, IToolPackageUninstaller toolPackageUninstaller) =
+                _createToolPackageStoreInstallerUninstaller(toolPath);
             IShellShimRepository shellShimRepository = _createShellShimRepository(toolPath);
 
 
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Tools.Tool.Update
                         shellShimRepository.RemoveShim(command.Name);
                     }
 
-                    oldPackage.Uninstall();
+                    toolPackageUninstaller.Uninstall(oldPackage.PackageDirectory);
                 });
 
                 RunWithHandlingInstallError(() =>

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         [InlineData(true)]
         public void GivenNoFeedInstallFailsWithException(bool testMockBehaviorIsInSync)
         {
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: new MockFeed[0]);
 
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         [InlineData(true)]
         public void GivenOfflineFeedInstallSucceeds(bool testMockBehaviorIsInSync)
         {
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 offlineFeed: new DirectoryPath(GetTestLocalFeedPath()),
                 feeds: GetOfflineMockFeed());
@@ -57,7 +57,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var package = installer.InstallPackage(new PackageLocation(), packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion), targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -70,17 +70,17 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var emptySource = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(emptySource);
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 offlineFeed: new DirectoryPath(GetTestLocalFeedPath()),
                 feeds: GetOfflineMockFeed());
 
-            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] {emptySource}),
+            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { emptySource }),
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -130,7 +130,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 transactionScope.Complete();
             }
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             /*
               From mytool.dll to project.assets.json
@@ -177,14 +177,14 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(useMock: false);
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(useMock: false);
 
             var package = installer.InstallPackage(
                 new PackageLocation(rootConfigDirectory: nugetConfigPath.GetDirectoryPath()), packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -196,7 +196,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -205,7 +205,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 packageId: TestPackageId,
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -217,7 +217,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -225,7 +225,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion));
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -237,16 +237,16 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
-            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] {source}),
+            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { source }),
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -258,7 +258,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -268,7 +268,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -280,16 +280,16 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
             var package = installer.InstallPackage(
-                new PackageLocation(additionalFeeds: new[] {new Uri(source).AbsoluteUri}), packageId: TestPackageId,
+                new PackageLocation(additionalFeeds: new[] { new Uri(source).AbsoluteUri }), packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -303,17 +303,17 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var emptySource = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(emptySource);
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(emptySource));
 
             var package = installer.InstallPackage(new PackageLocation(nugetConfig: nugetConfigPath,
-                    additionalFeeds: new[] {emptySource}),
+                    additionalFeeds: new[] { emptySource }),
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -323,7 +323,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         [InlineData(true)]
         public void GivenFailedRestoreInstallWillRollback(bool testMockBehaviorIsInSync)
         {
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync);
 
             Action a = () =>
@@ -350,7 +350,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -362,7 +362,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                     TransactionScopeOption.Required,
                     TimeSpan.Zero))
                 {
-                    installer.InstallPackage(new PackageLocation(additionalFeeds: new[] {source}),
+                    installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { source }),
                         packageId: TestPackageId,
                         versionRange: VersionRange.Parse(TestPackageVersion),
                         targetFramework: _testTargetframework);
@@ -384,7 +384,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -394,14 +394,14 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                     TransactionScopeOption.Required,
                     TimeSpan.Zero))
                 {
-                    Action first = () => installer.InstallPackage(new PackageLocation(additionalFeeds: new[] {source}),
+                    Action first = () => installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { source }),
                         packageId: TestPackageId,
                         versionRange: VersionRange.Parse(TestPackageVersion),
                         targetFramework: _testTargetframework);
 
                     first.ShouldNotThrow();
 
-                    installer.InstallPackage(new PackageLocation(additionalFeeds: new[] {source}),
+                    installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { source }),
                         packageId: TestPackageId,
                         versionRange: VersionRange.Parse(TestPackageVersion),
                         targetFramework: _testTargetframework);
@@ -427,18 +427,18 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
-            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] {source}),
+            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { source }),
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
-            Action secondCall = () => installer.InstallPackage(new PackageLocation(additionalFeeds: new[] {source}),
+            Action secondCall = () => installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { source }),
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
@@ -462,7 +462,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             fileSystem
                 .Directory
-                .EnumerateFileSystemEntries(store.Root.WithSubDirectories(ToolPackageStore.StagingDirectory).Value)
+                .EnumerateFileSystemEntries(store.Root.WithSubDirectories(ToolPackageStoreAndQuery.StagingDirectory).Value)
                 .Should()
                 .BeEmpty();
         }
@@ -474,20 +474,20 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
-            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] {source}),
+            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { source }),
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
 
-            store.EnumeratePackages().Should().BeEmpty();
+            storeQuery.EnumeratePackages().Should().BeEmpty();
         }
 
         [Theory]
@@ -497,17 +497,17 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
             var package = installer.InstallPackage(
-                new PackageLocation(additionalFeeds: new[] {source}),
+                new PackageLocation(additionalFeeds: new[] { source }),
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             using (var scope = new TransactionScope(
                 TransactionScopeOption.Required,
@@ -515,12 +515,12 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             {
                 uninstaller.Uninstall(package.PackageDirectory);
 
-                store.EnumeratePackages().Should().BeEmpty();
+                storeQuery.EnumeratePackages().Should().BeEmpty();
             }
 
-            package = store.EnumeratePackageVersions(TestPackageId).First();
+            package = storeQuery.EnumeratePackageVersions(TestPackageId).First();
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
         }
 
         [Theory]
@@ -531,16 +531,16 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
-            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] {source}),
+            var package = installer.InstallPackage(new PackageLocation(additionalFeeds: new[] { source }),
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             using (var scope = new TransactionScope(
                 TransactionScopeOption.Required,
@@ -550,7 +550,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 scope.Complete();
             }
 
-            store.EnumeratePackages().Should().BeEmpty();
+            storeQuery.EnumeratePackages().Should().BeEmpty();
         }
 
         [Theory]
@@ -560,7 +560,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -568,7 +568,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 packageId: new PackageId("GlObAl.TooL.coNsoLe.DemO"),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -579,7 +579,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
             var tempProject = GetUniqueTempProjectPathEachTest();
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: false,
                 tempProject: tempProject);
 
@@ -593,7 +593,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             reporter.Lines.Should().NotContain(l => l.Contains(tempProject.Value));
             reporter.Lines.Clear();
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -609,7 +609,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var root = new DirectoryPath(Path.Combine(TempRoot.Root, nonAscii, Path.GetRandomFileName()));
             var reporter = new BufferedReporter();
             var fileSystem = new FileSystemWrapper();
-            var store = new ToolPackageStore(root);
+            var store = new ToolPackageStoreAndQuery(root);
             var installer = new ToolPackageInstaller(
                 store: store,
                 projectRestorer: new ProjectRestorer(reporter),
@@ -621,7 +621,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 versionRange: VersionRange.Parse(TestPackageVersion),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, store);
 
             new ToolPackageUninstaller(store).Uninstall(package.PackageDirectory);
         }
@@ -636,17 +636,17 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var emptySource = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(emptySource);
 
-            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
+            var (store, storeQuery, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(emptySource));
 
             var package = installer.InstallPackage(new PackageLocation(nugetConfig: nugetConfigPath,
-                    additionalFeeds: new[] {emptySource}),
+                    additionalFeeds: new[] { emptySource }),
                 packageId: TestPackageId,
                 versionRange: VersionRange.Parse("1.0.0-rc*"),
                 targetFramework: _testTargetframework);
 
-            AssertPackageInstall(reporter, fileSystem, package, store);
+            AssertPackageInstall(reporter, fileSystem, package, store, storeQuery);
 
             uninstaller.Uninstall(package.PackageDirectory);
         }
@@ -655,7 +655,8 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             BufferedReporter reporter,
             IFileSystem fileSystem,
             IToolPackage package,
-            IToolPackageStore store)
+            IToolPackageStore store,
+            IToolPackageStoreQuery storeQuery)
         {
             reporter.Lines.Should().BeEmpty();
 
@@ -663,7 +664,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             package.Version.ToNormalizedString().Should().Be(TestPackageVersion);
             package.PackageDirectory.Value.Should().Contain(store.Root.Value);
 
-            store.EnumeratePackageVersions(TestPackageId)
+            storeQuery.EnumeratePackageVersions(TestPackageId)
                 .Select(p => p.Version.ToNormalizedString())
                 .Should()
                 .Equal(TestPackageVersion);
@@ -685,11 +686,11 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 .Directory
                 .EnumerateFileSystemEntries(store.Root.Value)
                 .Should()
-                .NotContain(e => Path.GetFileName(e) != ToolPackageStore.StagingDirectory);
+                .NotContain(e => Path.GetFileName(e) != ToolPackageStoreAndQuery.StagingDirectory);
 
             fileSystem
                 .Directory
-                .EnumerateFileSystemEntries(store.Root.WithSubDirectories(ToolPackageStore.StagingDirectory).Value)
+                .EnumerateFileSystemEntries(store.Root.WithSubDirectories(ToolPackageStoreAndQuery.StagingDirectory).Value)
                 .Should()
                 .BeEmpty();
         }
@@ -763,7 +764,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             };
         }
 
-        private static (IToolPackageStore, IToolPackageInstaller, IToolPackageUninstaller, BufferedReporter, IFileSystem
+        private static (IToolPackageStore, IToolPackageStoreQuery, IToolPackageInstaller, IToolPackageUninstaller, BufferedReporter, IFileSystem
             ) Setup(
                 bool useMock,
                 IEnumerable<MockFeed> feeds = null,
@@ -775,25 +776,30 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             IFileSystem fileSystem;
             IToolPackageStore store;
+            IToolPackageStoreQuery storeQuery;
             IToolPackageInstaller installer;
             IToolPackageUninstaller uninstaller;
             if (useMock)
             {
                 fileSystem = new FileSystemMockBuilder().Build();
-                store = new ToolPackageStoreMock(root, fileSystem);
+                var toolPackageStoreMock = new ToolPackageStoreMock(root, fileSystem);
+                store = toolPackageStoreMock;
+                storeQuery = toolPackageStoreMock;
                 installer = new ToolPackageInstallerMock(
                     fileSystem: fileSystem,
-                    store: store,
+                    store: toolPackageStoreMock,
                     projectRestorer: new ProjectRestorerMock(
                         fileSystem: fileSystem,
                         reporter: reporter,
                         feeds: feeds));
-                uninstaller = new ToolPackageUninstallerMock(fileSystem, store);
+                uninstaller = new ToolPackageUninstallerMock(fileSystem, toolPackageStoreMock);
             }
             else
             {
                 fileSystem = new FileSystemWrapper();
-                store = new ToolPackageStore(root);
+                var toolPackageStore = new ToolPackageStoreAndQuery(root);
+                store = toolPackageStore;
+                storeQuery = toolPackageStore;
                 installer = new ToolPackageInstaller(
                     store: store,
                     projectRestorer: new ProjectRestorer(reporter),
@@ -804,7 +810,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             store.Root.Value.Should().Be(Path.GetFullPath(root.Value));
 
-            return (store, installer, uninstaller, reporter, fileSystem);
+            return (store, storeQuery, installer, uninstaller, reporter, fileSystem);
         }
 
         private static FilePath WriteNugetConfigFileToPointToTheFeed()

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         [InlineData(true)]
         public void GivenNoFeedInstallFailsWithException(bool testMockBehaviorIsInSync)
         {
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: new MockFeed[0]);
 
@@ -49,7 +49,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         [InlineData(true)]
         public void GivenOfflineFeedInstallSucceeds(bool testMockBehaviorIsInSync)
         {
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 offlineFeed: new DirectoryPath(GetTestLocalFeedPath()),
                 feeds: GetOfflineMockFeed());
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var emptySource = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(emptySource);
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 offlineFeed: new DirectoryPath(GetTestLocalFeedPath()),
                 feeds: GetOfflineMockFeed());
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -103,7 +103,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -113,7 +113,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -132,7 +132,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -169,7 +169,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             fileSystem.File.Exists(assetJsonPath).Should().BeTrue();
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, reporter, fileSystem) = Setup(useMock: false);
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(useMock: false);
 
             var package = installer.InstallPackage(
                 new PackageLocation(rootConfigDirectory: nugetConfigPath.GetDirectoryPath()), packageId: TestPackageId,
@@ -186,7 +186,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -196,18 +196,18 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
             var package = installer.InstallPackage(
-                new PackageLocation(nugetConfig: nugetConfigPath), 
+                new PackageLocation(nugetConfig: nugetConfigPath),
                 packageId: TestPackageId,
                 targetFramework: _testTargetframework);
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -217,7 +217,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -227,7 +227,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -237,7 +237,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -248,7 +248,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -258,7 +258,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -270,7 +270,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -280,7 +280,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -291,7 +291,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -303,7 +303,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var emptySource = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(emptySource);
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(emptySource));
 
@@ -315,7 +315,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -323,7 +323,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         [InlineData(true)]
         public void GivenFailedRestoreInstallWillRollback(bool testMockBehaviorIsInSync)
         {
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync);
 
             Action a = () =>
@@ -350,7 +350,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -384,7 +384,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -427,7 +427,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -458,7 +458,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 .Should()
                 .BeTrue();
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
 
             fileSystem
                 .Directory
@@ -474,7 +474,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -485,7 +485,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
 
             store.EnumeratePackages().Should().BeEmpty();
         }
@@ -497,7 +497,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -513,7 +513,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 TransactionScopeOption.Required,
                 TimeSpan.Zero))
             {
-                package.Uninstall();
+                uninstaller.Uninstall(package.PackageDirectory);
 
                 store.EnumeratePackages().Should().BeEmpty();
             }
@@ -531,7 +531,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var source = GetTestLocalFeedPath();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(source));
 
@@ -546,7 +546,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 TransactionScopeOption.Required,
                 TimeSpan.Zero))
             {
-                package.Uninstall();
+                uninstaller.Uninstall(package.PackageDirectory);
                 scope.Complete();
             }
 
@@ -560,7 +560,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
         {
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForConfigFile(nugetConfigPath));
 
@@ -570,7 +570,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Fact]
@@ -579,7 +579,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
             var tempProject = GetUniqueTempProjectPathEachTest();
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: false,
                 tempProject: tempProject);
 
@@ -595,7 +595,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         [Fact]
@@ -623,7 +623,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            new ToolPackageUninstaller(store).Uninstall(package.PackageDirectory);
         }
 
         [Theory]
@@ -636,7 +636,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             var emptySource = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             Directory.CreateDirectory(emptySource);
 
-            var (store, installer, reporter, fileSystem) = Setup(
+            var (store, installer, uninstaller, reporter, fileSystem) = Setup(
                 useMock: testMockBehaviorIsInSync,
                 feeds: GetMockFeedsForSource(emptySource));
 
@@ -648,7 +648,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
 
             AssertPackageInstall(reporter, fileSystem, package, store);
 
-            package.Uninstall();
+            uninstaller.Uninstall(package.PackageDirectory);
         }
 
         private static void AssertPackageInstall(
@@ -763,11 +763,12 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             };
         }
 
-        private static (IToolPackageStore, IToolPackageInstaller, BufferedReporter, IFileSystem) Setup(
-            bool useMock,
-            IEnumerable<MockFeed> feeds = null,
-            FilePath? tempProject = null,
-            DirectoryPath? offlineFeed = null)
+        private static (IToolPackageStore, IToolPackageInstaller, IToolPackageUninstaller, BufferedReporter, IFileSystem
+            ) Setup(
+                bool useMock,
+                IEnumerable<MockFeed> feeds = null,
+                FilePath? tempProject = null,
+                DirectoryPath? offlineFeed = null)
         {
             var root = new DirectoryPath(Path.Combine(TempRoot.Root, Path.GetRandomFileName()));
             var reporter = new BufferedReporter();
@@ -775,6 +776,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
             IFileSystem fileSystem;
             IToolPackageStore store;
             IToolPackageInstaller installer;
+            IToolPackageUninstaller uninstaller;
             if (useMock)
             {
                 fileSystem = new FileSystemMockBuilder().Build();
@@ -786,6 +788,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                         fileSystem: fileSystem,
                         reporter: reporter,
                         feeds: feeds));
+                uninstaller = new ToolPackageUninstallerMock(fileSystem, store);
             }
             else
             {
@@ -796,11 +799,12 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                     projectRestorer: new ProjectRestorer(reporter),
                     tempProject: tempProject ?? GetUniqueTempProjectPathEachTest(),
                     offlineFeed: offlineFeed ?? new DirectoryPath("does not exist"));
+                uninstaller = new ToolPackageUninstaller(store);
             }
 
             store.Root.Value.Should().Be(Path.GetFullPath(root.Value));
 
-            return (store, installer, reporter, fileSystem);
+            return (store, installer, uninstaller, reporter, fileSystem);
         }
 
         private static FilePath WriteNugetConfigFileToPointToTheFeed()

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/Microsoft.DotNet.Tools.Tests.ComponentMocks.csproj
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/Microsoft.DotNet.Tools.Tests.ComponentMocks.csproj
@@ -7,7 +7,6 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\dotnet\dotnet.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageStoreMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageStoreMock.cs
@@ -15,16 +15,13 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
     internal class ToolPackageStoreMock : IToolPackageStore
     {
         private IFileSystem _fileSystem;
-        private Action _uninstallCallback;
 
         public ToolPackageStoreMock(
             DirectoryPath root,
-            IFileSystem fileSystem,
-            Action uninstallCallback = null)
+            IFileSystem fileSystem)
         {
             Root = new DirectoryPath(Path.GetFullPath(root.Value));
             _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
-            _uninstallCallback = uninstallCallback;
         }
 
         public DirectoryPath Root { get; private set; }
@@ -100,8 +97,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                     _fileSystem,
                     packageId,
                     NuGetVersion.Parse(Path.GetFileName(subdirectory)),
-                    new DirectoryPath(subdirectory),
-                    _uninstallCallback);
+                    new DirectoryPath(subdirectory));
             }
         }
 
@@ -112,7 +108,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             {
                 return null;
             }
-            return new ToolPackageMock(_fileSystem, packageId, version, directory, _uninstallCallback);
+            return new ToolPackageMock(_fileSystem, packageId, version, directory);
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageStoreMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageStoreMock.cs
@@ -12,7 +12,7 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 {
-    internal class ToolPackageStoreMock : IToolPackageStore
+    internal class ToolPackageStoreMock : IToolPackageStoreQuery, IToolPackageStore
     {
         private IFileSystem _fileSystem;
 
@@ -28,7 +28,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 
         public DirectoryPath GetRandomStagingDirectory()
         {
-            return Root.WithSubDirectories(ToolPackageStore.StagingDirectory, Path.GetRandomFileName());
+            return Root.WithSubDirectories(ToolPackageStoreAndQuery.StagingDirectory, Path.GetRandomFileName());
         }
 
         public NuGetVersion GetStagedPackageVersion(DirectoryPath stagingDirectory, PackageId packageId)
@@ -71,7 +71,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                 var name = Path.GetFileName(subdirectory);
                 var packageId = new PackageId(name);
 
-                if (name == ToolPackageStore.StagingDirectory || name != packageId.ToString())
+                if (name == ToolPackageStoreAndQuery.StagingDirectory || name != packageId.ToString())
                 {
                     continue;
                 }

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageUninstallerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageUninstallerMock.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Transactions;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.ToolPackage;
+using Microsoft.DotNet.Tools;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
+{
+    internal class ToolPackageUninstallerMock : IToolPackageUninstaller
+    {
+        private IToolPackageStore _toolPackageStore;
+        private Action _uninstallCallback;
+        private IFileSystem _fileSystem;
+
+        public ToolPackageUninstallerMock(IFileSystem fileSystem,
+            IToolPackageStore toolPackageStore,
+            Action uninstallCallback = null)
+        {
+            _toolPackageStore = toolPackageStore ?? throw new ArgumentNullException(nameof(toolPackageStore));
+            _uninstallCallback = uninstallCallback;
+            _fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+        }
+
+        public void Uninstall(DirectoryPath packageDirectory)
+        {
+            var rootDirectory = packageDirectory.GetParentPath();
+            string tempPackageDirectory = null;
+
+            TransactionalAction.Run(
+                action: () =>
+                {
+                    try
+                    {
+                        if (_fileSystem.Directory.Exists(packageDirectory.Value))
+                        {
+                            var tempPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+                            _fileSystem.Directory.Move(packageDirectory.Value, tempPath);
+                            tempPackageDirectory = tempPath;
+                        }
+
+                        if (_fileSystem.Directory.Exists(rootDirectory.Value) &&
+                            !_fileSystem.Directory.EnumerateFileSystemEntries(rootDirectory.Value).Any())
+                        {
+                            _fileSystem.Directory.Delete(rootDirectory.Value, false);
+                        }
+
+                        if (_uninstallCallback != null)
+                        {
+                            _uninstallCallback();
+                        }
+                    }
+                    catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
+                    {
+                        throw new ToolPackageException(ex.Message, ex);
+                    }
+                },
+                commit: () =>
+                {
+                    if (tempPackageDirectory != null)
+                    {
+                        _fileSystem.Directory.Delete(tempPackageDirectory, true);
+                    }
+                },
+                rollback: () =>
+                {
+                    if (tempPackageDirectory != null)
+                    {
+                        _fileSystem.Directory.CreateDirectory(rootDirectory.Value);
+                        _fileSystem.Directory.Move(tempPackageDirectory, packageDirectory.Value);
+                    }
+                });
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageUninstallerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageUninstallerMock.cs
@@ -16,12 +16,12 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 {
     internal class ToolPackageUninstallerMock : IToolPackageUninstaller
     {
-        private IToolPackageStore _toolPackageStore;
+        private IToolPackageStoreQuery _toolPackageStore;
         private Action _uninstallCallback;
         private IFileSystem _fileSystem;
 
         public ToolPackageUninstallerMock(IFileSystem fileSystem,
-            IToolPackageStore toolPackageStore,
+            IToolPackageStoreQuery toolPackageStore,
             Action uninstallCallback = null)
         {
             _toolPackageStore = toolPackageStore ?? throw new ArgumentNullException(nameof(toolPackageStore));

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -9,11 +9,12 @@ using FluentAssertions;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools;
+using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools.Tool.Install;
 using Microsoft.DotNet.Tools.Tests.ComponentMocks;
 using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.DotNet.ShellShim;
 using Microsoft.Extensions.DependencyModel.Tests;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using Newtonsoft.Json;
@@ -21,7 +22,6 @@ using Xunit;
 using Parser = Microsoft.DotNet.Cli.Parser;
 using System.Runtime.InteropServices;
 using LocalizableStrings = Microsoft.DotNet.Tools.Tool.Install.LocalizableStrings;
-using Microsoft.DotNet.ShellShim;
 
 namespace Microsoft.DotNet.Tests.Commands
 {

--- a/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallCommandTests.cs
@@ -29,8 +29,9 @@ namespace Microsoft.DotNet.Tests.Commands
     {
         private readonly IFileSystem _fileSystem;
         private readonly IToolPackageStore _toolPackageStore;
+        private readonly IToolPackageStoreQuery _toolPackageStoreQuery;
         private readonly CreateShellShimRepository _createShellShimRepository;
-        private readonly CreateToolPackageStoreAndInstaller _createToolPackageStoreAndInstaller;
+        private readonly CreateToolPackageStoresAndInstaller _createToolPackageStoreAndInstaller;
         private readonly EnvironmentPathInstructionMock _environmentPathInstructionMock;
         private readonly AppliedOption _appliedCommand;
         private readonly ParseResult _parseResult;
@@ -48,7 +49,9 @@ namespace Microsoft.DotNet.Tests.Commands
             _temporaryDirectory =  _fileSystem.Directory.CreateTemporaryDirectory().DirectoryPath;
             _pathToPlaceShim = Path.Combine(_temporaryDirectory, "pathToPlace");
             _pathToPlacePackages = _pathToPlaceShim + "Packages";
-            _toolPackageStore = new ToolPackageStoreMock(new DirectoryPath(_pathToPlacePackages), _fileSystem);
+            var toolPackageStoreMock = new ToolPackageStoreMock(new DirectoryPath(_pathToPlacePackages), _fileSystem);
+            _toolPackageStore = toolPackageStoreMock;
+            _toolPackageStoreQuery = toolPackageStoreMock;
             _createShellShimRepository =
                 (nonGlobalLocation) => new ShellShimRepository(
                     new DirectoryPath(_pathToPlaceShim),
@@ -57,7 +60,7 @@ namespace Microsoft.DotNet.Tests.Commands
                     filePermissionSetter: new NoOpFilePermissionSetter());
             _environmentPathInstructionMock =
                 new EnvironmentPathInstructionMock(_reporter, _pathToPlaceShim);
-            _createToolPackageStoreAndInstaller = (_) => (_toolPackageStore, CreateToolPackageInstaller());
+            _createToolPackageStoreAndInstaller = (_) => (_toolPackageStore, _toolPackageStoreQuery, CreateToolPackageInstaller());
 
             ParseResult result = Parser.Instance.Parse($"dotnet tool install -g {PackageId}");
             _appliedCommand = result["dotnet"]["tool"]["install"];
@@ -114,7 +117,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             var installCommand = new ToolInstallCommand(appliedCommand,
                 parseResult,
-                (_) => (_toolPackageStore, toolToolPackageInstaller),
+                (_) => (_toolPackageStore, _toolPackageStoreQuery, toolToolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -165,7 +168,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var installToolCommand = new ToolInstallCommand(
                 _appliedCommand,
                 _parseResult,
-                (_) => (_toolPackageStore, toolPackageInstaller),
+                (_) => (_toolPackageStore, _toolPackageStoreQuery, toolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -188,7 +191,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var installCommand = new ToolInstallCommand(
                 _appliedCommand,
                 _parseResult,
-                (_) => (_toolPackageStore, toolPackageInstaller),
+                (_) => (_toolPackageStore, _toolPackageStoreQuery, toolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -237,7 +240,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var installCommand = new ToolInstallCommand(
                 _appliedCommand,
                 _parseResult,
-                (_) => (_toolPackageStore, toolPackageInstaller),
+                (_) => (_toolPackageStore, _toolPackageStoreQuery, toolPackageInstaller),
                 _createShellShimRepository,
                 _environmentPathInstructionMock,
                 _reporter);
@@ -486,7 +489,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             var installCommand = new ToolInstallCommand(appliedCommand,
                 parseResult,
-                (_) => (_toolPackageStore, new ToolPackageInstallerMock(
+                (_) => (_toolPackageStore, _toolPackageStoreQuery, new ToolPackageInstallerMock(
                     fileSystem: _fileSystem,
                     store: _toolPackageStore,
                     packagedShimsMap: packagedShimsMap,

--- a/test/dotnet.Tests/CommandTests/ToolListCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolListCommandTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenAMissingGlobalOrToolPathOptionItErrors()
         {
-            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
 
             var command = CreateCommand(store.Object);
 
@@ -53,7 +53,7 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenBothGlobalAndToolPathOptionsItErrors()
         {
-            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
 
             var toolPath = Path.GetTempPath();
             var command = CreateCommand(store.Object, $"-g --tool-path {toolPath}", toolPath);
@@ -72,7 +72,7 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenNoInstalledPackagesItPrintsEmptyTable()
         {
-            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
             store
                 .Setup(s => s.EnumeratePackages())
                 .Returns(new IToolPackage[0]);
@@ -87,7 +87,7 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenAnInvalidToolPathItThrowsException()
         {
-            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
             store
                 .Setup(s => s.EnumeratePackages())
                 .Returns(new IToolPackage[0]);
@@ -107,7 +107,7 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenAToolPathItPassesToolPathToStoreFactory()
         {
-            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
             store
                 .Setup(s => s.EnumeratePackages())
                 .Returns(new IToolPackage[0]);
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenASingleInstalledPackageItPrintsThePackage()
         {
-            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
             store
                 .Setup(s => s.EnumeratePackages())
                 .Returns(new[] {
@@ -146,7 +146,7 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenMultipleInstalledPackagesItPrintsThePackages()
         {
-            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
             store
                 .Setup(s => s.EnumeratePackages())
                 .Returns(new[] {
@@ -183,7 +183,7 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenAPackageWithMultipleCommandsItListsThem()
         {
-            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
             store
                 .Setup(s => s.EnumeratePackages())
                 .Returns(new[] {
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenABrokenPackageItPrintsWarning()
         {
-            var store = new Mock<IToolPackageStore>(MockBehavior.Strict);
+            var store = new Mock<IToolPackageStoreQuery>(MockBehavior.Strict);
             store
                 .Setup(s => s.EnumeratePackages())
                 .Returns(new[] {
@@ -261,7 +261,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return package.Object;
         }
 
-        private ListToolCommand CreateCommand(IToolPackageStore store, string options = "", string expectedToolPath = null)
+        private ListToolCommand CreateCommand(IToolPackageStoreQuery store, string options = "", string expectedToolPath = null)
         {
             ParseResult result = Parser.Instance.Parse("dotnet tool list " + options);
             return new ListToolCommand(
@@ -284,7 +284,7 @@ namespace Microsoft.DotNet.Tests.Commands
             }
         }
 
-        private IEnumerable<string> EnumerateExpectedTableLines(IToolPackageStore store)
+        private IEnumerable<string> EnumerateExpectedTableLines(IToolPackageStoreQuery store)
         {
             string GetCommandsString(IToolPackage package)
             {
@@ -292,7 +292,7 @@ namespace Microsoft.DotNet.Tests.Commands
             }
 
             var packages = store.EnumeratePackages().Where(PackageHasCommands).OrderBy(package => package.Id);
-            var columnDelimiter = PrintableTable<IToolPackageStore>.ColumnDelimiter;
+            var columnDelimiter = PrintableTable<IToolPackageStoreQuery>.ColumnDelimiter;
 
             int packageIdColumnWidth = LocalizableStrings.PackageIdColumn.Length;
             int versionColumnWidth = LocalizableStrings.VersionColumn.Length;

--- a/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
@@ -219,13 +219,20 @@ namespace Microsoft.DotNet.Tests.Commands
         {
             ParseResult result = Parser.Instance.Parse("dotnet tool uninstall " + options);
 
+            (IToolPackageStore, IToolPackageUninstaller) createToolPackageStoreAndUninstaller(
+                DirectoryPath? directoryPath)
+            {
+                var store = new ToolPackageStoreMock(
+                    new DirectoryPath(_toolsDirectory),
+                    _fileSystem);
+                var packageUninstaller = new ToolPackageUninstallerMock(_fileSystem, store, uninstallCallback);
+                return (store, packageUninstaller);
+            }
+
             return new ToolUninstallCommand(
                 result["dotnet"]["tool"]["uninstall"],
                 result,
-                (_) => new ToolPackageStoreMock(
-                    new DirectoryPath(_toolsDirectory),
-                    _fileSystem,
-                    uninstallCallback),
+                createToolPackageStoreAndUninstaller,
                 (_) => new ShellShimRepository(
                     new DirectoryPath(_shimsDirectory),
                     fileSystem: _fileSystem,

--- a/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
@@ -206,7 +206,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return new ToolInstallCommand(
                 result["dotnet"]["tool"]["install"],
                 result,
-                (_) => (store, packageInstallerMock),
+                (_) => (store, store, packageInstallerMock),
                 (_) => new ShellShimRepository(
                     new DirectoryPath(_shimsDirectory),
                     fileSystem: _fileSystem,
@@ -219,14 +219,14 @@ namespace Microsoft.DotNet.Tests.Commands
         {
             ParseResult result = Parser.Instance.Parse("dotnet tool uninstall " + options);
 
-            (IToolPackageStore, IToolPackageUninstaller) createToolPackageStoreAndUninstaller(
+            (IToolPackageStore, IToolPackageStoreQuery, IToolPackageUninstaller) createToolPackageStoreAndUninstaller(
                 DirectoryPath? directoryPath)
             {
                 var store = new ToolPackageStoreMock(
                     new DirectoryPath(_toolsDirectory),
                     _fileSystem);
                 var packageUninstaller = new ToolPackageUninstallerMock(_fileSystem, store, uninstallCallback);
-                return (store, packageUninstaller);
+                return (store, store, packageUninstaller);
             }
 
             return new ToolUninstallCommand(

--- a/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var command = new ToolUpdateCommand(
                 result["dotnet"]["tool"]["update"],
                 result,
-                _ => (_store,
+                _ => (_store, _store,
                     new ToolPackageInstallerMock(
                         _fileSystem,
                         _store,
@@ -164,7 +164,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var command = new ToolUpdateCommand(
                 result["dotnet"]["tool"]["update"],
                 result,
-                _ => (_store,
+                _ => (_store, _store,
                     new ToolPackageInstallerMock(
                         _fileSystem,
                         _store,
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return new ToolInstallCommand(
                 result["dotnet"]["tool"]["install"],
                 result,
-                (_) => (_store, new ToolPackageInstallerMock(
+                (_) => (_store, _store, new ToolPackageInstallerMock(
                     _fileSystem,
                     _store,
                     new ProjectRestorerMock(
@@ -235,7 +235,7 @@ namespace Microsoft.DotNet.Tests.Commands
             return new ToolUpdateCommand(
                 result["dotnet"]["tool"]["update"],
                 result,
-                (_) => (_store, new ToolPackageInstallerMock(
+                (_) => (_store, _store, new ToolPackageInstallerMock(
                     _fileSystem,
                     _store,
                     new ProjectRestorerMock(

--- a/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
@@ -143,7 +143,8 @@ namespace Microsoft.DotNet.Tests.Commands
                             _reporter,
                             _mockFeeds
                         ),
-                        installCallback: () => throw new ToolConfigurationException("Simulated error"))),
+                        installCallback: () => throw new ToolConfigurationException("Simulated error")),
+                    new ToolPackageUninstallerMock(_fileSystem, _store)),
                 _ => GetMockedShellShimRepository(),
                 _reporter);
 
@@ -172,7 +173,8 @@ namespace Microsoft.DotNet.Tests.Commands
                             _reporter,
                             _mockFeeds
                         ),
-                        installCallback: () => throw new ToolConfigurationException("Simulated error"))),
+                        installCallback: () => throw new ToolConfigurationException("Simulated error")),
+                    new ToolPackageUninstallerMock(_fileSystem, _store)),
                 _ => GetMockedShellShimRepository(),
                 _reporter);
 
@@ -240,7 +242,8 @@ namespace Microsoft.DotNet.Tests.Commands
                         _fileSystem,
                         _reporter,
                         _mockFeeds
-                    ))),
+                    )),
+                    new ToolPackageUninstallerMock(_fileSystem, _store)),
                 (_) => GetMockedShellShimRepository(),
                 _reporter);
         }


### PR DESCRIPTION
Instead of a method on PackageInstance. Immediate goal is to reuse PackageInstance
on local tools, however local tools should not have Uninstall method.

At the same time, PackageStore is too powerful. It can create PackageInstance,
and PackageInstance can do side effect. It doesn’t make sense when PackageInstaller
has access of creating PackageInstance and delete other packages. I created IToolPackageStoreQuery
that can only return file locations to avoid this coupling.

