### PR TITLE
Make sure that an empty argument is preserved.  Fix for #8892.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
@@ -95,12 +95,13 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             var sb = new StringBuilder();
 
-            var needsQuotes = ShouldSurroundWithQuotes(arg);
+            var length = arg.Length;
+            var needsQuotes = length == 0 || ShouldSurroundWithQuotes(arg);
             var isQuoted = needsQuotes || IsSurroundedWithQuotes(arg);
 
             if (needsQuotes) sb.Append("\"");
 
-            for (int i = 0; i < arg.Length; ++i)
+            for (int i = 0; i < length; ++i)
             {
                 var backslashCount = 0;
 


### PR DESCRIPTION

These changes fix issue #8892.  The net effect is that when an empty argument is detected, a pair of double quotes will be emitted.
