### PR TITLE
[WIP] Add dotnet-tool list --local option

### DIFF
--- a/src/dotnet/commands/dotnet-tool/list/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/list/LocalizableStrings.resx
@@ -123,17 +123,26 @@
   <data name="GlobalOptionDescription" xml:space="preserve">
     <value>List tools in the current user's tools directory.</value>
   </data>
+  <data name="LocalOptionDescription" xml:space="preserve">
+    <value>List tools in the current user's current directory.</value>
+  </data>
   <data name="ToolPathOptionName" xml:space="preserve">
     <value>PATH</value>
   </data>
   <data name="ToolPathOptionDescription" xml:space="preserve">
     <value>The directory containing the tools to list.</value>
   </data>
-  <data name="NeedGlobalOrToolPath" xml:space="preserve">
-    <value>Please specify either the global option (--global) or the tool path option (--tool-path).</value>
+  <data name="NeedGlobalLocalOrToolPath" xml:space="preserve">
+    <value>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</value>
   </data>
   <data name="GlobalAndToolPathConflict" xml:space="preserve">
     <value>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</value>
+  </data>
+  <data name="LocalAndToolPathConflict" xml:space="preserve">
+    <value>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</value>
+  </data>
+  <data name="LocalAndGlobalConflict" xml:space="preserve">
+    <value>(--local) conflicts with the global option (--global). Please specify only one of the options.</value>
   </data>
   <data name="InvalidPackageWarning" xml:space="preserve">
     <value>Warning: tool package '{0}' is invalid: {1}</value>

--- a/src/dotnet/commands/dotnet-tool/list/ToolListCommandParser.cs
+++ b/src/dotnet/commands/dotnet-tool/list/ToolListCommandParser.cs
@@ -18,6 +18,10 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.GlobalOptionDescription,
                     Accept.NoArguments()),
                 Create.Option(
+                    "--local",
+                    LocalizableStrings.GlobalOptionDescription,
+                    Accept.NoArguments()),
+                Create.Option(
                     "--tool-path",
                     LocalizableStrings.ToolPathOptionDescription,
                     Accept.ExactlyOneArgument()

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.cs.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Upozornění: Balíček nástroje {0} je neplatný: {1}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">Zadejte prosím globální parametr (--global) nebo parametr cesty nástroje (--tool-path).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global) je v konfliktu s parametrem cesty nástroje (--tool-path). Zadejte prosím pouze jeden z parametrů.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">Adresář obsahující nástroje, které se mají vypsat</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.de.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Warnung: Das Toolpaket "{0}" ist ungültig: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">Geben Sie entweder die globale Option (--global) oder die Toolpfadoption (--tool-path) an.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global) verursacht einen Konflikt mit der Toolpfadoption (--tool-path). Geben Sie nur eine der beiden Optionen an.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">Das Verzeichnis, das die aufzulistenden Tools enthält.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.es.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Advertencia: El paquete de herramientas "{0}" no es válido: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">Especifique la opción global (--global) o la opción de la ruta de acceso de herramientas (--tool-path).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global) entra en conflicto con la opción de la ruta de acceso de herramientas (--tool-path). Especifique solo una de las opciones.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">El directorio que contiene las herramientas que se van a enumerar.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.fr.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Avertissement : Le package d'outils '{0}' n'est pas valide : {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">Spécifiez l'option globale (--global) ou l'option de chemin de l'outil (--tool-path).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global) est en conflit avec l'option de chemin de l'outil (--tool-path). Spécifiez uniquement l'une des options.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">Répertoire contenant les outils à lister.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.it.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Avviso: il pacchetto '{0}' dello strumento non è valido: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">Specificare l'opzione globale (--global) o quella relativa al percorso dello strumento (--tool-path).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global) è in conflitto con l'opzione relativa al percorso dello strumento (--tool-path). Specificare solo una delle opzioni.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">Directory contenente gli strumenti da elencare.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ja.xlf
@@ -32,11 +32,6 @@
         <target state="translated">警告: ツール パッケージ '{0}' が無効です: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">グローバル オプション (--global) またはツール パス オプション (--tool-path) のいずれかを指定してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global) とツール パス オプション (--tool-path) は競合します。どちらか片方のオプションのみを指定してください。</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">一覧表示するツールが入っているディレクトリ。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ko.xlf
@@ -32,11 +32,6 @@
         <target state="translated">경고: 도구 패키지 '{0}'이(가) 잘못되었습니다. {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">전역 옵션(-global) 또는 도구 경로 옵션(--tool-path)을 지정하세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(-global)이 도구 경로 옵션(--tool-path)과 충돌합니다. 옵션 중 하나만 지정하세요.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">나열할 도구를 포함하는 디렉터리입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pl.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Ostrzeżenie: pakiet narzędzia „{0}” jest nieprawidłowy: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">Określ opcję globalną (--global) lub opcję ścieżki narzędzia (--tool-path).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">Opcja (--global) powoduje konflikt z opcją ścieżki narzędzia (--tool-path). Określ tylko jedną z opcji.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">Katalog zawierający narzędzia do wyświetlenia na liście.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.pt-BR.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Aviso: o pacote de ferramentas '{0}' é inválido: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">Especifique a opção global (--global) ou a opção do caminho da ferramenta (--tool-path).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global) está em conflito com a opção do caminho da ferramenta (--tool-path). Especifique apenas uma das opções.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">O diretório que contém as ferramentas a serem listadas.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.ru.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Предупреждение. Пакет инструментов "{0}" недопустим: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">Укажите глобальный параметр (--global) или параметр пути к средству (--tool-path).</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global) конфликтует с параметром пути к средству (--tool-path). Укажите лишь один из них.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">Каталог, содержащий перечисляемые инструменты.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.tr.xlf
@@ -32,11 +32,6 @@
         <target state="translated">Uyarı: '{0}' araç paketi geçersiz: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">Lütfen genel seçeneğini (--global) veya araç yolu seçeneğini (--tool-path) belirtin.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global), araç yolu seçeneği (--tool-path) ile çakışıyor. Lütfen seçeneklerden yalnızca birini belirtin.</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">Listelenecek aracı içeren dizin.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hans.xlf
@@ -32,11 +32,6 @@
         <target state="translated">警告: 工具包“{0}”无效: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">请指定全局选项(--global)或工具路径选项(--tool-path)。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global)与工具路径选项(--tool-path)冲突。请仅指定其中一种选项。</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">包含要列出的工具的目录。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/list/xlf/LocalizableStrings.zh-Hant.xlf
@@ -32,11 +32,6 @@
         <target state="translated">警告: 工具套件 '{0}' 無效: {1}</target>
         <note />
       </trans-unit>
-      <trans-unit id="NeedGlobalOrToolPath">
-        <source>Please specify either the global option (--global) or the tool path option (--tool-path).</source>
-        <target state="translated">請指定全域選項 (--global) 或工具路徑選項 (--tool-path) 兩者之一。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GlobalAndToolPathConflict">
         <source>(--global) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
         <target state="translated">(--global) 與工具路徑選項 (--tool-path) 衝突。請只指定其中一個選項。</target>
@@ -55,6 +50,26 @@
       <trans-unit id="ToolPathOptionDescription">
         <source>The directory containing the tools to list.</source>
         <target state="translated">包含要列出之工具的目錄。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NeedGlobalLocalOrToolPath">
+        <source>Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</source>
+        <target state="new">Please specify either the global option (--global), local option (--local), or the tool path option (--tool-path).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndToolPathConflict">
+        <source>(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the tool path option (--tool-path). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalAndGlobalConflict">
+        <source>(--local) conflicts with the global option (--global). Please specify only one of the options.</source>
+        <target state="new">(--local) conflicts with the global option (--global). Please specify only one of the options.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="LocalOptionDescription">
+        <source>List tools in the current user's current directory.</source>
+        <target state="new">List tools in the current user's current directory.</target>
         <note />
       </trans-unit>
     </body>

--- a/test/dotnet.Tests/CommandTests/ToolListCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolListCommandTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.DotNet.Tests.Commands
              .And
              .Message
              .Should()
-             .Be(LocalizableStrings.NeedGlobalOrToolPath);
+             .Be(LocalizableStrings.NeedGlobalLocalOrToolPath);
         }
 
         [Fact]


### PR DESCRIPTION
This commit adds initial support for the dotnet-tool list --local
flag.  As mentioned in #9920, this lists the tools in the current
directory from where the executable is run.  This commit
does not include the proper test cases or i18n.
