### PR TITLE
Sign resolver satellites in layout

### DIFF
--- a/build/Signing.proj
+++ b/build/Signing.proj
@@ -97,6 +97,9 @@
       <FilesToSign Include="$(SdkResolverOutputDirectory)/Microsoft.DotNet.MSBuildSdkResolver.dll">
         <Authenticode>$(InternalCertificateId)</Authenticode>
       </FilesToSign>
+      <FilesToSign Include="$(SdkResolverOutputDirectory)/*/Microsoft.DotNet.MSBuildSdkResolver.resources.dll">
+        <Authenticode>$(InternalCertificateId)</Authenticode>
+      </FilesToSign>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
We have separate locations for what goes into the nupkg to myget vs. what goes into the VS nupkg.

We are signing both independently, but only updated one of them to include the satellites.
