### PR TITLE
Skip the self-contained roll-forward version tests.

### DIFF
--- a/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
+++ b/test/EndToEnd/GivenSelfContainedAppsRollForward.cs
@@ -15,7 +15,7 @@ namespace EndToEnd
     public partial class GivenSelfContainedAppsRollForward : TestBase
     {
 
-        [Theory]
+        [Theory(Skip = "https://github.com/dotnet/cli/issues/10879")]
         //  MemberData is used instead of InlineData here so we can access it in another test to
         //  verify that we are covering the latest release of .NET Core
         [ClassData(typeof(SupportedNetCoreAppVersions))]


### PR DESCRIPTION
See #10879. Disabling these tests until we figure out a way to make them work
for servicing builds that will be bumping the versions without the unreleased,
upcoming shared frameworks being available.


