### PR TITLE
Bump Microsoft.NET.Sdk package to 3.0.100-preview.18554.1.

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -24,7 +24,7 @@
     <MicrosoftNETCoreCompilersPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNETCoreCompilersPackageVersion>
     <MicrosoftCodeAnalysisBuildTasksPackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftCodeAnalysisBuildTasksPackageVersion>
     <MicrosoftNetCompilersNetcorePackageVersion>$(MicrosoftCodeAnalysisCSharpPackageVersion)</MicrosoftNetCompilersNetcorePackageVersion>
-    <MicrosoftNETSdkPackageVersion>3.0.100-preview1-63312-01</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>3.0.100-preview.18554.1</MicrosoftNETSdkPackageVersion>
     <MicrosoftNETBuildExtensionsPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftNETBuildExtensionsPackageVersion>
     <MicrosoftNETSdkRazorPackageVersion>2.2.0-preview3-35364</MicrosoftNETSdkRazorPackageVersion>
     <MicrosoftNETSdkWebPackageVersion>2.2.100-preview3-20181013-2115910</MicrosoftNETSdkWebPackageVersion>

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -205,8 +205,16 @@ namespace Microsoft.DotNet.Tools.Run
 
             CommandSpec commandSpec = new CommandSpec(runProgram, runArguments);
 
-            return CommandFactoryUsingResolver.Create(commandSpec)
+            var command = CommandFactoryUsingResolver.Create(commandSpec)
                 .WorkingDirectory(runWorkingDirectory);
+
+            var rootVariableName = Environment.Is64BitProcess ? "DOTNET_ROOT" : "DOTNET_ROOT(x86)";
+            if (Environment.GetEnvironmentVariable(rootVariableName) == null)
+            {
+                command.EnvironmentVariable(rootVariableName, Path.GetDirectoryName(new Muxer().MuxerPath));
+            }
+
+            return command;
         }
 
         private void ThrowUnableToRunError(ProjectInstance project)

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -7,6 +7,7 @@
     <AssemblyOriginatorKeyFile>../../tools/Key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -151,6 +151,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
             var outputDirectory = PublishApp(testAppName, rid: null, args: args);
 
             outputDirectory.Should().OnlyHaveFiles(new[] {
+                $"{testAppName}{Constants.ExeSuffix}",
                 $"{testAppName}.dll",
                 $"{testAppName}.pdb",
                 $"{testAppName}.deps.json",

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -650,12 +650,16 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         {
             var testInstance = TestAssets.Get("AppOutputsExecutablePath").CreateInstance().WithSourceFiles();
 
-            var result = new RunCommand()
-                .WithWorkingDirectory(testInstance.Root.FullName)
-                .ExecuteWithCapturedOutput();
+            var command = new RunCommand()
+                .WithWorkingDirectory(testInstance.Root.FullName);
 
-            result.Should().Pass()
-                .And.HaveStdOutContaining($"dotnet{Constants.ExeSuffix}");
+            command.Environment["UseAppHost"] = "false";
+
+            command.ExecuteWithCapturedOutput()
+                   .Should()
+                   .Pass()
+                   .And
+                   .HaveStdOutContaining($"dotnet{Constants.ExeSuffix}");
         }
 
         [Fact]
@@ -665,7 +669,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 
             var result = new RunCommand()
                 .WithWorkingDirectory(testInstance.Root.FullName)
-                .ExecuteWithCapturedOutput($"-r {RuntimeEnvironment.GetRuntimeIdentifier()}");
+                .ExecuteWithCapturedOutput();
 
             result.Should().Pass()
                 .And.HaveStdOutContaining($"AppOutputsExecutablePath{Constants.ExeSuffix}");


### PR DESCRIPTION
Bumping `Microsoft.NET.Sdk` package to `3.0.100-preview.18554.1`.

Other fixes to get CI green with the updated SDK package.