### PR TITLE
Unblock dotnet/sdk -> dotnet/cli flow

### DIFF
--- a/TestAssets/TestProjects/TestAppWithSlnAndSolutionFolders/src/App/App.csproj
+++ b/TestAssets/TestProjects/TestAppWithSlnAndSolutionFolders/src/App/App.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NewtonSoft.Json" Version="9.0.1" />
     <ProjectReference Include="..\src\Lib\Lib.csproj" />
   </ItemGroup>
 

--- a/build/Test.targets
+++ b/build/Test.targets
@@ -33,14 +33,14 @@
     <MSBuild
       BuildInParallel="False"
       Projects="%(TestPackageProject.ProjectPath)"
-      Properties="RestoreAdditionalProjectSources=$(TestPackagesDir);ImportDirectoryBuildTargets=false"
+      Properties="ImportDirectoryBuildTargets=false"
       Targets="Restore"
       RemoveProperties="TargetFramework" />
 
     <MSBuild
       BuildInParallel="False"
       Projects="%(TestPackageProject.ProjectPath)"
-      Properties="PackageOutputPath=$(TestPackagesDir);%(TestPackageProject.MsbuildArgs);RestoreAdditionalProjectSources=$(TestOutputDir)/packages;Version=%(TestPackageProject.Version)"
+      Properties="PackageOutputPath=$(TestPackagesDir);%(TestPackageProject.MsbuildArgs);Version=%(TestPackageProject.Version)"
       Targets="Pack"
       RemoveProperties="TargetFramework" />
   </Target>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <DotNetCoreSdkLKGVersion>3.0.100-preview3-010272</DotNetCoreSdkLKGVersion>
+    <DotNetCoreSdkLKGVersion>3.0.100-preview4-010615</DotNetCoreSdkLKGVersion>
     <MicrosoftAspNetCoreAllPackageVersion>2.2.1</MicrosoftAspNetCoreAllPackageVersion>
     <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>2.2.0</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <MicrosoftAspNetCoreAppPackageVersion>$(MicrosoftAspNetCoreAllPackageVersion)</MicrosoftAspNetCoreAppPackageVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>2.2.0</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>2.2.1</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftBuildPackageVersion>16.0.0-preview.360</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>16.1.0-preview.19</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildUtilitiesCorePackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview3-010272"
+    "dotnet": "3.0.100-preview4-010615"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19154.14"

--- a/test/Microsoft.DotNet.ShellShim.Tests/ShellShimRepositoryTests.cs
+++ b/test/Microsoft.DotNet.ShellShim.Tests/ShellShimRepositoryTests.cs
@@ -474,7 +474,6 @@ namespace Microsoft.DotNet.ShellShim.Tests
 
             TestAssetInstance testInstance = TestAssets.Get(testAppName)
                 .CreateInstance(instanceName)
-                .UseCurrentRuntimeFrameworkVersion()
                 .WithRestoreFiles()
                 .WithBuildFiles();
 

--- a/test/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.csproj
+++ b/test/Microsoft.DotNet.TestFramework/Microsoft.DotNet.TestFramework.csproj
@@ -7,7 +7,6 @@
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.DotNet.TestFramework/TestAssetInstance.cs
+++ b/test/Microsoft.DotNet.TestFramework/TestAssetInstance.cs
@@ -172,23 +172,6 @@ namespace Microsoft.DotNet.TestFramework
             return this;
         }
 
-        public TestAssetInstance UseCurrentRuntimeFrameworkVersion()
-        {
-            return WithProjectChanges(project =>
-            {
-                var ns = project.Root.Name.Namespace;
-
-                var propertyGroup = project.Root.Elements(ns + "PropertyGroup").LastOrDefault();
-                if (propertyGroup == null)
-                {
-                    propertyGroup = new XElement(ns + "PropertyGroup");
-                    project.Root.Add(propertyGroup);
-                }
-
-                propertyGroup.Add(new XElement(ns + "RuntimeFrameworkVersion", CurrentRuntimeFrameworkVersion));
-            });
-        }
-
         private static string RebasePath(string path, string oldBaseDirectory, string newBaseDirectory)
         {
             path = Path.IsPathRooted(path) ? PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(oldBaseDirectory), path) : path;

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/Microsoft.DotNet.Tools.Tests.Utilities.csproj
@@ -8,7 +8,6 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssetTargetFallback>$(AssetTargetFallback);dotnet5.4;portable-net451+win8</AssetTargetFallback>
-    <RuntimeFrameworkVersion>$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
+++ b/test/dotnet-list-package.Tests/GivenDotnetListPackage.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using System.Linq;
+using System.Xml.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Tools.Test.Utilities;
 using Xunit;
@@ -59,6 +62,7 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
                 .Get(testAsset)
                 .CreateInstance()
                 .WithSourceFiles()
+                .WithProjectChanges(ChangeTargetFrameworkTo2_1)
                 .Root
                 .FullName;
 
@@ -77,6 +81,13 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
                 .And.NotHaveStdErr()
                 .And.HaveStdOutContainingIgnoreSpaces("Microsoft.NETCore.App(A)")
                 .And.HaveStdOutContainingIgnoreSpaces("(A):Auto-referencedpackage");
+
+            void ChangeTargetFrameworkTo2_1(XDocument project)
+            {
+                project.Descendants()
+                       .Single(e => e.Name.LocalName == "TargetFramework")
+                       .Value = "netcoreapp2.1";
+            }
         }
 
         [Fact]
@@ -103,7 +114,7 @@ namespace Microsoft.DotNet.Cli.List.Package.Tests
                 .Should()
                 .Pass()
                 .And.NotHaveStdErr()
-                .And.HaveStdOutContainingIgnoreSpaces("Microsoft.NETCore.App");
+                .And.HaveStdOutContainingIgnoreSpaces("NewtonSoft.Json");
         }
 
         [Fact]

--- a/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
+++ b/test/dotnet-restore.Tests/GivenThatIWantToRestoreApp.cs
@@ -10,7 +10,7 @@ using Xunit;
 using FluentAssertions;
 using System.Linq;
 
-namespace Microsoft.DotNet.Restore.Tests
+namespace Microsoft.DotNet.Restore.Test
 {
     public class GivenThatIWantToRestoreApp : TestBase
     {
@@ -24,16 +24,17 @@ namespace Microsoft.DotNet.Restore.Tests
             string dir = "pkgs";
             string fullPath = Path.GetFullPath(Path.Combine(rootPath, dir));
 
-            string newArgs = $"console -o \"{rootPath}\" --no-restore";
-            new NewCommandShim()
-                .WithWorkingDirectory(rootPath)
-                .Execute(newArgs)
-                .Should()
-                .Pass();
+            var sln = "TestAppWithSlnAndSolutionFolders";
+            var projectDirectory = TestAssets
+                .Get(sln)
+                .CreateInstance()
+                .WithSourceFiles()
+                .Root
+                .FullName;
 
-            string args = $"--configfile {RepoRootNuGetConfig} --packages \"{dir}\"";
+            string args = $"--configfile {RepoRootNuGetConfig} --packages \"{fullPath}\"";
             new RestoreCommand()
-                 .WithWorkingDirectory(rootPath)
+                 .WithWorkingDirectory(projectDirectory)
                  .ExecuteWithCapturedOutput(args)
                  .Should()
                  .Pass()

--- a/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
+++ b/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
@@ -109,7 +109,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
         }
 
         //  Windows only for now due to https://github.com/dotnet/cli/issues/7501
-        [WindowsOnlyFact]
+        [WindowsOnlyFact(Skip = "https://github.com/dotnet/sdk/issues/2914")]
         public void ItPublishesAnAppWithMultipleProfiles()
         {
             var testAppName = "MultiDependentProject";

--- a/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
+++ b/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
         private static string _frameworkVersion = TestAssetInstance.CurrentRuntimeFrameworkVersion;
         private static string _arch = RuntimeEnvironment.RuntimeArchitecture.ToLowerInvariant();
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/sdk/issues/2914")]
         public void ItPublishesARunnablePortableApp()
         {
             var testAppName = "NewtonSoftDependentProject";

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -59,19 +59,14 @@ namespace Microsoft.DotNet.Tests
         }
 
         [Theory]
-        [InlineData("AppWithDirectAndToolDep", true)]
-        [InlineData("AppWithToolDependency", false)]
-        public void TestProjectToolIsAvailableThroughDriver(string appName, bool useCurrentFrameworkRuntimeVersion)
+        [InlineData("AppWithDirectAndToolDep")]
+        [InlineData("AppWithToolDependency")]
+        public void TestProjectToolIsAvailableThroughDriver(string appName)
         {
             var testInstance = TestAssets.Get(appName)
                 .CreateInstance()
                 .WithSourceFiles()
                 .WithNuGetConfig(new RepoDirectoriesProvider().TestPackages);
-
-            if (useCurrentFrameworkRuntimeVersion)
-            {
-                testInstance = testInstance.UseCurrentRuntimeFrameworkVersion();
-            }
 
             // restore again now that the project has changed
             new RestoreCommand()
@@ -281,7 +276,6 @@ namespace Microsoft.DotNet.Tests
             var testInstance = TestAssets.Get("AppWithDirectDep")
                 .CreateInstance()
                 .WithSourceFiles()
-                .UseCurrentRuntimeFrameworkVersion()
                 .WithNuGetConfig(new RepoDirectoriesProvider().TestPackages);
 
             // restore again now that the project has changed

--- a/testAsset.props
+++ b/testAsset.props
@@ -9,9 +9,6 @@
 
     <NoPackageAnalysis>true</NoPackageAnalysis>
 
-    <!-- Needed while dotnet/sdk version used does not support 3.0 yet -->
-    <NETCoreAppMaximumVersion>3.0</NETCoreAppMaximumVersion>
-
     <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
     <EnableSourceLink>false</EnableSourceLink>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>


### PR DESCRIPTION
1. Stop forcing runtime version in tests
2. Update .NET Core SDK LKG
3. Stop setting RestoreAdditionalProjectSources as global property
4. Disable dotnet store tests against dotnet/sdk#2914 (as was done in dotnet/sdk)
5. Fix tests that need at least one package reference vs. basic scenarios in 3.0 that don't have that by default
6. Fix SIGTERM shutdown race