### PR TITLE
Onboard with async publishing

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -4,15 +4,18 @@ trigger:
 
 variables:
   teamName: Roslyn-Project-System
+  _DotNetArtifactsCategory: .NETCore
   ${{ if eq(variables['System.TeamProject'], 'public') }}:
     PB_PublishBlobFeedKey:
     PB_PublishBlobFeedUrl:
     _DotNetPublishToBlobFeed: false
+    _PublishUsingPipelines: false
     _PublishType: none
     _SignType: test
   ${{ if ne(variables['System.TeamProject'], 'public') }}:
     PB_PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
     _DotNetPublishToBlobFeed: true
+    _PublishUsingPipelines: true
     _PublishType: blob
     _SignType: real
 
@@ -161,6 +164,7 @@ jobs:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: /eng/common/templates/phases/publish-build-assets.yml
     parameters:
+      publishUsingPipelines: true
       dependsOn:
         - Windows_NT
       queue:

--- a/eng/build.yml
+++ b/eng/build.yml
@@ -48,6 +48,8 @@ phases:
         - _PublishArgs: /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
                     /p:DotNetPublishBlobFeedUrl=$(PB_PublishBlobFeedUrl)
                     /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
+                    /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                    /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                     /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
                     /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                     /p:PB_PublishType=$(_PublishType)


### PR DESCRIPTION
Relates to: https://github.com/dotnet/arcade/issues/2444

Goal: mitigate `lock on the feed problem` and add further validations. [More details here.](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/AsyncPublishing_HowToUse.md)

Test build was here: https://dnceng.visualstudio.com/internal/_build/results?buildId=151209
Test release: https://dnceng.visualstudio.com/internal/_releaseProgress?_a=release-pipeline-progress&releaseId=4497