### PR TITLE
Add interactive for the list command

### DIFF
--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -44,7 +44,10 @@ namespace Microsoft.DotNet.Cli
                               LocalizableStrings.CmdSourceDescription,
                               Accept.OneOrMoreArguments()
                                     .With(name: LocalizableStrings.CmdSource)
-                                    .ForwardAsMany(o => ForwardedArguments("--source", o.Arguments))));
+                                    .ForwardAsMany(o => ForwardedArguments("--source", o.Arguments))),
+                Create.Option("--interactive", 
+                             LocalizableStrings.CmdInteractiveDescription,
+                             Accept.NoArguments().ForwardAs("--interactive")));
 
         private static IEnumerable<string> ForwardedArguments(string token, IEnumerable<string> arguments)
         {

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
@@ -162,4 +162,7 @@
   <data name="FileNotFound" xml:space="preserve">
     <value>Could not find file or directory '{0}'.</value>
   </data>
+  <data name="CmdInteractiveDescription" xml:space="preserve">
+    <value>Allows the command to stop and wait for user input or action (for example to complete authentication).</value>
+  </data>
 </root>


### PR DESCRIPTION
Fix for https://github.com/NuGet/Home/issues/7605 and https://github.com/NuGet/Home/issues/7727. 

The list command talks to the sources, so it needs an interactive switch. 

//cc @wli3 

I have trouble building locally. (build.cmd doesn't seem to be the right thing).

I'll bug people tomorrow to complete the fix. 

```
 "C:\Users\NK\Documents\Code\dotnet\cli\build.proj" (default target) (1) ->
         C:\Users\NK\Documents\Code\dotnet\cli\Directory.Build.props(38,3): error MSB4019: The imported project "C:\Users\NK\Documents\Code\dotnet\cli\bin\obj\GitCommitInfo.props" was not found. Confirm that the path in the <Import> declaration is correct, and that the file exists on disk. [C:\Users\NK\Documents\Code\dotnet\cli\build.proj]
```