### PR TITLE
Update implicit package default versions to final 2.2.0

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -161,7 +161,7 @@
                                LatestVersion="2.1.6" />
       <ImplicitPackageVariable Include="Microsoft.NETCore.App"
                                TargetFrameworkVersion="2.2"
-                               DefaultVersion="$(_NETCoreAppPackageVersion)"
+                               DefaultVersion="2.2.0"
                                LatestVersion="$(_NETCoreAppPackageVersion)" />
       
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.App"
@@ -174,11 +174,11 @@
                                LatestVersion="2.1.6"/>
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.App"
                                TargetFrameworkVersion="2.2"
-                               DefaultVersion="$(_AspNetCoreAppPackageVersion)"
+                               DefaultVersion="2.2.0"
                                LatestVersion="$(_AspNetCoreAppPackageVersion)"/>
       <ImplicitPackageVariable Include="Microsoft.AspNetCore.All"
                                TargetFrameworkVersion="2.2"
-                               DefaultVersion="$(_AspNetCoreAllPackageVersion)"
+                               DefaultVersion="2.2.0"
                                LatestVersion="$(_AspNetCoreAllPackageVersion)"/>
     </ItemGroup>
     


### PR DESCRIPTION
This should stop framework-dependent apps from rolling forward to 2.2.x patches (once those are available).