### PR TITLE
Set copyright and package license

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,12 +40,13 @@ tools\TestAssetsDependencies\TestAssetsDependencies.csproj
     <!-- https://github.com/dotnet/cli/issues/10637: frequent CI failures when test output is captured -->
     <TestCaptureOutput>false</TestCaptureOutput>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
-  </PropertyGroup>
-
+  
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+  <PropertyGroup Condition="'$(CopyrightNetFoundation)' != ''">
+    <Copyright>$(CopyrightNetFoundation)</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
 
   <Import Project="build/FileExtensions.props" />
   <Import Project="build/MSBuildExtensions.props" />


### PR DESCRIPTION
Prepares repo for change https://github.com/dotnet/arcade/pull/2003 by setting `Copyright` and `PackageLicenseExpression` properties. These values will be required to be set by each repository once https://github.com/dotnet/arcade/pull/2003 is merged.

In order to not break the current builds this change sets the properties conditionally. This condition can be removed once all repos switch to Arcade that has https://github.com/dotnet/arcade/pull/2003.

@markwilkie
