### PR TITLE
Make sure that an empty argument is preserved.

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/ArgumentEscaper.cs
@@ -95,12 +95,13 @@ namespace Microsoft.DotNet.Cli.Utils
         {
             var sb = new StringBuilder();
 
-            var needsQuotes = ShouldSurroundWithQuotes(arg);
+            var length = arg.Length;
+            var needsQuotes = length == 0 || ShouldSurroundWithQuotes(arg);
             var isQuoted = needsQuotes || IsSurroundedWithQuotes(arg);
 
             if (needsQuotes) sb.Append("\"");
 
-            for (int i = 0; i < arg.Length; ++i)
+            for (int i = 0; i < length; ++i)
             {
                 var backslashCount = 0;
 

--- a/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
+++ b/test/dotnet-run.Tests/GivenDotnetRunRunsCsProj.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.IO;
 using System.Xml.Linq;
 using FluentAssertions;
@@ -708,6 +709,23 @@ namespace Microsoft.DotNet.Cli.Run.Tests
 
             result.Should().Pass()
                 .And.HaveStdOutContaining($"AppOutputsExecutablePath{Constants.ExeSuffix}");
+        }
+
+        [Fact]
+        public void ItForwardsEmptyArgumentsToTheApp()
+        {
+            var testAppName = "TestAppSimple";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance()
+                .WithSourceFiles();
+
+            new RunCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .ExecuteWithCapturedOutput("a \"\" c")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining($"0 = a{Environment.NewLine}1 = {Environment.NewLine}2 = c");
         }
     }
 }


### PR DESCRIPTION
These changes fix issue #8892.

The net effect is that when an empty argument is detected, a pair of double quotes will be emitted.

See #10909 for the original PR.