### PR TITLE
Added --nologo option

### DIFF
--- a/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommandParser.cs
@@ -37,6 +37,11 @@ namespace Microsoft.DotNet.Cli
                     LocalizableStrings.NoDependenciesOptionDescription,
                     Accept.NoArguments()
                           .ForwardAs("-property:BuildProjectReferences=false")),
+                Create.Option(
+                    "--nologo|/nologo",
+                    LocalizableStrings.CmdNoLogo,
+                    Accept.NoArguments()
+                          .ForwardAs("-nologo")),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.InteractiveMsBuildForwardOption(),
                 CommonOptions.VerbosityOption());

--- a/src/dotnet/commands/dotnet-build/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-build/LocalizableStrings.resx
@@ -144,4 +144,7 @@
   <data name="ConfigurationOptionDescription" xml:space="preserve">
     <value>The configuration to use for building the project. The default for most projects is 'Debug'.</value>
   </data>
+  <data name="CmdNoLogo" xml:space="preserve">
+    <value>Do not display the startup banner or the copyright message.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">.NET Builder</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">Nesestaví odkazy mezi projekty a sestaví jen určený projekt.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">.NET-Generator</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">Hiermit werden keine Projekt-zu-Projekt-Verweise erstellt, sondern nur das angegebene Projekt wird erstellt.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Generador para .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">No compile referencias de proyecto a proyecto y compile solo el proyecto especificado.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Générateur .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">Ne générez pas les références de projet à projet, et générez uniquement le projet spécifié.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Generatore .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">Non compila i riferimenti P2P (da progetto a progetto) e compila solo il progetto specificato.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">.NET ビルダー</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">プロジェクト間参照をビルドせず、指定したプロジェクトだけをビルドします。</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">.NET 작성기</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">p2p(프로젝트 간) 참조를 빌드하지 않고 지정한 프로젝트만 빌드합니다.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Konstruktor platformy .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">Nie kompiluj odwołań między projektami i kompiluj tylko określony projekt.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Construtor do .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">Não criar referências de projeto para projeto e criar somente o projeto especificado.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Построитель .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">Не выполнять сборку для ссылок между проектами и выполнить сборку только для указанного проекта.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">.NET Oluşturucusu</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">Projeden projeye başvuruları derlemez ve yalnızca belirtilen projeyi derler.</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">.NET 生成器</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">请勿生成项目到项目引用，仅生成指定项目。</target>

--- a/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-build/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">.NET 產生器</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NoDependenciesOptionDescription">
         <source>Do not build project-to-project references and only build the specified project.</source>
         <target state="translated">請勿建置專案對專案的參考，而只建置指定的專案。</target>

--- a/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
+++ b/src/dotnet/commands/dotnet-clean/CleanCommandParser.cs
@@ -23,6 +23,11 @@ namespace Microsoft.DotNet.Cli
                                          Accept.ExactlyOneArgument()
                         .With(name: LocalizableStrings.CmdOutputDir)
                         .ForwardAsSingle(o => $"-property:OutputPath={CommandDirectoryContext.GetFullPath(o.Arguments.Single())}")),
+                Create.Option(
+                    "--nologo|/nologo",
+                    LocalizableStrings.CmdNoLogo,
+                    Accept.NoArguments()
+                          .ForwardAs("-nologo")),
                 CommonOptions.FrameworkOption(LocalizableStrings.FrameworkOptionDescription),
                 CommonOptions.RuntimeOption(LocalizableStrings.RuntimeOptionDescription),
                 CommonOptions.ConfigurationOption(LocalizableStrings.ConfigurationOptionDescription),

--- a/src/dotnet/commands/dotnet-clean/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-clean/LocalizableStrings.resx
@@ -138,4 +138,7 @@
   <data name="ConfigurationOptionDescription" xml:space="preserve">
     <value>The configuration to clean for. The default for most projects is 'Debug'.</value>
   </data>
+  <data name="CmdNoLogo" xml:space="preserve">
+    <value>Do not display the startup banner or the copyright message.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Příkaz slouží k vyčištění vygenerovaných výstupů buildů.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Befehl zum Bereinigen zuvor generierter Buildausgaben.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Comando para limpiar los archivos de salida de compilaciones anteriores.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">DIRECTORIO_DE_SALIDA</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Commande de nettoyage des sorties de build générées précédemment.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Comando per pulire gli output di compilazione generati in precedenza.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">DIR_OUTPUT</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">以前に生成されたビルド出力を消去するコマンド。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">이전에 생성된 빌드 출력을 정리하는 명령입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Polecenie służące do czyszczenia wcześniej wygenerowanych danych wyjściowych kompilacji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">KATALOG_WYJŚCIOWY</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Comando para limpar saídas de build geradas anteriormente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Команда для очистки ранее созданных выходных данных сборки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Daha önce oluşturulan derleme çıkışlarını temizleme komutu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">ÇIKIŞ_DİZİNİ</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">用于清除先前产生的生成输出的命令。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-clean/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">用以清除先前產生之建置輸出的命令。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-pack/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-pack/LocalizableStrings.resx
@@ -150,4 +150,7 @@
   <data name="ConfigurationOptionDescription" xml:space="preserve">
     <value>The configuration to use for building the package. The default for most projects is 'Debug'.</value>
   </data>
+  <data name="CmdNoLogo" xml:space="preserve">
+    <value>Do not display the startup banner or the copyright message.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
+++ b/src/dotnet/commands/dotnet-pack/PackCommandParser.cs
@@ -43,6 +43,11 @@ namespace Microsoft.DotNet.Cli
                     "-s|--serviceable",
                     LocalizableStrings.CmdServiceableDescription,
                     Accept.NoArguments().ForwardAs("-property:Serviceable=true")),
+                Create.Option(
+                    "--nologo|/nologo",
+                    LocalizableStrings.CmdNoLogo,
+                    Accept.NoArguments()
+                          .ForwardAs("-nologo")),
                 CommonOptions.InteractiveMsBuildForwardOption(),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">zabalit pro msbuild</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Für MSBuild packen</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">pack para MSBuild</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">DIRECTORIO_DE_SALIDA</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">compresser pour msbuild</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">pack per MSBuild</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">DIR_OUTPUT</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">msbuild のパック</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">msbuild용 팩입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">pakowanie dla programu MSBuild</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">KATALOG_WYJŚCIOWY</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">empacotar para o msbuild</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">упаковать для msbuild</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">msbuild paketi</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">ÇIKIŞ_DİZİNİ</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">用于 MSBuild 的包</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-pack/xlf/LocalizableStrings.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">MSBuild 套件</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdOutputDir">
         <source>OUTPUT_DIR</source>
         <target state="translated">OUTPUT_DIR</target>

--- a/src/dotnet/commands/dotnet-publish/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-publish/LocalizableStrings.resx
@@ -152,4 +152,7 @@ The default is to publish a framework-dependent application.</value>
   <data name="ConfigurationOptionDescription" xml:space="preserve">
     <value>The configuration to publish for. The default for most projects is 'Debug'.</value>
   </data>
+  <data name="CmdNoLogo" xml:space="preserve">
+    <value>Do not display the startup banner or the copyright message.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
+++ b/src/dotnet/commands/dotnet-publish/PublishCommandParser.cs
@@ -49,6 +49,11 @@ namespace Microsoft.DotNet.Cli
                             string value = o.Arguments.Any() ? o.Arguments.Single() : "true";
                             return $"-property:SelfContained={value}";
                         })),
+                Create.Option(
+                    "--nologo|/nologo",
+                    LocalizableStrings.CmdNoLogo,
+                    Accept.NoArguments()
+                          .ForwardAs("-nologo")),
                 CommonOptions.InteractiveMsBuildForwardOption(),
                 CommonOptions.NoRestoreOption(),
                 CommonOptions.VerbosityOption());

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Vydavatel pro platformu .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Herausgeber für die .NET-Plattform</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Publicador para la plataforma .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">PLATAFORMA</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Éditeur pour la plateforme .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Editore per la piattaforma .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">.NET Platform 用パブリッシャー</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">.NET 플랫폼용 게시자입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Wydawca dla platformy .NET.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">PLATFORMA</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Editor para a Plataforma .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Издатель для платформы .NET</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">.NET Platformunun yayımcısı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">ÇERÇEVE</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">适用于 .NET 平台的发布服务器</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-publish/xlf/LocalizableStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">.NET 平台的發行者</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdNoLogo">
+        <source>Do not display the startup banner or the copyright message.</source>
+        <target state="new">Do not display the startup banner or the copyright message.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FrameworkOption">
         <source>FRAMEWORK</source>
         <target state="translated">FRAMEWORK</target>

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -141,5 +141,25 @@ namespace Microsoft.DotNet.Cli.Build.Tests
             cmd.Should().Pass();
             cmd.StdOut.Should().ContainVisuallySameFragmentIfNotLocalized(expectedBuildSummary);
         }
+
+        [Fact]
+        public void ItDoesNotPrintCopyrightInfo()
+        {
+            var testInstance = TestAssets.Get("MSBuildTestApp")
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
+
+            var cmd = new BuildCommand()
+               .WithWorkingDirectory(testInstance.Root)
+               .ExecuteWithCapturedOutput("--nologo");
+
+            cmd.Should().Pass();
+
+            if (!DotnetUnderTest.IsLocalized())
+            {
+                cmd.Should().NotHaveStdOutContaining("Copyright (C) Microsoft Corporation. All rights reserved.");
+            }
+        }
     }
 }

--- a/test/dotnet-pack.Tests/PackTests.cs
+++ b/test/dotnet-pack.Tests/PackTests.cs
@@ -288,6 +288,26 @@ namespace Microsoft.DotNet.Tools.Pack.Tests
                 .Should().HaveFilesMatching("*.nupkg", SearchOption.AllDirectories);
         }
 
+        [Fact]
+        public void ItDoesNotPrintCopyrightInfo()
+        {
+            var testInstance = TestAssets.Get("MSBuildTestApp")
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
+
+            var result = new PackCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .ExecuteWithCapturedOutput("--nologo");
+
+            result.Should().Pass();
+
+            if (!DotnetUnderTest.IsLocalized())
+            {
+                result.Should().NotHaveStdOutContaining("Copyright (C) Microsoft Corporation. All rights reserved.");
+            }
+        }
+
         private void CopyProjectToTempDir(string projectDir, TempDirectory tempDir)
         {
             // copy all the files to temp dir

--- a/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
+++ b/test/dotnet-publish.Tests/GivenDotnetPublishPublishesProjects.cs
@@ -296,5 +296,25 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
                 .Should()
                 .Fail();
         }
+
+        [Fact]
+        public void ItDoesNotPrintCopyrightInfo()
+        {
+            var testInstance = TestAssets.Get("MSBuildTestApp")
+                .CreateInstance()
+                .WithSourceFiles()
+                .WithRestoreFiles();
+
+            var cmd = new PublishCommand()
+               .WithWorkingDirectory(testInstance.Root)
+               .ExecuteWithCapturedOutput("--nologo");
+
+            cmd.Should().Pass();
+
+            if (!DotnetUnderTest.IsLocalized())
+            {
+                cmd.Should().NotHaveStdOutContaining("Copyright (C) Microsoft Corporation. All rights reserved.");
+            }
+        }
     }
 }


### PR DESCRIPTION
Close #10825

I added the `--nologo` option for the `dotnet build`, `dotnet clean`, `dotnet pack` and `dotnet publish` commands. @peterhuene Did I miss other commands or is everything OK?