### PR TITLE
Add ImplicitPackageReferenceVersion items to bundled versions file

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -29,7 +29,7 @@
     <MicrosoftNETSdkPackageVersion>2.2.100-preview1-63215-01</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>2.1.1</MicrosoftNETSdkRazorPackageVersion>
-    <MicrosoftNETSdkWebPackageVersion>2.1.400-preview1-20180705-1834985</MicrosoftNETSdkWebPackageVersion>
+    <MicrosoftNETSdkWebPackageVersion>2.2.100-preview3-20180918-2041430</MicrosoftNETSdkWebPackageVersion>
     <MicrosoftNETSdkPublishPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkPublishPackageVersion>
     <MicrosoftNETSdkWebProjectSystemPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWebProjectSystemPackageVersion>
     <MicrosoftDotNetCommonItemTemplatesPackageVersion>1.0.2-beta4-20180803-1918431</MicrosoftDotNetCommonItemTemplatesPackageVersion>

--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -143,6 +143,46 @@
     </GetUseBundledNETCoreAppPackageVersionAsDefaultNetCorePatchVersion>
 
     <ItemGroup>
+      <ImplicitPackageVariable Include="Microsoft.NETCore.App"
+                               TargetFrameworkVersion="1.0"
+                               DefaultVersion="1.0.5"
+                               LatestVersion="1.0.12" />
+      <ImplicitPackageVariable Include="Microsoft.NETCore.App"
+                               TargetFrameworkVersion="1.1"
+                               DefaultVersion="1.1.2"
+                               LatestVersion="1.1.9" />
+      <ImplicitPackageVariable Include="Microsoft.NETCore.App"
+                               TargetFrameworkVersion="2.0"
+                               DefaultVersion="2.0.0"
+                               LatestVersion="2.0.9" />
+      <ImplicitPackageVariable Include="Microsoft.NETCore.App"
+                               TargetFrameworkVersion="2.1"
+                               DefaultVersion="2.1.0"
+                               LatestVersion="2.1.2" />
+      <ImplicitPackageVariable Include="Microsoft.NETCore.App"
+                               TargetFrameworkVersion="2.2"
+                               DefaultVersion="$(_NETCoreAppPackageVersion)"
+                               LatestVersion="$(_NETCoreAppPackageVersion)" />
+      
+      <ImplicitPackageVariable Include="Microsoft.AspNetCore.App"
+                               TargetFrameworkVersion="2.1"
+                               DefaultVersion="2.1.1"
+                               LatestVersion="2.1.3"/>
+      <ImplicitPackageVariable Include="Microsoft.AspNetCore.All"
+                               TargetFrameworkVersion="2.1"
+                               DefaultVersion="2.1.1"
+                               LatestVersion="2.1.3"/>
+      <ImplicitPackageVariable Include="Microsoft.AspNetCore.App"
+                               TargetFrameworkVersion="2.2"
+                               DefaultVersion="$(_AspNetCoreAppPackageVersion)"
+                               LatestVersion="$(_AspNetCoreAppPackageVersion)"/>
+      <ImplicitPackageVariable Include="Microsoft.AspNetCore.All"
+                               TargetFrameworkVersion="2.2"
+                               DefaultVersion="$(_AspNetCoreAllPackageVersion)"
+                               LatestVersion="$(_AspNetCoreAllPackageVersion)"/>
+    </ItemGroup>
+    
+    <ItemGroup>
       <BundledVersionsVariable Include="BundledAspNetCoreAllTargetFrameworkVersion" Value="$(_AspNetCoreAllTargetFrameworkVersion)" />
       <BundledVersionsVariable Include="BundledAspNetCoreAllPackageVersion" Value="$(_AspNetCoreAllPackageVersion)" />
       <BundledVersionsVariable Include="BundledAspNetCoreAppTargetFrameworkVersion" Value="$(_AspNetCoreAppTargetFrameworkVersion)" />
@@ -198,6 +238,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <LatestPatchVersionForNetCore2_0 Condition="'%24(LatestPatchVersionForNetCore2_0)' == ''">2.0.9</LatestPatchVersionForNetCore2_0>
     <LatestPatchVersionForNetCore2_1 Condition="'%24(LatestPatchVersionForNetCore2_1)' == ''">2.1.2</LatestPatchVersionForNetCore2_1>
   </PropertyGroup>
+  <ItemGroup>
+    @(ImplicitPackageVariable->'<ImplicitPackageReferenceVersion Include="%(Identity)" TargetFrameworkVersion="%(TargetFrameworkVersion)" DefaultVersion="%(DefaultVersion)" LatestVersion="%(LatestVersion)"/>', '%0A    ')
+  </ItemGroup>
 </Project>
 ]]>
     </BundledVersionsPropsContent>


### PR DESCRIPTION
Adds `ImplicitPackageReferenceVersion` items to bundled versions file, which will be consumed by code in https://github.com/dotnet/sdk/pull/2533

The results in the bundled version file look like this:

```xml
    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="1.0" DefaultVersion="1.0.5" LatestVersion="1.0.12"/>
    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="1.1" DefaultVersion="1.1.2" LatestVersion="1.1.9"/>
    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="2.0" DefaultVersion="2.0.0" LatestVersion="2.0.9"/>
    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="2.1" DefaultVersion="2.1.0" LatestVersion="2.1.2"/>
    <ImplicitPackageReferenceVersion Include="Microsoft.NETCore.App" TargetFrameworkVersion="2.2" DefaultVersion="2.2.0-preview2-26910-02" LatestVersion="2.2.0-preview2-26910-02"/>
    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App" TargetFrameworkVersion="2.1" DefaultVersion="2.1.1" LatestVersion="2.1.3"/>
    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All" TargetFrameworkVersion="2.1" DefaultVersion="2.1.1" LatestVersion="2.1.3"/>
    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.App" TargetFrameworkVersion="2.2" DefaultVersion="2.2.0-preview2-35157" LatestVersion="2.2.0-preview2-35157"/>
    <ImplicitPackageReferenceVersion Include="Microsoft.AspNetCore.All" TargetFrameworkVersion="2.2" DefaultVersion="2.2.0-preview2-35157" LatestVersion="2.2.0-preview2-35157"/>
```