### PR TITLE
Interactive switch for Remove package command

### DIFF
--- a/src/dotnet/commands/dotnet-remove/dotnet-remove-package/RemovePackageParser.cs
+++ b/src/dotnet/commands/dotnet-remove/dotnet-remove-package/RemovePackageParser.cs
@@ -13,7 +13,11 @@ namespace Microsoft.DotNet.Cli
                 Accept.ExactlyOneArgument()
                       .With(name: Tools.Add.PackageReference.LocalizableStrings.CmdPackage,
                             description: LocalizableStrings.AppHelpText),
-                CommonOptions.HelpOption());
+                CommonOptions.HelpOption()).
+                Create.Option("--interactive",
+                                 LocalizableStrings.CmdInteractiveRestoreDescription,
+                                 Accept.NoArguments()
+                                   .ForwardAs("--interactive"));
         }
     }
 }


### PR DESCRIPTION
Adding an interactive switch for the remove pkg command. 

//cc @wli3 

We should discuss whether this is truly the experience we want here as illustrated in the pull request.

Related NuGet change is https://github.com/NuGet/NuGet.Client/pull/2704.