### PR TITLE
Disable telemetry for a test explicitly to make sure cache files are not generated

### DIFF
--- a/eng/restore-toolset.sh
+++ b/eng/restore-toolset.sh
@@ -35,6 +35,7 @@ function InitializeCustomSDKToolset {
     return
   fi
 
+  InitializeDotNetCli true
   InstallDotNetSharedFramework "1.1.2"
   InstallDotNetSharedFramework "2.0.0"
   InstallDotNetSharedFramework "2.1.0"

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -121,6 +121,9 @@ namespace Microsoft.DotNet.Tests
             // Disable to prevent the creation of the .dotnet folder by optimizationdata.
             command.Environment["DOTNET_DISABLE_MULTICOREJIT"] = "true";
             command.Environment["SkipInvalidConfigurations"] = "true";
+            // Disable telemetry to prevent the creation of the .dotnet folder
+            // for machineid and docker cache files
+            command.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "true";
 
             command.ExecuteWithCapturedOutput("internal-reportinstallsuccess test").Should().Pass();
 


### PR DESCRIPTION
Disable telemetry for a test explicitly to make sure cache files are not generated when we are validating the cache folder is not created.

