### PR TITLE
Change SIGTERM handling to be more consistent.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/NativeMethods.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/NativeMethods.cs
@@ -68,9 +68,6 @@ namespace Microsoft.DotNet.Cli.Utils
         internal static class Posix
         {
             [DllImport("libc", SetLastError = true)]
-            internal static extern int getpgid(int pid);
-
-            [DllImport("libc", SetLastError = true)]
             internal static extern int kill(int pid, int sig);
 
             internal const int SIGINT = 2;

--- a/src/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
@@ -97,21 +97,7 @@ namespace Microsoft.DotNet.Cli.Utils
 
         private void HandleProcessExit(object sender, EventArgs args)
         {
-            var currentPid = Process.GetCurrentProcess().Id;
-            bool sendChildSIGTERM = true;
-
-            // First, try to SIGTERM our process group
-            // If the pgid is not the same as pid, then this process is not the root of the group
-            if (NativeMethods.Posix.getpgid(currentPid) == currentPid)
-            {
-                if (NativeMethods.Posix.kill(-currentPid, NativeMethods.Posix.SIGTERM) == 0)
-                {
-                    // Successfully sent the signal to the entire group; don't send again to child
-                    sendChildSIGTERM = false;
-                }
-            }
-
-            if (sendChildSIGTERM && NativeMethods.Posix.kill(_process.Id, NativeMethods.Posix.SIGTERM) != 0)
+            if (!_process.WaitForExit(0) && NativeMethods.Posix.kill(_process.Id, NativeMethods.Posix.SIGTERM) != 0)
             {
                 // Couldn't send the signal, don't wait
                 return;


### PR DESCRIPTION
This commit addresses code review feedback to the child process reaping change.
It removes the attempt to signal the current process as a process group and
instead makes the behavior consistent regardless of the process group of the
parent dotnet process.

It also makes it more consistent when running the application under `dotnet
run` and running it as an apphost as only the process that is running user code
will receive the SIGTERM; any additionally spawned processes are the
responsibility of the user code to signal.

With these changes, we only SIGTERM the child process.  Additionally, it
introduces a quick wait to see if the process is still present prior to
signaling.
