### PR TITLE
local tools changes

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Constants.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Constants.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.Cli.Utils
         public const string DefaultConfiguration = "Debug";
 
         public static readonly string ProjectFileName = "project.json";
+        public static readonly string DotConfigDirectoryName = ".config";
         public static readonly string ExeSuffix = CurrentPlatform == Platform.Windows ? ".exe" : string.Empty;
 
         public static readonly string BinDirectoryName = "bin";

--- a/src/dotnet/ToolManifest/LocalizableStrings.resx
+++ b/src/dotnet/ToolManifest/LocalizableStrings.resx
@@ -129,7 +129,7 @@
 {1}</value>
   </data>
   <data name="ManifestVersion0" xml:space="preserve">
-    <value>Manifest version 0 is not supported. Manifest file path: {0}</value>
+    <value>Manifest version 0 is not supported.</value>
   </data>
   <data name="ManifestVersionHigherThanSupported" xml:space="preserve">
     <value>Manifest version is {0}. This manifest may not be supported in this SDK version that can support up to manifest version {1}.</value>

--- a/src/dotnet/ToolManifest/LocalizableStrings.resx
+++ b/src/dotnet/ToolManifest/LocalizableStrings.resx
@@ -147,4 +147,7 @@
   <data name="JsonParsingError" xml:space="preserve">
     <value>Json parsing error in file {0} : {1}</value>
   </data>
+  <data name="ManifestMissingIsRoot" xml:space="preserve">
+    <value>Missing 'isRoot' entry.</value>
+  </data>
 </root>

--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -137,7 +137,7 @@ namespace Microsoft.DotNet.ToolManifest
 
             if (deserializedManifest.version == 0)
             {
-                errors.Add(string.Format(LocalizableStrings.ManifestVersion0, path.Value));
+                errors.Add(LocalizableStrings.ManifestVersion0);
             }
 
             if (deserializedManifest.version > SupportedVersion)

--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.ToolManifest
     {
         private readonly DirectoryPath _probStart;
         private readonly IFileSystem _fileSystem;
-        private const string _manifestFilenameConvention = "localtool.manifest.json";
+        private const string _manifestFilenameConvention = "dotnet-tools.json";
 
         // The supported tool manifest file version.
         private const int SupportedVersion = 1;

--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -209,9 +209,11 @@ namespace Microsoft.DotNet.ToolManifest
         private IEnumerable<FilePath> EnumerateDefaultAllPossibleManifests()
         {
             DirectoryPath? currentSearchDirectory = _probStart;
-            while (currentSearchDirectory != null)
+            while (currentSearchDirectory.HasValue)
             {
+                var currentSearchDotConfigDirectory = currentSearchDirectory.Value.WithSubDirectories(Constants.DotConfigDirectoryName);
                 var tryManifest = currentSearchDirectory.Value.WithFile(_manifestFilenameConvention);
+                yield return currentSearchDotConfigDirectory.WithFile(_manifestFilenameConvention);
                 yield return tryManifest;
                 currentSearchDirectory = currentSearchDirectory.Value.GetParentPathNullable();
             }

--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.ToolManifest
                     }
                 }
 
-                if (deserializedManifest.isRoot)
+                if (deserializedManifest.isRoot.Value)
                 {
                     return result;
                 }
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.ToolManifest
                     }
                 }
 
-                if (deserializedManifest.isRoot)
+                if (deserializedManifest.isRoot.Value)
                 {
                     return false;
                 }
@@ -146,6 +146,11 @@ namespace Microsoft.DotNet.ToolManifest
                     string.Format(
                         LocalizableStrings.ManifestVersionHigherThanSupported,
                         deserializedManifest.version, SupportedVersion));
+            }
+
+            if (!deserializedManifest.isRoot.HasValue)
+            {
+                errors.Add(string.Format(LocalizableStrings.ManifestMissingIsRoot, path.Value));
             }
 
             foreach (KeyValuePair<string, SerializableLocalToolSinglePackage> tools in deserializedManifest.tools)
@@ -218,9 +223,7 @@ namespace Microsoft.DotNet.ToolManifest
             [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
             public int version { get; set; }
 
-            [DefaultValue(false)]
-            [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]
-            public bool isRoot { get; set; }
+            public bool? isRoot { get; set; }
 
             [JsonProperty(Required = Required.Always)]
             // The dictionary's key is the package id

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
@@ -53,6 +53,11 @@
         <target state="new">Json parsing error in file {0} : {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ManifestMissingIsRoot">
+        <source>Missing 'isRoot' entry.</source>
+        <target state="new">Missing 'isRoot' entry.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
@@ -39,8 +39,8 @@
         <note />
       </trans-unit>
       <trans-unit id="ManifestVersion0">
-        <source>Manifest version 0 is not supported. Manifest file path: {0}</source>
-        <target state="new">Manifest version 0 is not supported. Manifest file path: {0}</target>
+        <source>Manifest version 0 is not supported.</source>
+        <target state="new">Manifest version 0 is not supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolMissingVersion">

--- a/test/Microsoft.DotNet.CommandFactory.Tests/GivenALocalToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.CommandFactory.Tests/GivenALocalToolsCommandResolver.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Tests
 {
     public class GivenALocalToolsCommandResolver : TestBase
     {
-        private const string ManifestFilename = "localtool.manifest.json";
+        private const string ManifestFilename = "dotnet-tools.json";
         private readonly string _testDirectoryRoot;
         private DirectoryPath _nugetGlobalPackagesFolder;
         private readonly LocalToolsResolverCache _localToolsResolverCache;

--- a/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
@@ -62,6 +62,18 @@ namespace Microsoft.DotNet.Tests.Commands
         }
 
         [Fact]
+        public void GivenManifestFileInDotConfigDirectoryItGetContent()
+        {
+            var dotnetconfigDirectory = Path.Combine(_testDirectoryRoot, ".config");
+            _fileSystem.Directory.CreateDirectory(dotnetconfigDirectory);
+            _fileSystem.File.WriteAllText(Path.Combine(dotnetconfigDirectory, _manifestFilename), _jsonContent);
+            var toolManifest = new ToolManifestFinder(new DirectoryPath(_testDirectoryRoot), _fileSystem);
+            var manifestResult = toolManifest.Find();
+
+            manifestResult.ShouldBeEquivalentTo(_defaultExpectedResult);
+        }
+
+        [Fact]
         // https://github.com/JamesNK/Newtonsoft.Json/issues/931#issuecomment-224104005
         // Due to a limitation of newtonsoft json
         public void GivenManifestWithDuplicatedPackageIdItReturnsTheLastValue()

--- a/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
@@ -482,6 +482,6 @@ namespace Microsoft.DotNet.Tests.Commands
 
         private readonly List<ToolManifestPackage> _defaultExpectedResult;
         private readonly string _testDirectoryRoot;
-        private const string _manifestFilename = "localtool.manifest.json";
+        private const string _manifestFilename = "dotnet-tools.json";
     }
 }

--- a/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolManifestTests.cs
@@ -194,6 +194,17 @@ namespace Microsoft.DotNet.Tests.Commands
         }
 
         [Fact]
+        public void MissingIsRootInManifestFileItShouldThrow()
+        {
+            _fileSystem.File.WriteAllText(Path.Combine(_testDirectoryRoot, _manifestFilename), _jsonContentIsRootMissing);
+            BufferedReporter bufferedReporter = new BufferedReporter();
+            var toolManifest = new ToolManifestFinder(new DirectoryPath(_testDirectoryRoot), _fileSystem);
+            Action a = () => toolManifest.Find();
+
+            a.ShouldThrow<ToolManifestException>().And.Message.Should().Contain(LocalizableStrings.ManifestMissingIsRoot);
+        }
+
+        [Fact]
         public void GivenManifestFileOnSameDirectoryWhenFindByCommandNameItGetContent()
         {
             _fileSystem.File.WriteAllText(Path.Combine(_testDirectoryRoot, _manifestFilename), _jsonContent);
@@ -384,6 +395,7 @@ namespace Microsoft.DotNet.Tests.Commands
         private string _jsonContentInCurrentDirectory =
             @"{
    ""version"":1,
+   ""isRoot"":true,
    ""tools"":{
       ""t-rex"":{
          ""version"":""1.0.49"",
@@ -455,6 +467,18 @@ namespace Microsoft.DotNet.Tests.Commands
          ""version"":""2.1.4"",
          ""commands"":[
             ""dotnetsay""
+         ]
+      }
+   }
+}";
+        private string _jsonContentIsRootMissing =
+    @"{
+   ""version"":1,
+   ""tools"":{
+      ""t-rex"":{
+         ""version"":""1.0.53"",
+         ""commands"":[
+            ""t-rex""
          ]
       }
    }


### PR DESCRIPTION
- Change manifest name to dotnet-tools.json

- Make isRoot required

- Remove redundant manifest file path in text

- Extra probing of .config folder

Since this text is indented under an error with manifest full path already