### PR TITLE
add FreeBSD to build platforms

### DIFF
--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/CurrentPlatform.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/CurrentPlatform.cs
@@ -36,6 +36,14 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             }
         }
 
+        public static bool IsFreeBSD
+        {
+            get
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
+            }
+        }
+
         public static bool IsUbuntu
         {
             get
@@ -85,7 +93,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         {
             get
             {
-                return IsLinux || IsOSX;
+                return IsLinux || IsOSX || IsFreeBSD;
             }
         }
 
@@ -140,6 +148,8 @@ namespace Microsoft.DotNet.Cli.Build.Framework
                     return IsUnix;
                 case BuildPlatform.Linux:
                     return IsLinux;
+                case BuildPlatform.FreeBSD:
+                    return IsFreeBSD;
                 default:
                     throw new Exception("Unrecognized Platform.");
             }
@@ -159,6 +169,10 @@ namespace Microsoft.DotNet.Cli.Build.Framework
             else if (IsOSX)
             {
                 return BuildPlatform.OSX;
+            }
+            else if (IsFreeBSD)
+            {
+                return BuildPlatform.FreeBSD;
             }
             else if (IsUbuntu)
             {

--- a/build_projects/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildPlatform.cs
+++ b/build_projects/Microsoft.DotNet.Cli.Build.Framework/Enumerations/BuildPlatform.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Cli.Build.Framework
         RHEL = 7,
         Debian = 8,
         Fedora = 9,
-        OpenSuse = 10
+        OpenSuse = 10,
+        FreeBSD = 11
     }
 }


### PR DESCRIPTION
This may not be complete fix yet but when running build on FreeBSD it sets targetGroup/targetOS to Linux. This at least add detection to FreeBSD and it also adds it to isUnix family. 