### PR TITLE
Expand relative paths for CLI arguments

### DIFF
--- a/src/dotnet/CommandDirectoryContext.cs
+++ b/src/dotnet/CommandDirectoryContext.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+
+namespace Microsoft.DotNet.Cli
+{
+    internal static class CommandDirectoryContext
+    {
+        [ThreadStatic]
+        private static string _currentDirectoryOverwrite;
+
+        /// <summary>
+        /// Expands a path similar to Path.GetFullPath() but allows unit tests a hook to inject an overwrite to the
+        /// current working directory.
+        /// </summary>
+        /// <param name="path">A realtive or absolute path specifier</param>
+        /// <returns>The full path to the target</returns>
+        public static string ExpandPath(string path)
+            => _currentDirectoryOverwrite is string basePath
+                ? Path.GetFullPath(path, basePath)
+                : Path.GetFullPath(path);
+
+        /// <summary>
+        /// Meant to be used only in unit test to remove dependency on special characters in the absolute repo path
+        /// The overwrite will only affect the current thread.
+        /// </summary>
+        /// <param name="currentDirectory">Directory to be used instead of the current working directory.</param>
+        /// <param name="action">Action to be executed with the overwritten directory in place.</param>
+        public static void PerformActionWithOverwrittenCurrentDirectory(string currentDirectory, Action action)
+        {
+            if (_currentDirectoryOverwrite != null)
+            {
+                throw new InvalidOperationException(
+                    $"Calls to {nameof(CommandDirectoryContext)}.{nameof(PerformActionWithOverwrittenCurrentDirectory)} cannot be nested.");
+            }
+            _currentDirectoryOverwrite = currentDirectory;
+            try
+            {
+                action();
+            }
+            finally
+            {
+                _currentDirectoryOverwrite = null;
+            }
+        }
+    }
+}

--- a/src/dotnet/CommandDirectoryContext.cs
+++ b/src/dotnet/CommandDirectoryContext.cs
@@ -6,40 +6,40 @@ namespace Microsoft.DotNet.Cli
     internal static class CommandDirectoryContext
     {
         [ThreadStatic]
-        private static string _currentDirectoryOverwrite;
+        private static string _basePath;
 
         /// <summary>
-        /// Expands a path similar to Path.GetFullPath() but allows unit tests a hook to inject an overwrite to the
-        /// current working directory.
+        /// Expands a path similar to Path.GetFullPath() but gives unit tests a hook to inject an overwrite to the
+        /// base path.
         /// </summary>
-        /// <param name="path">A realtive or absolute path specifier</param>
+        /// <param name="path">A relative or absolute path specifier</param>
         /// <returns>The full path to the target</returns>
-        public static string ExpandPath(string path)
-            => _currentDirectoryOverwrite is string basePath
-                ? Path.GetFullPath(path, basePath)
+        public static string GetFullPath(string path)
+            => _basePath != null
+                ? Path.GetFullPath(path, _basePath)
                 : Path.GetFullPath(path);
 
         /// <summary>
         /// Meant to be used only in unit test to remove dependency on special characters in the absolute repo path
         /// The overwrite will only affect the current thread.
         /// </summary>
-        /// <param name="currentDirectory">Directory to be used instead of the current working directory.</param>
+        /// <param name="basePath">Directory to be used as base path instead of the current working directory.</param>
         /// <param name="action">Action to be executed with the overwritten directory in place.</param>
-        public static void PerformActionWithOverwrittenCurrentDirectory(string currentDirectory, Action action)
+        public static void PerformActionWithBasePath(string basePath, Action action)
         {
-            if (_currentDirectoryOverwrite != null)
+            if (_basePath != null)
             {
                 throw new InvalidOperationException(
-                    $"Calls to {nameof(CommandDirectoryContext)}.{nameof(PerformActionWithOverwrittenCurrentDirectory)} cannot be nested.");
+                    $"Calls to {nameof(CommandDirectoryContext)}.{nameof(PerformActionWithBasePath)} cannot be nested.");
             }
-            _currentDirectoryOverwrite = currentDirectory;
+            _basePath = basePath;
             try
             {
                 action();
             }
             finally
             {
-                _currentDirectoryOverwrite = null;
+                _basePath = null;
             }
         }
     }

--- a/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.OutputOptionName)
-                          .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                          .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                 CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription),
                 CommonOptions.ConfigurationOption(LocalizableStrings.ConfigurationOptionDescription),
                 CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription),

--- a/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.OutputOptionName)
-                          .ForwardAsSingle(o => $"-property:OutputPath={o.Arguments.Single()}")),
+                          .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                 CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription),
                 CommonOptions.ConfigurationOption(LocalizableStrings.ConfigurationOptionDescription),
                 CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription),

--- a/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli
                               LocalizableStrings.CmdOutputDirDescription,
                                          Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.CmdOutputDir)
-                        .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                        .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                 CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription),
                 CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription),
                 CommonOptions.ConfigurationOption(LocalizableStrings.ConfigurationOptionDescription),

--- a/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Cli
                               LocalizableStrings.CmdOutputDirDescription,
                                          Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.CmdOutputDir)
-                        .ForwardAsSingle(o => $"-property:OutputPath={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                 CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription),
                 CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription),
                 CommonOptions.ConfigurationOption(LocalizableStrings.ConfigurationOptionDescription),

--- a/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.CmdOutputDirDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.CmdOutputDir)
-                        .ForwardAsSingle(o => $"-property:PackageOutputPath={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-property:PackageOutputPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                 Create.Option(
                     "--no-build",
                     LocalizableStrings.CmdNoBuildOptionDescription,

--- a/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.CmdOutputDirDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.CmdOutputDir)
-                        .ForwardAsSingle(o => $"-property:PackageOutputPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                        .ForwardAsSingle(o => $"-property:PackageOutputPath={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                 Create.Option(
                     "--no-build",
                     LocalizableStrings.CmdNoBuildOptionDescription,

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -24,7 +24,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.OutputOption)
-                        .ForwardAsSingle(o => $"-property:PublishDir={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                        .ForwardAsSingle(o => $"-property:PublishDir={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                 CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription),
                 CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription),
                 CommonOptions.ConfigurationOption(LocalizableStrings.ConfigurationOptionDescription),
@@ -34,7 +34,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.ManifestOptionDescription,
                     Accept.OneOrMoreArguments()
                         .With(name: LocalizableStrings.ManifestOption)
-                        .ForwardAsSingle(o => $"-property:TargetManifestFiles={string.Join("%3B", o.Arguments.Select(CommandDirectoryContext.ExpandPath))}")),
+                        .ForwardAsSingle(o => $"-property:TargetManifestFiles={string.Join("%3B", o.Arguments.Select(CommandDirectoryContext.GetFullPath))}")),
                 Create.Option(
                     "--no-build",
                     LocalizableStrings.NoBuildOptionDescription,

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools;
@@ -23,7 +24,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.OutputOption)
-                        .ForwardAsSingle(o => $"-property:PublishDir={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-property:PublishDir={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                 CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription),
                 CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription),
                 CommonOptions.ConfigurationOption(LocalizableStrings.ConfigurationOptionDescription),
@@ -33,7 +34,7 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.ManifestOptionDescription,
                     Accept.OneOrMoreArguments()
                         .With(name: LocalizableStrings.ManifestOption)
-                        .ForwardAsSingle(o => $"-property:TargetManifestFiles={string.Join("%3B", o.Arguments)}")),
+                        .ForwardAsSingle(o => $"-property:TargetManifestFiles={string.Join("%3B", o.Arguments.Select(CommandDirectoryContext.ExpandPath))}")),
                 Create.Option(
                     "--no-build",
                     LocalizableStrings.NoBuildOptionDescription,

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Cli
                     showHelp ? LocalizableStrings.CmdPackagesOptionDescription : string.Empty,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.CmdPackagesOption)
-                          .ForwardAsSingle(o => $"-property:RestorePackagesPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                          .ForwardAsSingle(o => $"-property:RestorePackagesPath={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                 Create.Option(
                     "--disable-parallel",
                     showHelp ? LocalizableStrings.CmdDisableParallelOptionDescription : string.Empty,
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Cli
                     showHelp ? LocalizableStrings.CmdConfigFileOptionDescription : string.Empty,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.CmdConfigFileOption)
-                          .ForwardAsSingle(o => $"-property:RestoreConfigFile={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                          .ForwardAsSingle(o => $"-property:RestoreConfigFile={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                 Create.Option(
                     "--no-cache",
                     showHelp ? LocalizableStrings.CmdNoCacheOptionDescription : string.Empty,

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -70,7 +70,7 @@ namespace Microsoft.DotNet.Cli
                     showHelp ? LocalizableStrings.CmdPackagesOptionDescription : string.Empty,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.CmdPackagesOption)
-                          .ForwardAsSingle(o => $"-property:RestorePackagesPath={o.Arguments.Single()}")),
+                          .ForwardAsSingle(o => $"-property:RestorePackagesPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                 Create.Option(
                     "--disable-parallel",
                     showHelp ? LocalizableStrings.CmdDisableParallelOptionDescription : string.Empty,
@@ -81,7 +81,7 @@ namespace Microsoft.DotNet.Cli
                     showHelp ? LocalizableStrings.CmdConfigFileOptionDescription : string.Empty,
                     Accept.ExactlyOneArgument()
                           .With(name: LocalizableStrings.CmdConfigFileOption)
-                          .ForwardAsSingle(o => $"-property:RestoreConfigFile={o.Arguments.Single()}")),
+                          .ForwardAsSingle(o => $"-property:RestoreConfigFile={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                 Create.Option(
                     "--no-cache",
                     showHelp ? LocalizableStrings.CmdNoCacheOptionDescription : string.Empty,

--- a/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Cli
                                   return new[]
                                   {
                                       materializedString,
-                                      $"-property:AdditionalProjects={string.Join("%3B", o.Arguments.Skip(1).Select(CommandDirectoryContext.ExpandPath))}"
+                                      $"-property:AdditionalProjects={string.Join("%3B", o.Arguments.Skip(1).Select(CommandDirectoryContext.GetFullPath))}"
                                   };
                               }
                           })),
@@ -55,13 +55,13 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.OutputOption)
-                        .ForwardAsSingle(o => $"-property:ComposeDir={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                        .ForwardAsSingle(o => $"-property:ComposeDir={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                 Create.Option(
                     "-w|--working-dir",
                     LocalizableStrings.IntermediateWorkingDirOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.IntermediateWorkingDirOption)
-                        .ForwardAsSingle(o => $"-property:ComposeWorkingDir={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                        .ForwardAsSingle(o => $"-property:ComposeWorkingDir={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                 Create.Option(
                     "--skip-optimization",
                     LocalizableStrings.SkipOptimizationOptionDescription,

--- a/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-store/StoreCommandParser.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using LocalizableStrings = Microsoft.DotNet.Tools.Store.LocalizableStrings;
@@ -23,6 +22,8 @@ namespace Microsoft.DotNet.Cli
                           .With(name: LocalizableStrings.ProjectManifest)
                           .ForwardAsMany(o =>
                           {
+                              // the first path doesn't need to go through CommandDirectoryContext.ExpandPath
+                              // since it is a direct argument to MSBuild, not a property
                               var materializedString = $"{o.Arguments.First()}";
 
                               if (o.Arguments.Count == 1)
@@ -37,7 +38,7 @@ namespace Microsoft.DotNet.Cli
                                   return new[]
                                   {
                                       materializedString,
-                                      $"-property:AdditionalProjects={string.Join("%3B", o.Arguments.Skip(1))}"
+                                      $"-property:AdditionalProjects={string.Join("%3B", o.Arguments.Skip(1).Select(CommandDirectoryContext.ExpandPath))}"
                                   };
                               }
                           })),
@@ -54,13 +55,13 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.OutputOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.OutputOption)
-                        .ForwardAsSingle(o => $"-property:ComposeDir={Path.GetFullPath(o.Arguments.Single())}")),
+                        .ForwardAsSingle(o => $"-property:ComposeDir={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                 Create.Option(
                     "-w|--working-dir",
                     LocalizableStrings.IntermediateWorkingDirOptionDescription,
                     Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.IntermediateWorkingDirOption)
-                        .ForwardAsSingle(o => $"-property:ComposeWorkingDir={o.Arguments.Single()}")),
+                        .ForwardAsSingle(o => $"-property:ComposeWorkingDir={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                 Create.Option(
                     "--skip-optimization",
                     LocalizableStrings.SkipOptimizationOptionDescription,

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdSettingsDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdSettingsFile)
-                              .ForwardAsSingle(o => $"-property:VSTestSetting={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:VSTestSetting={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                   Create.Option(
                         "-t|--list-tests",
                         LocalizableStrings.CmdListTestsDescription,
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdTestAdapterPathDescription,
                         Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.CmdTestAdapterPath)
-                              .ForwardAsSingle(o => $"-property:VSTestTestAdapterPath=\"{string.Join(";", o.Arguments)}\"")),
+                              .ForwardAsSingle(o => $"-property:VSTestTestAdapterPath=\"{string.Join(";", o.Arguments.Select(CommandDirectoryContext.ExpandPath))}\"")),
                   Create.Option(
                         "-l|--logger",
                         LocalizableStrings.CmdLoggerDescription,
@@ -62,13 +62,13 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdOutputDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdOutputDir)
-                              .ForwardAsSingle(o => $"-property:OutputPath={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                   Create.Option(
                         "-d|--diag",
                         LocalizableStrings.CmdPathTologFileDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdPathToLogFile)
-                              .ForwardAsSingle(o => $"-property:VSTestDiag={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:VSTestDiag={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                   Create.Option(
                         "--no-build",
                         LocalizableStrings.CmdNoBuildDescription,
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdResultsDirectoryDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdPathToResultsDirectory)
-                              .ForwardAsSingle(o => $"-property:VSTestResultsDirectory={o.Arguments.Single()}")),
+                              .ForwardAsSingle(o => $"-property:VSTestResultsDirectory={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
                   Create.Option(
                         "--collect",
                         LocalizableStrings.cmdCollectDescription,

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdSettingsDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdSettingsFile)
-                              .ForwardAsSingle(o => $"-property:VSTestSetting={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                              .ForwardAsSingle(o => $"-property:VSTestSetting={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                   Create.Option(
                         "-t|--list-tests",
                         LocalizableStrings.CmdListTestsDescription,
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdTestAdapterPathDescription,
                         Accept.OneOrMoreArguments()
                               .With(name: LocalizableStrings.CmdTestAdapterPath)
-                              .ForwardAsSingle(o => $"-property:VSTestTestAdapterPath=\"{string.Join(";", o.Arguments.Select(CommandDirectoryContext.ExpandPath))}\"")),
+                              .ForwardAsSingle(o => $"-property:VSTestTestAdapterPath=\"{string.Join(";", o.Arguments.Select(CommandDirectoryContext.GetFullPath))}\"")),
                   Create.Option(
                         "-l|--logger",
                         LocalizableStrings.CmdLoggerDescription,
@@ -62,13 +62,13 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdOutputDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdOutputDir)
-                              .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                              .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                   Create.Option(
                         "-d|--diag",
                         LocalizableStrings.CmdPathTologFileDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdPathToLogFile)
-                              .ForwardAsSingle(o => $"-property:VSTestDiag={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                              .ForwardAsSingle(o => $"-property:VSTestDiag={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                   Create.Option(
                         "--no-build",
                         LocalizableStrings.CmdNoBuildDescription,
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Cli
                         LocalizableStrings.CmdResultsDirectoryDescription,
                         Accept.ExactlyOneArgument()
                               .With(name: LocalizableStrings.CmdPathToResultsDirectory)
-                              .ForwardAsSingle(o => $"-property:VSTestResultsDirectory={CommandDirectoryContext.ExpandPath(o.Arguments.Single())}")),
+                              .ForwardAsSingle(o => $"-property:VSTestResultsDirectory={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
                   Create.Option(
                         "--collect",
                         LocalizableStrings.cmdCollectDescription,

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/TestPathUtilities.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/TestPathUtilities.cs
@@ -1,19 +1,18 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
-namespace Microsoft.DotNet.Tools.Test.Utilities
+namespace Microsoft.DotNet.Tools.Tests.Utilities
 {
     public static class TestPathUtilities
     {
-        public static string CreateAbsolutePath(string directoryName = null)
+        public static string FormatAbsolutePath(string directoryName = null)
             => Path.Combine(
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                     ? "A:"
                     : Path.DirectorySeparatorChar.ToString(),
-                directoryName ?? "testworkdir") + Path.DirectorySeparatorChar;
+                directoryName ?? "TestWorkDir") + Path.DirectorySeparatorChar;
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/TestPathUtilities.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/TestPathUtilities.cs
@@ -1,0 +1,19 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public static class TestPathUtilities
+    {
+        public static string CreateAbsolutePath(string directoryName = null)
+            => Path.Combine(
+                RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "A:"
+                    : Path.DirectorySeparatorChar.ToString(),
+                directoryName ?? "testworkdir") + Path.DirectorySeparatorChar;
+    }
+}

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.DotNet.Tools.Build;
 using FluentAssertions;
+using Microsoft.DotNet.Tools.Tests.Utilities;
 using Xunit;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
@@ -14,7 +15,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m";
 
         private static readonly string WorkingDirectory = 
-            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetBuildInvocation));
+            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetBuildInvocation));
 
         [Theory]
         [InlineData(new string[] { }, "-target:Build")]
@@ -35,7 +36,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                                   "-target:Rebuild -property:OutputPath=<cwd>myoutput -property:RuntimeIdentifier=myruntime -verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
             {
                 expectedAdditionalArgs =
                     (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")
@@ -62,7 +63,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             string expectedAdditionalArgsForRestore, 
             string expectedAdditionalArgs)
         {
-            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
             {
                 expectedAdditionalArgsForRestore = expectedAdditionalArgsForRestore.Replace("<cwd>", WorkingDirectory);
 

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.IO;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Tools.Build;
 using FluentAssertions;
 using Xunit;
@@ -11,12 +13,15 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     {
         const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m";
 
+        private static readonly string WorkingDirectory = 
+            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetBuildInvocation));
+
         [Theory]
         [InlineData(new string[] { }, "-target:Build")]
-        [InlineData(new string[] { "-o", "foo" }, "-target:Build -property:OutputPath=foo")]
+        [InlineData(new string[] { "-o", "foo" }, "-target:Build -property:OutputPath=<cwd>foo")]
         [InlineData(new string[] { "-property:Verbosity=diag" }, "-target:Build -property:Verbosity=diag")]
-        [InlineData(new string[] { "--output", "foo" }, "-target:Build -property:OutputPath=foo")]
-        [InlineData(new string[] { "-o", "foo1 foo2" }, "-target:Build \"-property:OutputPath=foo1 foo2\"")]
+        [InlineData(new string[] { "--output", "foo" }, "-target:Build -property:OutputPath=<cwd>foo")]
+        [InlineData(new string[] { "-o", "foo1 foo2" }, "-target:Build \"-property:OutputPath=<cwd>foo1 foo2\"")]
         [InlineData(new string[] { "--no-incremental" }, "-target:Rebuild")]
         [InlineData(new string[] { "-r", "rid" }, "-target:Build -property:RuntimeIdentifier=rid")]
         [InlineData(new string[] { "--runtime", "rid" }, "-target:Build -property:RuntimeIdentifier=rid")]
@@ -27,43 +32,54 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "-v", "diag" }, "-target:Build -verbosity:diag")]
         [InlineData(new string[] { "--verbosity", "diag" }, "-target:Build -verbosity:diag")]
         [InlineData(new string[] { "--no-incremental", "-o", "myoutput", "-r", "myruntime", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
-                                  "-target:Rebuild -property:OutputPath=myoutput -property:RuntimeIdentifier=myruntime -verbosity:diag /ArbitrarySwitchForMSBuild")]
+                                  "-target:Rebuild -property:OutputPath=<cwd>myoutput -property:RuntimeIdentifier=myruntime -verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
+            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            {
+                expectedAdditionalArgs =
+                    (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")
+                    .Replace("<cwd>", WorkingDirectory);
 
-            var msbuildPath = "<msbuildpath>";
-            var command = BuildCommand.FromArgs(args, msbuildPath);
+                var msbuildPath = "<msbuildpath>";
+                var command = BuildCommand.FromArgs(args, msbuildPath);
 
-            command.SeparateRestoreCommand.Should().BeNull();
+                command.SeparateRestoreCommand.Should().BeNull();
 
-            command.GetProcessStartInfo()
-                   .Arguments.Should()
-                   .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary{expectedAdditionalArgs}");
+                command.GetProcessStartInfo()
+                    .Arguments.Should()
+                    .Be($"{ExpectedPrefix} -restore -consoleloggerparameters:Summary{expectedAdditionalArgs}");
+            });
         }
 
         [Theory]
         [InlineData(new string[] { "-f", "tfm" }, "-target:Restore", "-target:Build -property:TargetFramework=tfm")]
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
-                                  "-target:Restore -property:OutputPath=myoutput -verbosity:diag /ArbitrarySwitchForMSBuild",
-                                  "-target:Build -property:OutputPath=myoutput -property:TargetFramework=tfm -verbosity:diag /ArbitrarySwitchForMSBuild")]
+                                  "-target:Restore -property:OutputPath=<cwd>myoutput -verbosity:diag /ArbitrarySwitchForMSBuild",
+                                  "-target:Build -property:OutputPath=<cwd>myoutput -property:TargetFramework=tfm -verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(
             string[] args, 
             string expectedAdditionalArgsForRestore, 
             string expectedAdditionalArgs)
         {
-            expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
+            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            {
+                expectedAdditionalArgsForRestore = expectedAdditionalArgsForRestore.Replace("<cwd>", WorkingDirectory);
 
-            var msbuildPath = "<msbuildpath>";
-            var command = BuildCommand.FromArgs(args, msbuildPath);
+                expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
+                expectedAdditionalArgs = expectedAdditionalArgs.Replace("<cwd>", WorkingDirectory);
 
-            command.SeparateRestoreCommand.GetProcessStartInfo()
-                   .Arguments.Should()
-                   .Be($"{ExpectedPrefix} {expectedAdditionalArgsForRestore}");
+                var msbuildPath = "<msbuildpath>";
+                var command = BuildCommand.FromArgs(args, msbuildPath);
 
-            command.GetProcessStartInfo()
-                   .Arguments.Should()
-                   .Be($"{ExpectedPrefix} -nologo -consoleloggerparameters:Summary{expectedAdditionalArgs}");
+                command.SeparateRestoreCommand.GetProcessStartInfo()
+                    .Arguments.Should()
+                    .Be($"{ExpectedPrefix} {expectedAdditionalArgsForRestore}");
+
+                command.GetProcessStartInfo()
+                    .Arguments.Should()
+                    .Be($"{ExpectedPrefix} -nologo -consoleloggerparameters:Summary{expectedAdditionalArgs}");
+            });
 
         }
     }

--- a/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
@@ -5,12 +5,17 @@ using Microsoft.DotNet.Tools.Clean;
 using FluentAssertions;
 using Xunit;
 using System;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetCleanInvocation
     {
         const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -verbosity:normal -target:Clean";
+
+        private static readonly string WorkingDirectory = 
+            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetCleanInvocation));
 
         [Fact]
         public void ItAddsProjectToMsbuildInvocation()
@@ -22,8 +27,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 
         [Theory]
         [InlineData(new string[] { }, "")]
-        [InlineData(new string[] { "-o", "<output>" }, "-property:OutputPath=<output>")]
-        [InlineData(new string[] { "--output", "<output>" }, "-property:OutputPath=<output>")]
+        [InlineData(new string[] { "-o", "<output>" }, "-property:OutputPath=<cwd><output>")]
+        [InlineData(new string[] { "--output", "<output>" }, "-property:OutputPath=<cwd><output>")]
         [InlineData(new string[] { "-f", "<framework>" }, "-property:TargetFramework=<framework>")]
         [InlineData(new string[] { "--framework", "<framework>" }, "-property:TargetFramework=<framework>")]
         [InlineData(new string[] { "-c", "<configuration>" }, "-property:Configuration=<configuration>")]
@@ -32,11 +37,16 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--verbosity", "diag" }, "-verbosity:diag")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
+            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            {
+                expectedAdditionalArgs =
+                    (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")
+                    .Replace("<cwd>", WorkingDirectory);
 
-            var msbuildPath = "<msbuildpath>";
-            CleanCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+                var msbuildPath = "<msbuildpath>";
+                CleanCommand.FromArgs(args, msbuildPath)
+                    .GetProcessStartInfo().Arguments.Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+            });
         }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetCleanInvocation.cs
@@ -7,6 +7,7 @@ using Xunit;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.Tools.Tests.Utilities;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -15,7 +16,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -verbosity:normal -target:Clean";
 
         private static readonly string WorkingDirectory = 
-            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetCleanInvocation));
+            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetCleanInvocation));
 
         [Fact]
         public void ItAddsProjectToMsbuildInvocation()
@@ -37,7 +38,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--verbosity", "diag" }, "-verbosity:diag")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
             {
                 expectedAdditionalArgs =
                     (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")

--- a/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPackInvocation.cs
@@ -8,6 +8,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.Tools.Tests.Utilities;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -17,7 +18,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         const string ExpectedNoBuildPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -target:pack";
 
         private static readonly string WorkingDirectory = 
-            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetPackInvocation));
+            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetPackInvocation));
 
         [Theory]
         [InlineData(new string[] { }, "")]
@@ -36,7 +37,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "<project>" }, "<project>")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
             {
                 expectedAdditionalArgs =
                     (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")

--- a/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools.Publish;
+using Microsoft.DotNet.Tools.Tests.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,7 +16,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     public class GivenDotnetPublishInvocation
     {
         private static readonly string WorkingDirectory = 
-            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetPublishInvocation));
+            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetPublishInvocation));
         private readonly ITestOutputHelper output;
 
         public GivenDotnetPublishInvocation(ITestOutputHelper output)
@@ -41,7 +42,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "<project>", "<extra-args>" }, "<project> <extra-args>")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
             {
                 expectedAdditionalArgs =
                     (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")
@@ -114,7 +115,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--no-build" }, "-property:NoBuild=true")]
         public void OptionForwardingIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
             {
                 var expectedArgs = expectedAdditionalArgs
                     .Replace("<cwd>", WorkingDirectory)

--- a/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetPublishInvocation.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 using FluentAssertions;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
@@ -13,6 +14,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     public class GivenDotnetPublishInvocation
     {
+        private static readonly string WorkingDirectory = 
+            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetPublishInvocation));
         private readonly ITestOutputHelper output;
 
         public GivenDotnetPublishInvocation(ITestOutputHelper output)
@@ -26,30 +29,35 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { }, "")]
         [InlineData(new string[] { "-r", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
         [InlineData(new string[] { "--runtime", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "-o", "<publishdir>" }, "-property:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "--output", "<publishdir>" }, "-property:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "-o", "<publishdir>" }, "-property:PublishDir=<cwd><publishdir>")]
+        [InlineData(new string[] { "--output", "<publishdir>" }, "-property:PublishDir=<cwd><publishdir>")]
         [InlineData(new string[] { "-c", "<config>" }, "-property:Configuration=<config>")]
         [InlineData(new string[] { "--configuration", "<config>" }, "-property:Configuration=<config>")]
         [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-property:VersionSuffix=<versionsuffix>")]
-        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-property:TargetManifestFiles=<manifestfiles>")]
+        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-property:TargetManifestFiles=<cwd><manifestfiles>")]
         [InlineData(new string[] { "-v", "minimal" }, "-verbosity:minimal")]
         [InlineData(new string[] { "--verbosity", "minimal" }, "-verbosity:minimal")]
         [InlineData(new string[] { "<project>" }, "<project>")]
         [InlineData(new string[] { "<project>", "<extra-args>" }, "<project> <extra-args>")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
+            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            {
+                expectedAdditionalArgs =
+                    (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")
+                    .Replace("<cwd>", WorkingDirectory);
 
-            var msbuildPath = "<msbuildpath>";
-            var command = PublishCommand.FromArgs(args, msbuildPath);
+                var msbuildPath = "<msbuildpath>";
+                var command = PublishCommand.FromArgs(args, msbuildPath);
 
-            command.SeparateRestoreCommand
-                   .Should()
-                   .BeNull();
+                command.SeparateRestoreCommand
+                    .Should()
+                    .BeNull();
 
-            command.GetProcessStartInfo()
-                   .Arguments.Should()
-                   .Be($"{ExpectedPrefix} -restore -target:Publish{expectedAdditionalArgs}");
+                command.GetProcessStartInfo()
+                    .Arguments.Should()
+                    .Be($"{ExpectedPrefix} -restore -target:Publish{expectedAdditionalArgs}");
+            });
         }
 
         [Theory]
@@ -95,27 +103,32 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--framework", "<tfm>" }, "-property:TargetFramework=<tfm>")]
         [InlineData(new string[] { "-r", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
         [InlineData(new string[] { "--runtime", "<rid>" }, "-property:RuntimeIdentifier=<rid>")]
-        [InlineData(new string[] { "-o", "<publishdir>" }, "-property:PublishDir=<publishdir>")]
-        [InlineData(new string[] { "--output", "<publishdir>" }, "-property:PublishDir=<publishdir>")]
+        [InlineData(new string[] { "-o", "<publishdir>" }, "-property:PublishDir=<cwd><publishdir>")]
+        [InlineData(new string[] { "--output", "<publishdir>" }, "-property:PublishDir=<cwd><publishdir>")]
         [InlineData(new string[] { "-c", "<config>" }, "-property:Configuration=<config>")]
         [InlineData(new string[] { "--configuration", "<config>" }, "-property:Configuration=<config>")]
         [InlineData(new string[] { "--version-suffix", "<versionsuffix>" }, "-property:VersionSuffix=<versionsuffix>")]
-        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-property:TargetManifestFiles=<manifestfiles>")]
+        [InlineData(new string[] { "--manifest", "<manifestfiles>" }, "-property:TargetManifestFiles=<cwd><manifestfiles>")]
         [InlineData(new string[] { "-v", "minimal" }, "-verbosity:minimal")]
         [InlineData(new string[] { "--verbosity", "minimal" }, "-verbosity:minimal")]
         [InlineData(new string[] { "--no-build" }, "-property:NoBuild=true")]
         public void OptionForwardingIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            var expectedArgs = expectedAdditionalArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            {
+                var expectedArgs = expectedAdditionalArgs
+                    .Replace("<cwd>", WorkingDirectory)
+                    .Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
-            var parser = Parser.Instance;
+                var parser = Parser.Instance;
 
-            var result = parser.ParseFrom("dotnet publish", args);
+                var result = parser.ParseFrom("dotnet publish", args);
 
-            result["dotnet"]["publish"]
-                .OptionValuesToBeForwarded()
-                .Should()
-                .BeEquivalentTo(expectedArgs);
+                result["dotnet"]["publish"]
+                    .OptionValuesToBeForwarded()
+                    .Should()
+                    .BeEquivalentTo(expectedArgs);
+            });
         }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -7,6 +7,7 @@ using Xunit;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.Tools.Tests.Utilities;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -15,7 +16,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         private const string ExpectedPrefix =
             "exec <msbuildpath> -maxcpucount -verbosity:m -nologo -target:Restore";
         private static readonly string WorkingDirectory = 
-            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetRestoreInvocation));
+            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetRestoreInvocation));
 
         [Theory]
         [InlineData(new string[] { }, "")]
@@ -35,7 +36,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--verbosity", "minimal" }, @"-verbosity:minimal")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
             {
                 expectedAdditionalArgs =
                     (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")

--- a/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetRestoreInvocation.cs
@@ -5,6 +5,8 @@ using Microsoft.DotNet.Tools.Restore;
 using FluentAssertions;
 using Xunit;
 using System;
+using System.IO;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
@@ -12,6 +14,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
     {
         private const string ExpectedPrefix =
             "exec <msbuildpath> -maxcpucount -verbosity:m -nologo -target:Restore";
+        private static readonly string WorkingDirectory = 
+            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetRestoreInvocation));
 
         [Theory]
         [InlineData(new string[] { }, "")]
@@ -21,9 +25,9 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "-r", "<runtime>" }, "-property:RuntimeIdentifiers=<runtime>")]
         [InlineData(new string[] { "--runtime", "<runtime>" }, "-property:RuntimeIdentifiers=<runtime>")]
         [InlineData(new string[] { "-r", "<runtime0>", "-r", "<runtime1>" }, "-property:RuntimeIdentifiers=<runtime0>%3B<runtime1>")]
-        [InlineData(new string[] { "--packages", "<packages>" }, "-property:RestorePackagesPath=<packages>")]
+        [InlineData(new string[] { "--packages", "<packages>" }, "-property:RestorePackagesPath=<cwd><packages>")]
         [InlineData(new string[] { "--disable-parallel" }, "-property:RestoreDisableParallel=true")]
-        [InlineData(new string[] { "--configfile", "<config>" }, "-property:RestoreConfigFile=<config>")]
+        [InlineData(new string[] { "--configfile", "<config>" }, "-property:RestoreConfigFile=<cwd><config>")]
         [InlineData(new string[] { "--no-cache" }, "-property:RestoreNoCache=true")]
         [InlineData(new string[] { "--ignore-failed-sources" }, "-property:RestoreIgnoreFailedSources=true")]
         [InlineData(new string[] { "--no-dependencies" }, "-property:RestoreRecursive=false")]
@@ -31,12 +35,17 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--verbosity", "minimal" }, @"-verbosity:minimal")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            expectedAdditionalArgs = (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}");
+            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            {
+                expectedAdditionalArgs =
+                    (string.IsNullOrEmpty(expectedAdditionalArgs) ? "" : $" {expectedAdditionalArgs}")
+                    .Replace("<cwd>", WorkingDirectory);
 
-            var msbuildPath = "<msbuildpath>";
-            RestoreCommand.FromArgs(args, msbuildPath)
-                .GetProcessStartInfo().Arguments
-                .Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+                var msbuildPath = "<msbuildpath>";
+                RestoreCommand.FromArgs(args, msbuildPath)
+                    .GetProcessStartInfo().Arguments
+                    .Should().Be($"{ExpectedPrefix}{expectedAdditionalArgs}");
+            });
         }
     }
 }

--- a/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetStoreInvocation.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Tools.Store;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Microsoft.DotNet.Tools.Tests.Utilities;
 using Xunit;
 
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
@@ -15,7 +16,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         const string ExpectedPrefix = "exec <msbuildpath> -maxcpucount -verbosity:m -target:ComposeStore <project>";
         static readonly string[] ArgsPrefix = { "--manifest", "<project>" };
         private static readonly string WorkingDirectory = 
-            Microsoft.DotNet.Tools.Test.Utilities.TestPathUtilities.CreateAbsolutePath(nameof(GivenDotnetStoreInvocation));
+            TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetStoreInvocation));
 
         [Theory]
         [InlineData("-m")]
@@ -36,7 +37,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         [InlineData(new string[] { "--manifest", "one.xml", "--manifest", "two.xml", "--manifest", "three.xml" }, @"-property:AdditionalProjects=<cwd>one.xml%3B<cwd>two.xml%3B<cwd>three.xml")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
-            CommandDirectoryContext.PerformActionWithOverwrittenCurrentDirectory(WorkingDirectory, () =>
+            CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
             {
                 args = ArgsPrefix.Concat(args).ToArray();
                 expectedAdditionalArgs =


### PR DESCRIPTION
Continuation of https://github.com/dotnet/cli/pull/7166 which was too late for 2.0

This changes the output directory for CLI commands to be expanded to a full path based on the current working directory.

This may be a breaking change for some users.

Fixes #6700, #4765