### PR TITLE
Stop capturing test output because it is somehow causing failures in CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,6 +36,8 @@ tools\TestAssetsDependencies\TestAssetsDependencies.csproj
     <EnableSourceControlManagerQueries Condition=" '$(Rid)' == 'rhel.6-x64' ">false</EnableSourceControlManagerQueries>
     <DeterministicSourcePaths Condition=" '$(Rid)' == 'rhel.6-x64' ">false</DeterministicSourcePaths>
     <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
+
+    <TestCaptureOutput>false</TestCaptureOutput>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,6 +37,7 @@ tools\TestAssetsDependencies\TestAssetsDependencies.csproj
     <DeterministicSourcePaths Condition=" '$(Rid)' == 'rhel.6-x64' ">false</DeterministicSourcePaths>
     <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
 
+    <!-- https://github.com/dotnet/cli/issues/10637: frequent CI failures when test output is captured -->
     <TestCaptureOutput>false</TestCaptureOutput>
   </PropertyGroup>
 


### PR DESCRIPTION
There may be a corefx or msbuild bug here, but I need to get CI unblocked. :(
