### PR TITLE
Change message when the executable cannot be found to File not found {0} for issue #10911

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
@@ -130,7 +130,11 @@
     <value>The project may not have been restored or restore failed - run `dotnet restore`</value>
   </data>
   <data name="NoExecutableFoundMatchingCommand" xml:space="preserve">
-    <value>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</value>
+    <value>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</value>
   </data>
   <data name="WaitingForDebuggerToAttach" xml:space="preserve">
     <value>Waiting for debugger to attach. Press ENTER to continue</value>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Nenašel se žádný spustitelný soubor odpovídající příkazu {0}. Další informace najdete na https://aka.ms/missing-command.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">Nenašel se žádný spustitelný soubor odpovídající příkazu {0}. Další informace najdete na https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Es wurde keine ausführbare Datei gefunden, die dem Befehl "{0}" entspricht. Weitere Informationen finden Sie unter https://aka.ms/missing-command.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">Es wurde keine ausführbare Datei gefunden, die dem Befehl "{0}" entspricht. Weitere Informationen finden Sie unter https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">No se ha encontrado un ejecutable que coincida con el comando "{0}". Consulte https://aka.ms/missing-command para obtener más información.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">No se ha encontrado un ejecutable que coincida con el comando "{0}". Consulte https://aka.ms/missing-command para obtener más información.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Aucun exécutable ne correspond à la commande "{0}". Consultez https://aka.ms/missing-command pour plus d'informations.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">Aucun exécutable ne correspond à la commande "{0}". Consultez https://aka.ms/missing-command pour plus d'informations.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Non è stato trovato alcun file eseguibile corrispondente al comando "{0}". Per altre informazioni, vedere https://aka.ms/missing-command.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">Non è stato trovato alcun file eseguibile corrispondente al comando "{0}". Per altre informazioni, vedere https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">コマンド "{0}" に対応する実行可能ファイルが見つかりません。詳細については https://aka.ms/missing-command を参照してください。</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">コマンド "{0}" に対応する実行可能ファイルが見つかりません。詳細については https://aka.ms/missing-command を参照してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">"{0}" 명령과 일치하는 실행 파일을 찾을 수 없습니다. 자세한 내용은 https://aka.ms/missing-command를 참조하세요.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">"{0}" 명령과 일치하는 실행 파일을 찾을 수 없습니다. 자세한 내용은 https://aka.ms/missing-command를 참조하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Nie znaleziono pliku wykonywalnego zgodnego z poleceniem „{0}”. Aby uzyskać więcej informacji, zobacz https://aka.ms/missing-command.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">Nie znaleziono pliku wykonywalnego zgodnego z poleceniem „{0}”. Aby uzyskać więcej informacji, zobacz https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Não foi encontrado nenhum executável correspondente ao comando "{0}". Consulte https://aka.ms/missing-command para obter mais informações.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">Não foi encontrado nenhum executável correspondente ao comando "{0}". Consulte https://aka.ms/missing-command para obter mais informações.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Не найден исполняемый файл, соответствующий команде "{0}". Дополнительные сведения см. на странице https://aka.ms/missing-command.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">Не найден исполняемый файл, соответствующий команде "{0}". Дополнительные сведения см. на странице https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">"{0}" komutuyla eşleşen yürütülebilir dosya bulunamadı. Daha fazla bilgi edinmek için bkz. https://aka.ms/missing-command.</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">"{0}" komutuyla eşleşen yürütülebilir dosya bulunamadı. Daha fazla bilgi edinmek için bkz. https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">找不到与命令“{0}”匹配的可执行文件。有关详细信息，请参阅 https://aka.ms/missing-command。</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">找不到与命令“{0}”匹配的可执行文件。有关详细信息，请参阅 https://aka.ms/missing-command。</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
@@ -23,8 +23,12 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">找不到任何符合命令 "{0}" 的可執行檔。如需詳細資料，請參閱 https://aka.ms/missing-command。</target>
+        <source>Could not execute because the specified command or file was not found.
+Possible reasons for this include:
+  * You misspelled a built-in dotnet command.
+  * You intended to execute a .NET Core program, but {0} does not exist.
+  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.</source>
+        <target state="needs-review-translation">找不到任何符合命令 "{0}" 的可執行檔。如需詳細資料，請參閱 https://aka.ms/missing-command。</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">


### PR DESCRIPTION
- Issue #10911 
- Change message when the executable cannot be found from "No executable found matching command" to "File not found {0}"

