### PR TITLE
Adding NU5123 to the NOWARN list.

### DIFF
--- a/build/BuildDefaults.props
+++ b/build/BuildDefaults.props
@@ -30,7 +30,8 @@
     <!-- Since we disabled the implict fallback to net461, this will only kick in when we have an explicit fallback and we don't need to be warned about it doing what we asked it to do. -->
     <!-- NU5104: Disable 'A stable release of a package should not have a prerelease dependency' warning globally -->
     <!-- The "pack" command under 'buildCrossTargeting' for 'Microsoft.DotNet.MSBuildSdkResolver' throws a "NU5104" warning/error while using a "2.1.300" stage0 SDK. For: Linux-x64, Linux-arm, and Linux-arm64 -->
-    <NoWarn>NU1701;NU5104</NoWarn>
+    <!-- NU5123: Disable warning for package installation path is too long. We are hitting this for some ni...map file in one of our packages. -->
+    <NoWarn>NU1701;NU5104;NU5123</NoWarn>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>

--- a/build/package/Installer.MSI.targets
+++ b/build/package/Installer.MSI.targets
@@ -102,17 +102,17 @@
             Inputs="@(GenerateSdkMsiInputs)"
             Outputs="$(SdkInstallerFile)">
 
-      <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateMsiPowershellScript)
-                      '$(SdkLayoutOutputDirectory)'
-                      '$(SdkInstallerFile)'
-                      '$(WixRoot)'
-                      '$(SdkBrandName)'
-                      '$(MsiVersion)'
-                      '$(SimpleVersion)'
-                      '$(NugetVersion)'
-                      '$(SdkInstallerUpgradeCode)'
-                      '$(Architecture)'
-                      '$(SdkStableFileIdForApphostTransform)'
+      <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateMsiPowershellScript) ^
+                      '$(SdkLayoutOutputDirectory)' ^
+                      '$(SdkInstallerFile)' ^
+                      '$(WixRoot)' ^
+                      '$(SdkBrandName)' ^
+                      '$(MsiVersion)' ^
+                      '$(SimpleVersion)' ^
+                      '$(NugetVersion)' ^
+                      '$(SdkInstallerUpgradeCode)' ^
+                      '$(Architecture)' ^
+                      '$(SdkStableFileIdForApphostTransform)' ^
                       " />
     </Target>
 
@@ -122,15 +122,15 @@
             Inputs="@(GenerateMSBuildExtensionsMsiInputs)"
             Outputs="$(MSBuildExtensionsInstallerFile)">
 
-      <Exec Command="powershell -NoProfile -NoLogo $(MSBuildExtensionsGenerateMsiPowershellScript)
-                      '$(MSBuildExtensionsOutputDirectory)'
-                      '$(MSBuildExtensionsInstallerFile)'
-                      '$(WixRoot)'
-                      '$(MSBuildExtensionsBrandName)'
-                      '$(SimpleVersion)'
-                      '$(SimpleVersion)'
-                      '$(NugetVersion)'
-                      '$(MSBuildExtensionsInstallerUpgradeCode)'
+      <Exec Command="powershell -NoProfile -NoLogo $(MSBuildExtensionsGenerateMsiPowershellScript) ^
+                      '$(MSBuildExtensionsOutputDirectory)' ^
+                      '$(MSBuildExtensionsInstallerFile)' ^
+                      '$(WixRoot)' ^
+                      '$(MSBuildExtensionsBrandName)' ^
+                      '$(SimpleVersion)' ^
+                      '$(SimpleVersion)' ^
+                      '$(NugetVersion)' ^
+                      '$(MSBuildExtensionsInstallerUpgradeCode)' ^
                       '$(Architecture)'" />
     </Target>
 
@@ -144,21 +144,21 @@
                     $(SdkGenerateBundlePowershellScript)"
             Outputs="$(CombinedFrameworkSdkHostInstallerFile)">
 
-      <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateBundlePowershellScript)
-                      '$(SdkInstallerFile)'
-                      '$(DownloadedAspNetCoreSharedFxInstallerFile)'
-                      '$(DownloadedSharedFrameworkInstallerFile)'
-                      '$(DownloadedHostFxrInstallerFile)'
-                      '$(DownloadedSharedHostInstallerFile)'
-                      '$(CombinedFrameworkSdkHostInstallerFile)'
-                      '$(WixRoot)'
-                      '$(SdkBrandName)'
-                      '$(MsiVersion)'
-                      '$(SimpleVersion)'
-                      '$(NugetVersion)'
-                      '$(CombinedFrameworkSDKHostInstallerUpgradeCode)'
-                      '$(Architecture)'
-                      '$(MicrosoftNETCoreAppPackageVersion)'
+      <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateBundlePowershellScript) ^
+                      '$(SdkInstallerFile)' ^
+                      '$(DownloadedAspNetCoreSharedFxInstallerFile)' ^
+                      '$(DownloadedSharedFrameworkInstallerFile)' ^
+                      '$(DownloadedHostFxrInstallerFile)' ^
+                      '$(DownloadedSharedHostInstallerFile)' ^
+                      '$(CombinedFrameworkSdkHostInstallerFile)' ^
+                      '$(WixRoot)' ^
+                      '$(SdkBrandName)' ^
+                      '$(MsiVersion)' ^
+                      '$(SimpleVersion)' ^
+                      '$(NugetVersion)' ^
+                      '$(CombinedFrameworkSDKHostInstallerUpgradeCode)' ^
+                      '$(Architecture)' ^
+                      '$(MicrosoftNETCoreAppPackageVersion)' ^
                       '$(AspNetCoreVersion)'" />
     </Target>
 
@@ -170,10 +170,10 @@
                     $(SdkGenerateNupkgPowershellScript)"
             Outputs="$(SdkInstallerNupkgFile)">
 
-      <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateNupkgPowershellScript)
-                      '$(CombinedFrameworkSdkHostInstallerFile)'
-                      '$(SuffixedNugetVersion)'
-                      '$(SdkInstallerNuspecFile)'
+      <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateNupkgPowershellScript) ^
+                      '$(CombinedFrameworkSdkHostInstallerFile)' ^
+                      '$(SuffixedNugetVersion)' ^
+                      '$(SdkInstallerNuspecFile)' ^
                       '$(SdkInstallerNupkgFile)'" />
     </Target>
 
@@ -185,10 +185,10 @@
                     $(SdkGenerateNupkgPowershellScript)"
             Outputs="$(SdkMSBuildExtensionsNupkgFile);$(SdkMSBuildExtensionsSwrFile)">
 
-      <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateNupkgPowershellScript)
-                      '$(MSBuildExtensionsLayoutDirectory)'
-                      '$(SuffixedNugetVersion)'
-                      '$(SdkMSBuildExtensionsNuspecFile)'
+      <Exec Command="powershell -NoProfile -NoLogo $(SdkGenerateNupkgPowershellScript) ^
+                      '$(MSBuildExtensionsLayoutDirectory)' ^
+                      '$(SuffixedNugetVersion)' ^
+                      '$(SdkMSBuildExtensionsNuspecFile)' ^
                       '$(SdkMSBuildExtensionsNupkgFile)'" />
       
       <GenerateMSBuildExtensionsSWR MSBuildExtensionsLayoutDirectory="$(MSBuildExtensionsLayoutDirectory)"
@@ -202,9 +202,9 @@
             DependsOnTargets="Init;MsiTargetsSetupInputOutputs;GenerateSdkMsi"
             Condition=" '$(OS)' == 'Windows_NT'" >
 
-      <Exec Command ="powershell -NoProfile -NoLogo $(SdkTestMsiPowershellScript)
-                      -InputMsi '$(SdkInstallerFile)'
-                      -DotnetDir '$(PreviousStageDirectory)'
+      <Exec Command ="powershell -NoProfile -NoLogo $(SdkTestMsiPowershellScript) ^
+                      -InputMsi '$(SdkInstallerFile)' ^
+                      -DotnetDir '$(PreviousStageDirectory)' ^
                       -TestDir '$(TestOutputDir)'" />
 
       <WriteLinesToFile

--- a/build/package/Installer.PKG.targets
+++ b/build/package/Installer.PKG.targets
@@ -118,13 +118,7 @@
         Glob="$(SdkPkgScriptFile)"
         Mode="ugo+x" />
 
-      <Exec Command="pkgbuild
-                     --root '$(SdkLayoutOutputDirectory)'
-                     --identifier '$(SdkComponentId)'
-                     --version '$(SdkVersion)'
-                     --install-location '$(PkgInstallDirectory)'
-                     --scripts '$(SdkPkgDestinationScriptsDirectory)'
-                     '$(SdkInstallerFile)'" />
+      <Exec Command="pkgbuild --root '$(SdkLayoutOutputDirectory)' --identifier '$(SdkComponentId)' --version '$(SdkVersion)' --install-location '$(PkgInstallDirectory)' --scripts '$(SdkPkgDestinationScriptsDirectory)' '$(SdkInstallerFile)'" />
     </Target>
 
     <Target Name="GenerateSdkProductArchive"
@@ -153,13 +147,7 @@
         ReplacementPatterns="@(DistributionTemplateReplacement -> '%(Identity)')"
         ReplacementStrings="@(DistributionTemplateReplacement -> '%(ReplacementString)')" />
 
-      <Exec Command="productbuild
-                     --version '$(SdkVersion)'
-                     --identifier '$(SdkProductArchiveId)'
-                     --package-path '$(PkgIntermediateDirectory)'
-                     --resources '$(SdkProductArchiveResourcesDirectory)'
-                     --distribution '$(SdkProductArchiveDistributionFile)'
-                     '$(CombinedFrameworkSdkHostInstallerFile)'" />
+      <Exec Command="productbuild --version '$(SdkVersion)' --identifier '$(SdkProductArchiveId)' --package-path '$(PkgIntermediateDirectory)' --resources '$(SdkProductArchiveResourcesDirectory)' --distribution '$(SdkProductArchiveDistributionFile)' '$(CombinedFrameworkSdkHostInstallerFile)'" />
     </Target>
 
     <Target Name="GeneratePkgs"

--- a/run-build.ps1
+++ b/run-build.ps1
@@ -92,8 +92,8 @@ if($Architecture.StartsWith("arm", [StringComparison]::OrdinalIgnoreCase))
     $InstallArchitecture = "x64"
 }
 
-Write-Output "$dotnetInstallPath -version ""2.1.300"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$InstallArchitecture"""
-Invoke-Expression "$dotnetInstallPath -version ""2.1.300"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$InstallArchitecture"""
+Write-Output "$dotnetInstallPath -version ""2.1.403"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$InstallArchitecture"""
+Invoke-Expression "$dotnetInstallPath -version ""2.1.403"" -InstallDir $env:DOTNET_INSTALL_DIR -Architecture ""$InstallArchitecture"""
 
 if ($LastExitCode -ne 0)
 {

--- a/run-build.sh
+++ b/run-build.sh
@@ -165,7 +165,7 @@ if [[ $archlower == 'arm'* ]]; then
 fi
 
 if [ "$STAGE0_SOURCE_DIR" == "" ]; then
-    (set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --version "2.1.300" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$INSTALL_ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS)
+    (set -x ; "$REPOROOT/scripts/obtain/dotnet-install.sh" --version "2.1.403" --install-dir "$DOTNET_INSTALL_DIR" --architecture "$INSTALL_ARCHITECTURE" $LINUX_PORTABLE_INSTALL_ARGS)
 else
     echo "Copying bootstrap cli from $STAGE0_SOURCE_DIR"
     cp -r $STAGE0_SOURCE_DIR/* "$DOTNET_INSTALL_DIR"


### PR DESCRIPTION
Adding NU5123 to the NOWARN list. This was a new warning introduced by NuGet that we started hitting when upgrading to a newer SDK.

This is breaking source build.

Fixes https://github.com/dotnet/cli/issues/10052
