### PR TITLE
Add --interactive to dotnet run and test

### DIFF
--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.Tools.Run
         public string Project { get; private set; }
         public IEnumerable<string> Args { get; set; }
         public bool NoRestore { get; private set; }
+        public bool Interactive { get; private set; }
         public IEnumerable<string> RestoreArgs { get; private set; }
 
         private bool ShouldBuild => !NoBuild;
@@ -70,6 +71,7 @@ namespace Microsoft.DotNet.Tools.Run
             string launchProfile,
             bool noLaunchProfile,
             bool noRestore,
+            bool interactive,
             IEnumerable<string> restoreArgs,
             IEnumerable<string> args)
         {
@@ -83,6 +85,7 @@ namespace Microsoft.DotNet.Tools.Run
             Args = args;
             RestoreArgs = restoreArgs;
             NoRestore = noRestore;
+            Interactive = interactive;
         }
 
         private bool ApplyLaunchProfileSettingsIfNeeded(ref ICommand targetCommand)
@@ -154,7 +157,8 @@ namespace Microsoft.DotNet.Tools.Run
 
             if (!RestoreArgs.Any(a => a.StartsWith("-verbosity:")))
             {
-                args.Add("-verbosity:quiet");
+                var defaultVerbosity = Interactive ? "minimal" : "quiet";
+                args.Add($"-verbosity:{defaultVerbosity}");
             }
 
             args.AddRange(RestoreArgs);

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -155,6 +155,8 @@ namespace Microsoft.DotNet.Tools.Run
                 "-nologo"
             };
 
+            // --interactive need to output guide for auth. It cannot be
+            // completely "quiet"
             if (!RestoreArgs.Any(a => a.StartsWith("-verbosity:")))
             {
                 var defaultVerbosity = Interactive ? "minimal" : "quiet";

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.Run;
@@ -28,6 +29,7 @@ namespace Microsoft.DotNet.Cli
                         launchProfile: o.SingleArgumentOrDefault("--launch-profile"),
                         noLaunchProfile: o.HasOption("--no-launch-profile"),
                         noRestore: o.HasOption("--no-restore") || o.HasOption("--no-build"),
+                        interactive:o.HasOption(Utils.Constants.RestoreInteractiveOption),
                         restoreArgs: o.OptionValuesToBeForwarded(),
                         args: o.Arguments
                     )),
@@ -53,6 +55,7 @@ namespace Microsoft.DotNet.Cli
                         "--no-build",
                         LocalizableStrings.CommandOptionNoBuildDescription,
                         Accept.NoArguments()),
+                    CommonOptions.InteractiveOption(),
                     CommonOptions.NoRestoreOption(),
                     CommonOptions.VerbosityOption()
                 });

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -1,9 +1,6 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Metadata;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.Tools.Run;

--- a/src/dotnet/commands/dotnet-run/RunCommandParser.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommandParser.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Cli
                         launchProfile: o.SingleArgumentOrDefault("--launch-profile"),
                         noLaunchProfile: o.HasOption("--no-launch-profile"),
                         noRestore: o.HasOption("--no-restore") || o.HasOption("--no-build"),
-                        interactive:o.HasOption(Utils.Constants.RestoreInteractiveOption),
+                        interactive: o.HasOption(Utils.Constants.RestoreInteractiveOption),
                         restoreArgs: o.OptionValuesToBeForwarded(),
                         args: o.Arguments
                     )),

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Tools.Test
             var msbuildArgs = new List<string>()
             {
                 "-target:VSTest",
-                $"-verbosity:{DefaultVerbosity(parsedTest)}",
+                $"-verbosity:{GetDefaultVerbosity(parsedTest)}",
                 "-nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
                 "-nologo"
             };
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Tools.Test
                 msbuildPath);
         }
 
-        private static string DefaultVerbosity(AppliedOption options)
+        private static string GetDefaultVerbosity(AppliedOption options)
         {
             var defaultVerbosity = "quiet";
             if (options.HasOption(Constants.RestoreInteractiveOption))

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -28,14 +28,6 @@ namespace Microsoft.DotNet.Tools.Test
 
         public static TestCommand FromArgs(string[] args, string msbuildPath = null)
         {
-            var msbuildArgs = new List<string>()
-            {
-                "-target:VSTest",
-                "-verbosity:quiet",
-                "-nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
-                "-nologo"
-            };
-
             var parser = Parser.Instance;
 
             var result = parser.ParseFrom("dotnet test", args);
@@ -44,6 +36,14 @@ namespace Microsoft.DotNet.Tools.Test
             result.ShowHelpOrErrorIfAppropriate();
 
             var parsedTest = result["dotnet"]["test"];
+
+            var msbuildArgs = new List<string>()
+            {
+                "-target:VSTest",
+                $"-verbosity:{DefaultVerbosity(parsedTest)}",
+                "-nodereuse:false", // workaround for https://github.com/Microsoft/vstest/issues/1503
+                "-nologo"
+            };
 
             msbuildArgs.AddRange(parsedTest.OptionValuesToBeForwarded());
 
@@ -78,6 +78,17 @@ namespace Microsoft.DotNet.Tools.Test
                 parsedTest.Arguments,
                 noRestore,
                 msbuildPath);
+        }
+
+        private static string DefaultVerbosity(AppliedOption parsedTest)
+        {
+            var defaultVerbosity = "quiet";
+            if (parsedTest.HasOption(Constants.RestoreInteractiveOption))
+            {
+                defaultVerbosity = "minimal";
+            }
+
+            return defaultVerbosity;
         }
 
         public static int Run(string[] args)

--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -80,10 +80,10 @@ namespace Microsoft.DotNet.Tools.Test
                 msbuildPath);
         }
 
-        private static string DefaultVerbosity(AppliedOption parsedTest)
+        private static string DefaultVerbosity(AppliedOption options)
         {
             var defaultVerbosity = "quiet";
-            if (parsedTest.HasOption(Constants.RestoreInteractiveOption))
+            if (options.HasOption(Constants.RestoreInteractiveOption))
             {
                 defaultVerbosity = "minimal";
             }

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -92,6 +92,7 @@ namespace Microsoft.DotNet.Cli
                         Accept.NoArguments()
                               .ForwardAsSingle(o => "-property:VSTestBlame=true")),
                   CommonOptions.NoRestoreOption(),
+                  CommonOptions.InteractiveOption(),
                   CommonOptions.VerbosityOption());
 
         private static string GetSemiColonEscapedstring(string arg)

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/ProjectModification.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/ProjectModification.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Xml.Linq;
+
+namespace Microsoft.DotNet.Tools.Test.Utilities
+{
+    public static class ProjectModification
+    {
+        public static void AddDisplayMessageToProject(XDocument project, string beforeTargets)
+        {
+            XNamespace ns = project.Root.Name.Namespace;
+
+            XElement itemGroup = new XElement(ns + "Target", new XAttribute("Name", "DisplayMessages"),
+                new XAttribute("BeforeTargets", beforeTargets));
+            project.Root.Add(itemGroup);
+
+            itemGroup.Add(new XElement(ns + "Message", new XAttribute("Text", "Important text"),
+                new XAttribute("Importance", "high")));
+        }
+
+        public static void AddDisplayMessageBeforeVsTestToProject(XDocument project)
+        {
+            AddDisplayMessageToProject(project, "VSTest");
+        }
+
+        public static void AddDisplayMessageBeforeRestoreToProject(XDocument project)
+        {
+            AddDisplayMessageToProject(project, "Restore");
+        }
+    }
+}

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/ProjectModification.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/ProjectModification.cs
@@ -11,11 +11,11 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         {
             XNamespace ns = project.Root.Name.Namespace;
 
-            XElement itemGroup = new XElement(ns + "Target", new XAttribute("Name", "DisplayMessages"),
+            XElement target = new XElement(ns + "Target", new XAttribute("Name", "DisplayMessages"),
                 new XAttribute("BeforeTargets", beforeTargets));
-            project.Root.Add(itemGroup);
+            project.Root.Add(target);
 
-            itemGroup.Add(new XElement(ns + "Message", new XAttribute("Text", "Important text"),
+            target.Add(new XElement(ns + "Message", new XAttribute("Text", "Important text"),
                 new XAttribute("Importance", "high")));
         }
 

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -647,7 +647,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
-        public void ItDoesNotShowImportantMessageLevelByDefault()
+        public void ItDoesNotShowImportantLevelMessageByDefault()
         {
             var testAppName = "MSBuildTestApp";
             var testInstance = TestAssets.Get(testAppName)
@@ -664,7 +664,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         }
 
         [Fact]
-        public void ItShowImportantMessageLevelWhenPassInteractive()
+        public void ItShowImportantLevelMessageWhenPassInteractive()
         {
             var testAppName = "MSBuildTestApp";
             var testInstance = TestAssets.Get(testAppName)

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.PlatformAbstractions;
@@ -643,6 +644,40 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                 result.Should().HaveStdOutContaining("Restore")
                     .And.HaveStdOutContaining("CoreCompile");
             }
+        }
+
+        [Fact]
+        public void ItDoesNotShowImportantMessageLevelByDefault()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithProjectChanges(ProjectModification.AddDisplayMessageBeforeRestoreToProject);
+
+            var result = new RunCommand()
+                .WithWorkingDirectory(testInstance.Root.FullName)
+                .ExecuteWithCapturedOutput();
+
+            result.Should().Pass()
+                .And.NotHaveStdOutContaining("Important text");
+        }
+
+        [Fact]
+        public void ItShowImportantMessageLevelWhenPassInteractive()
+        {
+            var testAppName = "MSBuildTestApp";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithProjectChanges(ProjectModification.AddDisplayMessageBeforeRestoreToProject);
+
+            var result = new RunCommand()
+                .WithWorkingDirectory(testInstance.Root.FullName)
+                .ExecuteWithCapturedOutput("--interactive");
+
+            result.Should().Pass()
+                .And.HaveStdOutContaining("Important text");
         }
 
         [Fact]

--- a/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
+++ b/test/dotnet-test.Tests/GivenDotnetTestBuildsAndRunsTestfromCsproj.cs
@@ -8,8 +8,10 @@ using Microsoft.DotNet.TestFramework;
 using Microsoft.DotNet.Cli.Utils;
 using System.IO;
 using System;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Xml;
+using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Cli.Test.Tests
 {
@@ -464,6 +466,56 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             }
 
             result.ExitCode.Should().Be(0);
+        }
+
+        [Fact]
+        public void ItShouldNotShowImportantMessage()
+        {
+            string testAppName = "VSTestCore";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithProjectChanges(ProjectModification.AddDisplayMessageBeforeVsTestToProject);
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            // Call test
+            CommandResult result = new DotnetTestCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput();
+
+            // Verify
+            if (!DotnetUnderTest.IsLocalized())
+            {
+                result.StdOut.Should().NotContain("Important text");
+            }
+
+            result.ExitCode.Should().Be(1);
+        }
+
+        [Fact]
+        public void ItShouldShowImportantMessageWhenInteractiveFlagIsPassed()
+        {
+            string testAppName = "VSTestCore";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithProjectChanges(ProjectModification.AddDisplayMessageBeforeVsTestToProject);
+
+            var testProjectDirectory = testInstance.Root.FullName;
+
+            // Call test
+            CommandResult result = new DotnetTestCommand()
+                .WithWorkingDirectory(testProjectDirectory)
+                .ExecuteWithCapturedOutput("--interactive");
+
+            // Verify
+            if (!DotnetUnderTest.IsLocalized())
+            {
+                result.StdOut.Should().Contain("Important text");
+            }
+
+            result.ExitCode.Should().Be(1);
         }
 
         private string CopyAndRestoreVSTestDotNetCoreTestApp([CallerMemberName] string callingMethod = "")


### PR DESCRIPTION
These 2 verb have verbosity set to quiet. And we need to change it to minimal during --interface
to show the nuget plugin guide

part of #10529 