### PR TITLE
Fix VS option to disallow previews in resolver

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -192,11 +192,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public ICommand EnvironmentVariable(string name, string value)
         {
-#if NET451
-            _process.StartInfo.EnvironmentVariables[name] = value;
-#else
             _process.StartInfo.Environment[name] = value;
-#endif
             return this;
         }
 

--- a/src/Microsoft.DotNet.MSBuildSdkResolver/Interop.cs
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/Interop.cs
@@ -10,14 +10,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
 {
     internal static partial class Interop
     {
-        internal static readonly bool RunningOnWindows =
-#if NET46
-            // Not using RuntimeInformation on NET46 to avoid non-in-box framework API, 
-            // which create deployment problems for the resolver.
-            Path.DirectorySeparatorChar == '\\';
-#else
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#endif
+        internal static readonly bool RunningOnWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         static Interop()
         {

--- a/src/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/Microsoft.DotNet.MSBuildSdkResolver.csproj
@@ -24,13 +24,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETStandard'">
-    <PackageReference Include="NETStandard.Library" Version="2.0.0" />
+    <PackageReference Include="NETStandard.Library" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="All" ExcludeAssets="Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.MSBuildSdkResolver/VSSettings.cs
+++ b/src/Microsoft.DotNet.MSBuildSdkResolver/VSSettings.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 
-#if NET46
+#if NETFRAMEWORK
 using Microsoft.VisualStudio.Setup.Configuration;
 #endif
 
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.MSBuildSdkResolver
 
         private VSSettings()
         {
-#if NET46
+#if NETFRAMEWORK
             if (!Interop.RunningOnWindows)
             {
                 return;

--- a/test/Microsoft.DotNet.TestFramework/TestAssets.cs
+++ b/test/Microsoft.DotNet.TestFramework/TestAssets.cs
@@ -77,11 +77,8 @@ namespace Microsoft.DotNet.TestFramework
 
         private string GetTestDestinationDirectoryPath(string testProjectName, string callingMethod, string identifier)
         {
-#if NET451
-            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
-#else
             string baseDirectory = AppContext.BaseDirectory;
-#endif
+
             //  Find the name of the assembly the test comes from based on the the base directory and how the output path has been constructed
             string testAssemblyName = new DirectoryInfo(baseDirectory).Parent.Parent.Name;
 

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Commands/TestCommand.cs
@@ -183,11 +183,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
         private string GetBaseDirectory()
         {
-#if NET451
-            return AppDomain.CurrentDomain.BaseDirectory;
-#else
             return AppContext.BaseDirectory;
-#endif
         }
 
         private void ResolveCommand(ref string executable, ref string args)
@@ -220,11 +216,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
         {
             foreach (var name in _cliGeneratedEnvironmentVariables)
             {
-#if NET451
-                psi.EnvironmentVariables.Remove(name);
-#else
                 psi.Environment.Remove(name);
-#endif
             }
         }
 
@@ -234,11 +226,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 
             foreach (var item in Environment)
             {
-#if NET451
-                psi.EnvironmentVariables[item.Key] = item.Value;
-#else
                 psi.Environment[item.Key] = item.Value;
-#endif
             }
 
             //  Flow the TEST_PACKAGES environment variable to the child process

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Extensions/ProcessExtensions.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Extensions/ProcessExtensions.cs
@@ -12,11 +12,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 {
     internal static class ProcessExtensions
     {
-#if NET451
-        private static readonly bool _isWindows = true;
-#else
         private static readonly bool _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#endif
         private static readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
 
         public static void KillTree(this Process process)

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/RepoDirectoriesProvider.cs
@@ -33,11 +33,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
                     return s_repoRoot;
                 }
 
-#if NET451
-                string directory = AppDomain.CurrentDomain.BaseDirectory;
-#else
                 string directory = AppContext.BaseDirectory;
-#endif
 
                 while (directory != null)
                 {


### PR DESCRIPTION
When the resolver was retargeted to net472, #if NET46 became unused, causing the default x-plat behavior of never disallowing previews to be used.

This had not been caught because:

1. VS 16 is the only version with a resolver having this bug and it is still in preview and therefore grays out the option to disallow previews of SDK.

2. VSSettings have to be mocked in unit tests

Also:

* Fix unnecessary deployment of embedded Microsoft.VisualStudio.Setup.Configuration.Interop.
* Remove explicit package dependency on NETStandard.Library on the unofficial nupkg of resolver
* Remove unnecessary unused #if NET46/NET451 that can now use the same API on net472 as netstandard/netcoreapp
