### PR TITLE
Improve Ctrl-C experience for `dotnet run`.

### DIFF
--- a/TestAssets/TestProjects/TestAppThatWaits/Program.cs
+++ b/TestAssets/TestProjects/TestAppThatWaits/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace TestAppThatWaits
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.CancelKeyPress += HandleCancelKeyPress;
+            Console.WriteLine(Process.GetCurrentProcess().Id);
+            Console.Out.Flush();
+            Console.Read();
+            Thread.Sleep(10000);
+        }
+
+        static void HandleCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        {
+            Console.WriteLine("Interrupted!");
+            Environment.Exit(42);
+        }
+    }
+}

--- a/TestAssets/TestProjects/TestAppThatWaits/TestAppThatWaits.csproj
+++ b/TestAssets/TestProjects/TestAppThatWaits/TestAppThatWaits.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -28,7 +29,6 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public CommandResult Execute()
         {
-
             Reporter.Verbose.WriteLine(string.Format(
                 LocalizableStrings.RunningFileNameArguments,
                 _process.StartInfo.FileName,
@@ -39,6 +39,8 @@ namespace Microsoft.DotNet.Cli.Utils
             _running = true;
 
             _process.EnableRaisingEvents = true;
+
+            Console.CancelKeyPress += HandleCancelKeyPress;
 
 #if DEBUG
             var sw = Stopwatch.StartNew();
@@ -60,6 +62,8 @@ namespace Microsoft.DotNet.Cli.Utils
                 taskOut?.Wait();
                 taskErr?.Wait();
             }
+
+            Console.CancelKeyPress -= HandleCancelKeyPress;
 
             var exitCode = _process.ExitCode;
 
@@ -210,6 +214,12 @@ namespace Microsoft.DotNet.Cli.Utils
                     LocalizableStrings.UnableToInvokeMemberNameAfterCommand,
                     memberName));
             }
+        }
+
+        private void HandleCancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        {
+            // Ignore SIGINT/SIGQUIT so that the child can process the signal
+            e.Cancel = true;
         }
     }
 }

--- a/test/dotnet-run.Tests/GivenDotnetRunIsInterrupted.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunIsInterrupted.cs
@@ -1,0 +1,60 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Test.Utilities;
+
+namespace Microsoft.DotNet.Cli.Run.Tests
+{
+    public class GivenDotnetRunIsInterrupted : TestBase
+    {
+        // This test is Unix only for the same reason that CoreFX does not test Console.CancelKeyPress on Windows
+        // See https://github.com/dotnet/corefx/blob/a10890f4ffe0fadf090c922578ba0e606ebdd16c/src/System.Console/tests/CancelKeyPress.Unix.cs#L63-L67
+        [UnixOnlyFact]
+        public void ItIgnoresSIGINT()
+        {
+            var asset = TestAssets.Get("TestAppThatWaits")
+                .CreateInstance()
+                .WithSourceFiles();
+
+            var command = new RunCommand()
+                .WithWorkingDirectory(asset.Root.FullName);
+
+            bool killed = false;
+            command.OutputDataReceived += (s, e) =>
+            {
+                if (killed)
+                {
+                    return;
+                }
+
+                // Simulate a SIGINT sent to a process group (i.e. both `dotnet run` and `TestAppThatWaits`).
+                // Ideally we would send SIGINT to an actual process group, but the new child process (i.e. `dotnet run`)
+                // will inherit the current process group from the `dotnet test` process that is running this test.
+                // We would need to fork(), setpgid(), and then execve() to break out of the current group and that is
+                // too complex for a simple unit test.
+                kill(command.CurrentProcess.Id, SIGINT).Should().Be(0); // dotnet run
+                kill(Convert.ToInt32(e.Data), SIGINT).Should().Be(0);   // TestAppThatWaits
+
+                killed = true;
+            };
+
+            command
+                .ExecuteWithCapturedOutput()
+                .Should()
+                .ExitWith(42)
+                .And
+                .HaveStdOutContaining("Interrupted!");
+
+            killed.Should().BeTrue();
+        }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int kill(int pid, int sig);
+
+        private const int SIGINT = 2;
+    }
+}


### PR DESCRIPTION
This commit improves the handling of the SIGINT signal from `dotnet run`.

The current behavior of `dotnet run` is to use the default handler for the
SIGINT signal.  This results in the termination of the `dotnet run` process
with an exit status of 130 on POSIX systems and 0xC000013A on Windows.  This
prevents a child process to gracefully handle SIGINT by returning a zero exit
code or from ignoring the signal entirely and letting the process appear to
continue to run.

Additionally, the child process of `dotnet run` may still be writing to stdout
during the handling of SIGINT.  Because `dotnet run` may terminate before the
child process does, a waiting parent of `dotnet run`, such as a shell, may
proceed to print out a new prompt to the user while the child continues to
write to stdout.  This results in inconsistent and interleaved output in a
terminal and can be a source of confusion to users.

This commit changes `dotnet` to always ignore SIGINT when spawning a child
process.  This allows the child process to handle the signal and decide what to
do with it.  As a result, the UX from when the user program is run directly or
via `dotnet run` is the same regarding SIGINT.

Fixes #812.