### PR TITLE
Fix flaky SIGINT/SIGTERM tests.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Command.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Command.cs
@@ -47,10 +47,11 @@ namespace Microsoft.DotNet.Cli.Utils
 #endif
             using (PerfTrace.Current.CaptureTiming($"{Path.GetFileNameWithoutExtension(_process.StartInfo.FileName)} {_process.StartInfo.Arguments}"))
             {
-                _process.Start();
-
-                using (new ProcessReaper(_process))
+                using (var reaper = new ProcessReaper(_process))
                 {
+                    _process.Start();
+                    reaper.NotifyProcessStarted();
+
                     Reporter.Verbose.WriteLine(string.Format(
                         LocalizableStrings.ProcessId,
                         _process.Id));

--- a/src/Microsoft.DotNet.Cli.Utils/ProcessStartInfoExtensions.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ProcessStartInfoExtensions.cs
@@ -20,10 +20,10 @@ namespace Microsoft.DotNet.Cli.Utils
                 StartInfo = startInfo
             };
 
-            process.Start();
-
-            using (new ProcessReaper(process))
+            using (var reaper = new ProcessReaper(process))
             {
+                process.Start();
+                reaper.NotifyProcessStarted();
                 process.WaitForExit();
             }
 
@@ -45,10 +45,11 @@ namespace Microsoft.DotNet.Cli.Utils
 
             process.EnableRaisingEvents = true;
 
-            process.Start();
-
-            using (new ProcessReaper(process))
+            using (var reaper = new ProcessReaper(process))
             {
+                process.Start();
+                reaper.NotifyProcessStarted();
+
                 var taskOut = outStream.BeginRead(process.StandardOutput);
                 var taskErr = errStream.BeginRead(process.StandardError);
 


### PR DESCRIPTION
This commit fixes the race condition that caused failures of the SIGINT/SIGTERM
handling tests on non-Windows platforms.

The tests are designed to spawn `dotnet run`, which will itself spawn a child
process.  The tests look for output from the child process; when the child
outputs the needed data, the tests' process will start signaling the dotnet
process.

The race lies between the call to start the process and the attempt to register
the signal handlers in dotnet. If the child process outputs the needed data and
the test process signals the dotnet process *before* the dotnet process has had
a chance to register the signal handlers, then the default signal handlers will
be invoked.  For SIGINT, this results in dotnet exiting with 130 and not
waiting for the child process to terminate.  For SIGTERM, it won't forward the
signal to the child process or exit with the same exit code that the child
exited with.

The fix is to register the handlers prior to the process starting.  On Windows,
we still need to perform an action after the process has started (namely that
the child process is added to the job object) because it needs the handle to
the child process.
