### PR TITLE
Nicer message for `dotnet tool install` failure

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/GracefulException.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/GracefulException.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Cli.Utils
             IsUserError = isUserError;
             if (verboseMessages != null)
             {
-                VerboseMessage = string.Join(Environment.NewLine, VerboseMessage);
+                VerboseMessage = string.Join(Environment.NewLine, verboseMessages);
             }
 
             Data.Add(ExceptionExtensions.CLI_User_Displayed_Exception, true);

--- a/src/dotnet/ToolManifest/LocalizableStrings.resx
+++ b/src/dotnet/ToolManifest/LocalizableStrings.resx
@@ -117,9 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CannotFindAnyManifestsFileSearched" xml:space="preserve">
-    <value>Cannot find any manifests file. Searched:
-{0}</value>
+  <data name="CannotFindAManifestFile" xml:space="preserve">
+    <value>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</value>
   </data>
   <data name="FieldCommandsIsMissing" xml:space="preserve">
     <value>Missing 'commands' entry.</value>
@@ -158,5 +158,9 @@
   </data>
   <data name="ManifestHasMarkOfTheWeb" xml:space="preserve">
     <value>File {0} came from another computer and might be blocked to help protect this computer. For more information, including how to unblock, see https://aka.ms/motw</value>
+  </data>
+  <data name="ListOfSearched" xml:space="preserve">
+    <value>The list of searched path:
+{0}</value>
   </data>
 </root>

--- a/src/dotnet/ToolManifest/LocalizableStrings.resx
+++ b/src/dotnet/ToolManifest/LocalizableStrings.resx
@@ -119,7 +119,7 @@
   </resheader>
   <data name="CannotFindAManifestFile" xml:space="preserve">
     <value>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</value>
+For a list of locations searched, specify the "-d" option before the tool name.</value>
   </data>
   <data name="FieldCommandsIsMissing" xml:space="preserve">
     <value>Missing 'commands' entry.</value>

--- a/src/dotnet/ToolManifest/LocalizableStrings.resx
+++ b/src/dotnet/ToolManifest/LocalizableStrings.resx
@@ -160,7 +160,7 @@ For a list of locations searched, specify the "-d" option before the tool name.<
     <value>File {0} came from another computer and might be blocked to help protect this computer. For more information, including how to unblock, see https://aka.ms/motw</value>
   </data>
   <data name="ListOfSearched" xml:space="preserve">
-    <value>The list of searched path:
+    <value>The list of searched paths:
 {0}</value>
   </data>
 </root>

--- a/src/dotnet/ToolManifest/ToolManifestCannotBeFoundException.cs
+++ b/src/dotnet/ToolManifest/ToolManifestCannotBeFoundException.cs
@@ -11,5 +11,10 @@ namespace Microsoft.DotNet.ToolManifest
         public ToolManifestCannotBeFoundException(string message) : base(new[] { message }, null, false)
         {
         }
+
+        public ToolManifestCannotBeFoundException(string message, string optionalMessage)
+            : base(new[] { message }, new[] { optionalMessage }, false)
+        {
+        }
     }
 }

--- a/src/dotnet/ToolManifest/ToolManifestFinder.cs
+++ b/src/dotnet/ToolManifest/ToolManifestFinder.cs
@@ -41,8 +41,9 @@ namespace Microsoft.DotNet.ToolManifest
             if (!findAnyManifest)
             {
                 throw new ToolManifestCannotBeFoundException(
-                    string.Format(LocalizableStrings.CannotFindAnyManifestsFileSearched,
-                        string.Join(Environment.NewLine, allPossibleManifests.Select(f => f.manifestfile.Value))));
+                    LocalizableStrings.CannotFindAManifestFile,
+                    string.Format(LocalizableStrings.ListOfSearched,
+                        string.Join(Environment.NewLine, allPossibleManifests.Select(f => "\t" + f.manifestfile.Value))));
             }
 
             return toolManifestPackageAndSource.Select(t => t.toolManifestPackage).ToArray();
@@ -162,9 +163,10 @@ namespace Microsoft.DotNet.ToolManifest
             }
 
             throw new ToolManifestCannotBeFoundException(
-                string.Format(LocalizableStrings.CannotFindAnyManifestsFileSearched,
+                LocalizableStrings.CannotFindAManifestFile,
+                string.Format(LocalizableStrings.ListOfSearched,
                     string.Join(Environment.NewLine,
-                        EnumerateDefaultAllPossibleManifests().Select(f => f.manifestfile.Value))));
+                        EnumerateDefaultAllPossibleManifests().Select(f => "\t" + f.manifestfile.Value))));
         }
     }
 }

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">V souboru manifestu nejde najít balíček s ID {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">Neplatný soubor manifestu. Cesta {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">Nejde najít žádný soubor manifestu. Prohledávalo se:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.cs.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">Es wurde kein Paket mit der Paket-ID {0} in der Manifestdatei gefunden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">Ungültige Manifestdatei. Pfad "{0}":
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">Es wurde keine Manifestdatei gefunden. Durchsucht:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.de.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">No puede encontrar un paquete con el id. de paquete {0} en el archivo de manifiesto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,12 +46,6 @@
 {1}</source>
         <target state="translated">Archivo de manifiesto no válido. Ruta {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">No encuentra ningún archivo de manifiestos. Buscado: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.es.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">Package avec l'ID {0} introuvable dans le fichier manifeste.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">Fichier manifeste non valide. Chemin {0} :
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">Fichiers manifeste introuvables. Recherche effectuée dans :
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.fr.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">Nel file manifesto non è possibile trovare un pacchetto con ID {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">Il file manifesto non è valido. Percorso: {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">Non è possibile trovare file manifesto. Ricerca eseguita in:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.it.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">マニフェスト ファイルにパッケージ ID {0} のパッケージが見つかりません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">マニフェスト ファイルが無効です。パス {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">マニフェスト ファイルが見つかりません。検索対象:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ja.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">매니페스트 파일에서 패키지 ID가 {0}인 패키지를 찾을 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">매니페스트 파일이 잘못되었습니다. 경로 {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">매니페스트 파일을 찾을 수 없습니다. 검색함:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ko.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">W pliku manifestu nie można odnaleźć pakietu o identyfikatorze {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">Nieprawidłowy plik manifestu. Ścieżka {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">Nie można odnaleźć żadnych plików manifestów. Przeszukano:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pl.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">Não é possível encontrar um pacote com a ID do pacote {0} no arquivo de manifesto.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">Arquivo de manifesto inválido. Caminho {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">Não é possível encontrar nenhum arquivo de manifestos. Pesquisado:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.pt-BR.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.ru.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">Не удается найти пакет с идентификатором {0} в файле манифеста.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">Недопустимый файл манифеста. Путь {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">Не удается найти ни одного файла манифеста. Поисковый запрос:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">Bildirim dosyasında {0} paket kimliğine sahip bir paket bulunamadı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,13 +46,6 @@
 {1}</source>
         <target state="translated">Bildirim dosyası geçersiz. Yol {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">Herhangi bir bildirim dosyası bulunamadı. Aranan:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.tr.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">未在清单文件中找到包 ID 为 {0} 的包。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -32,12 +46,6 @@
 {1}</source>
         <target state="translated">清单文件无效。路径 {0}:
 {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">找不到任何清单文件。已搜索: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hans.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
@@ -4,9 +4,9 @@
     <body>
       <trans-unit id="CannotFindAManifestFile">
         <source>Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+For a list of locations searched, specify the "-d" option before the tool name.</source>
         <target state="new">Cannot find a manifest file.
-For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+For a list of locations searched, specify the "-d" option before the tool name.</target>
         <note />
       </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,9 +2,23 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="CannotFindAManifestFile">
+        <source>Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</source>
+        <target state="new">Cannot find a manifest file.
+For a list of locations searched, use `dotnet -d tool install &lt;toolname&gt;`</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CannotFindPackageIdInManifest">
         <source>Cannot find a package with the package id {0} in the manifest file.</source>
         <target state="translated">在資訊清單檔中找不到套件識別碼為 {0} 的套件。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListOfSearched">
+        <source>The list of searched path:
+{0}</source>
+        <target state="new">The list of searched path:
+{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="ManifestHasMarkOfTheWeb">
@@ -31,12 +45,6 @@
         <source>Invalid manifest file. Path {0}:
 {1}</source>
         <target state="translated">資訊清單檔無效。路徑 {0}: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CannotFindAnyManifestsFileSearched">
-        <source>Cannot find any manifests file. Searched:
-{0}</source>
-        <target state="translated">找不到任何資訊清單檔。已搜尋: {0}</target>
         <note />
       </trans-unit>
       <trans-unit id="InPackage">

--- a/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/ToolManifest/xlf/LocalizableStrings.zh-Hant.xlf
@@ -15,9 +15,9 @@ For a list of locations searched, specify the "-d" option before the tool name.<
         <note />
       </trans-unit>
       <trans-unit id="ListOfSearched">
-        <source>The list of searched path:
+        <source>The list of searched paths:
 {0}</source>
-        <target state="new">The list of searched path:
+        <target state="new">The list of searched paths:
 {0}</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
@@ -224,6 +224,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
     <value>The local option(--local) does not support the framework option (--framework).</value>
   </data>
   <data name="NoManifestGuide" xml:space="preserve">
-    <value>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</value>
+    <value>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
@@ -225,6 +225,6 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
   </data>
   <data name="NoManifestGuide" xml:space="preserve">
     <value>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</value>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/install/ToolInstallLocalCommand.cs
@@ -172,6 +172,7 @@ namespace Microsoft.DotNet.Tools.Tool.Install
                         e.Message,
                         LocalizableStrings.NoManifestGuide
                     },
+                    verboseMessages: new[] { e.VerboseMessage },
                     isUserError: false);
             }
         }

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
@@ -42,8 +42,9 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Položka se přidala do so
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">Pokud chcete nainstalovat globální nástroj, přidejte přepínač -g. Pokud chcete použít manifest nástroje, musíte ho napřed vytvořit pomocí příkazu dotnet new tool-manifest.</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Pokud chcete nainstalovat globální nástroj, přidejte přepínač -g. Pokud chcete použít manifest nástroje, musíte ho napřed vytvořit pomocí příkazu dotnet new tool-manifest.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
@@ -43,7 +43,7 @@ Nástroj {1} (verze {2}) se úspěšně nainstaloval. Položka se přidala do so
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">Pokud chcete nainstalovat globální nástroj, přidejte přepínač -g. Pokud chcete použít manifest nástroje, musíte ho napřed vytvořit pomocí příkazu dotnet new tool-manifest.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
@@ -42,8 +42,9 @@ Das Tool "{1}" (Version "{2}") wurde erfolgreich installiert. Der Eintrag wird z
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">Wenn Sie ein globales Tool installieren möchten, fügen Sie "-g" hinzu. Wenn Sie ein Toolmanifest verwenden möchten, müssen Sie es zunächst mit "dotnet new tool-manifest" erstellen.</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Wenn Sie ein globales Tool installieren möchten, fügen Sie "-g" hinzu. Wenn Sie ein Toolmanifest verwenden möchten, müssen Sie es zunächst mit "dotnet new tool-manifest" erstellen.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
@@ -43,7 +43,7 @@ Das Tool "{1}" (Version "{2}") wurde erfolgreich installiert. Der Eintrag wird z
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">Wenn Sie ein globales Tool installieren möchten, fügen Sie "-g" hinzu. Wenn Sie ein Toolmanifest verwenden möchten, müssen Sie es zunächst mit "dotnet new tool-manifest" erstellen.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
@@ -43,7 +43,7 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. La entrada se h
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">Si desea instalar una herramienta global, agregue "-g". Si desea utilizar un manifiesto de herramientas, primero debe crearlo con "dotnet new tool-manifest".</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
@@ -42,8 +42,9 @@ La herramienta "{1}" (versión "{2}") se instaló correctamente. La entrada se h
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">Si desea instalar una herramienta global, agregue "-g". Si desea utilizar un manifiesto de herramientas, primero debe crearlo con "dotnet new tool-manifest".</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Si desea instalar una herramienta global, agregue "-g". Si desea utilizar un manifiesto de herramientas, primero debe crearlo con "dotnet new tool-manifest".</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
@@ -42,8 +42,9 @@ L'outil '{1}' (version '{2}') a été installé. L'entrée est ajoutée au fichi
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">Si vous voulez installer un outil global, ajoutez '-g'. Si vous voulez utiliser un manifeste d'outil, vous devez d'abord le créer avec 'dotnet new tool-manifest'.</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Si vous voulez installer un outil global, ajoutez '-g'. Si vous voulez utiliser un manifeste d'outil, vous devez d'abord le créer avec 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
@@ -43,7 +43,7 @@ L'outil '{1}' (version '{2}') a été installé. L'entrée est ajoutée au fichi
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">Si vous voulez installer un outil global, ajoutez '-g'. Si vous voulez utiliser un manifeste d'outil, vous devez d'abord le créer avec 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
@@ -42,8 +42,9 @@ Lo strumento '{1}' (versione '{2}') è stato installato. La voce è stata aggiun
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">Se si vuole installare uno strumento globale, aggiungere '-g'. Se si vuole usare un manifesto dello strumento, è prima necessario crearlo con 'dotnet new tool-manifest'.</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Se si vuole installare uno strumento globale, aggiungere '-g'. Se si vuole usare un manifesto dello strumento, è prima necessario crearlo con 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
@@ -43,7 +43,7 @@ Lo strumento '{1}' (versione '{2}') è stato installato. La voce è stata aggiun
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">Se si vuole installare uno strumento globale, aggiungere '-g'. Se si vuole usare un manifesto dello strumento, è prima necessario crearlo con 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
@@ -43,7 +43,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">グローバル ツールをインストールする場合、'-g' を追加します。ツール マニフェストを使用する場合には、'dotnet new tool-manifest' を使用してマニフェストを最初に作成する必要があります。</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
@@ -42,8 +42,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">グローバル ツールをインストールする場合、'-g' を追加します。ツール マニフェストを使用する場合には、'dotnet new tool-manifest' を使用してマニフェストを最初に作成する必要があります。</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">グローバル ツールをインストールする場合、'-g' を追加します。ツール マニフェストを使用する場合には、'dotnet new tool-manifest' を使用してマニフェストを最初に作成する必要があります。</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
@@ -43,7 +43,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">전역 도구를 설치하려는 경우 '-g'를 추가합니다. 도구 매니페스트를 사용하려는 경우 먼저 'dotnet new tool-manifest'를 사용하여 도구 매니패스트를 만들어야 합니다.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
@@ -42,8 +42,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">전역 도구를 설치하려는 경우 '-g'를 추가합니다. 도구 매니페스트를 사용하려는 경우 먼저 'dotnet new tool-manifest'를 사용하여 도구 매니패스트를 만들어야 합니다.</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">전역 도구를 설치하려는 경우 '-g'를 추가합니다. 도구 매니페스트를 사용하려는 경우 먼저 'dotnet new tool-manifest'를 사용하여 도구 매니패스트를 만들어야 합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
@@ -42,8 +42,9 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Dodan
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">Jeśli chcesz zainstalować narzędzie globalne, dodaj opcję „-g”. Jeśli chcesz użyć manifestu narzędzi, najpierw utwórz go za pomocą polecenia „dotnet new tool-manifest”.</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Jeśli chcesz zainstalować narzędzie globalne, dodaj opcję „-g”. Jeśli chcesz użyć manifestu narzędzi, najpierw utwórz go za pomocą polecenia „dotnet new tool-manifest”.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
@@ -43,7 +43,7 @@ Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Dodan
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">Jeśli chcesz zainstalować narzędzie globalne, dodaj opcję „-g”. Jeśli chcesz użyć manifestu narzędzi, najpierw utwórz go za pomocą polecenia „dotnet new tool-manifest”.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -43,7 +43,7 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">Se você deseja instalar uma ferramenta global, adicione '-g'. Se deseja usar uma ferramenta de manifesto, crie-a primeiro com 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -42,8 +42,9 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adici
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">Se você deseja instalar uma ferramenta global, adicione '-g'. Se deseja usar uma ferramenta de manifesto, crie-a primeiro com 'dotnet new tool-manifest'.</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Se você deseja instalar uma ferramenta global, adicione '-g'. Se deseja usar uma ferramenta de manifesto, crie-a primeiro com 'dotnet new tool-manifest'.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
@@ -42,8 +42,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">Если вы хотите установить глобальный инструмент, укажите параметр "-g". Если вы хотите использовать манифест инструмента, необходимо сначала создать манифест, выполнив команду  "dotnet new tool-manifest".</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Если вы хотите установить глобальный инструмент, укажите параметр "-g". Если вы хотите использовать манифест инструмента, необходимо сначала создать манифест, выполнив команду  "dotnet new tool-manifest".</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
@@ -43,7 +43,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">Если вы хотите установить глобальный инструмент, укажите параметр "-g". Если вы хотите использовать манифест инструмента, необходимо сначала создать манифест, выполнив команду  "dotnet new tool-manifest".</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
@@ -42,8 +42,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">Genel bir araç yüklemek istiyorsanız, '-g' ekleyin. Bir araç bildirimi kullanmak istiyorsanız önce bunu 'dotnet new tool-manifest' içinde oluşturmanız gerekir.</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">Genel bir araç yüklemek istiyorsanız, '-g' ekleyin. Bir araç bildirimi kullanmak istiyorsanız önce bunu 'dotnet new tool-manifest' içinde oluşturmanız gerekir.</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
@@ -43,7 +43,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">Genel bir araç yüklemek istiyorsanız, '-g' ekleyin. Bir araç bildirimi kullanmak istiyorsanız önce bunu 'dotnet new tool-manifest' içinde oluşturmanız gerekir.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -43,7 +43,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">如果要安装全局工具，请添加 "-g"。如果要使用工具清单，则必须先使用 "dotnet new tool-manifest" 创建该清单。</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -42,8 +42,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">如果要安装全局工具，请添加 "-g"。如果要使用工具清单，则必须先使用 "dotnet new tool-manifest" 创建该清单。</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">如果要安装全局工具，请添加 "-g"。如果要使用工具清单，则必须先使用 "dotnet new tool-manifest" 创建该清单。</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -42,8 +42,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
         <note />
       </trans-unit>
       <trans-unit id="NoManifestGuide">
-        <source>If you want to install a global tool, add '-g'. If you want to use a tool manifest, you must first create it with 'dotnet new tool-manifest'.</source>
-        <target state="translated">若要安裝全域工具，請新增 '-g'。您必須先使用 'dotnet new tool-manifest’ 建立工具資訊清單，才可加以使用。</target>
+        <source>If you intended to install a global tool, add `--global` to the command.
+If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+        <target state="needs-review-translation">若要安裝全域工具，請新增 '-g'。您必須先使用 'dotnet new tool-manifest’ 建立工具資訊清單，才可加以使用。</target>
         <note />
       </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -43,7 +43,7 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
       </trans-unit>
       <trans-unit id="NoManifestGuide">
         <source>If you intended to install a global tool, add `--global` to the command.
-If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.</source>
+If you would like to create a manifest, use `dotnet new tool-manifest`, usually in the repo root directory.</source>
         <target state="needs-review-translation">若要安裝全域工具，請新增 '-g'。您必須先使用 'dotnet new tool-manifest’ 建立工具資訊清單，才可加以使用。</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -87,6 +87,11 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
             }
             catch (ToolManifestCannotBeFoundException e)
             {
+                if (CommandContext.IsVerbose())
+                {
+                    _reporter.WriteLine(string.Join(Environment.NewLine, e.VerboseMessage).Yellow());
+                }
+
                 _reporter.WriteLine(e.Message.Yellow());
                 _reporter.WriteLine(LocalizableStrings.NoToolsWereRestored.Yellow());
                 return 0;

--- a/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
@@ -171,4 +171,7 @@
   <data name="UninstallLocalToolSucceeded" xml:space="preserve">
     <value>Tool '{0}' was successfully uninstalled and removed from manifest file {1}.</value>
   </data>
+  <data name="NoManifestGuide" xml:space="preserve">
+    <value>If you intended to uninstall a global tool, add `--global` to the command.</value>
+  </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/uninstall/ToolUninstallLocalCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/uninstall/ToolUninstallLocalCommand.cs
@@ -48,11 +48,27 @@ namespace Microsoft.DotNet.Tools.Tool.Uninstall
 
         public override int Execute()
         {
-            var manifestFile = string.IsNullOrWhiteSpace(_explicitManifestFile)
-                ? _toolManifestFinder.FindFirst()
-                : new FilePath(_explicitManifestFile);
+            FilePath manifestFile;
+
+            try
+            {
+                manifestFile = string.IsNullOrWhiteSpace(_explicitManifestFile)
+                   ? _toolManifestFinder.FindFirst()
+                   : new FilePath(_explicitManifestFile);
+            }
+            catch (ToolManifestCannotBeFoundException e)
+            {
+                throw new GracefulException(new[]
+                    {
+                        e.Message,
+                        LocalizableStrings.NoManifestGuide
+                    },
+                    verboseMessages: new[] { e.VerboseMessage },
+                    isUserError: false);
+            }
 
             _toolManifestEditor.Remove(manifestFile, _packageId);
+
             _reporter.WriteLine(
                 string.Format(
                     LocalizableStrings.UninstallLocalToolSucceeded,

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">Zadání manifestu nástroje (--tool-manifest) je platné jenom s parametrem lokálního nástroje (--local nebo výchozí).</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Pfad</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">Das Angeben des Toolmanifests (--tool-manifest) ist nur mit der lokalen Option (--local oder Standardeinstellung) gültig.</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">La especificación del manifiesto de la herramienta (--tool-manifest) solo es válida con la opción local (--local o el valor predeterminado).</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">La spécification du manifeste de l'outil (--tool-manifest) est uniquement valide avec l'option local (--local ou la valeur par défaut).</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PERCORSO</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">La specifica del manifesto dello sturmento (--tool-manifest) è valida solo con l'opzione local (--local o impostazione predefinita).</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">ツール マニフェストの指定 (--tool-manifest) は、ローカル オプション (--local または指定しない) と併用する場合にのみ有効です。</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">도구 매니페스트 지정(--tool-manifest)은 로컬 옵션(--local 또는 기본값)과 함께 사용되는 경우에만 유효합니다.</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">ŚCIEŻKA</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">Określenie manifestu narzędzi (--tool-manifest) jest prawidłowe tylko w przypadku opcji lokalnej (--local lub wartość domyślna).</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">Só é válido especificar o manifesto de ferramenta (--manifesto de ferramenta) com a opção local (--local ou a padrão).</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Путь</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">Указать манифест средства (--tool-manifest) можно только с параметром local (--local или по умолчанию).</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">Araç bildiriminin (--tool-manifest) belirtilmesi yalnızca yerel seçeneğiyle (--local veya varsayılan) geçerlidir.</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">指定工具清单(--tool-manifest)的操作仅在使用本地选项(--loca 或默认)时有效。</target>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
+        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="translated">指定工具資訊清單 (--tool-manifest) 僅對本機選項 (--local 或預設) 有效。</target>

--- a/test/dotnet.Tests/CommandTests/ToolInstallLocalCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallLocalCommandTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.DotNet.Tests.Commands
             Action a = () => toolInstallLocalCommand.Execute();
             a.ShouldThrow<GracefulException>()
                 .And.Message.Should()
-                .Contain(string.Format(ToolManifest.LocalizableStrings.CannotFindAnyManifestsFileSearched, ""));
+                .Contain(ToolManifest.LocalizableStrings.CannotFindAManifestFile);
         }
 
         [Fact]
@@ -136,6 +136,13 @@ namespace Microsoft.DotNet.Tests.Commands
             a.ShouldThrow<GracefulException>()
                 .And.Message.Should()
                 .Contain(LocalizableStrings.NoManifestGuide);
+
+            a.ShouldThrow<GracefulException>()
+                .And.Message.Should()
+                .Contain(ToolManifest.LocalizableStrings.CannotFindAManifestFile);
+
+            a.ShouldThrow<GracefulException>()
+                .And.VerboseMessage.Should().Contain(string.Format(ToolManifest.LocalizableStrings.ListOfSearched, ""));
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/ToolManifestFinderTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolManifestFinderTests.cs
@@ -157,7 +157,13 @@ namespace Microsoft.DotNet.Tests.Commands
 
             Action a = () => toolManifest.Find(new FilePath(Path.Combine(_testDirectoryRoot, "non-exists")));
             a.ShouldThrow<ToolManifestCannotBeFoundException>().And.Message.Should()
-                .Contain(string.Format(LocalizableStrings.CannotFindAnyManifestsFileSearched, ""));
+                .Contain(LocalizableStrings.CannotFindAManifestFile);
+
+            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
+                .Contain(string.Format(LocalizableStrings.ListOfSearched, ""))
+                .And.Contain(
+                    Path.Combine(_testDirectoryRoot, "non-exists"),
+                    "the specificied manifest file name is in the 'searched list'");
         }
 
         [Fact]
@@ -171,7 +177,10 @@ namespace Microsoft.DotNet.Tests.Commands
 
             Action a = () => toolManifest.Find();
             a.ShouldThrow<ToolManifestCannotBeFoundException>().And.Message.Should()
-                .Contain(string.Format(LocalizableStrings.CannotFindAnyManifestsFileSearched, ""));
+                 .Contain(LocalizableStrings.CannotFindAManifestFile);
+
+            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
+                .Contain(string.Format(LocalizableStrings.ListOfSearched, ""));
         }
 
         [Fact]
@@ -537,7 +546,10 @@ namespace Microsoft.DotNet.Tests.Commands
             Action a = () => toolManifest.FindFirst();
 
             a.ShouldThrow<ToolManifestCannotBeFoundException>().And.Message.Should()
-                .Contain(string.Format(LocalizableStrings.CannotFindAnyManifestsFileSearched, ""));
+                .Contain(LocalizableStrings.CannotFindAManifestFile);
+
+            a.ShouldThrow<ToolManifestCannotBeFoundException>().And.VerboseMessage.Should()
+                .Contain(string.Format(LocalizableStrings.ListOfSearched, ""));
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolRestoreCommandTests.cs
@@ -335,7 +335,7 @@ namespace Microsoft.DotNet.Tests.Commands
 
             _reporter.Lines.Should()
                 .Contain(l =>
-                    l.Contains(string.Format(ToolManifest.LocalizableStrings.CannotFindAnyManifestsFileSearched, "")));
+                    l.Contains(ToolManifest.LocalizableStrings.CannotFindAManifestFile));
         }
 
         [Fact]

--- a/test/dotnet.Tests/CommandTests/ToolUninstallLocalCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUninstallLocalCommandTests.cs
@@ -76,9 +76,17 @@ namespace Microsoft.DotNet.Tests.Commands
         {
             _fileSystem.File.Delete(_manifestFilePath);
             Action a = () => _defaultToolUninstallLocalCommand.Execute().Should().Be(0);
+
+            a.ShouldThrow<GracefulException>()
+               .And.Message.Should()
+               .Contain(LocalizableStrings.NoManifestGuide);
+
             a.ShouldThrow<GracefulException>()
                 .And.Message.Should()
-                .Contain(string.Format(ToolManifest.LocalizableStrings.CannotFindAnyManifestsFileSearched, ""));
+                .Contain(ToolManifest.LocalizableStrings.CannotFindAManifestFile);
+
+            a.ShouldThrow<GracefulException>()
+                .And.VerboseMessage.Should().Contain(string.Format(ToolManifest.LocalizableStrings.ListOfSearched, ""));
         }
 
         [Fact]


### PR DESCRIPTION
Fix https://github.com/dotnet/cli/issues/10863

-v vs -d
First -v is not correct. To have verbose output we need `-v detailed`. Only commands piped to MBuild (including nuget) honor this flag. And existing global tools use -d to include stack trace since the existing infrastructure of GracefulException only honor -d. Project tools also ask the user to use `-d` to investigate further. I prefer -d in the end due to.

- we will be more consistent with the past using -v. and minimal code change no need to make CLI layer understand msbuild verbose flag
- -d will only include the “manifest file searched” instead of adding msbuild and nuget’s log which is several pages.
- -d will not be confused with user’s command in dotnet tool run mymake -v that’s also why Project Tools cannot move output of this flag to use -v

- On the downside, use -d will further increase the separation of 2 flag to control output.

Since cannot find manifest is shared. To add “-g” does not make sense in many contexts I did not follow the text in the issue completely.
The final result:
λ dotnet tool uninstall apackage
Cannot find a manifest file.
For a list of locations searched, use `dotnet -d tool install <toolname>`
If you intended to uninstall a global tool, add `--global` to the command.

```
λ dotnet -d  tool uninstall apackage
Telemetry is: Enabled
The list of searched path:
        c:\work\cli\test\dotnet.Tests\.config\dotnet-tools.json
        c:\work\cli\test\dotnet.Tests\dotnet-tools.json
        c:\work\cli\test\.config\dotnet-tools.json
        c:\work\cli\test\dotnet-tools.json
        c:\work\cli\.config\dotnet-tools.json
        c:\work\cli\dotnet-tools.json
        c:\work\.config\dotnet-tools.json
        c:\work\dotnet-tools.json
        c:\.config\dotnet-tools.json
        c:\dotnet-tools.json
Cannot find a manifest file.
For a list of locations searched, use `dotnet -d tool install <toolname>`
If you intended to uninstall a global tool, add `--global` to the command.

λ dotnet tool install apackage
Cannot find a manifest file.
For a list of locations searched, use `dotnet -d tool install <toolname>`
If you intended to install a global tool, add `--global` to the command.
If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.

λ dotnet -d tool install apackage
Telemetry is: Enabled
The list of searched path:
        c:\work\cli\test\dotnet.Tests\.config\dotnet-tools.json
        c:\work\cli\test\dotnet.Tests\dotnet-tools.json
        c:\work\cli\test\.config\dotnet-tools.json
        c:\work\cli\test\dotnet-tools.json
        c:\work\cli\.config\dotnet-tools.json
        c:\work\cli\dotnet-tools.json
        c:\work\.config\dotnet-tools.json
        c:\work\dotnet-tools.json
        c:\.config\dotnet-tools.json
        c:\dotnet-tools.json
Cannot find a manifest file.
For a list of locations searched, use `dotnet -d tool install <toolname>`
If you intended to install a global tool, add `--global` to the command.
If you would like to create a manifest, use `dotnet new tool-manifest` first, usually in the repo root directory.

λ dotnet tool  restore
Cannot find a manifest file.
For a list of locations searched, use `dotnet -d tool install <toolname>`
No tools were restored.
```