### PR TITLE
update NUnit3.DotNetNew.Template dependency version to 1.6.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,7 +44,7 @@
     <MicrosoftNETTestSdkPackageVersion>15.9.0</MicrosoftNETTestSdkPackageVersion>
     <MSTestVersion>1.3.2</MSTestVersion>
     <XUnitVersion>2.3.1</XUnitVersion>
-    <NUnit3TemplatesVersion>1.5.1</NUnit3TemplatesVersion>
+    <NUnit3TemplatesVersion>1.6.1</NUnit3TemplatesVersion>
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</CLI_NETStandardLibraryNETFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Update dotnet-new-nunit dependency version to latest 1.6.1 (requested in https://github.com/nunit/dotnet-new-nunit/issues/21).

Is `master` branch right place for .NET Core 3.0 development?

I didn't found `BundledTemplates.props` and `DependencyVersions.props` files in `master` branch. Where are them now?