### PR TITLE
add option for FreeBSD

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -166,6 +166,9 @@ get_current_os_name() {
     if [ "$uname" = "Darwin" ]; then
         echo "osx"
         return 0
+    elif [ "$uname" = "FreeBSD" ]; then
+        echo "freebsd"
+        return 0        
     elif [ "$uname" = "Linux" ]; then
         local linux_platform_name
         linux_platform_name="$(get_linux_platform_name)" || { echo "linux" && return 0 ; }


### PR DESCRIPTION
This is now used by Arcade to build corefx.

running it now on FreeBSD 11.2 produces:

> toweinfu@toweinfu-fbsd /mnt/resource/source-build/src/cli/scripts/obtain]$ bash dotnet-install.sh
> dotnet-install: Downloading link: https://dotnetcli.azureedge.net/dotnet/Sdk/2.1.403/dotnet-sdk-2.1.403-freebsd-x64.tar.gz
> curl: (22) The requested URL returned error: 404
> 

instead of failure. 
