### PR TITLE
Add specific guide for no manifest

### DIFF
--- a/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
@@ -223,4 +223,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
   <data name="LocalOptionDoesNotSupportFrameworkOption" xml:space="preserve">
     <value>The local option(--local) does not support the framework option (--framework).</value>
   </data>
+  <data name="NoManifestGuide" xml:space="preserve">
+    <value>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
@@ -224,6 +224,6 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     <value>The local option(--local) does not support the framework option (--framework).</value>
   </data>
   <data name="NoManifestGuide" xml:space="preserve">
-    <value>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</value>
+    <value>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
@@ -104,9 +104,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
 
             try
             {
-                var manifestFile = string.IsNullOrWhiteSpace(_explicitManifestFile)
-                    ? _toolManifestFinder.FindFirst()
-                    : new FilePath(_explicitManifestFile);
+                FilePath manifestFile = GetManifestFilePath();
 
                 IToolPackage toolDownloadedPackage =
                     _toolPackageInstaller.InstallPackageToExternalManagedLocation(
@@ -155,6 +153,25 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                 throw new GracefulException(
                     messages: InstallToolCommandLowLevelErrorConverter.GetUserFacingMessages(ex, _packageId),
                     verboseMessages: new[] {ex.ToString()},
+                    isUserError: false);
+            }
+        }
+
+        private FilePath GetManifestFilePath()
+        {
+            try
+            {
+                return string.IsNullOrWhiteSpace(_explicitManifestFile)
+                    ? _toolManifestFinder.FindFirst()
+                    : new FilePath(_explicitManifestFile);
+            }
+            catch (ToolManifestCannotBeFoundException e)
+            {
+                throw new GracefulException(new[]
+                    {
+                        e.Message,
+                        LocalizableStrings.NoManifestGuide
+                    },
                     isUserError: false);
             }
         }

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -42,8 +42,8 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -41,6 +41,11 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <target state="new">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
+        <target state="new">If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</target>

--- a/src/dotnet/commands/dotnet-tool/restore/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/restore/LocalizableStrings.resx
@@ -182,4 +182,7 @@
   <data name="PackagesCommandNameCollisionForOnePackage" xml:space="preserve">
     <value>A command "{0}" in package "{1}"</value>
   </data>
+  <data name="NoToolsWereRestored" xml:space="preserve">
+    <value>No tools were restored.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -88,6 +88,7 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
             catch (ToolManifestCannotBeFoundException e)
             {
                 _reporter.WriteLine(e.Message.Yellow());
+                _reporter.WriteLine(LocalizableStrings.NoToolsWereRestored.Yellow());
                 return 0;
             }
 

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.cs.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.de.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.es.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.fr.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.it.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ja.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ko.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pl.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ru.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.tr.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -14,6 +14,11 @@
 {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoToolsWereRestored">
+        <source>No tools were restored.</source>
+        <target state="new">No tools were restored.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PackageIdColumn">
         <source>Package Id</source>
         <target state="new">Package Id</target>

--- a/test/dotnet.Tests/CommandTests/ToolInstallLocalCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallLocalCommandTests.cs
@@ -127,6 +127,18 @@ namespace Microsoft.DotNet.Tests.Commands
         }
 
         [Fact]
+        public void GivenNoManifestFileItShouldThrowAndContainNoManifestGuide()
+        {
+            _fileSystem.File.Delete(_manifestFilePath);
+            var toolInstallLocalCommand = GetDefaultTestToolInstallLocalCommand();
+
+            Action a = () => toolInstallLocalCommand.Execute();
+            a.ShouldThrow<GracefulException>()
+                .And.Message.Should()
+                .Contain(LocalizableStrings.NoManifestGuide);
+        }
+
+        [Fact]
         public void WhenRunWithExplicitManifestFileItShouldAddEntryToExplicitManifestFile()
         {
             var explicitManifestFilePath = Path.Combine(_temporaryDirectory, "subdirectory", "dotnet-tools.json");


### PR DESCRIPTION
fix https://github.com/dotnet/cli/issues/10499

Actual message:
```
Cannot find any manifests file. Searched:
/.config/dotnet-tools.json
/dotnet-tools.json
No tools were restored.

Cannot find any manifests file. Searched:
/.config/dotnet-tools.json
/dotnet-tools.json
If you want to install a global tool, add '-g'. If you want to add to a tool manifest, you must first create it with 'dotnet new tool-manifest'.
```