### PR TITLE
Write ExternalRestoreSources to some tests NuGet.Config file

### DIFF
--- a/build/Test.targets
+++ b/build/Test.targets
@@ -10,6 +10,7 @@
     <TestPackagesDir>$(TestOutputDir)/packages/</TestPackagesDir>
     <TestArtifactsDir>$(TestOutputDir)/artifacts/</TestArtifactsDir>
     <TestResultXmlDir>$(TestOutputDir)/results/</TestResultXmlDir>
+    <ExternalRestoreSourcesTestsContainer>$(TestArtifactsDir)/ExternalRestoreSourcesForTestsContainer.txt</ExternalRestoreSourcesTestsContainer>
   </PropertyGroup>
 
   <Target Name="Test"
@@ -51,6 +52,11 @@
           DependsOnTargets="Init;
                             SetupTestProjectData">
     <MakeDir Directories="$(TestPackagesDir)" Condition="!Exists('$(TestPackagesDir)')"/>
+
+    <WriteLinesToFile Condition="'$(ExternalRestoreSources)' != ''"
+                      File="$(ExternalRestoreSourcesTestsContainer)"
+                      Lines="&lt;add key=&quot;PrivateBlobFeed%(NugetConfigPrivateFeeds.Identity)&quot; value=&quot;%(NugetConfigPrivateFeeds.Identity)&quot; /&gt;"
+                      Overwrite="false" />
   </Target>
 
   <Target Name="RestoreTests"

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/GivenAProjectToolsCommandResolver.cs
@@ -339,7 +339,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssets.Get("AppWithFallbackFolderToolDependency")
                 .CreateInstance()
                 .WithSourceFiles()
-                .WithNuGetConfig(new RepoDirectoriesProvider().TestPackages);
+                .WithNuGetConfigAndExternalRestoreSources(new RepoDirectoriesProvider().TestPackages);
             var testProjectDirectory = testInstance.Root.FullName;
             var fallbackFolder = Path.Combine(testProjectDirectory, "fallbackFolder");
 
@@ -382,7 +382,7 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssets.Get("AppWithFallbackFolderToolDependency")
                 .CreateInstance()
                 .WithSourceFiles()
-                .WithNuGetConfig(new RepoDirectoriesProvider().TestPackages);
+                .WithNuGetConfigAndExternalRestoreSources(new RepoDirectoriesProvider().TestPackages);
             var testProjectDirectory = testInstance.Root.FullName;
             var fallbackFolder = Path.Combine(testProjectDirectory, "fallbackFolder");
 

--- a/test/Microsoft.DotNet.TestFramework/TestAssetInstance.cs
+++ b/test/Microsoft.DotNet.TestFramework/TestAssetInstance.cs
@@ -109,19 +109,23 @@ namespace Microsoft.DotNet.TestFramework
             return this;
         }
 
-        public TestAssetInstance WithNuGetConfig(string nugetCache)
+        public TestAssetInstance WithNuGetConfig(string nugetCache, string externalRestoreSources = null)
         {
             var thisAssembly = typeof(TestAssetInstance).GetTypeInfo().Assembly;
             var newNuGetConfig = Root.GetFile("NuGet.Config");
+            externalRestoreSources = externalRestoreSources ?? string.Empty;
 
             var content = @"<?xml version=""1.0"" encoding=""utf-8""?>
             <configuration>
               <packageSources>
                 <add key=""dotnet-core"" value=""https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"" />
                 <add key=""test-packages"" value=""$fullpath$"" />
+                $externalRestoreSources$
               </packageSources>
             </configuration>";
-            content = content.Replace("$fullpath$", nugetCache);
+            content = content
+                .Replace("$fullpath$", nugetCache)
+                .Replace("$externalRestoreSources$", externalRestoreSources);
 
             using (var newNuGetConfigStream =
                 new FileStream(newNuGetConfig.FullName, FileMode.Create, FileAccess.Write))

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
@@ -22,6 +22,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         private string _stage2WithBackwardsCompatibleRuntimesDirectory;
         private string _testPackages;
         private string _testWorkingFolder;
+        private string _testArtifactsFolder;
 
         public static string RepoRoot
         {
@@ -92,6 +93,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         public string Stage2WithBackwardsCompatibleRuntimesDirectory => _stage2WithBackwardsCompatibleRuntimesDirectory;
         public string TestPackages => _testPackages;
         public string TestWorkingFolder => _testWorkingFolder;
+        public string TestArtifactsFolder => _testArtifactsFolder;
 
         public RepoDirectoriesProvider(
             string artifacts = null,
@@ -122,6 +124,8 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
             {
                 _testPackages = Path.Combine(_artifacts, "test", "packages");
             }
+
+            _testArtifactsFolder = Path.Combine(_artifacts, "test", "artifacts");
 
             _testWorkingFolder = Path.Combine(RepoRoot,
                                               "bin",

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/TestAssetInstanceExtensions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/TestAssetInstanceExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.TestFramework;
+using Microsoft.DotNet.Tools.Common;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public static class TestAssetInstanceExtensions
+    {
+        public static TestAssetInstance WithNuGetConfigAndExternalRestoreSources(
+            this TestAssetInstance testAssetInstance, string nugetCache)
+        {
+            var externalRestoreSourcesForTests = Path.Combine(
+                new RepoDirectoriesProvider().TestArtifactsFolder, "ExternalRestoreSourcesForTestsContainer.txt");
+            var externalRestoreSources = File.Exists(externalRestoreSourcesForTests) ?
+                File.ReadAllText(externalRestoreSourcesForTests) :
+                string.Empty;
+
+            return testAssetInstance.WithNuGetConfig(nugetCache, externalRestoreSources);
+        }
+    }
+}


### PR DESCRIPTION
We have a few tests that write their own NuGet.Config file to use during restore. Those tests need access to the ExternalRestoreSources value to be added to this NuGet config so that they can restore properly. This change writes a file in the test/artifacts folder containing the value of ExternalRestoreSources value. The tests can then use it to write that to their NuGet.Config. There is a failure in ProdCon that this addresses.
