### PR TITLE
 Add install package to nuget GlobalPackagesFolder

### DIFF
--- a/src/dotnet/ToolPackage/IToolPackageInstaller.cs
+++ b/src/dotnet/ToolPackage/IToolPackageInstaller.cs
@@ -14,5 +14,10 @@ namespace Microsoft.DotNet.ToolPackage
             VersionRange versionRange = null,
             string targetFramework = null,
             string verbosity = null);
+
+        IToolPackage InstallPackageToExternalManagedLocation(PackageLocation packageLocation, PackageId packageId,
+            VersionRange versionRange = null,
+            string targetFramework = null,
+            string verbosity = null);
     }
 }

--- a/src/dotnet/ToolPackage/ToolPackageInstaller.cs
+++ b/src/dotnet/ToolPackage/ToolPackageInstaller.cs
@@ -122,9 +122,6 @@ namespace Microsoft.DotNet.ToolPackage
             string targetFramework = null,
             string verbosity = null)
         {
-            var stageDirectory = _store.GetRandomStagingDirectory();
-            Directory.CreateDirectory(stageDirectory.Value);
-
             var tempDirectoryForAssetJson = new DirectoryPath(Path.GetTempPath())
                 .WithSubDirectories(Path.GetRandomFileName());
 

--- a/src/dotnet/ToolPackage/ToolPackageInstaller.cs
+++ b/src/dotnet/ToolPackage/ToolPackageInstaller.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Configurer;
 using Microsoft.DotNet.Tools;
 using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.ProjectModel;
 using NuGet.Versioning;
 
 namespace Microsoft.DotNet.ToolPackage
@@ -85,7 +86,10 @@ namespace Microsoft.DotNet.ToolPackage
                         FileAccessRetrier.RetryOnMoveAccessFailure(() => Directory.Move(stageDirectory.Value, packageDirectory.Value));
                         rollbackDirectory = packageDirectory.Value;
 
-                        return new ToolPackageInstance(packageId, version, packageDirectory);
+                        return new ToolPackageInstance(id: packageId,
+                            version: version,
+                            packageDirectory: packageDirectory,
+                            assetsJsonParentDirectory: packageDirectory);
                     }
                     catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
                     {
@@ -112,10 +116,48 @@ namespace Microsoft.DotNet.ToolPackage
                 });
         }
 
+        public IToolPackage InstallPackageToExternalManagedLocation(PackageLocation packageLocation,
+            PackageId packageId,
+            VersionRange versionRange = null,
+            string targetFramework = null,
+            string verbosity = null)
+        {
+            var stageDirectory = _store.GetRandomStagingDirectory();
+            Directory.CreateDirectory(stageDirectory.Value);
+
+            var tempDirectoryForAssetJson = new DirectoryPath(Path.GetTempPath())
+                .WithSubDirectories(Path.GetRandomFileName());
+
+            Directory.CreateDirectory(tempDirectoryForAssetJson.Value);
+
+            var tempProject = CreateTempProject(
+                packageId: packageId,
+                versionRange: versionRange,
+                targetFramework: targetFramework ?? BundledTargetFramework.GetTargetFrameworkMoniker(),
+                assetJsonOutputDirectory: tempDirectoryForAssetJson,
+                restoreDirectory: null,
+                rootConfigDirectory: packageLocation.RootConfigDirectory,
+                additionalFeeds: packageLocation.AdditionalFeeds);
+
+            try
+            {
+                _projectRestorer.Restore(
+                    tempProject,
+                    packageLocation,
+                    verbosity: verbosity);
+            }
+            finally
+            {
+                File.Delete(tempProject.Value);
+            }
+
+            return ToolPackageInstance.CreateFromAssetFile(packageId, tempDirectoryForAssetJson);
+        }
+
         private FilePath CreateTempProject(PackageId packageId,
             VersionRange versionRange,
             string targetFramework,
-            DirectoryPath restoreDirectory,
+            DirectoryPath? restoreDirectory,
             DirectoryPath assetJsonOutputDirectory,
             DirectoryPath? rootConfigDirectory,
             string[] additionalFeeds)
@@ -141,7 +183,7 @@ namespace Microsoft.DotNet.ToolPackage
                         new XAttribute("Sdk", "Microsoft.NET.Sdk")),
                     new XElement("PropertyGroup",
                         new XElement("TargetFramework", targetFramework),
-                        new XElement("RestorePackagesPath", restoreDirectory.Value),
+                        restoreDirectory.HasValue ? new XElement("RestorePackagesPath", restoreDirectory.Value.Value) : null,
                         new XElement("RestoreProjectStyle", "DotnetToolReference"), // without it, project cannot reference tool package
                         new XElement("RestoreRootConfigDirectory", rootConfigDirectory?.Value ?? Directory.GetCurrentDirectory()), // config file probing start directory
                         new XElement("DisableImplicitFrameworkReferences", "true"), // no Microsoft.NETCore.App in tool folder

--- a/src/dotnet/ToolPackage/ToolPackageStoreAndQuery.cs
+++ b/src/dotnet/ToolPackage/ToolPackageStoreAndQuery.cs
@@ -92,9 +92,10 @@ namespace Microsoft.DotNet.ToolPackage
 
             foreach (var subdirectory in Directory.EnumerateDirectories(packageRootDirectory.Value))
             {
-                yield return new ToolPackageInstance(packageId,
-                    NuGetVersion.Parse(Path.GetFileName(subdirectory)),
-                    new DirectoryPath(subdirectory));
+                yield return new ToolPackageInstance(id: packageId,
+                    version: NuGetVersion.Parse(Path.GetFileName(subdirectory)),
+                    packageDirectory: new DirectoryPath(subdirectory),
+                    assetsJsonParentDirectory: new DirectoryPath(subdirectory));
             }
         }
 
@@ -110,7 +111,11 @@ namespace Microsoft.DotNet.ToolPackage
             {
                 return null;
             }
-            return new ToolPackageInstance(packageId, version, directory);
+
+            return new ToolPackageInstance(id: packageId,
+                version: version,
+                packageDirectory: directory,
+                assetsJsonParentDirectory: directory);
         }
     }
 }

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerNugetCacheTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageInstallerNugetCacheTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Tools.Tool.Install;
+using Microsoft.DotNet.Tools.Tests.ComponentMocks;
+using Microsoft.Extensions.DependencyModel.Tests;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Xunit;
+using NuGet.Versioning;
+
+namespace Microsoft.DotNet.ToolPackage.Tests
+{
+    public class ToolPackageInstallToManagedLocationInstaller : TestBase
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GivenNugetConfigInstallSucceeds(bool testMockBehaviorIsInSync)
+        {
+            var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
+
+            var (store, installer, reporter, fileSystem) = Setup(
+                useMock: testMockBehaviorIsInSync,
+                feeds: GetMockFeedsForConfigFile(nugetConfigPath));
+
+            var nugetCacheLocation =
+                new DirectoryPath(Path.GetTempPath()).WithSubDirectories(Path.GetRandomFileName());
+
+            IToolPackage toolPackage = installer.InstallPackageToExternalManagedLocation(
+                packageId: TestPackageId,
+                versionRange: VersionRange.Parse(TestPackageVersion),
+                packageLocation : new PackageLocation(nugetConfig: nugetConfigPath),
+                targetFramework: _testTargetframework);
+
+            var commands = toolPackage.Commands;
+            commands[0].Executable.Value.Should().StartWith(NuGetGlobalPackagesFolder.GetLocation());
+
+            fileSystem.File
+                .Exists(commands[0].Executable.Value)
+                .Should().BeTrue($"{commands[0].Executable.Value} should exist");
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GivenNugetConfigVersionRangeInstallSucceeds(bool testMockBehaviorIsInSync)
+        {
+            var nugetConfigPath = WriteNugetConfigFileToPointToTheFeed();
+
+            var (store, installer, reporter, fileSystem) = Setup(
+                useMock: testMockBehaviorIsInSync,
+                feeds: GetMockFeedsForConfigFile(nugetConfigPath));
+
+            var nugetCacheLocation =
+                new DirectoryPath(Path.GetTempPath()).WithSubDirectories(Path.GetRandomFileName());
+
+            IToolPackage toolPackage = installer.InstallPackageToExternalManagedLocation(
+                packageId: TestPackageId,
+                versionRange: VersionRange.Parse("1.0.0-*"),
+                packageLocation: new PackageLocation(nugetConfig: nugetConfigPath),
+                targetFramework: _testTargetframework);
+
+            var commands = toolPackage.Commands;
+            commands[0].Executable.Value.Should().StartWith(NuGetGlobalPackagesFolder.GetLocation());
+            toolPackage.Version.Should().Be(NuGetVersion.Parse(TestPackageVersion));
+        }
+
+        private static FilePath GetUniqueTempProjectPathEachTest()
+        {
+            var tempProjectDirectory =
+                new DirectoryPath(Path.GetTempPath()).WithSubDirectories(Path.GetRandomFileName());
+            var tempProjectPath =
+                tempProjectDirectory.WithFile(Path.GetRandomFileName() + ".csproj");
+            return tempProjectPath;
+        }
+
+        private static IEnumerable<MockFeed> GetMockFeedsForConfigFile(FilePath nugetConfig)
+        {
+            return new MockFeed[]
+            {
+                new MockFeed
+                {
+                    Type = MockFeedType.ExplicitNugetConfig,
+                    Uri = nugetConfig.Value,
+                    Packages = new List<MockFeedPackage>
+                    {
+                        new MockFeedPackage
+                        {
+                            PackageId = TestPackageId.ToString(),
+                            Version = TestPackageVersion
+                        }
+                    }
+                }
+            };
+        }
+
+        private static (IToolPackageStore, IToolPackageInstaller, BufferedReporter, IFileSystem) Setup(
+            bool useMock,
+            IEnumerable<MockFeed> feeds = null,
+            FilePath? tempProject = null,
+            DirectoryPath? offlineFeed = null)
+        {
+            var root = new DirectoryPath(Path.Combine(Directory.GetCurrentDirectory(), Path.GetRandomFileName()));
+            var reporter = new BufferedReporter();
+
+            IFileSystem fileSystem;
+            IToolPackageStore store;
+            IToolPackageInstaller installer;
+            if (useMock)
+            {
+                fileSystem = new FileSystemMockBuilder().Build();
+                store = new ToolPackageStoreMock(root, fileSystem);
+                installer = new ToolPackageInstallerMock(
+                    fileSystem: fileSystem,
+                    store: store,
+                    projectRestorer: new ProjectRestorerMock(
+                        fileSystem: fileSystem,
+                        reporter: reporter,
+                        feeds: feeds));
+            }
+            else
+            {
+                fileSystem = new FileSystemWrapper();
+                store = new ToolPackageStoreAndQuery(root);
+                installer = new ToolPackageInstaller(
+                    store: store,
+                    projectRestorer: new ProjectRestorer(reporter),
+                    tempProject: tempProject ?? GetUniqueTempProjectPathEachTest(),
+                    offlineFeed: offlineFeed ?? new DirectoryPath("does not exist"));
+            }
+
+            return (store, installer, reporter, fileSystem);
+        }
+
+        private static FilePath WriteNugetConfigFileToPointToTheFeed()
+        {
+            var nugetConfigName = "nuget.config";
+
+            var tempPathForNugetConfigWithWhiteSpace =
+                Path.Combine(Path.GetTempPath(),
+                    Path.GetRandomFileName() + " " + Path.GetRandomFileName());
+            Directory.CreateDirectory(tempPathForNugetConfigWithWhiteSpace);
+
+            NuGetConfig.Write(
+                directory: tempPathForNugetConfigWithWhiteSpace,
+                configname: nugetConfigName,
+                localFeedPath: GetTestLocalFeedPath());
+
+            return new FilePath(Path.GetFullPath(Path.Combine(tempPathForNugetConfigWithWhiteSpace, nugetConfigName)));
+        }
+
+        private static string GetTestLocalFeedPath() => Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "TestAssetLocalNugetFeed");
+        private readonly string _testTargetframework = BundledTargetFramework.GetTargetFrameworkMoniker();
+        private const string TestPackageVersion = "1.0.4";
+        private static readonly PackageId TestPackageId = new PackageId("global.tool.console.demo");
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/Microsoft.DotNet.Tools.Tests.ComponentMocks.csproj
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/Microsoft.DotNet.Tools.Tests.ComponentMocks.csproj
@@ -10,5 +10,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\dotnet\dotnet.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.DotNet.Cli.Utils\Microsoft.DotNet.Cli.Utils.csproj" />
+    <ProjectReference Include="..\Microsoft.DotNet.Tools.Tests.Utilities\Microsoft.DotNet.Tools.Tests.Utilities.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
@@ -112,7 +112,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                 fakeExecutablePath);
         }
 
-        private MockFeedPackage GetPackage(
+        public MockFeedPackage GetPackage(
             string packageId,
             VersionRange versionRange = null,
             FilePath? nugetConfig = null)

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
@@ -9,6 +9,7 @@ using System.Transactions;
 using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools;
+using Microsoft.DotNet.Tools.Test.Utilities;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.Versioning;
 
@@ -19,7 +20,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
         private const string ProjectFileName = "TempProject.csproj";
 
         private readonly IToolPackageStore _store;
-        private readonly IProjectRestorer _projectRestorer;
+        private readonly ProjectRestorerMock _projectRestorer;
         private readonly IFileSystem _fileSystem;
         private readonly Action _installCallback;
         private readonly Dictionary<PackageId, IEnumerable<string>> _warningsMap;
@@ -28,7 +29,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
         public ToolPackageInstallerMock(
             IFileSystem fileSystem,
             IToolPackageStore store,
-            IProjectRestorer projectRestorer,
+            ProjectRestorerMock projectRestorer,
             Action installCallback = null,
             Dictionary<PackageId, IEnumerable<string>> warningsMap = null,
             Dictionary<PackageId, IReadOnlyList<FilePath>> packagedShimsMap = null)
@@ -50,7 +51,8 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             string rollbackDirectory = null;
 
             return TransactionalAction.Run<IToolPackage>(
-                action: () => {
+                action: () =>
+                {
                     var stageDirectory = _store.GetRandomStagingDirectory();
                     _fileSystem.Directory.CreateDirectory(stageDirectory.Value);
                     rollbackDirectory = stageDirectory.Value;
@@ -96,7 +98,8 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 
                     return new ToolPackageMock(_fileSystem, packageId, version, packageDirectory, warnings: warnings, packagedShims: packedShims);
                 },
-                rollback: () => {
+                rollback: () =>
+                {
                     if (rollbackDirectory != null && _fileSystem.Directory.Exists(rollbackDirectory))
                     {
                         _fileSystem.Directory.Delete(rollbackDirectory, true);
@@ -107,6 +110,45 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                         _fileSystem.Directory.Delete(packageRootDirectory.Value, false);
                     }
                 });
+        }
+
+        public IToolPackage InstallPackageToExternalManagedLocation(
+            PackageLocation packageLocation,
+            PackageId packageId,
+            VersionRange versionRange = null,
+            string targetFramework = null,
+            string verbosity = null)
+        {
+            var packageDirectory = new DirectoryPath(NuGetGlobalPackagesFolder.GetLocation()).WithSubDirectories(packageId.ToString());
+            _fileSystem.Directory.CreateDirectory(packageDirectory.Value);
+            var executable = packageDirectory.WithFile("exe");
+            _fileSystem.File.CreateEmptyFile(executable.Value);
+
+            MockFeedPackage package = _projectRestorer.GetPackage(packageId.ToString(), versionRange, packageLocation.NugetConfig);
+
+            return new TestToolPackage
+            {
+                Id = packageId,
+                Version = NuGetVersion.Parse(package.Version),
+                Commands = new List<CommandSettings> {
+                    new CommandSettings(ProjectRestorerMock.FakeCommandName, "runner", executable) },
+                Warnings = Array.Empty<string>(),
+                PackagedShims = Array.Empty<FilePath>()
+            };
+        }
+
+        private class TestToolPackage : IToolPackage
+        {
+            public PackageId Id { get; set; }
+
+            public NuGetVersion Version { get; set; }
+            public DirectoryPath PackageDirectory { get; set; }
+
+            public IReadOnlyList<CommandSettings> Commands { get; set; }
+
+            public IEnumerable<string> Warnings { get; set; }
+
+            public IReadOnlyList<FilePath> PackagedShims { get; set; }
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/NuGetGlobalPackagesFolder.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/NuGetGlobalPackagesFolder.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using NuGet.Configuration;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public static class NuGetGlobalPackagesFolder
+    {
+        public static string GetLocation()
+        {
+            ISettings nugetSetting = Settings.LoadDefaultSettings(
+                Directory.GetCurrentDirectory(),
+                configFileName: null,
+                machineWideSettings: new XPlatMachineWideSetting());
+
+            return SettingsUtility.GetGlobalPackagesFolder(nugetSetting);
+        }
+    }
+}


### PR DESCRIPTION
Allow separate asset.json folder in PackageInstance and make read actual package location from assetjson.

https://github.com/dotnet/cli/issues/9921