### PR TITLE
Update command description

### DIFF
--- a/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -16,8 +16,8 @@ namespace Microsoft.DotNet.Cli
                 "build",
                 LocalizableStrings.AppFullName,
                 Accept.ZeroOrMoreArguments()
-                      .With(name: CommonLocalizableStrings.ProjectArgumentName,
-                            description: CommonLocalizableStrings.ProjectArgumentDescription),
+                      .With(name: CommonLocalizableStrings.SolutionOrProjectArgumentName,
+                            description: CommonLocalizableStrings.SolutionOrProjectArgumentDescription),
                 CommonOptions.HelpOption(),
                 Create.Option(
                     "-o|--output",

--- a/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -15,8 +15,8 @@ namespace Microsoft.DotNet.Cli
                 "clean",
                 LocalizableStrings.AppFullName,
                 Accept.ZeroOrMoreArguments()
-                      .With(name: CommonLocalizableStrings.ProjectArgumentName,
-                            description: CommonLocalizableStrings.ProjectArgumentDescription),
+                      .With(name: CommonLocalizableStrings.SolutionOrProjectArgumentName,
+                            description: CommonLocalizableStrings.SolutionOrProjectArgumentDescription),
                 CommonOptions.HelpOption(),
                 Create.Option("-o|--output", 
                               LocalizableStrings.CmdOutputDirDescription,

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -16,8 +16,8 @@ namespace Microsoft.DotNet.Cli
                 "publish",
                 LocalizableStrings.AppDescription,
                 Accept.ZeroOrMoreArguments()
-                      .With(name: CommonLocalizableStrings.ProjectArgumentName,
-                            description: CommonLocalizableStrings.ProjectArgumentDescription),
+                      .With(name: CommonLocalizableStrings.SolutionOrProjectArgumentName,
+                            description: CommonLocalizableStrings.SolutionOrProjectArgumentDescription),
                 CommonOptions.HelpOption(),
                 Create.Option(
                     "-o|--output",

--- a/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
+++ b/src/dotnet/commands/dotnet-restore/RestoreCommandParser.cs
@@ -17,8 +17,8 @@ namespace Microsoft.DotNet.Cli
                 "restore",
                 LocalizableStrings.AppFullName,
                 Accept.ZeroOrMoreArguments()
-                      .With(name: CommonLocalizableStrings.ProjectArgumentName,
-                            description: CommonLocalizableStrings.ProjectArgumentDescription),
+                      .With(name: CommonLocalizableStrings.SolutionOrProjectArgumentName,
+                            description: CommonLocalizableStrings.SolutionOrProjectArgumentDescription),
                 FullRestoreOptions());
 
         private static Option[] FullRestoreOptions()

--- a/src/dotnet/commands/dotnet-test/TestCommandParser.cs
+++ b/src/dotnet/commands/dotnet-test/TestCommandParser.cs
@@ -16,8 +16,8 @@ namespace Microsoft.DotNet.Cli
                   "test",
                   LocalizableStrings.AppFullName,
                   Accept.ZeroOrMoreArguments()
-                        .With(name: CommonLocalizableStrings.ProjectArgumentName,
-                              description: CommonLocalizableStrings.ProjectArgumentDescription),
+                        .With(name: CommonLocalizableStrings.SolutionOrProjectArgumentName,
+                              description: CommonLocalizableStrings.SolutionOrProjectArgumentDescription),
                   false,
                   CommonOptions.HelpOption(),
                   Create.Option(


### PR DESCRIPTION
I've updated `dotnet clean`, `dotnet restore`, `dotnet build`, `dotnet publish`, and `dotnet test` commands description.

Fixes #10744
