### PR TITLE
Limit job object usage to Windows 8/2012 or later.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ProcessReaper.cs
@@ -51,7 +51,16 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             if (RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows)
             {
-                _job = AssignProcessToJobObject(_process.Handle);
+                // Limit the use of job objects to versions of Windows that support nested jobs (i.e. Windows 8/2012 or later).
+                // Ideally, we would check for some new API export or OS feature instead of the OS version,
+                // but nested jobs are transparently implemented with respect to the Job Objects API.
+                // Note: Windows 8.1 and later may report as Windows 8 (see https://docs.microsoft.com/en-us/windows/desktop/sysinfo/operating-system-version).
+                //       However, for the purpose of this check that is still sufficient.
+                if (Environment.OSVersion.Version.Major > 6 ||
+                   (Environment.OSVersion.Version.Major == 6 && Environment.OSVersion.Version.Minor >= 2))
+                {
+                    _job = AssignProcessToJobObject(_process.Handle);
+                }
             }
         }
 


### PR DESCRIPTION
The ASP.NET Core team has a test that runs on Windows 7/2008 which spawns IIS
Express.  The test is running under `dotnet test` and thus the child
process gets assigned to dotnet's job object for process reaping.  However, IIS
Express maintains its own job object for the process it spawns and the dotnet
job object assignment interferes with IIS Express' use of its job objects.

This occurs on Windows 7 and Windows Server 2008 because those versions of
Windows do not support nested jobs.

The fix taken here is to limit the use of job objects for process reaping to
Windows 8 / Windows Server 2012 or later.  This is done with an explicit OS
version check because there is no change to the Job Objects API to enable
support for nested jobs and thus no other way to determine if the feature is
available to us.

Fixes #10947.