### PR TITLE
Tool restore pending works

### DIFF
--- a/src/dotnet/ToolManifest/LocalizableStrings.Designer.cs
+++ b/src/dotnet/ToolManifest/LocalizableStrings.Designer.cs
@@ -64,6 +64,18 @@ namespace Microsoft.DotNet.Cli.ToolManifest {
             }
         }
         
+        public static string ManifestMissionVersion {
+            get {
+                return ResourceManager.GetString("ManifestMissionVersion", resourceCulture);
+            }
+        }
+        
+        public static string ManifestVersionHigherThanSupported {
+            get {
+                return ResourceManager.GetString("ManifestVersionHigherThanSupported", resourceCulture);
+            }
+        }
+        
         public static string MissingVersion {
             get {
                 return ResourceManager.GetString("MissingVersion", resourceCulture);

--- a/src/dotnet/ToolManifest/LocalizableStrings.resx
+++ b/src/dotnet/ToolManifest/LocalizableStrings.resx
@@ -126,14 +126,11 @@
   <data name="InvalidManifestFilePrefix" xml:space="preserve">
     <value>Invalid manifest file.</value>
   </data>
-  <data name="ManifestMissingVersion" xml:space="preserve">
-    <value>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </value>
+  <data name="ManifestVersion0" xml:space="preserve">
+    <value>Manifest version 0 is not supported</value>
   </data>
   <data name="ManifestVersionHigherThanSupported" xml:space="preserve">
     <value>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </value>
-  </data>
-  <data name="MissingVersion" xml:space="preserve">
-    <value>field version is missing.</value>
   </data>
   <data name="InPackage" xml:space="preserve">
     <value>In package {0}:</value>
@@ -143,5 +140,8 @@
   </data>
   <data name="VersionIsInvalid" xml:space="preserve">
     <value>version {0} is invalid.</value>
+  </data>
+  <data name="ToolMissingVersion" xml:space="preserve">
+    <value>field version is missing.</value>
   </data>
 </root>

--- a/src/dotnet/ToolManifest/LocalizableStrings.resx
+++ b/src/dotnet/ToolManifest/LocalizableStrings.resx
@@ -126,6 +126,12 @@
   <data name="InvalidManifestFilePrefix" xml:space="preserve">
     <value>Invalid manifest file.</value>
   </data>
+  <data name="ManifestMissionVersion" xml:space="preserve">
+    <value>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </value>
+  </data>
+  <data name="ManifestVersionHigherThanSupported" xml:space="preserve">
+    <value>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </value>
+  </data>
   <data name="MissingVersion" xml:space="preserve">
     <value>field version is missing.</value>
   </data>

--- a/src/dotnet/ToolManifest/LocalizableStrings.resx
+++ b/src/dotnet/ToolManifest/LocalizableStrings.resx
@@ -126,7 +126,7 @@
   <data name="InvalidManifestFilePrefix" xml:space="preserve">
     <value>Invalid manifest file.</value>
   </data>
-  <data name="ManifestMissionVersion" xml:space="preserve">
+  <data name="ManifestMissingVersion" xml:space="preserve">
     <value>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </value>
   </data>
   <data name="ManifestVersionHigherThanSupported" xml:space="preserve">

--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.ToolManifest
 
             if (!findAnyManifest)
             {
-                throw new ToolManifestException(
+                throw new ToolManifestCannotFindException(
                     string.Format(LocalizableStrings.CannotFindAnyManifestsFileSearched,
                         string.Join(Environment.NewLine, allPossibleManifests.Select(f => f.Value))));
             }
@@ -92,10 +92,10 @@ namespace Microsoft.DotNet.ToolManifest
             if (deserializedManifest.version == 0)
             {
                 _reporter.WriteLine(
-                    LocalizableStrings.ManifestMissionVersion +
+                    LocalizableStrings.ManifestMissingVersion +
                     path.Value);
             }
-            
+
             if (deserializedManifest.version > SupportedVersion)
             {
                 _reporter.WriteLine(
@@ -160,14 +160,13 @@ namespace Microsoft.DotNet.ToolManifest
                     result.Add(new ToolManifestPackage(
                         packageId,
                         version,
-                        ToolCommandName.Convert(tools.Value.commands),
-                        targetFramework));
+                        ToolCommandName.Convert(tools.Value.commands)));
                 }
             }
 
             if (errors.Any())
             {
-                throw new ToolManifestCannotFindException(LocalizableStrings.InvalidManifestFilePrefix +
+                throw new ToolManifestException(LocalizableStrings.InvalidManifestFilePrefix +
                                                 string.Join(string.Empty,
                                                     errors.Select(e => Environment.NewLine + "  " + e)));
             }

--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
@@ -28,92 +29,136 @@ namespace Microsoft.DotNet.ToolManifest
 
         public IReadOnlyCollection<ToolManifestPackage> Find(FilePath? filePath = null)
         {
-            var result = new List<ToolManifestPackage>();
-
             IEnumerable<FilePath> allPossibleManifests =
                 filePath != null
-                    ? new[] { filePath.Value }
+                    ? new[] {filePath.Value}
                     : EnumerateDefaultAllPossibleManifests();
 
+            bool findAnyManifest = false;
+            var result = new List<ToolManifestPackage>();
             foreach (FilePath possibleManifest in allPossibleManifests)
             {
                 if (_fileSystem.File.Exists(possibleManifest.Value))
                 {
-                    SerializableLocalToolsManifest deserializedManifest = JsonConvert.DeserializeObject<SerializableLocalToolsManifest>(
-                        _fileSystem.File.ReadAllText(possibleManifest.Value), new JsonSerializerSettings
-                        {
-                            MissingMemberHandling = MissingMemberHandling.Ignore
-                        });
+                    findAnyManifest = true;
+                    SerializableLocalToolsManifest deserializedManifest =
+                        DeserializableLocalToolsManifest(possibleManifest);
 
-                    var errors = new List<string>();
-
-                    if (!deserializedManifest.isRoot)
+                    foreach (ToolManifestPackage p in GetToolManifestPackageFromOneManifestFile(deserializedManifest))
                     {
-                        errors.Add("isRoot is false is not supported.");
-                    }
-
-                    if (deserializedManifest.version != 1)
-                    {
-                        errors.Add(string.Format("Tools manifest format version {0} is not supported.",
-                            deserializedManifest.version));
-                    }
-
-                    foreach (var tools in deserializedManifest.tools)
-                    {
-                        var packageLevelErrors = new List<string>();
-                        var packageIdString = tools.Key;
-                        var packageId = new PackageId(packageIdString);
-
-                        string versionString = tools.Value.version;
-                        NuGetVersion version = null;
-                        if (versionString is null)
+                        if (!result.Any(addedToolManifestPackages =>
+                            addedToolManifestPackages.PackageId.Equals(p.PackageId)))
                         {
-                            packageLevelErrors.Add(LocalizableStrings.MissingVersion);
-                        }
-                        else
-                        {
-                            var versionParseResult = NuGetVersion.TryParse(
-                                versionString, out version);
-
-                            if (!versionParseResult)
-                            {
-                                packageLevelErrors.Add(string.Format(LocalizableStrings.VersionIsInvalid, versionString));
-                            }
-                        }
-
-                        if (tools.Value.commands == null
-                            || (tools.Value.commands != null && tools.Value.commands.Length == 0))
-                        {
-                            packageLevelErrors.Add(LocalizableStrings.FieldCommandsIsMissing);
-                        }
-
-                        if (packageLevelErrors.Any())
-                        {
-                            var joined = string.Join(string.Empty, packageLevelErrors.Select(e => Environment.NewLine + "    " + e));
-                            errors.Add(string.Format(LocalizableStrings.InPackage, packageId.ToString()) + joined);
-                        }
-                        else
-                        {
-                            result.Add(new ToolManifestPackage(
-                                packageId,
-                                version,
-                                ToolCommandName.Convert(tools.Value.commands)));
+                            result.Add(p);
                         }
                     }
 
-                    if (errors.Any())
+                    if (deserializedManifest.isRoot)
                     {
-                        throw new ToolManifestException(LocalizableStrings.InvalidManifestFilePrefix +
-                            string.Join(string.Empty, errors.Select(e => Environment.NewLine + "  " + e)));
+                        return result;
                     }
-
-                    return result;
                 }
             }
 
-            throw new ToolManifestCannotFindException(
-                string.Format(LocalizableStrings.CannotFindAnyManifestsFileSearched,
-                    string.Join(Environment.NewLine, allPossibleManifests.Select(f => f.Value))));
+            if (!findAnyManifest)
+            {
+                throw new ToolManifestException(
+                    string.Format(LocalizableStrings.CannotFindAnyManifestsFileSearched,
+                        string.Join(Environment.NewLine, allPossibleManifests.Select(f => f.Value))));
+            }
+
+            return result;
+        }
+
+        private SerializableLocalToolsManifest DeserializableLocalToolsManifest(FilePath possibleManifest)
+        {
+            return JsonConvert.DeserializeObject<SerializableLocalToolsManifest>(
+                _fileSystem.File.ReadAllText(possibleManifest.Value), new JsonSerializerSettings
+                {
+                    MissingMemberHandling = MissingMemberHandling.Ignore
+                });
+        }
+
+        private static List<ToolManifestPackage> GetToolManifestPackageFromOneManifestFile(
+            SerializableLocalToolsManifest deserializedManifest)
+        {
+            List<ToolManifestPackage> result = new List<ToolManifestPackage>();
+            var errors = new List<string>();
+
+            if (deserializedManifest.version != 1)
+            {
+                errors.Add(string.Format("Tools manifest format version {0} is not supported.",
+                    deserializedManifest.version));
+            }
+
+            foreach (var tools in deserializedManifest.tools)
+            {
+                var packageLevelErrors = new List<string>();
+                var packageIdString = tools.Key;
+                var packageId = new PackageId(packageIdString);
+
+                string versionString = tools.Value.version;
+                NuGetVersion version = null;
+                if (versionString is null)
+                {
+                    packageLevelErrors.Add(LocalizableStrings.MissingVersion);
+                }
+                else
+                {
+                    var versionParseResult = NuGetVersion.TryParse(
+                        versionString, out version);
+
+                    if (!versionParseResult)
+                    {
+                        packageLevelErrors.Add(string.Format(LocalizableStrings.VersionIsInvalid, versionString));
+                    }
+                }
+
+                NuGetFramework targetFramework = null;
+                var targetFrameworkString = tools.Value.targetFramework;
+                if (!(targetFrameworkString is null))
+                {
+                    targetFramework = NuGetFramework.Parse(
+                        targetFrameworkString);
+
+                    if (targetFramework.IsUnsupported)
+                    {
+                        packageLevelErrors.Add(
+                            string.Format(LocalizableStrings.TargetFrameworkIsUnsupported,
+                                targetFrameworkString));
+                    }
+                }
+
+                if (tools.Value.commands == null
+                    || (tools.Value.commands != null && tools.Value.commands.Length == 0))
+                {
+                    packageLevelErrors.Add(LocalizableStrings.FieldCommandsIsMissing);
+                }
+
+                if (packageLevelErrors.Any())
+                {
+                    var joined = string.Join(string.Empty,
+                        packageLevelErrors.Select(e => Environment.NewLine + "    " + e));
+                    errors.Add(string.Format(LocalizableStrings.InPackage, packageId.ToString()) + joined);
+                }
+                else
+                {
+                    result.Add(new ToolManifestPackage(
+                        packageId,
+                        version,
+                        ToolCommandName.Convert(tools.Value.commands),
+                        targetFramework));
+                }
+            }
+
+            if (errors.Any())
+            {
+                throw new ToolManifestCannotFindException(LocalizableStrings.InvalidManifestFilePrefix +
+                                                string.Join(string.Empty,
+                                                    errors.Select(e => Environment.NewLine + "  " + e)));
+            }
+
+            return result;
         }
 
         private IEnumerable<FilePath> EnumerateDefaultAllPossibleManifests()
@@ -132,7 +177,8 @@ namespace Microsoft.DotNet.ToolManifest
             [JsonProperty(Required = Required.Always)]
             public int version { get; set; }
 
-            [JsonProperty(Required = Required.Always)]
+            [DefaultValue(false)]
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
             public bool isRoot { get; set; }
 
             [JsonProperty(Required = Required.Always)]

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="MissingVersion">
-        <source>field version is missing.</source>
-        <target state="new">field version is missing.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="VersionIsInvalid">
         <source>version {0} is invalid.</source>
         <target state="new">version {0} is invalid.</target>
@@ -42,9 +37,14 @@
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissingVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+      <trans-unit id="ManifestVersion0">
+        <source>Manifest version 0 is not supported</source>
+        <target state="new">Manifest version 0 is not supported</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolMissingVersion">
+        <source>field version is missing.</source>
+        <target state="new">field version is missing.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
@@ -37,6 +37,16 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissionVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestVersionHigherThanSupported">
+        <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
+        <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
@@ -37,14 +37,14 @@
         <target state="new">In package {0}:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ManifestMissionVersion">
-        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
-        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
-        <note />
-      </trans-unit>
       <trans-unit id="ManifestVersionHigherThanSupported">
         <source>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </source>
         <target state="new">Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}. Manifest file path: </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ManifestMissingVersion">
+        <source>Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </source>
+        <target state="new">Manifest version is missing or is 0. This manifest may not be supported in this SDK version. Manifest file path: </target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/LocalizableStrings.Designer.cs
+++ b/src/dotnet/commands/dotnet-tool/restore/LocalizableStrings.Designer.cs
@@ -160,6 +160,12 @@ namespace Microsoft.DotNet.Cli.commands.restore {
             }
         }
         
+        public static string RestoreSuccessful {
+            get {
+                return ResourceManager.GetString("RestoreSuccessful", resourceCulture);
+            }
+        }
+        
         public static string RestorePartiallySuccessful {
             get {
                 return ResourceManager.GetString("RestorePartiallySuccessful", resourceCulture);

--- a/src/dotnet/commands/dotnet-tool/restore/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/restore/LocalizableStrings.resx
@@ -174,6 +174,9 @@
   <data name="PackagesCommandNameCollision" xml:space="preserve">
     <value>Packages {0} have a command with the same name {1} regardless of the casing.</value>
   </data>
+  <data name="RestoreSuccessful" xml:space="preserve">
+    <value>Tool '{0}' (version '{1}') was restored. Available commands: {2}</value>
+  </data>
   <data name="RestorePartiallySuccessful" xml:space="preserve">
     <value>Restore Partially Successful.</value>
   </data>

--- a/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -59,8 +59,9 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
                 _toolPackageInstaller = toolPackageInstaller;
             }
 
-            _toolManifestFinder = toolManifestFinder
-                                  ?? new ToolManifestFinder(new DirectoryPath(Directory.GetCurrentDirectory()));
+            _toolManifestFinder
+                = toolManifestFinder
+                  ?? new ToolManifestFinder(new DirectoryPath(Directory.GetCurrentDirectory()), reporter: _reporter);
 
             _localToolsResolverCache = localToolsResolverCache ??
                                        new LocalToolsResolverCache(

--- a/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -61,7 +61,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
 
             _toolManifestFinder
                 = toolManifestFinder
-                  ?? new ToolManifestFinder(new DirectoryPath(Directory.GetCurrentDirectory()), reporter: _reporter);
+                  ?? new ToolManifestFinder(new DirectoryPath(Directory.GetCurrentDirectory()));
 
             _localToolsResolverCache = localToolsResolverCache ??
                                        new LocalToolsResolverCache(
@@ -180,7 +180,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
             }
 
             _reporter.WriteLine("Restore was successful.");
-            _reporter.WriteLine(string.Join(Environment.NewLine, successMessages));
+            _reporter.WriteLine(string.Join(Environment.NewLine, successMessages).Green());
 
             return 0;
         }

--- a/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
                     }
 
                     successMessages.Add(string.Format(
-                        "Tool '{0}' (version '{1}') was restored. Available commands: {2}", package.PackageId,
+                        LocalizableStrings.RestoreSuccessful, package.PackageId,
                         package.Version.ToNormalizedString(), string.Join(" ", package.CommandNames)));
                 }
                 catch (ToolPackageException e)

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.cs.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.de.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.es.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.fr.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.it.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ja.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ko.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pl.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ru.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.tr.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -107,6 +107,11 @@
         <target state="new">Path to the manifest file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RestoreSuccessful">
+        <source>Tool '{0}' (version '{1}') was restored. Available commands: {2}</source>
+        <target state="new">Tool '{0}' (version '{1}') was restored. Available commands: {2}</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
@@ -121,6 +121,8 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             string targetFramework = null,
             string verbosity = null)
         {
+            _installCallback?.Invoke();
+
             var packageDirectory = new DirectoryPath(NuGetGlobalPackagesFolder.GetLocation()).WithSubDirectories(packageId.ToString());
             _fileSystem.Directory.CreateDirectory(packageDirectory.Value);
             var executable = packageDirectory.WithFile("exe");

--- a/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
@@ -147,23 +147,20 @@ namespace Microsoft.DotNet.Tests.Commands
                 p => p == new ToolManifestPackage(
                          new PackageId("t-rex"),
                          NuGetVersion.Parse("1.0.49"),
-                         new[] {new ToolCommandName("t-rex")},
-                         NuGetFramework.Parse("netcoreapp2.1")),
+                         new[] {new ToolCommandName("t-rex")}),
                 because: "when different manifest file has the same package id, " +
                          "only keep entry that is in the manifest close to current directory");
             manifestResult.Should().Contain(
                 p => p == new ToolManifestPackage(
                          new PackageId("dotnetsay"),
                          NuGetVersion.Parse("2.1.4"),
-                         new[] {new ToolCommandName("dotnetsay")},
-                         null));
+                         new[] {new ToolCommandName("dotnetsay")}));
 
             manifestResult.Should().Contain(
                 p => p == new ToolManifestPackage(
                          new PackageId("dotnetsay"),
                          NuGetVersion.Parse("2.1.4"),
-                         new[] {new ToolCommandName("dotnetsay")},
-                         null),
+                         new[] {new ToolCommandName("dotnetsay")}),
                 because: "combine both content in different manifests");
         }
 
@@ -209,7 +206,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             bufferedReporter.Lines.Should()
                 .Contain(l =>
-                    l.Contains(LocalizableStrings.ManifestMissionVersion));
+                    l.Contains(LocalizableStrings.ManifestMissingVersion));
         }
 
         private string _jsonContent =
@@ -217,13 +214,13 @@ namespace Microsoft.DotNet.Tests.Commands
    ""version"":1,
    ""isRoot"":true,
    ""tools"":{
-      ""t-rex"":{  
+      ""t-rex"":{
          ""version"":""1.0.53"",
          ""commands"":[
             ""t-rex""
          ]
       },
-      ""dotnetsay"":{  
+      ""dotnetsay"":{
          ""version"":""2.1.4"",
          ""commands"":[
             ""dotnetsay""
@@ -237,13 +234,13 @@ namespace Microsoft.DotNet.Tests.Commands
    ""version"":1,
    ""isRoot"":true,
    ""tools"":{
-      ""t-rex"":{  
+      ""t-rex"":{
          ""version"":""1.0.53"",
          ""commands"":[
             ""t-rex""
          ]
       },
-      ""t-rex"":{  
+      ""t-rex"":{
          ""version"":""2.1.4"",
          ""commands"":[
             ""t-rex""
@@ -257,18 +254,18 @@ namespace Microsoft.DotNet.Tests.Commands
    ""version"":1,
    ""isRoot"":true,
    ""tools"":{
-      ""t-rex"":{  
+      ""t-rex"":{
          ""extra"":1
       }
    }
 }";
 
         private string _jsonWithInvalidField =
-            @"{  
+            @"{
    ""version"":1,
    ""isRoot"":true,
    ""tools"":{
-      ""t-rex"":{  
+      ""t-rex"":{
          ""version"":""1.*"",
          ""commands"":[
             ""t-rex""
@@ -285,8 +282,7 @@ namespace Microsoft.DotNet.Tests.Commands
          ""version"":""1.0.49"",
          ""commands"":[
             ""t-rex""
-         ],
-         ""targetFramework"":""netcoreapp2.1""
+         ]
       },
       ""dotnetsay"":{
          ""version"":""2.1.4"",
@@ -296,7 +292,7 @@ namespace Microsoft.DotNet.Tests.Commands
       }
    }
 }";
-        
+
         private string _jsonContentInCurrentDirectoryIsRootTrue =
             @"{
    ""version"":1,
@@ -306,8 +302,7 @@ namespace Microsoft.DotNet.Tests.Commands
          ""version"":""1.0.49"",
          ""commands"":[
             ""t-rex""
-         ],
-         ""targetFramework"":""netcoreapp2.1""
+         ]
       },
       ""dotnetsay"":{
          ""version"":""2.1.4"",
@@ -324,12 +319,11 @@ namespace Microsoft.DotNet.Tests.Commands
    ""version"":1,
    ""isRoot"":false,
    ""tools"":{
-      ""t-rex"":{  
+      ""t-rex"":{
          ""version"":""1.0.53"",
          ""commands"":[
             ""t-rex""
-         ],
-         ""targetFramework"":""netcoreapp2.1""
+         ]
       },
       ""dotnetsay2"":{
          ""version"":""4.0.0"",
@@ -339,19 +333,18 @@ namespace Microsoft.DotNet.Tests.Commands
       }
    }
 }";
-        
+
         private string _jsonContentNoVersion =
             @"{
    ""isRoot"":true,
    ""tools"":{
-      ""t-rex"":{  
+      ""t-rex"":{
          ""version"":""1.0.53"",
          ""commands"":[
             ""t-rex""
-         ],
-         ""targetFramework"":""netcoreapp2.1""
+         ]
       },
-      ""dotnetsay"":{  
+      ""dotnetsay"":{
          ""version"":""2.1.4"",
          ""commands"":[
             ""dotnetsay""
@@ -359,20 +352,19 @@ namespace Microsoft.DotNet.Tests.Commands
       }
    }
 }";
-        
+
         private string _jsonContentHigherVersion =
             @"{
    ""isRoot"":true,
    ""version"":99,
    ""tools"":{
-      ""t-rex"":{  
+      ""t-rex"":{
          ""version"":""1.0.53"",
          ""commands"":[
             ""t-rex""
-         ],
-         ""targetFramework"":""netcoreapp2.1""
+         ]
       },
-      ""dotnetsay"":{  
+      ""dotnetsay"":{
          ""version"":""2.1.4"",
          ""commands"":[
             ""dotnetsay""

--- a/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
@@ -183,14 +183,33 @@ namespace Microsoft.DotNet.Tests.Commands
         }
 
 
-        [Fact(Skip = "pending implementation")]
+        [Fact]
         public void DifferentVersionOfManifestFileItShouldHaveWarnings()
         {
+            _fileSystem.File.WriteAllText(Path.Combine(_testDirectoryRoot, _manifestFilename), _jsonContentHigherVersion);
+            BufferedReporter bufferedReporter = new BufferedReporter();
+            var toolManifest = new ToolManifestFinder(new DirectoryPath(_testDirectoryRoot), _fileSystem, bufferedReporter);
+            toolManifest.Find();
+
+            bufferedReporter.Lines.Should()
+                .Contain(l =>
+                    l.Contains(
+                        string.Format(
+                            LocalizableStrings.ManifestVersionHigherThanSupported,
+                            99, 1)));
         }
 
-        [Fact(Skip = "pending implementation")]
-        public void DifferentVersionOfManifestFileItShouldNotThrow()
+        [Fact]
+        public void NoVersionInManifestFileItShouldHaveWarnings()
         {
+            _fileSystem.File.WriteAllText(Path.Combine(_testDirectoryRoot, _manifestFilename), _jsonContentNoVersion);
+            BufferedReporter bufferedReporter = new BufferedReporter();
+            var toolManifest = new ToolManifestFinder(new DirectoryPath(_testDirectoryRoot), _fileSystem, bufferedReporter);
+            toolManifest.Find();
+
+            bufferedReporter.Lines.Should()
+                .Contain(l =>
+                    l.Contains(LocalizableStrings.ManifestMissionVersion));
         }
 
         private string _jsonContent =
@@ -316,6 +335,47 @@ namespace Microsoft.DotNet.Tests.Commands
          ""version"":""4.0.0"",
          ""commands"":[
             ""dotnetsay2""
+         ]
+      }
+   }
+}";
+        
+        private string _jsonContentNoVersion =
+            @"{
+   ""isRoot"":true,
+   ""tools"":{
+      ""t-rex"":{  
+         ""version"":""1.0.53"",
+         ""commands"":[
+            ""t-rex""
+         ],
+         ""targetFramework"":""netcoreapp2.1""
+      },
+      ""dotnetsay"":{  
+         ""version"":""2.1.4"",
+         ""commands"":[
+            ""dotnetsay""
+         ]
+      }
+   }
+}";
+        
+        private string _jsonContentHigherVersion =
+            @"{
+   ""isRoot"":true,
+   ""version"":99,
+   ""tools"":{
+      ""t-rex"":{  
+         ""version"":""1.0.53"",
+         ""commands"":[
+            ""t-rex""
+         ],
+         ""targetFramework"":""netcoreapp2.1""
+      },
+      ""dotnetsay"":{  
+         ""version"":""2.1.4"",
+         ""commands"":[
+            ""dotnetsay""
          ]
       }
    }

--- a/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
@@ -178,6 +178,8 @@ namespace Microsoft.DotNet.Tests.Commands
             _reporter.Lines.Should().Contain(l => l.Contains(string.Format(
                 LocalizableStrings.RestoreSuccessful, _packageIdB,
                 _packageVersionB.ToNormalizedString(), _toolCommandNameB)));
+
+            _reporter.Lines.Should().Contain(l => l.Contains("\x1B[32m"), "ansicolor code for green, message should be green");
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
@@ -172,12 +172,11 @@ namespace Microsoft.DotNet.Tests.Commands
 
             toolRestoreCommand.Execute().Should().Be(0);
 
-            _reporter.Lines.Should().Contain(l => l.Contains("Restore was successful."));
             _reporter.Lines.Should().Contain(l => l.Contains(string.Format(
-                "Tool '{0}' (version '{1}') was restored. Available commands: {2}", _packageIdA,
+                LocalizableStrings.RestoreSuccessful, _packageIdA,
                 _packageVersionA.ToNormalizedString(), _toolCommandNameA)));
             _reporter.Lines.Should().Contain(l => l.Contains(string.Format(
-                "Tool '{0}' (version '{1}') was restored. Available commands: {2}", _packageIdB,
+                LocalizableStrings.RestoreSuccessful, _packageIdB,
                 _packageVersionB.ToNormalizedString(), _toolCommandNameB)));
         }
 

--- a/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
@@ -156,9 +156,9 @@ namespace Microsoft.DotNet.Tests.Commands
                 new MockManifestFileFinder(new[]
                 {
                     new ToolManifestPackage(_packageIdA, _packageVersionA,
-                        new[] {_toolCommandNameA}, null),
+                        new[] {_toolCommandNameA}),
                     new ToolManifestPackage(_packageIdB, _packageVersionB,
-                        new[] {_toolCommandNameB}, _targetFrameworkB)
+                        new[] {_toolCommandNameB})
                 });
 
             ToolRestoreCommand toolRestoreCommand = new ToolRestoreCommand(_appliedCommand,


### PR DESCRIPTION
Fix https://github.com/dotnet/cli/issues/10032

-  success message after dotnet tool restore
-  Avoid restore every thing in manifest file, only restore diff
-  IsRoot != true support for manifest file
-  should throw when manifest file version bigger than 1
-  Handling version missing case, default to 1
