### PR TITLE
Prevent stage0 bundled versions from interfering with the build.

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -163,9 +163,9 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <LatestPatchVersionForNetCore1_0 Condition="'$(LatestPatchVersionForNetCore1_0)' == ''">1.0.14</LatestPatchVersionForNetCore1_0>
-      <LatestPatchVersionForNetCore1_1 Condition="'$(LatestPatchVersionForNetCore1_1)' == ''">1.1.11</LatestPatchVersionForNetCore1_1>
-      <LatestPatchVersionForNetCore2_0 Condition="'$(LatestPatchVersionForNetCore2_0)' == ''">2.0.9</LatestPatchVersionForNetCore2_0>
+      <MicrosoftNETCoreAppLatestVersion1_0 Condition="'$(MicrosoftNETCoreAppLatestVersion1_0)' == ''">1.0.14</MicrosoftNETCoreAppLatestVersion1_0>
+      <MicrosoftNETCoreAppLatestVersion1_1 Condition="'$(MicrosoftNETCoreAppLatestVersion1_1)' == ''">1.1.11</MicrosoftNETCoreAppLatestVersion1_1>
+      <MicrosoftNETCoreAppLatestVersion2_0 Condition="'$(MicrosoftNETCoreAppLatestVersion2_0)' == ''">2.0.9</MicrosoftNETCoreAppLatestVersion2_0>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -199,9 +199,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     <DefaultPatchVersionForAspNetCoreApp2_1>$(_DefaultPatchVersionForAspNetCoreApp2_1)</DefaultPatchVersionForAspNetCoreApp2_1>
 
     <!-- Latest patch versions for each minor version of .NET Core -->
-    <LatestPatchVersionForNetCore1_0 Condition="'%24(LatestPatchVersionForNetCore1_0)' == ''">$(LatestPatchVersionForNetCore1_0)</LatestPatchVersionForNetCore1_0>
-    <LatestPatchVersionForNetCore1_1 Condition="'%24(LatestPatchVersionForNetCore1_1)' == ''">$(LatestPatchVersionForNetCore1_1)</LatestPatchVersionForNetCore1_1>
-    <LatestPatchVersionForNetCore2_0 Condition="'%24(LatestPatchVersionForNetCore2_0)' == ''">$(LatestPatchVersionForNetCore2_0)</LatestPatchVersionForNetCore2_0>
+    <LatestPatchVersionForNetCore1_0 Condition="'%24(LatestPatchVersionForNetCore1_0)' == ''">$(MicrosoftNETCoreAppLatestVersion1_0)</LatestPatchVersionForNetCore1_0>
+    <LatestPatchVersionForNetCore1_1 Condition="'%24(LatestPatchVersionForNetCore1_1)' == ''">$(MicrosoftNETCoreAppLatestVersion1_1)</LatestPatchVersionForNetCore1_1>
+    <LatestPatchVersionForNetCore2_0 Condition="'%24(LatestPatchVersionForNetCore2_0)' == ''">$(MicrosoftNETCoreAppLatestVersion2_0)</LatestPatchVersionForNetCore2_0>
   </PropertyGroup>
 </Project>
 ]]>


### PR DESCRIPTION
A change to enable the parameterization of the latest known patch numbers for
Microsoft.NETCore.App reused the same property names as those in the generated
bundled versions props file.

When building locally, the stage0 dotnet install was setting the properties
first, resulting in older versions as the fallbacks then what is currently
being used in the repo.

However, when building from an orchestrated build where the properties were
being set globally, those properties get respected and the values are
the expected ones.

This commit fixes this by renaming the properties to those that aren't used in
the bundled versions props file.  The names chosen match those we're using for
the 2.2 builds for consistency.

