### PR TITLE
Improve --roll-forward-on-no-candidate-fx usage text.

### DIFF
--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -9,10 +9,10 @@ $@"{LocalizableStrings.Usage}: dotnet [runtime-options] [path-to-application] [a
 {LocalizableStrings.ExecutionUsageDescription}
 
 runtime-options:
-  --additionalprobingpath <path>     {LocalizableStrings.AdditionalprobingpathDefinition}
-  --additional-deps <path>           {LocalizableStrings.AdditionalDeps}
-  --fx-version <version>             {LocalizableStrings.FxVersionDefinition}
-  --roll-forward-on-no-candidate-fx  {LocalizableStrings.RollForwardOnNoCandidateFxDefinition}
+  --additionalprobingpath <path>         {LocalizableStrings.AdditionalprobingpathDefinition}
+  --additional-deps <path>               {LocalizableStrings.AdditionalDeps}
+  --fx-version <version>                 {LocalizableStrings.FxVersionDefinition}
+  --roll-forward-on-no-candidate-fx <n>  {LocalizableStrings.RollForwardOnNoCandidateFxDefinition}
 
 path-to-application:
   {LocalizableStrings.PathToApplicationDefinition}

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -265,7 +265,7 @@
     <value>Version of the installed Shared Framework to use to run the application.</value>
   </data>
   <data name="RollForwardOnNoCandidateFxDefinition" xml:space="preserve">
-    <value>Roll forward on no candidate shared framework is enabled.</value>
+    <value>Set roll forward on no candidate shared framework behavior.</value>
   </data>
   <data name="AdditionalDeps" xml:space="preserve">
     <value>Path to additional deps.json file.</value>

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -265,7 +265,7 @@
     <value>Version of the installed Shared Framework to use to run the application.</value>
   </data>
   <data name="RollForwardOnNoCandidateFxDefinition" xml:space="preserve">
-    <value>Set roll forward on no candidate shared framework behavior.</value>
+    <value>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</value>
   </data>
   <data name="AdditionalDeps" xml:space="preserve">
     <value>Path to additional deps.json file.</value>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">Posune se vpřed, pokud není povolený žádný kandidát sdílené architektury.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">Posune se vpřed, pokud není povolený žádný kandidát sdílené architektury.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">Posune se vpřed, pokud není povolený žádný kandidát sdílené architektury.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">Rollforward für freigegebenes Framework ohne Kandidaten ist aktiviert.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">Rollforward für freigegebenes Framework ohne Kandidaten ist aktiviert.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">Rollforward für freigegebenes Framework ohne Kandidaten ist aktiviert.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">Puesta al día activada, no hay ninguna instancia de Shared Framework habilitada.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">Puesta al día activada, no hay ninguna instancia de Shared Framework habilitada.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">Puesta al día activada, no hay ninguna instancia de Shared Framework habilitada.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">Effectuez une restauration par progression si aucun framework partagé candidat n'est activé.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">Effectuez une restauration par progression si aucun framework partagé candidat n'est activé.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">Effectuez une restauration par progression si aucun framework partagé candidat n'est activé.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">Esegue il roll forward nel caso in cui non è abilitata nessuna versione candidata di Shared Framework.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">Esegue il roll forward nel caso in cui non è abilitata nessuna versione candidata di Shared Framework.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">Esegue il roll forward nel caso in cui non è abilitata nessuna versione candidata di Shared Framework.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">候補がない Shared Framework に対するロールフォワードが有効です。</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">候補がない Shared Framework に対するロールフォワードが有効です。</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">候補がない Shared Framework に対するロールフォワードが有効です。</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">사용되지 않는 후보 공유 프레임워크에 대해 롤포워드합니다.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">사용되지 않는 후보 공유 프레임워크에 대해 롤포워드합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">사용되지 않는 후보 공유 프레임워크에 대해 롤포워드합니다.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">Nie przenoś do przodu w czasie dla żadnego kandydata, dla którego jest włączona platforma współużytkowana.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">Nie przenoś do przodu w czasie dla żadnego kandydata, dla którego jest włączona platforma współużytkowana.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">Nie przenoś do przodu w czasie dla żadnego kandydata, dla którego jest włączona platforma współużytkowana.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">Avançar quando nenhuma estrutura compartilhada candidata estiver habilitada.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">Avançar quando nenhuma estrutura compartilhada candidata estiver habilitada.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">Avançar quando nenhuma estrutura compartilhada candidata estiver habilitada.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">Если потенциальная общая платформа не включена, выполняется накат.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">Если потенциальная общая платформа не включена, выполняется накат.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">Если потенциальная общая платформа не включена, выполняется накат.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">Aday paylaşılan çerçevelerin hiçbirinde ileri sarma etkin değil.</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">Aday paylaşılan çerçevelerin hiçbirinde ileri sarma etkin değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">Aday paylaşılan çerçevelerin hiçbirinde ileri sarma etkin değil.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">已启用“不前滚到候选共享框架”。</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">已启用“不前滚到候选共享框架”。</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">已启用“不前滚到候选共享框架”。</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -233,8 +233,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Roll forward on no candidate shared framework is enabled.</source>
-        <target state="translated">已啟用在沒有候選共用架構上的向前復原。</target>
+        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <target state="needs-review-translation">已啟用在沒有候選共用架構上的向前復原。</target>
         <note />
       </trans-unit>
       <trans-unit id="AdditionalDeps">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -233,7 +233,7 @@
         <note />
       </trans-unit>
       <trans-unit id="RollForwardOnNoCandidateFxDefinition">
-        <source>Set roll forward on no candidate shared framework behavior.</source>
+        <source>Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major &amp; minor).</source>
         <target state="needs-review-translation">已啟用在沒有候選共用架構上的向前復原。</target>
         <note />
       </trans-unit>

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -19,10 +19,10 @@ namespace Microsoft.DotNet.Help.Tests
 Execute a .NET Core application.
 
 runtime-options:
-  --additionalprobingpath <path>     Path containing probing policy and assemblies to probe for.
-  --additional-deps <path>           Path to additional deps.json file.
-  --fx-version <version>             Version of the installed Shared Framework to use to run the application.
-  --roll-forward-on-no-candidate-fx  Roll forward on no candidate shared framework is enabled.
+  --additionalprobingpath <path>         Path containing probing policy and assemblies to probe for.
+  --additional-deps <path>               Path to additional deps.json file.
+  --fx-version <version>                 Version of the installed Shared Framework to use to run the application.
+  --roll-forward-on-no-candidate-fx <n>  Set roll forward on no candidate shared framework behavior.
 
 path-to-application:
   The path to an application .dll file to execute.

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -22,7 +22,7 @@ runtime-options:
   --additionalprobingpath <path>         Path containing probing policy and assemblies to probe for.
   --additional-deps <path>               Path to additional deps.json file.
   --fx-version <version>                 Version of the installed Shared Framework to use to run the application.
-  --roll-forward-on-no-candidate-fx <n>  Set roll forward on no candidate shared framework behavior.
+  --roll-forward-on-no-candidate-fx <n>  Roll forward on no candidate framework (0=off, 1=roll minor, 2=roll major & minor).
 
 path-to-application:
   The path to an application .dll file to execute.


### PR DESCRIPTION
Make it explicit that the --roll-forward-on-no-candidate-fx options requires a value. Modify the description since the argument sets the behavior (it doesn't just enable it, it can also disable and so on).

Related to dotnet/core-setup#4873