### PR TITLE
Update MicrosoftNETCoreAppPackageVersion

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -10,8 +10,8 @@
     <DotnetSqlCachePackageVersion>2.2.0-preview2-35157</DotnetSqlCachePackageVersion>
     <DotnetUserSecretsPackageVersion>2.2.0-preview2-35157</DotnetUserSecretsPackageVersion>
     <DotnetWatchPackageVersion>2.2.0-preview2-35157</DotnetWatchPackageVersion>
-    <MicrosoftNETCoreAppPackageVersion>2.2.0-preview1-26609-02</MicrosoftNETCoreAppPackageVersion>
-    
+    <MicrosoftNETCoreAppPackageVersion>2.2.0-preview2-26910-02</MicrosoftNETCoreAppPackageVersion>
+
     <!-- https://github.com/dotnet/cli/issues/9851  -->
     <MicrosoftNETCoreDotNetHostResolverPackageVersion_ForMSBuildSdkResolverOnly>3.0.0-preview1-26816-04</MicrosoftNETCoreDotNetHostResolverPackageVersion_ForMSBuildSdkResolverOnly>
 


### PR DESCRIPTION
Current release/2.2.1xx cannot pass tests due to net coreapp version is too low. Lower than what aspnet tools uses. I find the version from prodcon version page