### PR TITLE
Update BuildTasksFeedToolVersion

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -76,7 +76,7 @@
 
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>
-    <BuildTasksFeedToolVersion>2.1.0-prerelease-02430-04</BuildTasksFeedToolVersion>
+    <BuildTasksFeedToolVersion>2.1.0-rc1-03130-05</BuildTasksFeedToolVersion>
     <VersionToolsVersion>$(BuildTasksFeedToolVersion)</VersionToolsVersion>
     <DotnetDebToolVersion>2.0.0</DotnetDebToolVersion>
   </PropertyGroup>

--- a/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
+++ b/build_projects/dotnet-cli-build/dotnet-cli-build.csproj
@@ -28,5 +28,7 @@
     <PackageReference Include="Microsoft.DotNet.VersionTools" Version="$(VersionToolsVersion)" />
     <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(BuildTasksFeedToolVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
+    <PackageReference Include="Nuget.Versioning" Version="4.7.0-preview1-4992" />
+
  </ItemGroup>
 </Project>


### PR DESCRIPTION
I ported a fix in 2.1.0-rc1-03130-05 that should address the failures seen here: 
https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?_a=summary&buildId=1991247

Tracked via https://github.com/dotnet/core-eng/issues/4133 
