### PR TITLE
Converging dotnet test and dotnet vstest

### DIFF
--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -84,6 +84,13 @@ namespace Microsoft.DotNet.Tools.Test
         {
             DebugHelper.HandleDebugSwitch(ref args);
 
+            // Fix for https://github.com/Microsoft/vstest/issues/1453
+            // Try to run dll/exe directly using the VSTestForwardingApp
+            if (ContainsBuiltTestSources(args))
+            {
+                return new VSTestForwardingApp(args).Execute();
+            }
+
             TestCommand cmd;
 
             try
@@ -112,6 +119,19 @@ namespace Microsoft.DotNet.Tools.Test
             }
 
             return result;
+        }
+
+        private static bool ContainsBuiltTestSources(string[] args)
+        {
+            foreach (var arg in args)
+            {
+                if (!(arg.StartsWith("--") || arg.StartsWith("/")) &&
+                    (arg.EndsWith("dll", StringComparison.OrdinalIgnoreCase) || arg.EndsWith("exe", StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private static string GetSemiColonEscapedString(string arg)


### PR DESCRIPTION
Fixes: https://github.com/Microsoft/vstest/issues/1453

### Description
Add the ability inside the dotnet test verb to honor dll/exe as input just like dotnet vstest verb.

Raising it against 2.2.2xx for now.
Will cherry-pick to 2.2.3xx and 3.0.1xx if advised.

