### PR TITLE
Fixing the external restore sources file.

### DIFF
--- a/build/Test.targets
+++ b/build/Test.targets
@@ -52,6 +52,7 @@
           DependsOnTargets="Init;
                             SetupTestProjectData">
     <MakeDir Directories="$(TestPackagesDir)" Condition="!Exists('$(TestPackagesDir)')"/>
+    <MakeDir Directories="$(TestArtifactsDir)" Condition="!Exists('$(TestArtifactsDir)')"/>
 
     <WriteLinesToFile Condition="'$(ExternalRestoreSources)' != ''"
                       File="$(ExternalRestoreSourcesTestsContainer)"


### PR DESCRIPTION
Fixing the external restore sources file. We needed to create the test artifact folder.
