### PR TITLE
Installer metadata in ARP uses HTTP URLs rel/1.1.0

### DIFF
--- a/packaging/windows/clisdk/bundle.wxs
+++ b/packaging/windows/clisdk/bundle.wxs
@@ -8,7 +8,7 @@
 
   <Bundle Name="$(var.ProductName)" Manufacturer="$(var.Manufacturer)"
           Version="$(var.DisplayVersion)" UpgradeCode="$(var.UpgradeCode)"
-          AboutUrl="http://dotnet.github.io/"
+          AboutUrl="https://dotnet.github.io/"
           Compressed="yes">
 
     <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.Foundation">


### PR DESCRIPTION
#### Description
SDK Windows installer metadata in ARP uses HTTP URLs instead of HTTPS
#### Customer Impact
http link is not secure.
#### Regression?
No
#### Risk
Low, only installer metadata change

Issue:
https://github.com/dotnet/cli/issues/9977

Porting 2.2.1xx change https://github.com/dotnet/cli/pull/9857