### PR TITLE
Update NUnit DotNet New to version 1.5.3

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -60,7 +60,7 @@
     <MicroBuildCorePackageVersion>0.2.0</MicroBuildCorePackageVersion>
     <MSTestVersion>1.3.2</MSTestVersion>
     <XUnitVersion>2.3.1</XUnitVersion>
-    <NUnit3TemplatesVersion>1.5.2</NUnit3TemplatesVersion>
+    <NUnit3TemplatesVersion>1.5.3</NUnit3TemplatesVersion>
   </PropertyGroup>
 
   <!-- NOTE: The property group above is in alignment with orchestrated build version naming conventions. -->


### PR DESCRIPTION
The NUnit team received a request (https://github.com/nunit/dotnet-new-nunit/issues/16) to update the nunit dotnet new template to default to `netcoreapp2.1` when creating new test projects. We have made that change and published a [new version 1.5.3 to NuGet](https://www.nuget.org/packages/NUnit3.DotNetNew.Template/1.5.3).

This updates the version here as we did in #9984. I am targeting the `release/2.1.5xx` branch as we did before since it looks like it has not been released yet. If it needs to target another branch let me know and I will fix it.

CC @halex2005 
