### PR TITLE
Remove skip first run flag

### DIFF
--- a/src/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
+++ b/src/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
@@ -7,17 +7,13 @@ namespace Microsoft.DotNet.Configurer
     {
         public bool GenerateAspNetCertificate { get; }
 
-        public bool SkipFirstRunExperience { get; }
-
         public bool TelemetryOptout { get; }
 
         public DotnetFirstRunConfiguration(
             bool generateAspNetCertificate,
-            bool skipFirstRunExperience,
             bool telemetryOptout)
         {
             GenerateAspNetCertificate = generateAspNetCertificate;
-            SkipFirstRunExperience = skipFirstRunExperience;
             TelemetryOptout = telemetryOptout;
         }
     }

--- a/src/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
+++ b/src/Microsoft.DotNet.Configurer/DotnetFirstRunConfiguration.cs
@@ -8,13 +8,19 @@ namespace Microsoft.DotNet.Configurer
         public bool GenerateAspNetCertificate { get; }
 
         public bool TelemetryOptout { get; }
+        public bool AddGlobalToolsToPath { get; }
+        public bool UseShortFirstRunMessage { get; }
 
         public DotnetFirstRunConfiguration(
             bool generateAspNetCertificate,
-            bool telemetryOptout)
+            bool telemetryOptout,
+            bool addGlobalToolsToPath,
+            bool useShortFirstRunMessage)
         {
             GenerateAspNetCertificate = generateAspNetCertificate;
             TelemetryOptout = telemetryOptout;
+            AddGlobalToolsToPath = addGlobalToolsToPath;
+            UseShortFirstRunMessage = useShortFirstRunMessage;
         }
     }
 }

--- a/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -89,15 +89,14 @@ namespace Microsoft.DotNet.Configurer
 #if EXCLUDE_ASPNETCORE
             return false;
 #else
-            return ShouldRunFirstRunExperience() &&
-                _dotnetFirstRunConfiguration.GenerateAspNetCertificate &&
+            return _dotnetFirstRunConfiguration.GenerateAspNetCertificate &&
                 !_aspNetCertificateSentinel.Exists();
 #endif
         }
 
         private bool ShouldAddPackageExecutablePath()
         {
-            return ShouldRunFirstRunExperience() && !_toolPathSentinel.Exists();
+            return !_toolPathSentinel.Exists();
         }
 
         private void AddPackageExecutablePath()
@@ -109,8 +108,7 @@ namespace Microsoft.DotNet.Configurer
 
         private bool ShouldPrintFirstTimeUseNotice()
         {
-            return ShouldRunFirstRunExperience() &&
-                !_firstTimeUseNoticeSentinel.Exists();
+            return !_firstTimeUseNoticeSentinel.Exists();
         }
 
         private bool ShouldPrintShortFirstTimeUseNotice()
@@ -145,19 +143,6 @@ namespace Microsoft.DotNet.Configurer
         {
             _reporter.WriteLine();
             _reporter.WriteLine(LocalizableStrings.ShortTelemetryMessage);
-        }
-
-        private void PrintUnauthorizedAccessMessage()
-        {
-            _reporter.WriteLine();
-            _reporter.WriteLine(string.Format(
-                LocalizableStrings.UnauthorizedAccessMessage,
-                _cliFallbackFolderPath));
-        }
-
-        private bool ShouldRunFirstRunExperience()
-        {
-            return !_dotnetFirstRunConfiguration.SkipFirstRunExperience;
         }
     }
 }

--- a/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
+++ b/src/Microsoft.DotNet.Configurer/DotnetFirstTimeUseConfigurer.cs
@@ -96,7 +96,8 @@ namespace Microsoft.DotNet.Configurer
 
         private bool ShouldAddPackageExecutablePath()
         {
-            return !_toolPathSentinel.Exists();
+            return _dotnetFirstRunConfiguration.AddGlobalToolsToPath &&
+                !_toolPathSentinel.Exists();
         }
 
         private void AddPackageExecutablePath()
@@ -108,7 +109,8 @@ namespace Microsoft.DotNet.Configurer
 
         private bool ShouldPrintFirstTimeUseNotice()
         {
-            return !_firstTimeUseNoticeSentinel.Exists();
+            return !_dotnetFirstRunConfiguration.UseShortFirstRunMessage &&
+                !_firstTimeUseNoticeSentinel.Exists();
         }
 
         private bool ShouldPrintShortFirstTimeUseNotice()

--- a/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Configurer/LocalizableStrings.resx
@@ -123,16 +123,6 @@
 Learn more about .NET Core: https://aka.ms/dotnet-docs
 Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli-docs</value>
   </data>
-  <data name="UnauthorizedAccessMessage" xml:space="preserve">
-    <value>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </value>
-  </data>
   <data name="AspNetCertificateInstalled" xml:space="preserve">
     <value>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.cs.xlf
@@ -13,24 +13,6 @@ Další informace o .NET Core: https://aka.ms/dotnet-docs
 Pomocí příkazu dotnet --help můžete zobrazit dostupné příkazy nebo navštivte tuto adresu: https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">Byla vám odepřena oprávnění k úpravě složky {0}.
-
-Tady jsou některé možnosti, jak tuto chybu vyřešit:
-----------------------------------------
-1. Spusťte tento příkaz znovu se zvýšenými přístupovými oprávněními.
-2. Zakažte prostředí prvního spuštění nastavením proměnné prostředí DOTNET_SKIP_FIRST_TIME_EXPERIENCE na hodnotu true.
-3. Zkopírujte sadu .NET Core SDK do nechráněného umístění a použijte ji odtud.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.de.xlf
@@ -13,24 +13,6 @@ Weitere Informationen zu .NET Core: https://aka.ms/dotnet-docs
 Verwenden Sie 'dotnet --help', um die verfügbaren Befehle anzuzeigen, oder besuchen Sie folgende Seite: https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">Berechtigung für das Ändern des Ordners "{0}" verweigert.
-
-Folgende Optionen sind zum Beheben des Problems verfügbar:
-----------------------------------------
-1. Führen Sie den Befehl mit erhöhten Rechten erneut aus.
-2. Deaktivieren Sie die erste Ausführung, indem Sie die Umgebungsvariable DOTNET_SKIP_FIRST_TIME_EXPERIENCE auf "true" festlegen.
-3. Kopieren Sie das .NET Core SDK an einen nicht geschützten Speicherort, und verwenden Sie es von diesem Speicherort aus.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.es.xlf
@@ -13,24 +13,6 @@ Más información sobre .NET Core: https://aka.ms/dotnet-docs
 Use "dotnet --help" para ver los comandos disponibles o visite: https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">Permiso denegado para modificar la carpeta "{0}".
-
-Estas son algunas opciones para solucionar este error:
-----------------------------------------
-1. Vuelva a ejecutar este comando con acceso elevado.
-2. Deshabilite la primera experiencia de ejecución estableciendo la variable de entorno DOTNET_SKIP_FIRST_TIME_EXPERIENCE en true.
-3. Copie el SDK de .NET Core SDK a un lugar no protegido y úselo desde ahí.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.fr.xlf
@@ -13,24 +13,6 @@ Découvrez plus d'informations sur .NET Core : https://aka.ms/dotnet-docs
 Utilisez 'dotnet --help' pour voir les commandes disponibles ou visitez : https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">Autorisation refusée pour modifier le dossier '{0}'.
-
-Voici des options pour corriger cette erreur :
-----------------------------------------
-1. Réexécutez cette commande avec un accès élevé.
-2. Désactivez l'introduction de l'interface logicielle lors de la première utilisation en définissant la variable d'environnement DOTNET_SKIP_FIRST_TIME_EXPERIENCE sur true.
-3. Copiez le SDK .NET Core dans un emplacement non protégé et utilisez-le à partir de là.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.it.xlf
@@ -13,24 +13,6 @@ Per altre informazioni su .NET Core, vedere https://aka.ms/dotnet-docs
 Per visualizzare i comandi disponibili, usare 'dotnet --help' oppure vedere https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">Autorizzazione negata per la modifica della cartella '{0}'.
-
-Ecco alcune opzioni per correggere questo errore:
-----------------------------------------
-1. Ripetere questo comando con accesso con privilegi elevati.
-2. Disabilitare il completamento dell'installazione impostando la variabile di ambiente DOTNET_SKIP_FIRST_TIME_EXPERIENCE su true.
-3. Copiare .NET Core SDK in un percorso non protetto e usarlo da tale posizione.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ja.xlf
@@ -13,24 +13,6 @@ Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cl
 'dotnet--help' で利用可能なコマンドを参照することができます。または、https://aka.ms/dotnet-cli-docs を参照してください。</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">アクセス許可により、フォルダ '{0}' の変更が拒否されました。
-
-このエラーを修正するためのオプションは次のとおりです。
-----------------------------------------
-1. 昇格させたアクセス権でこのコマンドを再実行します。
-2. 環境変数 DOTNET_SKIP_FIRST_TIME_EXPERIENCE を true に設定し、最初のエクスペリエンスの実行を無効にします。
-3. .NET Core SDK を保護されていない場所にコピーし、そこから利用します。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ko.xlf
@@ -13,24 +13,6 @@ Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cl
 'dotnet --help'를 사용하여 사용 가능한 명령을 보거나 https://aka.ms/dotnet-cli-docs를 방문하세요.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">'{0}' 폴더를 수정하는 데 필요한 사용 권한이 거부되었습니다.
-
-이 오류를 해결하기 위한 옵션을 다음과 같습니다.
-----------------------------------------
-1. 높은 액세스 권한으로 이 명령을 다시 실행합니다.
-2. 환경 변수 DOTNET_SKIP_FIRST_TIME_EXPERIENCE를 true로 설정하여 첫 실행 경험을 사용하지 않도록 설정합니다.
-3. .NET Core SDK를 보호되지 않은 위치로 복사한 후 이 위치에서 사용합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pl.xlf
@@ -13,24 +13,6 @@ Dowiedz się więcej na temat platformy .NET Core: https://aka.ms/dotnet-docs
 Aby zobaczyć dostępne polecenia, wydaj polecenie „dotnet --help” lub odwiedź witrynę: https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">Odmowa uprawnień do modyfikowania folderu „{0}”.
-
-Oto kilka możliwości usunięcia tego błędu:
-----------------------------------------
-1. Ponownie uruchom to polecenie z podniesionym poziomem uprawnień.
-2. Wyłącz środowisko pierwszego uruchomienia, ustawiając zmienną środowiskową DOTNET_SKIP_FIRST_TIME_EXPERIENCE na wartość true.
-3. Skopiuj zestaw .NET Core SDK do niechronionej lokalizacji i tam z niego korzystaj.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.pt-BR.xlf
@@ -13,24 +13,6 @@ Saiba mais sobre o .NET Core: https://aka.ms/dotnet-docs
 Use 'dotnet --help' para ver os comandos disponíveis ou acesse: https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">Permissão negada para modificar a pasta '{0}'.
-
-Aqui estão algumas opções para corrigir este erro:
-----------------------------------------
-1. Execute novamente este comando com privilégios de acesso elevado.
-2. Desabilite a primeira experiência de execução definindo a variável de ambiente DOTNET_SKIP_FIRST_TIME_EXPERIENCE como true.
-3. Copie o SDK do .NET Core para um local não protegido e use-o de lá.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.ru.xlf
@@ -13,24 +13,6 @@ Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cl
 Для просмотра списка доступных команд, выполните команду 'dotnet --help', или зайдите на страницу https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">Отсутствует разрешение на изменение папки '{0}'.
-
-Чтобы исправить эту ошибку, попробуйте выполнить одно из указанных действий:
-----------------------------------------
-1. Повторно запустите эту команду с расширенными разрешениями.
-2. Отключите поведение при первом запуске, установив значение true для переменной среды DOTNET_SKIP_FIRST_TIME_EXPERIENCE.
-3. Скопируйте пакет SDK для .NET Core в незащищенное расположение и используйте его оттуда.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.tr.xlf
@@ -13,24 +13,6 @@ Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cl
 Kullanılabilen komutları görmek için 'dotnet --help' komutunu kullanın veya şu adresi ziyaret edin: https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">'{0}' klasörünü değiştirme izni reddedildi.
-
-İşte bu hatayı düzeltmeye yönelik bazı seçenekler:
-----------------------------------------
-1. Bu komutu yükseltilmiş erişimle yeniden çalıştırın.
-2. DOTNET_SKIP_FIRST_TIME_EXPERIENCE ortam değişkenini true değerine ayarlayarak ilk çalıştırma deneyimini devre dışı bırakın.
-3. .NET Core SDK'yı korunmayan bir konuma kopyalayın ve oradan kullanın.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hans.xlf
@@ -13,25 +13,6 @@ Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cl
 请使用 "dotnet --help"来查看可用命令或访问 https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">权限被拒，无法修改“{0}”文件夹。
-
-
-下面是可解决此问题的几个选项:
-----------------------------------------
-1. 借助提升的访问权限重新运行此命令。
-2. 通过将环境变量 DOTNET_SKIP_FIRST_TIME_EXPERIENCE 设置为 true，禁用首次运行体验。
-3. 将 .NET Core SDK 复制到不受保护的位置，再从此处进行使用。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Configurer/xlf/LocalizableStrings.zh-Hant.xlf
@@ -13,24 +13,6 @@ Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cl
 使用 'dotnet --help' 查看可用的命令，或前往: https://aka.ms/dotnet-cli-docs</target>
         <note />
       </trans-unit>
-      <trans-unit id="UnauthorizedAccessMessage">
-        <source>Permission denied to modify the '{0}' folder.
-
-Here are some options to fix this error:
-----------------------------------------
-1. Re-run this command with elevated access.
-2. Disable the first run experience by setting the environment variable DOTNET_SKIP_FIRST_TIME_EXPERIENCE to true.
-3. Copy the .NET Core SDK to a non-protected location and use it from there.
-    </source>
-        <target state="translated">沒有修改 '{0}' 資料夾的權限。
-
-以下幾個選項可修正這項錯誤:
-----------------------------------------
-1. 以較高的存取權重新執行此命令。
-2. 將環境變數 DOTNET_SKIP_FIRST_TIME_EXPERIENCE 設為 true，以停用初次執行體驗。
-3. 將 .NET Core SDK 複製到未保護的位置，並從該處使用。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AspNetCertificateInstalled">
         <source>ASP.NET Core
 ------------

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -144,8 +144,6 @@ namespace Microsoft.DotNet.Cli
 
                         bool generateAspNetCertificate =
                             environmentProvider.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true);
-                        bool skipFirstRunExperience =
-                            environmentProvider.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false);
                         bool telemetryOptout =
                             environmentProvider.GetEnvironmentVariableAsBool("DOTNET_CLI_TELEMETRY_OPTOUT", false);
 
@@ -162,12 +160,10 @@ namespace Microsoft.DotNet.Cli
 
                             // When running through a native installer, we want the cache expansion to happen, so
                             // we need to override this.
-                            skipFirstRunExperience = false;
                         }
 
                         var dotnetFirstRunConfiguration = new DotnetFirstRunConfiguration(
                             generateAspNetCertificate: generateAspNetCertificate,
-                            skipFirstRunExperience: skipFirstRunExperience,
                             telemetryOptout: telemetryOptout);
 
                         ConfigureDotNetForFirstTimeUse(

--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -143,9 +143,13 @@ namespace Microsoft.DotNet.Cli
                         var environmentProvider = new EnvironmentProvider();
 
                         bool generateAspNetCertificate =
-                            environmentProvider.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true);
+                            environmentProvider.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", defaultValue: true);
                         bool telemetryOptout =
-                            environmentProvider.GetEnvironmentVariableAsBool("DOTNET_CLI_TELEMETRY_OPTOUT", false);
+                          environmentProvider.GetEnvironmentVariableAsBool("DOTNET_CLI_TELEMETRY_OPTOUT", defaultValue: false);
+                        bool addGlobalToolsToPath =
+                            environmentProvider.GetEnvironmentVariableAsBool("DOTNET_ADD_GLOBAL_TOOLS_TO_PATH", defaultValue: true);
+                        bool useShortFirstRunMessage =
+                            environmentProvider.GetEnvironmentVariableAsBool("DOTNET_USE_SHORT_FIRST_RUN_MESSAGE", defaultValue: false);
 
                         ReportDotnetHomeUsage(environmentProvider);
 
@@ -157,14 +161,14 @@ namespace Microsoft.DotNet.Cli
                             firstTimeUseNoticeSentinel = new NoOpFirstTimeUseNoticeSentinel();
                             toolPathSentinel = new NoOpFileSentinel(exists: false);
                             hasSuperUserAccess = true;
-
-                            // When running through a native installer, we want the cache expansion to happen, so
-                            // we need to override this.
                         }
 
                         var dotnetFirstRunConfiguration = new DotnetFirstRunConfiguration(
                             generateAspNetCertificate: generateAspNetCertificate,
-                            telemetryOptout: telemetryOptout);
+                            telemetryOptout: telemetryOptout,
+                            addGlobalToolsToPath: addGlobalToolsToPath,
+                            useShortFirstRunMessage: useShortFirstRunMessage
+                            );
 
                         ConfigureDotNetForFirstTimeUse(
                             firstTimeUseNoticeSentinel,

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
@@ -45,7 +45,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    telemetryOptout: false
+                    telemetryOptout: false,
+                    addGlobalToolsToPath: true,
+                    useShortFirstRunMessage: false
                 ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -70,7 +72,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    telemetryOptout: false
+                    telemetryOptout: false,
+                    addGlobalToolsToPath: true,
+                    useShortFirstRunMessage: false
                 ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -95,7 +99,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    telemetryOptout: false
+                    telemetryOptout: false,
+                    addGlobalToolsToPath: true,
+                    useShortFirstRunMessage: false
                 ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -120,7 +126,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    telemetryOptout: false
+                    telemetryOptout: false,
+                    addGlobalToolsToPath: true,
+                    useShortFirstRunMessage: false
                 ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -145,7 +153,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    telemetryOptout: false
+                    telemetryOptout: false,
+                    addGlobalToolsToPath: true,
+                    useShortFirstRunMessage: false
                 ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -170,7 +180,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: false,
-                    telemetryOptout: false
+                    telemetryOptout: false,
+                    addGlobalToolsToPath: true,
+                    useShortFirstRunMessage: false
                 ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -195,7 +207,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    telemetryOptout: false
+                    telemetryOptout: false,
+                    addGlobalToolsToPath: true,
+                    useShortFirstRunMessage: false
                 ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -209,7 +223,7 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Fact]
-        public void It_adds_the_tool_path_to_the_environment_if_the_first_run_experience_is_not_skipped()
+        public void It_adds_the_tool_path_to_the_environment_if_addGlobalToolsToPath_is_enabled()
         {
             var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
                 _firstTimeUseNoticeSentinelMock.Object,
@@ -219,7 +233,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    telemetryOptout: false
+                    telemetryOptout: false,
+                    addGlobalToolsToPath: true,
+                    useShortFirstRunMessage: false
                 ),
                 _reporterMock.Object,
                 CliFallbackFolderPath,
@@ -228,6 +244,30 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             dotnetFirstTimeUseConfigurer.Configure();
 
             _pathAdderMock.Verify(p => p.AddPackageExecutablePathToUserPath(), Times.Once);
+        }
+
+        [Fact]
+        public void It_does_not_add_the_tool_path_to_the_environment_if_addGlobalToolsToPath_is_disabled()
+        {
+            var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
+                _firstTimeUseNoticeSentinelMock.Object,
+                _aspNetCertificateSentinelMock.Object,
+                _aspNetCoreCertificateGeneratorMock.Object,
+                _toolPathSentinelMock.Object,
+                new DotnetFirstRunConfiguration
+                (
+                    generateAspNetCertificate: true,
+                    telemetryOptout: false,
+                    addGlobalToolsToPath: false,
+                    useShortFirstRunMessage: false
+                ),
+                _reporterMock.Object,
+                CliFallbackFolderPath,
+                _pathAdderMock.Object);
+
+            dotnetFirstTimeUseConfigurer.Configure();
+
+            _pathAdderMock.Verify(p => p.AddPackageExecutablePathToUserPath(), Times.Never);
         }
     }
 }

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
@@ -45,7 +45,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: false,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -71,7 +70,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: true,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -97,7 +95,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: false,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -123,7 +120,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: false,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -149,7 +145,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: false,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -175,7 +170,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: false,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -201,7 +195,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: true,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -227,7 +220,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: false,
-                    skipFirstRunExperience: false,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -253,7 +245,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: false,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -278,7 +269,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: false,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,
@@ -301,7 +291,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 new DotnetFirstRunConfiguration
                 (
                     generateAspNetCertificate: true,
-                    skipFirstRunExperience: true,
                     telemetryOptout: false
                 ),
                 _reporterMock.Object,

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurer.cs
@@ -58,31 +58,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Fact]
-        public void It_does_not_print_the_first_time_use_notice_when_the_user_has_set_the_DOTNET_SKIP_FIRST_TIME_EXPERIENCE_environment_variable()
-        {
-            _firstTimeUseNoticeSentinelMock.Setup(n => n.Exists()).Returns(false);
-
-            var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
-                _firstTimeUseNoticeSentinelMock.Object,
-                _aspNetCertificateSentinelMock.Object,
-                _aspNetCoreCertificateGeneratorMock.Object,
-                _toolPathSentinelMock.Object,
-                new DotnetFirstRunConfiguration
-                (
-                    generateAspNetCertificate: true,
-                    telemetryOptout: false
-                ),
-                _reporterMock.Object,
-                CliFallbackFolderPath,
-                _pathAdderMock.Object);
-
-            dotnetFirstTimeUseConfigurer.Configure();
-
-            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.FirstTimeWelcomeMessage)), Times.Never);
-            _reporterMock.Verify(r => r.Write(It.IsAny<string>()), Times.Never);
-        }
-
-        [Fact]
         public void It_prints_the_telemetry_if_the_sentinel_does_not_exist()
         {
             _firstTimeUseNoticeSentinelMock.Setup(n => n.Exists()).Returns(false);
@@ -183,31 +158,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Fact]
-        public void It_does_not_generate_the_aspnet_https_development_certificate_when_the_user_has_set_the_DOTNET_SKIP_FIRST_TIME_EXPERIENCE_environment_variable()
-        {
-            _aspNetCertificateSentinelMock.Setup(n => n.Exists()).Returns(false);
-
-            var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
-                _firstTimeUseNoticeSentinelMock.Object,
-                _aspNetCertificateSentinelMock.Object,
-                _aspNetCoreCertificateGeneratorMock.Object,
-                _toolPathSentinelMock.Object,
-                new DotnetFirstRunConfiguration
-                (
-                    generateAspNetCertificate: true,
-                    telemetryOptout: false
-                ),
-                _reporterMock.Object,
-                CliFallbackFolderPath,
-                _pathAdderMock.Object);
-
-            dotnetFirstTimeUseConfigurer.Configure();
-
-            _reporterMock.Verify(r => r.WriteLine(It.Is<string>(str => str == LocalizableStrings.AspNetCertificateInstalled)), Times.Never);
-            _aspNetCoreCertificateGeneratorMock.Verify(s => s.GenerateAspNetCoreDevelopmentCertificate(), Times.Never);
-        }
-
-        [Fact]
         public void It_does_not_generate_the_aspnet_https_development_certificate_when_the_user_has_set_the_DOTNET_GENERATE_ASPNET_CERTIFICATE_environment_variable()
         {
             _aspNetCertificateSentinelMock.Setup(n => n.Exists()).Returns(false);
@@ -278,28 +228,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             dotnetFirstTimeUseConfigurer.Configure();
 
             _pathAdderMock.Verify(p => p.AddPackageExecutablePathToUserPath(), Times.Once);
-        }
-
-        [Fact]
-        public void It_does_not_add_the_tool_path_to_the_environment_if_the_first_run_experience_is_skipped()
-        {
-            var dotnetFirstTimeUseConfigurer = new DotnetFirstTimeUseConfigurer(
-                _firstTimeUseNoticeSentinelMock.Object,
-                _aspNetCertificateSentinelMock.Object,
-                _aspNetCoreCertificateGeneratorMock.Object,
-                _toolPathSentinelMock.Object,
-                new DotnetFirstRunConfiguration
-                (
-                    generateAspNetCertificate: true,
-                    telemetryOptout: false
-                ),
-                _reporterMock.Object,
-                CliFallbackFolderPath,
-                _pathAdderMock.Object);
-
-            dotnetFirstTimeUseConfigurer.Configure();
-
-            _pathAdderMock.Verify(p => p.AddPackageExecutablePathToUserPath(), Times.Never);
         }
     }
 }

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
@@ -47,26 +47,17 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Theory]
-        [InlineData(false, false, false, false, Never, FirstRun, Never, FirstRun, Never, Never, true, true)]
-        [InlineData(true, false, false, false, FirstRun, FirstRun, Never, FirstRun, Never, FirstRun, true, true)]
-        [InlineData(false, true, false, false, Never, Never, FirstRun, Never, FirstRun, Never, true, true)]
-        [InlineData(true, true, false, false, Never, Never, FirstRun, Never, FirstRun, Never, true, true)]
-        [InlineData(false, false, true, false, Never, FirstRun, Never, Never, Never, Never, false, false)]
-        [InlineData(true, false, true, false, FirstRun, FirstRun, Never, Never, Never, FirstRun, false, false)]
-        [InlineData(false, true, true, false, Never, Never, FirstRun, Never, FirstRun, Never, false, false)]
-        [InlineData(true, true, true, false, Never, Never, FirstRun, Never, FirstRun, Never, false, false)]
-        [InlineData(false, false, false, true, Never, SecondRun, Never, SecondRun, Never, Never, true, true)]
-        [InlineData(true, false, false, true, SecondRun, SecondRun, Never, SecondRun, Never, SecondRun, true, true)]
-        [InlineData(false, true, false, true, Never, Never, SecondRun, Never, SecondRun, Never, true, true)]
-        [InlineData(true, true, false, true, Never, Never, SecondRun, Never, SecondRun, Never, true, true)]
-        [InlineData(false, false, true, true, Never, SecondRun, Never, Never, Never, Never, false, false)]
-        [InlineData(true, false, true, true, SecondRun, SecondRun, Never, Never, Never, SecondRun, false, false)]
-        [InlineData(false, true, true, true, Never, Never, SecondRun, Never, SecondRun, Never, false, false)]
-        [InlineData(true, true, true, true, Never, Never, SecondRun, Never, SecondRun, Never, false, false)]
+        [InlineData(false, false, false, Never, FirstRun, Never, FirstRun, Never, Never, true, true)]
+        [InlineData(false, false, true, Never, SecondRun, Never, SecondRun, Never, Never, true, true)]
+        [InlineData(false, true, false, Never, FirstRun, Never, Never, Never, Never, false, false)]
+        [InlineData(false, true, true, Never, SecondRun, Never, Never, Never, Never, false, false)]
+        [InlineData(true, false, false, FirstRun, FirstRun, Never, FirstRun, Never, FirstRun, true, true)]
+        [InlineData(true, false, true, SecondRun, SecondRun, Never, SecondRun, Never, SecondRun, true, true)]
+        [InlineData(true, true, false, FirstRun, FirstRun, Never, Never, Never, FirstRun, false, false)]
+        [InlineData(true, true, true, SecondRun, SecondRun, Never, Never, Never, SecondRun, false, false)]
         public void FlagsCombinationAndAction(
             // Inputs
             bool DOTNET_GENERATE_ASPNET_CERTIFICATE,
-            bool DOTNET_SKIP_FIRST_TIME_EXPERIENCE,
             bool DOTNET_CLI_TELEMETRY_OPTOUT,
             //   true to simulate install via installer. The first run is during installer,
             //   silent but has sudo permission
@@ -88,9 +79,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             _environmentProvider
             .Setup(p => p.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", It.IsAny<bool>()))
             .Returns(DOTNET_GENERATE_ASPNET_CERTIFICATE);
-            _environmentProvider
-                .Setup(p => p.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", It.IsAny<bool>()))
-                .Returns(DOTNET_SKIP_FIRST_TIME_EXPERIENCE);
             _environmentProvider
                 .Setup(p => p.GetEnvironmentVariableAsBool("DOTNET_CLI_TELEMETRY_OPTOUT", It.IsAny<bool>()))
                 .Returns(DOTNET_CLI_TELEMETRY_OPTOUT);
@@ -227,8 +215,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             var _environmentProviderObject = _environmentProvider.Object;
             bool generateAspNetCertificate =
                  _environmentProviderObject.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true);
-            bool skipFirstRunExperience =
-                _environmentProviderObject.GetEnvironmentVariableAsBool("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", false);
             bool telemetryOptout =
                 _environmentProviderObject.GetEnvironmentVariableAsBool("DOTNET_CLI_TELEMETRY_OPTOUT", false);
 
@@ -241,10 +227,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                 aspNetCertificateSentinel = new NoOpAspNetCertificateSentinel();
                 firstTimeUseNoticeSentinel = new NoOpFirstTimeUseNoticeSentinel();
                 toolPathSentinel = new NoOpFileSentinel(exists: false);
-
-                // When running through a native installer, we want the cache expansion to happen, so
-                // we need to override this.
-                skipFirstRunExperience = false;
             }
             else
             {

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
@@ -47,17 +47,26 @@ namespace Microsoft.DotNet.Configurer.UnitTests
         }
 
         [Theory]
-        [InlineData(false, false, false, Never, FirstRun, Never, FirstRun, Never, Never, true, true)]
-        [InlineData(false, false, true, Never, SecondRun, Never, SecondRun, Never, Never, true, true)]
-        [InlineData(false, true, false, Never, FirstRun, Never, Never, Never, Never, false, false)]
-        [InlineData(false, true, true, Never, SecondRun, Never, Never, Never, Never, false, false)]
-        [InlineData(true, false, false, FirstRun, FirstRun, Never, FirstRun, Never, FirstRun, true, true)]
-        [InlineData(true, false, true, SecondRun, SecondRun, Never, SecondRun, Never, SecondRun, true, true)]
-        [InlineData(true, true, false, FirstRun, FirstRun, Never, Never, Never, FirstRun, false, false)]
-        [InlineData(true, true, true, SecondRun, SecondRun, Never, Never, Never, SecondRun, false, false)]
+        [InlineData(false, false, false, false, Never, FirstRun, Never, FirstRun, Never, Never, true, true)]
+        [InlineData(true, false, false, false, FirstRun, FirstRun, Never, FirstRun, Never, FirstRun, true, true)]
+        [InlineData(false, true, false, false, Never, Never, FirstRun, Never, FirstRun, Never, true, true)]
+        [InlineData(true, true, false, false, FirstRun, Never, FirstRun, Never, FirstRun, FirstRun, true, true)]
+        [InlineData(false, false, true, false, Never, FirstRun, Never, Never, Never, Never, false, false)]
+        [InlineData(true, false, true, false, FirstRun, FirstRun, Never, Never, Never, FirstRun, false, false)]
+        [InlineData(false, true, true, false, Never, Never, FirstRun, Never, FirstRun, Never, false, false)]
+        [InlineData(true, true, true, false, FirstRun, Never, FirstRun, Never, FirstRun, FirstRun, false, false)]
+        [InlineData(false, false, false, true, Never, SecondRun, Never, SecondRun, Never, Never, true, true)]
+        [InlineData(true, false, false, true, SecondRun, SecondRun, Never, SecondRun, Never, SecondRun, true, true)]
+        [InlineData(false, true, false, true, Never, Never, SecondRun, Never, SecondRun, Never, true, true)]
+        [InlineData(true, true, false, true, SecondRun, Never, SecondRun, Never, SecondRun, SecondRun, true, true)]
+        [InlineData(false, false, true, true, Never, SecondRun, Never, Never, Never, Never, false, false)]
+        [InlineData(true, false, true, true, SecondRun, SecondRun, Never, Never, Never, SecondRun, false, false)]
+        [InlineData(false, true, true, true, Never, Never, SecondRun, Never, SecondRun, Never, false, false)]
+        [InlineData(true, true, true, true, SecondRun, Never, SecondRun, Never, SecondRun, SecondRun, false, false)]
         public void FlagsCombinationAndAction(
             // Inputs
             bool DOTNET_GENERATE_ASPNET_CERTIFICATE,
+            bool DOTNET_USE_SHORT_FIRST_RUN_MESSAGE,
             bool DOTNET_CLI_TELEMETRY_OPTOUT,
             //   true to simulate install via installer. The first run is during installer,
             //   silent but has sudo permission
@@ -82,6 +91,12 @@ namespace Microsoft.DotNet.Configurer.UnitTests
             _environmentProvider
                 .Setup(p => p.GetEnvironmentVariableAsBool("DOTNET_CLI_TELEMETRY_OPTOUT", It.IsAny<bool>()))
                 .Returns(DOTNET_CLI_TELEMETRY_OPTOUT);
+            _environmentProvider
+                .Setup(p => p.GetEnvironmentVariableAsBool("DOTNET_USE_SHORT_FIRST_RUN_MESSAGE", It.IsAny<bool>()))
+                .Returns(DOTNET_USE_SHORT_FIRST_RUN_MESSAGE);
+            _environmentProvider
+                .Setup(p => p.GetEnvironmentVariableAsBool("DOTNET_ADD_GLOBAL_TOOLS_TO_PATH", It.IsAny<bool>()))
+                .Returns(true);
             _pathAdderMock.Setup(p => p.AddPackageExecutablePathToUserPath()).Verifiable();
             // box a bool so it will be captured by reference in closure
             object generateAspNetCoreDevelopmentCertificateCalled = false;
@@ -217,6 +232,10 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                  _environmentProviderObject.GetEnvironmentVariableAsBool("DOTNET_GENERATE_ASPNET_CERTIFICATE", true);
             bool telemetryOptout =
                 _environmentProviderObject.GetEnvironmentVariableAsBool("DOTNET_CLI_TELEMETRY_OPTOUT", false);
+            bool addGlobalToolsToPath =
+                _environmentProviderObject.GetEnvironmentVariableAsBool("DOTNET_ADD_GLOBAL_TOOLS_TO_PATH", defaultValue: true);
+            bool useShortFirstRunMessage =
+                _environmentProviderObject.GetEnvironmentVariableAsBool("DOTNET_USE_SHORT_FIRST_RUN_MESSAGE", defaultValue: false);
 
             IAspNetCertificateSentinel aspNetCertificateSentinel;
             IFirstTimeUseNoticeSentinel firstTimeUseNoticeSentinel;
@@ -243,7 +262,9 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                  dotnetFirstRunConfiguration: new DotnetFirstRunConfiguration
                  (
                      generateAspNetCertificate: generateAspNetCertificate,
-                     telemetryOptout: telemetryOptout
+                     telemetryOptout: telemetryOptout,
+                     addGlobalToolsToPath: addGlobalToolsToPath,
+                     useShortFirstRunMessage: useShortFirstRunMessage
                  ),
                  reporter: _reporterMock,
                  cliFallbackFolderPath: CliFallbackFolderPath,

--- a/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
+++ b/test/Microsoft.DotNet.Configurer.UnitTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
@@ -261,7 +261,6 @@ namespace Microsoft.DotNet.Configurer.UnitTests
                  dotnetFirstRunConfiguration: new DotnetFirstRunConfiguration
                  (
                      generateAspNetCertificate: generateAspNetCertificate,
-                     skipFirstRunExperience: skipFirstRunExperience,
                      telemetryOptout: telemetryOptout
                  ),
                  reporter: _reporterMock,

--- a/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
+++ b/test/dotnet.Tests/GivenThatTheUserIsRunningDotNetForTheFirstTime.cs
@@ -40,7 +40,6 @@ namespace Microsoft.DotNet.Tests
             command.Environment["DOTNET_CLI_TEST_FALLBACKFOLDER"] = cliTestFallbackFolder;
             command.Environment["DOTNET_CLI_TEST_LINUX_PROFILED_PATH"] = profiled;
             command.Environment["DOTNET_CLI_TEST_OSX_PATHSD_PATH"] = pathsd;
-            command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
             command.Environment["SkipInvalidConfigurations"] = "true";
 
             _firstDotnetNonVerbUseCommandResult = command.ExecuteWithCapturedOutput("--info");
@@ -115,7 +114,6 @@ namespace Microsoft.DotNet.Tests
             command.Environment["USERPROFILE"] = emptyHome;
             command.Environment["APPDATA"] = emptyHome;
             command.Environment["DOTNET_CLI_TEST_FALLBACKFOLDER"] = _nugetFallbackFolder.FullName;
-            command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
             command.Environment["DOTNET_CLI_TEST_LINUX_PROFILED_PATH"] = profiled;
             command.Environment["DOTNET_CLI_TEST_OSX_PATHSD_PATH"] = pathsd;
             // Disable to prevent the creation of the .dotnet folder by optimizationdata.
@@ -147,7 +145,6 @@ namespace Microsoft.DotNet.Tests
             command.Environment["DOTNET_CLI_TEST_FALLBACKFOLDER"] = _nugetFallbackFolder.FullName;
             command.Environment["DOTNET_CLI_TEST_LINUX_PROFILED_PATH"] = profiled;
             command.Environment["DOTNET_CLI_TEST_OSX_PATHSD_PATH"] = pathsd;
-            command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
             command.Environment["SkipInvalidConfigurations"] = "true";
 
             command.ExecuteWithCapturedOutput("internal-reportinstallsuccess test").Should().Pass();
@@ -175,7 +172,6 @@ namespace Microsoft.DotNet.Tests
             command.Environment["DOTNET_CLI_TEST_FALLBACKFOLDER"] = _nugetFallbackFolder.FullName;
             command.Environment["DOTNET_CLI_TEST_LINUX_PROFILED_PATH"] = profiled;
             command.Environment["DOTNET_CLI_TEST_OSX_PATHSD_PATH"] = pathsd;
-            command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
             command.Environment["SkipInvalidConfigurations"] = "true";
 
             command.ExecuteWithCapturedOutput("internal-reportinstallsuccess test").Should().Pass();
@@ -198,7 +194,6 @@ namespace Microsoft.DotNet.Tests
             command.Environment["USERPROFILE"] = emptyHome;
             command.Environment["APPDATA"] = emptyHome;
             command.Environment["DOTNET_CLI_TEST_FALLBACKFOLDER"] = _nugetFallbackFolder.FullName;
-            command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
             command.Environment["DOTNET_CLI_TEST_LINUX_PROFILED_PATH"] = profiled;
             command.Environment["DOTNET_DISABLE_MULTICOREJIT"] = "true";
             command.Environment["SkipInvalidConfigurations"] = "true";
@@ -220,7 +215,6 @@ namespace Microsoft.DotNet.Tests
             command.Environment["USERPROFILE"] = emptyHome;
             command.Environment["APPDATA"] = emptyHome;
             command.Environment["DOTNET_CLI_TEST_FALLBACKFOLDER"] = _nugetFallbackFolder.FullName;
-            command.Environment["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "";
             command.Environment["DOTNET_CLI_TEST_OSX_PATHSD_PATH"] = pathsd;
             command.Environment["DOTNET_DISABLE_MULTICOREJIT"] = "true";
             command.Environment["SkipInvalidConfigurations"] = "true";


### PR DESCRIPTION
fix #10364

Replace one big flag with DOTNET_ADD_GLOBAL_TOOLS_TO_PATH and DOTNET_USE_SHORT_FIRST_RUN_MESSAGE