### PR TITLE
NuGet prob nuget.config should start from the directory of the manifest file

### DIFF
--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -18,16 +18,16 @@ namespace Microsoft.DotNet.ToolManifest
 {
     internal class ToolManifestFinder : IToolManifestFinder
     {
-        private readonly DirectoryPath _probStart;
+        private readonly DirectoryPath _probeStart;
         private readonly IFileSystem _fileSystem;
         private const string _manifestFilenameConvention = "dotnet-tools.json";
 
         // The supported tool manifest file version.
         private const int SupportedVersion = 1;
 
-        public ToolManifestFinder(DirectoryPath probStart, IFileSystem fileSystem = null)
+        public ToolManifestFinder(DirectoryPath probeStart, IFileSystem fileSystem = null)
         {
-            _probStart = probStart;
+            _probeStart = probeStart;
             _fileSystem = fileSystem ?? new FileSystemWrapper();
         }
 
@@ -211,7 +211,7 @@ namespace Microsoft.DotNet.ToolManifest
 
         private IEnumerable<(FilePath manifestfile, DirectoryPath manifestFileFirstAffect)> EnumerateDefaultAllPossibleManifests()
         {
-            DirectoryPath? currentSearchDirectory = _probStart;
+            DirectoryPath? currentSearchDirectory = _probeStart;
             while (currentSearchDirectory.HasValue)
             {
                 var currentSearchDotConfigDirectory = currentSearchDirectory.Value.WithSubDirectories(Constants.DotConfigDirectoryName);

--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -33,14 +33,14 @@ namespace Microsoft.DotNet.ToolManifest
 
         public IReadOnlyCollection<ToolManifestPackage> Find(FilePath? filePath = null)
         {
-            IEnumerable<FilePath> allPossibleManifests =
+            IEnumerable<(FilePath manifestfile, DirectoryPath manifestFileFirstAffect)> allPossibleManifests =
                 filePath != null
-                    ? new[] {filePath.Value}
+                    ? new[] {(filePath.Value, filePath.Value.GetDirectoryPath())}
                     : EnumerateDefaultAllPossibleManifests();
 
             bool findAnyManifest = false;
             var result = new List<ToolManifestPackage>();
-            foreach (FilePath possibleManifest in allPossibleManifests)
+            foreach ((FilePath possibleManifest, DirectoryPath correspondingDirectory) in allPossibleManifests)
             {
                 if (!_fileSystem.File.Exists(possibleManifest.Value))
                 {
@@ -52,7 +52,7 @@ namespace Microsoft.DotNet.ToolManifest
                     DeserializeLocalToolsManifest(possibleManifest);
 
                 List<ToolManifestPackage> toolManifestPackageFromOneManifestFile =
-                    GetToolManifestPackageFromOneManifestFile(deserializedManifest, possibleManifest);
+                    GetToolManifestPackageFromOneManifestFile(deserializedManifest, possibleManifest, correspondingDirectory);
 
                 foreach (ToolManifestPackage p in toolManifestPackageFromOneManifestFile)
                 {
@@ -73,7 +73,7 @@ namespace Microsoft.DotNet.ToolManifest
             {
                 throw new ToolManifestCannotBeFoundException(
                     string.Format(LocalizableStrings.CannotFindAnyManifestsFileSearched,
-                        string.Join(Environment.NewLine, allPossibleManifests.Select(f => f.Value))));
+                        string.Join(Environment.NewLine, allPossibleManifests.Select(f => f.manifestfile.Value))));
             }
 
             return result;
@@ -82,7 +82,7 @@ namespace Microsoft.DotNet.ToolManifest
         public bool TryFind(ToolCommandName toolCommandName, out ToolManifestPackage toolManifestPackage)
         {
             toolManifestPackage = default(ToolManifestPackage);
-            foreach (FilePath possibleManifest in EnumerateDefaultAllPossibleManifests())
+            foreach ((FilePath possibleManifest, DirectoryPath correspondingDirectory) in EnumerateDefaultAllPossibleManifests())
             {
                 if (!_fileSystem.File.Exists(possibleManifest.Value))
                 {
@@ -93,7 +93,7 @@ namespace Microsoft.DotNet.ToolManifest
                     DeserializeLocalToolsManifest(possibleManifest);
 
                 List<ToolManifestPackage> toolManifestPackages =
-                    GetToolManifestPackageFromOneManifestFile(deserializedManifest, possibleManifest);
+                    GetToolManifestPackageFromOneManifestFile(deserializedManifest, possibleManifest, correspondingDirectory);
 
                 foreach (var package in toolManifestPackages)
                 {
@@ -130,7 +130,9 @@ namespace Microsoft.DotNet.ToolManifest
         }
 
         private List<ToolManifestPackage> GetToolManifestPackageFromOneManifestFile(
-            SerializableLocalToolsManifest deserializedManifest, FilePath path)
+            SerializableLocalToolsManifest deserializedManifest,
+            FilePath path,
+            DirectoryPath correspondingDirectory)
         {
             List<ToolManifestPackage> result = new List<ToolManifestPackage>();
             var errors = new List<string>();
@@ -191,7 +193,8 @@ namespace Microsoft.DotNet.ToolManifest
                     result.Add(new ToolManifestPackage(
                         packageId,
                         version,
-                        ToolCommandName.Convert(tools.Value.commands)));
+                        ToolCommandName.Convert(tools.Value.commands),
+                        correspondingDirectory));
                 }
             }
 
@@ -206,15 +209,15 @@ namespace Microsoft.DotNet.ToolManifest
             return result;
         }
 
-        private IEnumerable<FilePath> EnumerateDefaultAllPossibleManifests()
+        private IEnumerable<(FilePath manifestfile, DirectoryPath manifestFileFirstAffect)> EnumerateDefaultAllPossibleManifests()
         {
             DirectoryPath? currentSearchDirectory = _probStart;
             while (currentSearchDirectory.HasValue)
             {
                 var currentSearchDotConfigDirectory = currentSearchDirectory.Value.WithSubDirectories(Constants.DotConfigDirectoryName);
                 var tryManifest = currentSearchDirectory.Value.WithFile(_manifestFilenameConvention);
-                yield return currentSearchDotConfigDirectory.WithFile(_manifestFilenameConvention);
-                yield return tryManifest;
+                yield return (currentSearchDotConfigDirectory.WithFile(_manifestFilenameConvention), currentSearchDirectory.Value);
+                yield return (tryManifest, currentSearchDirectory.Value);
                 currentSearchDirectory = currentSearchDirectory.Value.GetParentPathNullable();
             }
         }

--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.ToolManifest
 
         public IReadOnlyCollection<ToolManifestPackage> Find(FilePath? filePath = null)
         {
-            IEnumerable<(FilePath manifestfile, DirectoryPath manifestFileFirstAffect)> allPossibleManifests =
+            IEnumerable<(FilePath manifestfile, DirectoryPath _)> allPossibleManifests =
                 filePath != null
                     ? new[] {(filePath.Value, filePath.Value.GetDirectoryPath())}
                     : EnumerateDefaultAllPossibleManifests();
@@ -209,7 +209,7 @@ namespace Microsoft.DotNet.ToolManifest
             return result;
         }
 
-        private IEnumerable<(FilePath manifestfile, DirectoryPath manifestFileFirstAffect)> EnumerateDefaultAllPossibleManifests()
+        private IEnumerable<(FilePath manifestfile, DirectoryPath manifestFileFirstEffectDirectory)> EnumerateDefaultAllPossibleManifests()
         {
             DirectoryPath? currentSearchDirectory = _probeStart;
             while (currentSearchDirectory.HasValue)

--- a/src/dotnet/ToolManifest/ToolManifestPackage.cs
+++ b/src/dotnet/ToolManifest/ToolManifestPackage.cs
@@ -27,9 +27,9 @@ namespace Microsoft.DotNet.ToolManifest
         public ToolManifestPackage(PackageId packagePackageId,
             NuGetVersion version,
             ToolCommandName[] toolCommandNames,
-            DirectoryPath firstAffectDirectory)
+            DirectoryPath firstEffectDirectory)
         {
-            FirstEffectDirectory = firstAffectDirectory;
+            FirstEffectDirectory = firstEffectDirectory;
             PackageId = packagePackageId;
             Version = version ?? throw new ArgumentNullException(nameof(version));
             CommandNames = toolCommandNames ?? throw new ArgumentNullException(nameof(toolCommandNames));

--- a/src/dotnet/ToolManifest/ToolManifestPackage.cs
+++ b/src/dotnet/ToolManifest/ToolManifestPackage.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.ToolPackage;
+using Microsoft.Extensions.EnvironmentAbstractions;
 using NuGet.Frameworks;
 using NuGet.Versioning;
 
@@ -16,12 +17,19 @@ namespace Microsoft.DotNet.ToolManifest
         public PackageId PackageId { get; }
         public NuGetVersion Version { get; }
         public ToolCommandName[] CommandNames { get; }
+        /// <summary>
+        /// The directory the will take affect first.
+        /// When it is under .config directory, it is not .config directory
+        /// it is .config's parent directory
+        /// </summary>
+        public DirectoryPath FirstAffectDirectory { get; }
 
-        public ToolManifestPackage(
-            PackageId packagePackageId,
+        public ToolManifestPackage(PackageId packagePackageId,
             NuGetVersion version,
-            ToolCommandName[] toolCommandNames)
+            ToolCommandName[] toolCommandNames,
+            DirectoryPath firstAffectDirectory)
         {
+            FirstAffectDirectory = firstAffectDirectory;
             PackageId = packagePackageId;
             Version = version ?? throw new ArgumentNullException(nameof(version));
             CommandNames = toolCommandNames ?? throw new ArgumentNullException(nameof(toolCommandNames));
@@ -37,7 +45,9 @@ namespace Microsoft.DotNet.ToolManifest
         {
             return PackageId.Equals(other.PackageId) &&
                    EqualityComparer<NuGetVersion>.Default.Equals(Version, other.Version) &&
-                   CommandNamesEqual(other.CommandNames);
+                   CommandNamesEqual(other.CommandNames) &&
+                   FirstAffectDirectory.Value.TrimEnd('/', '\\')
+                     .Equals(other.FirstAffectDirectory.Value.TrimEnd('/', '\\'), StringComparison.Ordinal);
         }
 
         private bool CommandNamesEqual(ToolCommandName[] otherCommandNames)

--- a/src/dotnet/ToolManifest/ToolManifestPackage.cs
+++ b/src/dotnet/ToolManifest/ToolManifestPackage.cs
@@ -22,14 +22,14 @@ namespace Microsoft.DotNet.ToolManifest
         /// When it is under .config directory, it is not .config directory
         /// it is .config's parent directory
         /// </summary>
-        public DirectoryPath FirstAffectDirectory { get; }
+        public DirectoryPath FirstEffectDirectory { get; }
 
         public ToolManifestPackage(PackageId packagePackageId,
             NuGetVersion version,
             ToolCommandName[] toolCommandNames,
             DirectoryPath firstAffectDirectory)
         {
-            FirstAffectDirectory = firstAffectDirectory;
+            FirstEffectDirectory = firstAffectDirectory;
             PackageId = packagePackageId;
             Version = version ?? throw new ArgumentNullException(nameof(version));
             CommandNames = toolCommandNames ?? throw new ArgumentNullException(nameof(toolCommandNames));
@@ -46,8 +46,8 @@ namespace Microsoft.DotNet.ToolManifest
             return PackageId.Equals(other.PackageId) &&
                    EqualityComparer<NuGetVersion>.Default.Equals(Version, other.Version) &&
                    CommandNamesEqual(other.CommandNames) &&
-                   FirstAffectDirectory.Value.TrimEnd('/', '\\')
-                     .Equals(other.FirstAffectDirectory.Value.TrimEnd('/', '\\'), StringComparison.Ordinal);
+                   FirstEffectDirectory.Value.TrimEnd('/', '\\')
+                     .Equals(other.FirstEffectDirectory.Value.TrimEnd('/', '\\'), StringComparison.Ordinal);
         }
 
         private bool CommandNamesEqual(ToolCommandName[] otherCommandNames)

--- a/src/dotnet/ToolManifest/ToolManifestPackage.cs
+++ b/src/dotnet/ToolManifest/ToolManifestPackage.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.ToolManifest
         public NuGetVersion Version { get; }
         public ToolCommandName[] CommandNames { get; }
         /// <summary>
-        /// The directory the will take affect first.
+        /// The directory that will take effect first.
         /// When it is under .config directory, it is not .config directory
         /// it is .config's parent directory
         /// </summary>

--- a/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -123,7 +123,8 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
                         _toolPackageInstaller.InstallPackageToExternalManagedLocation(
                             new PackageLocation(
                                 nugetConfig: configFile,
-                                additionalFeeds: _sources),
+                                additionalFeeds: _sources,
+                                rootConfigDirectory: package.FirstAffectDirectory),
                             package.PackageId, ToVersionRangeWithOnlyOneVersion(package.Version), targetFramework,
                             verbosity: _verbosity);
 

--- a/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
                             new PackageLocation(
                                 nugetConfig: configFile,
                                 additionalFeeds: _sources,
-                                rootConfigDirectory: package.FirstAffectDirectory),
+                                rootConfigDirectory: package.FirstEffectDirectory),
                             package.PackageId, ToVersionRangeWithOnlyOneVersion(package.Version), targetFramework,
                             verbosity: _verbosity);
 

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/MockFeedType.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/MockFeedType.cs
@@ -5,6 +5,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 {
     public enum MockFeedType
     {
+        FeedFromGlobalNugetConfig,
         FeedFromLookUpNugetConfig,
         ExplicitNugetConfig,
         ImplicitAdditionalFeed

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             {
                 _feeds.Add(new MockFeed
                     {
-                        Type = MockFeedType.FeedFromLookUpNugetConfig,
+                        Type = MockFeedType.FeedFromGlobalNugetConfig,
                         Packages = new List<MockFeedPackage>
                         {
                             new MockFeedPackage
@@ -96,7 +96,8 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             var feedPackage = GetPackage(
                 packageId,
                 versionRange,
-                packageLocation.NugetConfig);
+                packageLocation.NugetConfig,
+                packageLocation.RootConfigDirectory);
 
             var packageVersion = feedPackage.Version;
             targetFramework = string.IsNullOrEmpty(targetFramework) ? "targetFramework" : targetFramework;
@@ -121,25 +122,31 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 
         public MockFeedPackage GetPackage(
             string packageId,
-            VersionRange versionRange = null,
-            FilePath? nugetConfig = null)
+            VersionRange versionRange,
+            FilePath? nugetConfig = null,
+            DirectoryPath? rootConfigDirectory = null)
         {
             var allPackages = _feeds
-                .Where(f =>
+                .Where(feed =>
                 {
-                    if (nugetConfig != null)
+                    if (nugetConfig == null)
                     {
-                        return ExcludeOtherFeeds(nugetConfig, f);
+                        return SimulateNugetSearchNugetConfigAndMatch(
+                            rootConfigDirectory,
+                            feed);
                     }
-
-                    return true;
+                    else
+                    {
+                        return ExcludeOtherFeeds(nugetConfig.Value, feed);
+                    }
                 })
                 .SelectMany(f => f.Packages)
-                .Where(f => f.PackageId == packageId);
+                .Where(f => f.PackageId == packageId)
+                .ToList();
 
             var bestVersion = versionRange.FindBestMatch(allPackages.Select(p => NuGetVersion.Parse(p.Version)));
 
-            var package = allPackages.Where(p => NuGetVersion.Parse(p.Version).Equals(bestVersion)).FirstOrDefault();
+            var package = allPackages.FirstOrDefault(p => NuGetVersion.Parse(p.Version).Equals(bestVersion));
 
             if (package == null)
             {
@@ -150,10 +157,49 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             return package;
         }
 
-        private static bool ExcludeOtherFeeds(FilePath? nugetConfig, MockFeed f)
+        /// <summary>
+        /// Simulate NuGet search nuget config from parent directories.
+        /// Assume all nuget.config has Clear
+        /// And then filter against mock feed
+        /// </summary>
+        private bool SimulateNugetSearchNugetConfigAndMatch(
+            DirectoryPath? rootConfigDirectory,
+            MockFeed feed)
+        {
+            if (rootConfigDirectory != null)
+            {
+                var probedNugetConfig = EnumerateDefaultAllPossibleNuGetConfig(rootConfigDirectory.Value)
+                    .FirstOrDefault(possibleNugetConfig =>
+                        _fileSystem.File.Exists(possibleNugetConfig.Value));
+
+                if (!Equals(probedNugetConfig, default(FilePath)))
+                {
+                    return (feed.Type == MockFeedType.FeedFromLookUpNugetConfig) ||
+                           (feed.Type == MockFeedType.ImplicitAdditionalFeed) ||
+                           (feed.Type == MockFeedType.FeedFromLookUpNugetConfig
+                            && feed.Uri == probedNugetConfig.Value);
+                }
+            }
+
+            return feed.Type != MockFeedType.ExplicitNugetConfig
+                    && feed.Type != MockFeedType.FeedFromLookUpNugetConfig;
+        }
+
+        private static IEnumerable<FilePath> EnumerateDefaultAllPossibleNuGetConfig(DirectoryPath probStart)
+        {
+            DirectoryPath? currentSearchDirectory = probStart;
+            while (currentSearchDirectory.HasValue)
+            {
+                var tryNugetConfig = currentSearchDirectory.Value.WithFile("nuget.config");
+                yield return tryNugetConfig;
+                currentSearchDirectory = currentSearchDirectory.Value.GetParentPathNullable();
+            }
+        }
+
+        private static bool ExcludeOtherFeeds(FilePath nugetConfig, MockFeed f)
         {
             return f.Type == MockFeedType.ImplicitAdditionalFeed
-                   || (f.Type == MockFeedType.ExplicitNugetConfig && f.Uri == nugetConfig.Value.Value);
+                   || (f.Type == MockFeedType.ExplicitNugetConfig && f.Uri == nugetConfig.Value);
         }
     }
 }

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ToolPackageInstallerMock.cs
@@ -128,7 +128,11 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
             var executable = packageDirectory.WithFile("exe");
             _fileSystem.File.CreateEmptyFile(executable.Value);
 
-            MockFeedPackage package = _projectRestorer.GetPackage(packageId.ToString(), versionRange, packageLocation.NugetConfig);
+            MockFeedPackage package = _projectRestorer.GetPackage(
+                packageId.ToString(),
+                versionRange,
+                packageLocation.NugetConfig,
+                packageLocation.RootConfigDirectory);
 
             return new TestToolPackage
             {

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/NuGetConfig.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/NuGetConfig.cs
@@ -23,8 +23,15 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
             File.WriteAllText(path, contents);
         }
-        
+
         public static void Write(string directory, string configname, string localFeedPath)
+        {
+            var path = Path.Combine(directory, configname);
+
+            File.WriteAllText(path, Format(localFeedPath));
+        }
+
+        public static string Format(string localFeedPath)
         {
             const string template = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
@@ -36,10 +43,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 <add key=""dotnet-core"" value=""https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"" />
 </packageSources>
 </configuration>";
-
-            var path = Path.Combine(directory, configname);
-
-            File.WriteAllText(path, string.Format(template, localFeedPath));
+            return string.Format(template, localFeedPath);
         }
     }
 }

--- a/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
@@ -120,9 +120,11 @@ namespace Microsoft.DotNet.Tests.Commands
                 new MockManifestFileFinder(new[]
                 {
                     new ToolManifestPackage(_packageIdA, _packageVersionA,
-                        new[] {_toolCommandNameA}),
+                        new[] {_toolCommandNameA},
+                        new DirectoryPath(_temporaryDirectory)),
                     new ToolManifestPackage(_packageIdB, _packageVersionB,
-                        new[] {_toolCommandNameB})
+                        new[] {_toolCommandNameB},
+                        new DirectoryPath(_temporaryDirectory))
                 });
 
             ToolRestoreCommand toolRestoreCommand = new ToolRestoreCommand(_appliedCommand,
@@ -157,9 +159,11 @@ namespace Microsoft.DotNet.Tests.Commands
                 new MockManifestFileFinder(new[]
                 {
                     new ToolManifestPackage(_packageIdA, _packageVersionA,
-                        new[] {_toolCommandNameA}),
+                        new[] {_toolCommandNameA},
+                        new DirectoryPath(_temporaryDirectory)),
                     new ToolManifestPackage(_packageIdB, _packageVersionB,
-                        new[] {_toolCommandNameB})
+                        new[] {_toolCommandNameB},
+                        new DirectoryPath(_temporaryDirectory))
                 });
 
             ToolRestoreCommand toolRestoreCommand = new ToolRestoreCommand(_appliedCommand,
@@ -192,9 +196,11 @@ namespace Microsoft.DotNet.Tests.Commands
                 new MockManifestFileFinder(new[]
                 {
                     new ToolManifestPackage(_packageIdA, _packageVersionA,
-                        new[] {_toolCommandNameA}),
+                        new[] {_toolCommandNameA},
+                        new DirectoryPath(_temporaryDirectory)),
                     new ToolManifestPackage(_packageIdWithCommandNameCollisionWithA,
-                        _packageVersionWithCommandNameCollisionWithA, new[] {_toolCommandNameA})
+                        _packageVersionWithCommandNameCollisionWithA, new[] {_toolCommandNameA},
+                        new DirectoryPath(_temporaryDirectory))
                 });
 
             ToolRestoreCommand toolRestoreCommand = new ToolRestoreCommand(_appliedCommand,
@@ -228,9 +234,11 @@ namespace Microsoft.DotNet.Tests.Commands
                 new MockManifestFileFinder(new[]
                 {
                     new ToolManifestPackage(_packageIdA, _packageVersionA,
-                        new[] {_toolCommandNameA}),
+                        new[] {_toolCommandNameA},
+                        new DirectoryPath(_temporaryDirectory)),
                     new ToolManifestPackage(new PackageId("non-exists"), NuGetVersion.Parse("1.0.0"),
-                        new[] {new ToolCommandName("non-exists"),})
+                        new[] {new ToolCommandName("non-exists")},
+                        new DirectoryPath(_temporaryDirectory))
                 });
 
             ToolRestoreCommand toolRestoreCommand = new ToolRestoreCommand(_appliedCommand,
@@ -271,7 +279,8 @@ namespace Microsoft.DotNet.Tests.Commands
                 new MockManifestFileFinder(new[]
                 {
                     new ToolManifestPackage(_packageIdA, _packageVersionA,
-                        new[] {differentCommandNameA, differentCommandNameB}),
+                        new[] {differentCommandNameA, differentCommandNameB},
+                        new DirectoryPath(_temporaryDirectory)),
                 });
 
             ToolRestoreCommand toolRestoreCommand = new ToolRestoreCommand(_appliedCommand,
@@ -322,7 +331,8 @@ namespace Microsoft.DotNet.Tests.Commands
                 new MockManifestFileFinder(new[]
                 {
                     new ToolManifestPackage(_packageIdA, _packageVersionA,
-                        new[] {_toolCommandNameA})
+                        new[] {_toolCommandNameA},
+                        new DirectoryPath(_temporaryDirectory))
                 });
 
             ToolRestoreCommand toolRestoreCommand = new ToolRestoreCommand(_appliedCommand,
@@ -350,7 +360,8 @@ namespace Microsoft.DotNet.Tests.Commands
                 new MockManifestFileFinder(new[]
                 {
                     new ToolManifestPackage(_packageIdA, _packageVersionA,
-                        new[] {_toolCommandNameA})
+                        new[] {_toolCommandNameA},
+                        new DirectoryPath(_temporaryDirectory))
                 });
 
             ToolRestoreCommand toolRestoreCommand = new ToolRestoreCommand(_appliedCommand,

--- a/test/dotnet.Tests/CommandTests/ToolRestoreCommandWithMultipleNugetConfigTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolRestoreCommandWithMultipleNugetConfigTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Microsoft.DotNet.Cli;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ToolManifest;
+using Microsoft.DotNet.ToolPackage;
+using Microsoft.DotNet.Tools.Test.Utilities;
+using Microsoft.DotNet.Tools.Tests.ComponentMocks;
+using Microsoft.DotNet.Tools.Tool.Restore;
+using Microsoft.Extensions.DependencyModel.Tests;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using Microsoft.TemplateEngine.Cli;
+using NuGet.Frameworks;
+using NuGet.Versioning;
+using Xunit;
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.Tests.Commands
+{
+    public class ToolRestoreCommandWithMultipleNugetConfigTests
+    {
+        private readonly IFileSystem _fileSystem;
+        private ToolPackageInstallerMock _toolPackageInstallerMock;
+        private readonly AppliedOption _appliedCommand;
+        private readonly ParseResult _parseResult;
+        private readonly BufferedReporter _reporter;
+        private readonly ILocalToolsResolverCache _localToolsResolverCache;
+
+        private readonly PackageId _packageIdA = new PackageId("local.tool.console.a");
+        private readonly NuGetVersion _packageVersionA;
+        private readonly ToolCommandName _toolCommandNameA = new ToolCommandName("a");
+        private readonly PackageId _packageIdB = new PackageId("local.tool.console.B");
+        private readonly NuGetVersion _packageVersionB;
+        private readonly ToolCommandName _toolCommandNameB = new ToolCommandName("b");
+
+        private readonly DirectoryPath _nugetGlobalPackagesFolder;
+        private string _nugetConfigUnderTestRoot;
+        private string _nugetConfigUnderSubDir;
+
+        public ToolRestoreCommandWithMultipleNugetConfigTests()
+        {
+            _packageVersionA = NuGetVersion.Parse("1.0.4");
+            _packageVersionB = NuGetVersion.Parse("1.0.4");
+
+            _reporter = new BufferedReporter();
+            _fileSystem = new FileSystemMockBuilder().UseCurrentSystemTemporaryDirectory().Build();
+            _nugetGlobalPackagesFolder = new DirectoryPath(NuGetGlobalPackagesFolder.GetLocation());
+            string temporaryDirectory = _fileSystem.Directory.CreateTemporaryDirectory().DirectoryPath;
+
+            string pathToPlacePackages = Path.Combine(temporaryDirectory, "pathToPlacePackage");
+            ToolPackageStoreMock toolPackageStoreMock =
+                new ToolPackageStoreMock(new DirectoryPath(pathToPlacePackages), _fileSystem);
+
+            SetupFileLayoutAndFeed(temporaryDirectory, toolPackageStoreMock);
+
+            ParseResult result = Parser.Instance.Parse("dotnet tool restore");
+            _appliedCommand = result["dotnet"]["tool"]["restore"];
+            Cli.CommandLine.Parser parser = Parser.Instance;
+            _parseResult = parser.ParseFrom("dotnet tool", new[] {"restore"});
+
+            _localToolsResolverCache
+                = new LocalToolsResolverCache(
+                    _fileSystem,
+                    new DirectoryPath(Path.Combine(temporaryDirectory, "cache")),
+                    1);
+        }
+
+        private void SetupFileLayoutAndFeed(string temporaryDirectory, ToolPackageStoreMock toolPackageStoreMock)
+        {
+            var testRoot = Path.Combine(temporaryDirectory, "testRoot");
+            _fileSystem.Directory.CreateDirectory(testRoot);
+            _nugetConfigUnderTestRoot = Path.Combine(testRoot, "nuget.config");
+            _fileSystem.File.CreateEmptyFile(_nugetConfigUnderTestRoot);
+            var subDir = Path.Combine(testRoot, "sub");
+            _fileSystem.Directory.CreateDirectory(subDir);
+            _nugetConfigUnderSubDir = Path.Combine(subDir, "nuget.config");
+            _fileSystem.File.CreateEmptyFile(_nugetConfigUnderSubDir);
+
+            _toolPackageInstallerMock = new ToolPackageInstallerMock(
+                _fileSystem,
+                toolPackageStoreMock,
+                new ProjectRestorerMock(
+                    _fileSystem,
+                    _reporter,
+                    new[]
+                    {
+                        new MockFeed
+                        {
+                            Type = MockFeedType.FeedFromLookUpNugetConfig,
+                            Uri = _nugetConfigUnderTestRoot,
+                            Packages = new List<MockFeedPackage>
+                            {
+                                new MockFeedPackage
+                                {
+                                    PackageId = _packageIdA.ToString(),
+                                    Version = _packageVersionA.ToNormalizedString(),
+                                    ToolCommandName = _toolCommandNameA.ToString()
+                                },
+                            }
+                        },
+
+                        new MockFeed
+                        {
+                            Type = MockFeedType.FeedFromLookUpNugetConfig,
+                            Uri = _nugetConfigUnderSubDir,
+                            Packages = new List<MockFeedPackage>
+                            {
+                                new MockFeedPackage
+                                {
+                                    PackageId = _packageIdB.ToString(),
+                                    Version = _packageVersionB.ToNormalizedString(),
+                                    ToolCommandName = _toolCommandNameB.ToString()
+                                },
+                            }
+                        }
+                    }));
+        }
+
+        [Fact]
+        public void WhenManifestPackageAreFromDifferentDirectoryItCanFindTheRightNugetConfigAndSaveToCache()
+        {
+            IToolManifestFinder manifestFileFinder =
+                new MockManifestFileFinder(new[]
+                {
+                    new ToolManifestPackage(_packageIdA, _packageVersionA,
+                        new[] {_toolCommandNameA},
+                        new DirectoryPath(Path.GetDirectoryName(_nugetConfigUnderTestRoot))),
+                    new ToolManifestPackage(_packageIdB, _packageVersionB,
+                        new[] {_toolCommandNameB},
+                        new DirectoryPath(Path.GetDirectoryName(_nugetConfigUnderSubDir)))
+                });
+
+            ToolRestoreCommand toolRestoreCommand = new ToolRestoreCommand(_appliedCommand,
+                _parseResult,
+                _toolPackageInstallerMock,
+                manifestFileFinder,
+                _localToolsResolverCache,
+                _fileSystem,
+                _nugetGlobalPackagesFolder,
+                _reporter
+            );
+
+            toolRestoreCommand.Execute().Should()
+                .Be(0, "if nuget prob from sub dir, it will find only the nuget.config under sub dir. " +
+                       "And it does not have the feed to package A. However, since package A is set in " +
+                       "manifest file under repository root, nuget should prob from manifest file directory " +
+                       "and there is another nuget.config set beside the manifest file under repository root");
+
+            _localToolsResolverCache.TryLoad(
+                    new RestoredCommandIdentifier(
+                        _packageIdA,
+                        _packageVersionA,
+                        NuGetFramework.Parse(BundledTargetFramework.GetTargetFrameworkMoniker()),
+                        Constants.AnyRid,
+                        _toolCommandNameA), _nugetGlobalPackagesFolder, out RestoredCommand _)
+                .Should().BeTrue();
+
+            _localToolsResolverCache.TryLoad(
+                    new RestoredCommandIdentifier(
+                        _packageIdB,
+                        _packageVersionB,
+                        NuGetFramework.Parse(BundledTargetFramework.GetTargetFrameworkMoniker()),
+                        Constants.AnyRid,
+                        _toolCommandNameB), _nugetGlobalPackagesFolder, out RestoredCommand _)
+                .Should().BeTrue();
+        }
+
+        private class MockManifestFileFinder : IToolManifestFinder
+        {
+            private readonly IReadOnlyCollection<ToolManifestPackage> _toReturn;
+
+            public MockManifestFileFinder(IReadOnlyCollection<ToolManifestPackage> toReturn)
+            {
+                _toReturn = toReturn;
+            }
+
+            public IReadOnlyCollection<ToolManifestPackage> Find(FilePath? filePath = null)
+            {
+                return _toReturn;
+            }
+        }
+    }
+}

--- a/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Tests.Commands
             {
                 new MockFeed
                 {
-                    Type = MockFeedType.FeedFromLookUpNugetConfig,
+                    Type = MockFeedType.FeedFromGlobalNugetConfig,
                     Packages = new List<MockFeedPackage>
                     {
                         new MockFeedPackage

--- a/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUpdateCommandTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.DotNet.Tests.Commands
         }
 
         [Fact]
-        public void GivenANonExistentPackageItErrors()
+        public void GivenANonFeedExistentPackageItErrors()
         {
             var packageId = "does.not.exist";
             var command = CreateUpdateCommand($"-g {packageId}");
@@ -78,9 +78,18 @@ namespace Microsoft.DotNet.Tests.Commands
 
             a.ShouldThrow<GracefulException>().And.Message
                 .Should().Contain(
-                    string.Format(
-                        LocalizableStrings.ToolNotInstalled,
-                        packageId));
+                   Tools.Tool.Install.LocalizableStrings.ToolInstallationRestoreFailed);
+        }
+
+        [Fact]
+        public void GivenANonExistentPackageItInstallTheLatest()
+        {
+            var command = CreateUpdateCommand($"-g {_packageId}");
+
+            command.Execute();
+
+            _store.EnumeratePackageVersions(_packageId).Single().Version.ToFullString().Should()
+                .Be(HigherPackageVersion);
         }
 
         [Fact]


### PR DESCRIPTION
The production change is rather small. However, nuget prob nuget config
and CLI prob manifest file is quite complex problem logic and it is even
worse when 2 are combined. The bug caused by it would be very nasty, as
in the test’s scenario. So, I added infrastructure to simulate this situation.
