### PR TITLE
Remove test for scenario which is better covered elsewhere

### DIFF
--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -73,59 +73,5 @@ namespace Microsoft.DotNet.New.Tests
                 .Execute($"--configfile {configFile} --packages {packagesDirectory}")
                 .Should().Pass();
         }
-
-        // Remove the expectedVersion parameter once we have templates targetting netcoreapp2.2.
-        [Theory]
-        [InlineData("console", "microsoft.netcore.app", null)]
-        [InlineData("classlib", "netstandard.library", "2.0.3")] // FIXME: This is pinned to 2.0.3 due to https://github.com/dotnet/sdk/issues/2410
-        public void NewProjectRestoresCorrectPackageVersion(string type, string packageName, string expectedVersion)
-        {
-            var rootPath = TestAssets.CreateTestDirectory(identifier: $"_{type}").FullName;
-            var packagesDirectory = Path.Combine(rootPath, "packages");
-            var projectName = "Project";
-            expectedVersion = expectedVersion ?? GetFrameworkPackageVersion();
-
-            var repoRootNuGetConfig = Path.Combine(RepoDirectoriesProvider.RepoRoot, "NuGet.Config");
-
-            new NewCommand()
-                .WithWorkingDirectory(rootPath)
-                .Execute($"{type} --name {projectName} -o . --debug:ephemeral-hive --no-restore")
-                .Should().Pass();
-
-            new RestoreCommand()
-                .WithWorkingDirectory(rootPath)
-                .Execute($"--configfile {repoRootNuGetConfig} --packages {packagesDirectory}")
-                .Should().Pass();
-
-            new DirectoryInfo(Path.Combine(packagesDirectory, packageName))
-                .Should().Exist()
-                .And.HaveDirectory(expectedVersion);
-
-            string GetFrameworkPackageVersion()
-            {
-                var dotnetDir = new FileInfo(DotnetUnderTest.FullName).Directory;
-                var sharedFxDir = dotnetDir
-                    .GetDirectory("shared", "Microsoft.NETCore.App")
-                    .EnumerateDirectories()
-                    .Single(d => d.Name.StartsWith("2.2."));
-
-                if (packageName == "microsoft.netcore.app")
-                {
-                    return sharedFxDir.Name;
-                }
-
-                var depsFile = Path.Combine(sharedFxDir.FullName, "Microsoft.NETCore.App.deps.json");
-                using (var stream = File.OpenRead(depsFile))
-                using (var reader = new DependencyContextJsonReader())
-                {
-                    var context = reader.Read(stream);
-                    var dependency = context
-                        .RuntimeLibraries
-                        .Single(library => string.Equals(library.Name, packageName, StringComparison.OrdinalIgnoreCase));
-
-                    return dependency.Version;
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
The GivenFrameworkDependentApps and GivenSelfContainedAppsRollForward tests do a better job of covering this scenario