### PR TITLE
Fix the dotnet nuget parsing

### DIFF
--- a/src/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -25,7 +25,8 @@ namespace Microsoft.DotNet.Cli
                     Create.Option("-s|--source", Parser.CompletionOnlyDescription, Accept.ExactlyOneArgument()),
                     Create.Option("--non-interactive", Parser.CompletionOnlyDescription),
                     Create.Option("-k|--api-key", Parser.CompletionOnlyDescription, Accept.ExactlyOneArgument()),
-                    Create.Option("--no-service-endpoint", Parser.CompletionOnlyDescription)),
+                    Create.Option("--no-service-endpoint", Parser.CompletionOnlyDescription),
+                    Create.Option("--interactive", Parser.CompletionOnlyDescription)),
                 Create.Command(
                     "locals",
                     Parser.CompletionOnlyDescription,
@@ -33,6 +34,7 @@ namespace Microsoft.DotNet.Cli
                         "all",
                         "http-cache",
                         "global-packages",
+                        "plugins-cache",
                         "temp"),
                     Create.Option("-h|--help", Parser.CompletionOnlyDescription),
                     Create.Option("--force-english-output", Parser.CompletionOnlyDescription),
@@ -51,6 +53,8 @@ namespace Microsoft.DotNet.Cli
                     Create.Option("-sk|--symbol-api-key", Parser.CompletionOnlyDescription, Accept.ExactlyOneArgument()),
                     Create.Option("-d|--disable-buffering", Parser.CompletionOnlyDescription),
                     Create.Option("-n|--no-symbols", Parser.CompletionOnlyDescription),
-                    Create.Option("--no-service-endpoint", Parser.CompletionOnlyDescription)));
+                    Create.Option("--no-service-endpoint", Parser.CompletionOnlyDescription),
+                    Create.Option("--interactive", Parser.CompletionOnlyDescription)
+                    ));
     }
 }

--- a/test/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -131,9 +131,10 @@ namespace Microsoft.DotNet.Tests.Commands
                 "--no-service-endpoint",
                 "--non-interactive",
                 "--source",
+                "--interactive",
                 "-h",
                 "-k",
-                "-s"
+                "-s",
             };
 
             var reporter = new BufferedReporter();
@@ -155,7 +156,8 @@ namespace Microsoft.DotNet.Tests.Commands
                 "all",
                 "global-packages",
                 "http-cache",
-                "temp"
+                "temp",
+                "plugins-cache"
             };
 
             var reporter = new BufferedReporter();
@@ -166,7 +168,8 @@ namespace Microsoft.DotNet.Tests.Commands
         [Fact]
         public void GivenNuGetPushCommandItDisplaysCompletions()
         {
-            var expected = new string[] {
+            var expected = new string[]
+            {
                 "--api-key",
                 "--disable-buffering",
                 "--force-english-output",
@@ -177,6 +180,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 "--symbol-api-key",
                 "--symbol-source",
                 "--timeout",
+                "--interactive",
                 "-d",
                 "-h",
                 "-k",


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/7519. 

We added support for the --interactive flag in the dotnet nuget commands.
https://github.com/NuGet/NuGet.Client/pull/2414
https://github.com/NuGet/NuGet.Client/pull/2395

We didn't add the parsing logic in CLI. 

It'd be nice if the logic for the parsing was fully deferred to nuget, or at least propagating the arguments that are not understood to make this whole thing more resilient.

//cc @livarcocc @rrelyea 