### PR TITLE
Do not print 'MSBuild version header' when building or publishing

### DIFF
--- a/src/dotnet/commands/dotnet-build/BuildCommand.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommand.cs
@@ -27,7 +27,10 @@ namespace Microsoft.DotNet.Tools.Build
 
         public static BuildCommand FromArgs(string[] args, string msbuildPath = null)
         {
-            var msbuildArgs = new List<string>();
+            var msbuildArgs = new List<string>
+            {
+                "-nologo"
+            };
 
             var parser = Parser.Instance;
 
@@ -67,7 +70,7 @@ namespace Microsoft.DotNet.Tools.Build
             DebugHelper.HandleDebugSwitch(ref args);
 
             BuildCommand cmd;
-            
+
             try
             {
                 cmd = FromArgs(args);

--- a/src/dotnet/commands/dotnet-publish/Program.cs
+++ b/src/dotnet/commands/dotnet-publish/Program.cs
@@ -27,7 +27,10 @@ namespace Microsoft.DotNet.Tools.Publish
         {
             DebugHelper.HandleDebugSwitch(ref args);
 
-            var msbuildArgs = new List<string>();
+            var msbuildArgs = new List<string>
+            {
+                "-nologo"
+            };
 
             var parser = Parser.Instance;
 

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -290,5 +290,29 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
                 .Should()
                 .Fail();
         }
+
+        [Fact]
+        public void QuietPublishDoesNotPrintVersionHeader()
+        {
+            var testInstance = TestAssets.Get("TestAppSimple")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            var rootPath = testInstance.Root;
+
+            new BuildCommand()
+                .WithWorkingDirectory(rootPath)
+                .ExecuteWithCapturedOutput()
+                .Should()
+                .Pass();
+
+            var cmd = new PublishCommand()
+                .WithWorkingDirectory(rootPath)
+                .ExecuteWithCapturedOutput("--verbosity quiet");
+
+            cmd.Should().Pass();
+            cmd.StdOut.Should().NotContain("Microsoft (R) Build Engine version");
+            cmd.StdErr.Should().BeEmpty();
+        }
     }
 }


### PR DESCRIPTION
When running `dotnet build` or `dotnet publish` (especially with --verbosity quiet`) it should not print MSBuild version header. Related to #6121.