### PR TITLE
Better no executable found message

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/CommandUnknownException.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/CommandUnknownException.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.IO;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
@@ -9,16 +10,26 @@ namespace Microsoft.DotNet.Cli.Utils
     {
         public CommandUnknownException(string commandName) : base(string.Format(
             LocalizableStrings.NoExecutableFoundMatchingCommand,
-            commandName))
+            RemoveLeadingDotnet(commandName), Path.GetFileNameWithoutExtension(commandName)))
         {
         }
 
         public CommandUnknownException(string commandName, Exception innerException) : base(
             string.Format(
                 LocalizableStrings.NoExecutableFoundMatchingCommand,
-                commandName),
+                RemoveLeadingDotnet(commandName), Path.GetFileNameWithoutExtension(commandName)),
             innerException)
         {
+        }
+
+        public static string RemoveLeadingDotnet(string commandName)
+        {
+            if (commandName.StartsWith("dotnet-", StringComparison.OrdinalIgnoreCase))
+            {
+                return commandName.Substring("dotnet-".Length);
+            }
+
+            return commandName;
         }
     }
 }

--- a/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
+++ b/src/Microsoft.DotNet.Cli.Utils/LocalizableStrings.resx
@@ -130,7 +130,10 @@
     <value>The project may not have been restored or restore failed - run `dotnet restore`</value>
   </data>
   <data name="NoExecutableFoundMatchingCommand" xml:space="preserve">
-    <value>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</value>
+    <value>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</value>
   </data>
   <data name="WaitingForDebuggerToAttach" xml:space="preserve">
     <value>Waiting for debugger to attach. Press ENTER to continue</value>

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.cs.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Nenašel se žádný spustitelný soubor odpovídající příkazu {0}. Další informace najdete na https://aka.ms/missing-command.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">Nenašel se žádný spustitelný soubor odpovídající příkazu {0}. Další informace najdete na https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.de.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Es wurde keine ausführbare Datei gefunden, die dem Befehl "{0}" entspricht. Weitere Informationen finden Sie unter https://aka.ms/missing-command.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">Es wurde keine ausführbare Datei gefunden, die dem Befehl "{0}" entspricht. Weitere Informationen finden Sie unter https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.es.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">No se ha encontrado un ejecutable que coincida con el comando "{0}". Consulte https://aka.ms/missing-command para obtener más información.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">No se ha encontrado un ejecutable que coincida con el comando "{0}". Consulte https://aka.ms/missing-command para obtener más información.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.fr.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Aucun exécutable ne correspond à la commande "{0}". Consultez https://aka.ms/missing-command pour plus d'informations.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">Aucun exécutable ne correspond à la commande "{0}". Consultez https://aka.ms/missing-command pour plus d'informations.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.it.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Non è stato trovato alcun file eseguibile corrispondente al comando "{0}". Per altre informazioni, vedere https://aka.ms/missing-command.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">Non è stato trovato alcun file eseguibile corrispondente al comando "{0}". Per altre informazioni, vedere https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ja.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">コマンド "{0}" に対応する実行可能ファイルが見つかりません。詳細については https://aka.ms/missing-command を参照してください。</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">コマンド "{0}" に対応する実行可能ファイルが見つかりません。詳細については https://aka.ms/missing-command を参照してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ko.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">"{0}" 명령과 일치하는 실행 파일을 찾을 수 없습니다. 자세한 내용은 https://aka.ms/missing-command를 참조하세요.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">"{0}" 명령과 일치하는 실행 파일을 찾을 수 없습니다. 자세한 내용은 https://aka.ms/missing-command를 참조하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pl.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Nie znaleziono pliku wykonywalnego zgodnego z poleceniem „{0}”. Aby uzyskać więcej informacji, zobacz https://aka.ms/missing-command.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">Nie znaleziono pliku wykonywalnego zgodnego z poleceniem „{0}”. Aby uzyskać więcej informacji, zobacz https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.pt-BR.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Não foi encontrado nenhum executável correspondente ao comando "{0}". Consulte https://aka.ms/missing-command para obter mais informações.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">Não foi encontrado nenhum executável correspondente ao comando "{0}". Consulte https://aka.ms/missing-command para obter mais informações.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.ru.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">Не найден исполняемый файл, соответствующий команде "{0}". Дополнительные сведения см. на странице https://aka.ms/missing-command.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">Не найден исполняемый файл, соответствующий команде "{0}". Дополнительные сведения см. на странице https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.tr.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">"{0}" komutuyla eşleşen yürütülebilir dosya bulunamadı. Daha fazla bilgi edinmek için bkz. https://aka.ms/missing-command.</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">"{0}" komutuyla eşleşen yürütülebilir dosya bulunamadı. Daha fazla bilgi edinmek için bkz. https://aka.ms/missing-command.</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hans.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">找不到与命令“{0}”匹配的可执行文件。有关详细信息，请参阅 https://aka.ms/missing-command。</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">找不到与命令“{0}”匹配的可执行文件。有关详细信息，请参阅 https://aka.ms/missing-command。</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.DotNet.Cli.Utils/xlf/LocalizableStrings.zh-Hant.xlf
@@ -23,8 +23,11 @@
         <note />
       </trans-unit>
       <trans-unit id="NoExecutableFoundMatchingCommand">
-        <source>No executable found matching command "{0}". See https://aka.ms/missing-command for more information.</source>
-        <target state="translated">找不到任何符合命令 "{0}" 的可執行檔。如需詳細資料，請參閱 https://aka.ms/missing-command。</target>
+        <source>Could not run anything - file not found.
+	If you passed path '{0}' it was not found.
+	If you intended to call a dotnet command, you may have misspelled it.
+	If you were calling a global tool, '{1}' was not found.</source>
+        <target state="needs-review-translation">找不到任何符合命令 "{0}" 的可執行檔。如需詳細資料，請參閱 https://aka.ms/missing-command。</target>
         <note />
       </trans-unit>
       <trans-unit id="WaitingForDebuggerToAttach">

--- a/test/dotnet.Tests/GivenThatDotNetRunsCommands.cs
+++ b/test/dotnet.Tests/GivenThatDotNetRunsCommands.cs
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Tests
                 .WithWorkingDirectory(testInstance)
                 .ExecuteWithCapturedOutput("crash")
                 .Should().Fail()
-                     .And.HaveStdErrContaining(string.Format(LocalizableStrings.NoExecutableFoundMatchingCommand, "dotnet-crash"));
+                     .And.HaveStdErrContaining(string.Format(LocalizableStrings.NoExecutableFoundMatchingCommand, "crash", "dotnet-crash"));
         }
 
         [Theory]

--- a/test/dotnet.Tests/PackagedCommandTests.cs
+++ b/test/dotnet.Tests/PackagedCommandTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.Tests
                 .WithWorkingDirectory(testInstance.Root)
                 .ExecuteWithCapturedOutput("nonexistingtool")
                 .Should().Fail()
-                    .And.HaveStdErrContaining(string.Format(LocalizableStrings.NoExecutableFoundMatchingCommand, "dotnet-nonexistingtool"));
+                    .And.HaveStdErrContaining(string.Format(LocalizableStrings.NoExecutableFoundMatchingCommand, "nonexistingtool", "dotnet-nonexistingtool"));
         }
 
         [Fact]
@@ -295,7 +295,7 @@ namespace Microsoft.DotNet.Tests
                 .WithWorkingDirectory(testInstance.Root)
                 .ExecuteWithCapturedOutput();
 
-            result.StdErr.Should().Contain(string.Format(LocalizableStrings.NoExecutableFoundMatchingCommand, "dotnet-hello"));
+            result.StdErr.Should().Contain(string.Format(LocalizableStrings.NoExecutableFoundMatchingCommand, "hello", "dotnet-hello"));
             
             result.Should().Fail();        
         }


### PR DESCRIPTION
Fix https://github.com/dotnet/cli/issues/10911

```
> dotnet non-exist-tool
Could not run anything - file not found.
        If you passed path 'non-exist-tool' it was not found.
        If you intended to call a dotnet command, you may have misspelled it.
        If you were calling a global tool, 'dotnet-non-exist-tool' was not found.

> dotnet c:\non\exist\executable.dll
Could not run anything - file not found.
        If you passed path 'c:\non\exist\executable.dll' it was not found.
        If you intended to call a dotnet command, you may have misspelled it.
        If you were calling a global tool, 'executable' was not found.
```

- If this PR should not run tests please add text "skip[REMOVE_THIS]ci[REMOVE_THIS]please" (remove the marked text, no quotes).
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
