### PR TITLE
Fix bash completion when the SDK is not installed

### DIFF
--- a/scripts/register-completions.bash
+++ b/scripts/register-completions.bash
@@ -5,7 +5,10 @@ _dotnet_bash_complete()
   local word=${COMP_WORDS[COMP_CWORD]}
 
   local completions
-  completions="$(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}")"
+  completions="$(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}" 2>/dev/null)"
+  if [ $? -ne 0 ]; then
+    completions=""
+  fi
 
   COMPREPLY=( $(compgen -W "$completions" -- "$word") )
 }


### PR DESCRIPTION
The `dotnet complete` command is an SDK command. If the SDK is not installed, `dotnet complete` is not available. Triggering completion in bash without the SDK installed results in errors being shown.

Fix it by checking if `dotnet complete` is installed before trying to use to get completions. If the SDK is not installed, we will only show file completions.

Fixes #11044