### PR TITLE
Invoke localtool with dotnet

### DIFF
--- a/src/dotnet/CommandFactory/CommandResolution/DefaultCommandResolverPolicy.cs
+++ b/src/dotnet/CommandFactory/CommandResolution/DefaultCommandResolverPolicy.cs
@@ -46,6 +46,7 @@ namespace Microsoft.DotNet.CommandFactory
 
             compositeCommandResolver.AddCommandResolver(new MuxerCommandResolver());
             compositeCommandResolver.AddCommandResolver(new DotnetToolsCommandResolver());
+            compositeCommandResolver.AddCommandResolver(new LocalToolsCommandResolver());
             compositeCommandResolver.AddCommandResolver(new RootedCommandResolver());
             compositeCommandResolver.AddCommandResolver(
                 new ProjectToolsCommandResolver(packagedCommandSpecFactory, environment));

--- a/src/dotnet/CommandFactory/CommandResolution/LocalToolsCommandResolver.cs
+++ b/src/dotnet/CommandFactory/CommandResolution/LocalToolsCommandResolver.cs
@@ -62,19 +62,18 @@ namespace Microsoft.DotNet.CommandFactory
                 return null;
             }
 
-            var resolveResultWithoutLeadingDotnet = GetPackageCommandSpecUsingMuxer(arguments,
+            // Try resolving without prefix first
+            var result = GetPackageCommandSpecUsingMuxer(
+                arguments,
                 new ToolCommandName(arguments.CommandName.Substring(LeadingDotnetPrefix.Length)));
 
-            var resolveResultWithLeadingDotnet = GetPackageCommandSpecUsingMuxer(arguments, new ToolCommandName(arguments.CommandName));
+            if (result != null)
+            {
+                return result;
+            }
 
-            if (resolveResultWithoutLeadingDotnet != null && resolveResultWithLeadingDotnet != null)
-            {
-                return resolveResultWithoutLeadingDotnet;
-            }
-            else
-            {
-                return resolveResultWithoutLeadingDotnet ?? resolveResultWithLeadingDotnet;
-            }
+            // Fallback to resolving with the prefix
+            return GetPackageCommandSpecUsingMuxer(arguments, new ToolCommandName(arguments.CommandName));
         }
 
         private CommandSpec GetPackageCommandSpecUsingMuxer(CommandResolverArguments arguments,

--- a/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
@@ -161,7 +161,7 @@
 Tool '{1}' (version '{2}') was successfully installed.</value>
   </data>
   <data name="LocalToolInstallationSucceeded" xml:space="preserve">
-    <value>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+    <value>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</value>
   </data>
   <data name="GlobalOptionDescription" xml:space="preserve">

--- a/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
@@ -161,7 +161,7 @@
 Tool '{1}' (version '{2}') was successfully installed.</value>
   </data>
   <data name="LocalToolInstallationSucceeded" xml:space="preserve">
-    <value>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+    <value>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</value>
   </data>
   <data name="GlobalOptionDescription" xml:space="preserve">

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
@@ -25,7 +25,7 @@ Nástroj {1} (verze {2}) byl úspěšně nainstalován.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">Nástroj můžete vyvolat z tohoto adresáře pomocí následujícího příkazu: dotnet tool run {0}
 Nástroj {1} (verze {2}) se úspěšně nainstaloval. Položka se přidala do souboru manifestu {3}.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
@@ -25,9 +25,9 @@ Nástroj {1} (verze {2}) byl úspěšně nainstalován.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">Nástroj můžete vyvolat z tohoto adresáře pomocí následujícího příkazu: dotnet tool run {0}
+        <target state="needs-review-translation">Nástroj můžete vyvolat z tohoto adresáře pomocí následujícího příkazu: dotnet tool run {0}
 Nástroj {1} (verze {2}) se úspěšně nainstaloval. Položka se přidala do souboru manifestu {3}.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
@@ -25,9 +25,9 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">Sie können das Tool aus diesem Verzeichnis mit dem folgenden Befehl aufrufen: dotnet tool run {0}
+        <target state="needs-review-translation">Sie können das Tool aus diesem Verzeichnis mit dem folgenden Befehl aufrufen: dotnet tool run {0}
 Das Tool "{1}" (Version "{2}") wurde erfolgreich installiert. Der Eintrag wird zur Manifestdatei {3} hinzugefügt.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
@@ -25,7 +25,7 @@ Das Tool "{1}" (Version {2}) wurde erfolgreich installiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">Sie können das Tool aus diesem Verzeichnis mit dem folgenden Befehl aufrufen: dotnet tool run {0}
 Das Tool "{1}" (Version "{2}") wurde erfolgreich installiert. Der Eintrag wird zur Manifestdatei {3} hinzugefügt.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
@@ -25,7 +25,7 @@ La herramienta "{1}" (versión '{2}') se instaló correctamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">Se puede invocar la herramienta de este directorio mediante el comando siguiente: dotnet tool run {0}
 La herramienta "{1}" (versión "{2}") se instaló correctamente. La entrada se ha agregado al archivo del manifiesto {3}.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
@@ -25,9 +25,9 @@ La herramienta "{1}" (versión '{2}') se instaló correctamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">Se puede invocar la herramienta de este directorio mediante el comando siguiente: dotnet tool run {0}
+        <target state="needs-review-translation">Se puede invocar la herramienta de este directorio mediante el comando siguiente: dotnet tool run {0}
 La herramienta "{1}" (versión "{2}") se instaló correctamente. La entrada se ha agregado al archivo del manifiesto {3}.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
@@ -25,7 +25,7 @@ L'outil '{1}' (version '{2}') a été installé correctement.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">Vous pouvez appeler l'outil à partir de son répertoire à l'aide de la commande suivante : dotnet tool run {0}
 L'outil '{1}' (version '{2}') a été installé. L'entrée est ajoutée au fichier manifeste {3}.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
@@ -25,9 +25,9 @@ L'outil '{1}' (version '{2}') a été installé correctement.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">Vous pouvez appeler l'outil à partir de son répertoire à l'aide de la commande suivante : dotnet tool run {0}
+        <target state="needs-review-translation">Vous pouvez appeler l'outil à partir de son répertoire à l'aide de la commande suivante : dotnet tool run {0}
 L'outil '{1}' (version '{2}') a été installé. L'entrée est ajoutée au fichier manifeste {3}.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
@@ -25,9 +25,9 @@ Lo strumento '{1}' (versione '{2}') è stato installato.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">È possibile richiamare lo strumento da questa directory usando il comando seguente: dotnet tool run {0}
+        <target state="needs-review-translation">È possibile richiamare lo strumento da questa directory usando il comando seguente: dotnet tool run {0}
 Lo strumento '{1}' (versione '{2}') è stato installato. La voce è stata aggiunta al file manifesto {3}.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
@@ -25,7 +25,7 @@ Lo strumento '{1}' (versione '{2}') è stato installato.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">È possibile richiamare lo strumento da questa directory usando il comando seguente: dotnet tool run {0}
 Lo strumento '{1}' (versione '{2}') è stato installato. La voce è stata aggiunta al file manifesto {3}.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
@@ -25,7 +25,7 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">次のコマンドを使用してこのディレクトリからツールを実行することができます: dotnet tool run {0}
 ツール '{1}' (バージョン '{2}') は正常にインストールされました。マニフェスト ファイル {3} にエントリが追加されました。</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
@@ -25,9 +25,9 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">次のコマンドを使用してこのディレクトリからツールを実行することができます: dotnet tool run {0}
+        <target state="needs-review-translation">次のコマンドを使用してこのディレクトリからツールを実行することができます: dotnet tool run {0}
 ツール '{1}' (バージョン '{2}') は正常にインストールされました。マニフェスト ファイル {3} にエントリが追加されました。</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
@@ -25,9 +25,9 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">다음 명령을 사용하여 이 디렉터리에서 도구를 호출할 수 있습니다. dotnet tool run {0}
+        <target state="needs-review-translation">다음 명령을 사용하여 이 디렉터리에서 도구를 호출할 수 있습니다. dotnet tool run {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
@@ -25,7 +25,7 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">다음 명령을 사용하여 이 디렉터리에서 도구를 호출할 수 있습니다. dotnet tool run {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
@@ -25,9 +25,9 @@ Pomyślnie zainstalowano narzędzie „{1}” (wersja: „{2}”).</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">Narzędzie można wywołać z tego katalogu za pomocą następującego polecenia: dotnet tool run {0}
+        <target state="needs-review-translation">Narzędzie można wywołać z tego katalogu za pomocą następującego polecenia: dotnet tool run {0}
 Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Dodano wpis do pliku manifestu {3}.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
@@ -25,7 +25,7 @@ Pomyślnie zainstalowano narzędzie „{1}” (wersja: „{2}”).</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">Narzędzie można wywołać z tego katalogu za pomocą następującego polecenia: dotnet tool run {0}
 Narzędzie „{1}” (wersja „{2}”) zostało pomyślnie zainstalowane. Dodano wpis do pliku manifestu {3}.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -25,7 +25,7 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">Você pode invocar a ferramenta deste diretório usando o seguinte comando: dotnet tool run {0}
 A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adicionada ao arquivo de manifesto {3}.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -25,9 +25,9 @@ A ferramenta '{1}' (versão '{2}') foi instalada com êxito.</target>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">Você pode invocar a ferramenta deste diretório usando o seguinte comando: dotnet tool run {0}
+        <target state="needs-review-translation">Você pode invocar a ferramenta deste diretório usando o seguinte comando: dotnet tool run {0}
 A ferramenta '{1}' (versão '{2}') foi instalada com êxito. A entrada foi adicionada ao arquivo de manifesto {3}.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
@@ -25,9 +25,9 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">Вы можете вызвать средство из этого каталога, выполнив следующую команду: dotnet tool run {0}
+        <target state="needs-review-translation">Вы можете вызвать средство из этого каталога, выполнив следующую команду: dotnet tool run {0}
 Средство '{1}' (версия '{2}') успешно установлено. Запись добавлена в файл манифеста {3}.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
@@ -25,7 +25,7 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">Вы можете вызвать средство из этого каталога, выполнив следующую команду: dotnet tool run {0}
 Средство '{1}' (версия '{2}') успешно установлено. Запись добавлена в файл манифеста {3}.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
@@ -25,7 +25,7 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">Şu komutu kullanarak aracı bu dizinden çağırabilirsiniz: dotnet tool run {0}
 '{1}' aracı (sürüm '{2}') başarıyla yüklendi. {3} bildirim dosyasına giriş eklendi.</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
@@ -25,9 +25,9 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">Şu komutu kullanarak aracı bu dizinden çağırabilirsiniz: dotnet tool run {0}
+        <target state="needs-review-translation">Şu komutu kullanarak aracı bu dizinden çağırabilirsiniz: dotnet tool run {0}
 '{1}' aracı (sürüm '{2}') başarıyla yüklendi. {3} bildirim dosyasına giriş eklendi.</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -25,9 +25,9 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">可使用下列命令从此目录中调用工具 : dotnet tool run {0}
+        <target state="needs-review-translation">可使用下列命令从此目录中调用工具 : dotnet tool run {0}
 已成功安装工具“{1}”(版本“{2}”)。已将条目添加到清单文件 {3}。</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -25,7 +25,7 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">可使用下列命令从此目录中调用工具 : dotnet tool run {0}
 已成功安装工具“{1}”(版本“{2}”)。已将条目添加到清单文件 {3}。</target>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -25,9 +25,9 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0}
+        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
-        <target state="translated">您可以使用下列命令從這個目錄叫用工具: dotnet tool run {0}
+        <target state="needs-review-translation">您可以使用下列命令從這個目錄叫用工具: dotnet tool run {0}
 工具 '{1}' ('{2}' 版) 已成功安裝。項目已新增到資訊清單檔 {3}。</target>
         <note />
       </trans-unit>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -25,7 +25,7 @@ Tool '{1}' (version '{2}') was successfully installed.</source>
         <note />
       </trans-unit>
       <trans-unit id="LocalToolInstallationSucceeded">
-        <source>You can invoke the tool from this directory using the following command: dotnet tool run {0} or dotnet {0}
+        <source>You can invoke the tool from this directory using the following commands: 'dotnet tool run {0}' or 'dotnet {0}'.
 Tool '{1}' (version '{2}') was successfully installed. Entry is added to the manifest file {3}.</source>
         <target state="needs-review-translation">您可以使用下列命令從這個目錄叫用工具: dotnet tool run {0}
 工具 '{1}' ('{2}' 版) 已成功安裝。項目已新增到資訊清單檔 {3}。</target>

--- a/src/dotnet/commands/dotnet-tool/run/ToolRunCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/run/ToolRunCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Tools.Tool.Run
 
         public override int Execute()
         {
-            CommandSpec commandspec = _localToolsCommandResolver.Resolve(new CommandResolverArguments()
+            CommandSpec commandspec = _localToolsCommandResolver.ResolveStrict(new CommandResolverArguments()
             {
                 // since LocalToolsCommandResolver is a resolver, and all resolver input have dotnet-
                 CommandName = $"dotnet-{_toolCommandName}",

--- a/test/Microsoft.DotNet.CommandFactory.Tests/GivenADefaultCommandResolver.cs
+++ b/test/Microsoft.DotNet.CommandFactory.Tests/GivenADefaultCommandResolver.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Tests
 
             var resolvers = defaultCommandResolver.OrderedCommandResolvers;
 
-            resolvers.Should().HaveCount(8);
+            resolvers.Should().HaveCount(9);
 
             resolvers.Select(r => r.GetType())
                 .Should()
@@ -26,6 +26,7 @@ namespace Microsoft.DotNet.Tests
                     new []{
                         typeof(MuxerCommandResolver),
                         typeof(DotnetToolsCommandResolver),
+                        typeof(LocalToolsCommandResolver),
                         typeof(RootedCommandResolver),
                         typeof(ProjectToolsCommandResolver),
                         typeof(AppBaseDllCommandResolver),


### PR DESCRIPTION
enable invoke tool with `dotnet TOOLNAME`

largely bring back the code from https://github.com/dotnet/cli/pull/10341 but still keep `dotnet tool run TOOLNAME` as non ambiguous version