### PR TITLE
Fix no restore command error message

### DIFF
--- a/src/dotnet/CommandFactory/CommandResolution/LocalToolsCommandResolver.cs
+++ b/src/dotnet/CommandFactory/CommandResolution/LocalToolsCommandResolver.cs
@@ -82,8 +82,11 @@ namespace Microsoft.DotNet.CommandFactory
                     restoredCommand.Executable.Value,
                     arguments.CommandArguments);
             }
-
-            return null;
+            else
+            {
+                throw new GracefulException(string.Format(LocalizableStrings.NeedRunToolRestore,
+                        toolCommandName.ToString()));
+            }
         }
     }
 }

--- a/test/Microsoft.DotNet.CommandFactory.Tests/GivenALocalToolsCommandResolver.cs
+++ b/test/Microsoft.DotNet.CommandFactory.Tests/GivenALocalToolsCommandResolver.cs
@@ -124,6 +124,31 @@ namespace Microsoft.DotNet.Tests
                 toolCommandNameA.ToString()));
         }
 
+        [Fact]
+        public void WhenNuGetGlobalPackageLocationIsNotRestoredItThrowsGracefulException()
+        {
+            ToolCommandName toolCommandNameA = new ToolCommandName("a");
+            NuGetVersion packageVersionA = NuGetVersion.Parse("1.0.4");
+            _fileSystem.File.WriteAllText(Path.Combine(_testDirectoryRoot, ManifestFilename),
+                _jsonContent.Replace("$TOOLCOMMAND$", toolCommandNameA.Value));
+            ToolManifestFinder toolManifest =
+                new ToolManifestFinder(new DirectoryPath(_testDirectoryRoot), _fileSystem);
+
+            var localToolsCommandResolver = new LocalToolsCommandResolver(
+                toolManifest,
+                _localToolsResolverCache,
+                _fileSystem,
+                _nugetGlobalPackagesFolder);
+
+            Action action = () => localToolsCommandResolver.Resolve(new CommandResolverArguments()
+            {
+                CommandName = $"dotnet-{toolCommandNameA.ToString()}",
+            });
+
+            action.ShouldThrow<GracefulException>(string.Format(CommandFactory.LocalizableStrings.NeedRunToolRestore,
+                toolCommandNameA.ToString()));
+        }
+
         private string _jsonContent =
             @"{
    ""version"":1,


### PR DESCRIPTION
It should show _Run "dotnet tool restore" to make the "dotnetsay" command available._ instead of _Cannot find a command with command name 'dotnetsay'_ when there is no restore.

Root cause, a case forget to test