### PR TITLE
Fix some shellcheck warnings for dotnet bash completion

### DIFF
--- a/scripts/register-completions.bash
+++ b/scripts/register-completions.bash
@@ -4,7 +4,8 @@ _dotnet_bash_complete()
 {
   local word=${COMP_WORDS[COMP_CWORD]}
 
-  local completions=("$(dotnet complete --position ${COMP_POINT} "${COMP_LINE}")")
+  local completions
+  completions="$(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}")"
 
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )
 }


### PR DESCRIPTION
Running shellcheck on the bash completion script produces a few
warnings:

1. SC2086: Double quote to prevent globbing and word splitting.
```
    local completions=("$(dotnet complete --position ${COMP_POINT} "${COMP_LINE}")")
                                                     ^--
```
Fix this by quoting `COMP_POINT`

2. SC2128: Expanding an array without an index only gives the first element.
```
    COMPREPLY=( $(compgen -W "$completions" -- "$word") )
                              ^--
```
   `completions` was actually an array, but with only one element. So
   this code worked as expected. Simplify things by making it a normal
   variable instead of an array.

3. SC2155: Declare and assign separately to avoid masking return values.
```
    local completions="$(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}")"
          ^--
```
   Fix this by splitting this code into two lines.

There's still one remmaining warning: "SC2207: Prefer mapfile or read -a
to split command output (or quote to avoid splitting)" for the line
where COMPREPLY is initialized. But the fix for this makes the code much
harder to understand. Relying on COMPREPLY to do the default word
splitting works just fine.