### PR TITLE
dotnet tool uninstall should find the first manifest file contain package id

### DIFF
--- a/src/dotnet/commands/dotnet-tool/common/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/common/LocalizableStrings.resx
@@ -117,7 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="NoManifestGuide" xml:space="preserve">
+    <value>If you intended to perform an action on a global tool, use the `--global` option for the command.</value>
+  </data>
   <data name="OnlyLocalOptionSupportManifestFileOption" xml:space="preserve">
     <value>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</value>
+  </data>
+  <data name="SamePackageIdInOtherManifestFile" xml:space="preserve">
+    <value>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/common/ToolManifestFinderExtensions.cs
+++ b/src/dotnet/commands/dotnet-tool/common/ToolManifestFinderExtensions.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.DotNet.Cli.Utils;
+using Microsoft.DotNet.ToolManifest;
+using Microsoft.DotNet.ToolPackage;
+using Microsoft.Extensions.EnvironmentAbstractions;
+using NuGet.Frameworks;
+
+namespace Microsoft.DotNet.Tools.Tool.Common
+{
+    internal static class ToolManifestFinderExtensions
+    {
+        public static (FilePath? filePath, string warningMessage) ExplicitManifestOrFindManifestContainPackageId(
+            this IToolManifestFinder toolManifestFinder,
+            string explicitManifestFile,
+            PackageId packageId)
+        {
+            if (!string.IsNullOrWhiteSpace(explicitManifestFile))
+            {
+                return (new FilePath(explicitManifestFile), null);
+            }
+
+            IReadOnlyList<FilePath> manifestFilesContainPackageId;
+            try
+            {
+                manifestFilesContainPackageId
+                 = toolManifestFinder.FindByPackageId(packageId);
+            }
+            catch (ToolManifestCannotBeFoundException e)
+            {
+                throw new GracefulException(new[]
+                    {
+                        e.Message,
+                        LocalizableStrings.NoManifestGuide
+                    },
+                    verboseMessages: new[] { e.VerboseMessage },
+                    isUserError: false);
+            }
+
+            if (manifestFilesContainPackageId.Any())
+            {
+                string warning = null;
+                if (manifestFilesContainPackageId.Count > 1)
+                {
+                    warning =
+                        string.Format(
+                            LocalizableStrings.SamePackageIdInOtherManifestFile,
+                            string.Join(
+                                Environment.NewLine,
+                                manifestFilesContainPackageId.Skip(1).Select(m => $"\t{m}")));
+                }
+
+                return (manifestFilesContainPackageId.First(), warning);
+            }
+
+            return (null, null);
+        }
+    }
+}

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.cs.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.de.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.es.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.fr.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.it.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.ja.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.ko.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.pl.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.ru.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.tr.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/common/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,9 +2,21 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="NoManifestGuide">
+        <source>If you intended to perform an action on a global tool, use the `--global` option for the command.</source>
+        <target state="new">If you intended to perform an action on a global tool, use the `--global` option for the command.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OnlyLocalOptionSupportManifestFileOption">
         <source>Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</source>
         <target state="new">Specifying the tool manifest option (--tool-manifest) is only valid with the local option (--local or the default).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SamePackageIdInOtherManifestFile">
+        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</source>
+        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
+{0}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
@@ -169,6 +169,6 @@
     <value>Tool '{0}' was successfully uninstalled and removed from manifest file {1}.</value>
   </data>
   <data name="NoManifestFileContainPackageId" xml:space="preserve">
-    <value>Cannot find a manifest file contain the package id '{0}'.</value>
+    <value>Cannot find a manifest file that contains package id '{0}'.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
@@ -168,7 +168,7 @@
   <data name="UninstallLocalToolSucceeded" xml:space="preserve">
     <value>Tool '{0}' was successfully uninstalled and removed from manifest file {1}.</value>
   </data>
-  <data name="NoManifestGuide" xml:space="preserve">
-    <value>If you intended to uninstall a global tool, add `--global` to the command.</value>
+  <data name="NoManifestFileContainPackageId" xml:space="preserve">
+    <value>Cannot find a manifest file contain the package id '{0}'.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
@@ -17,9 +17,9 @@
         <target state="translated">Pfad</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PERCORSO</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
@@ -17,9 +17,9 @@
         <target state="translated">ŚCIEŻKA</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
@@ -17,9 +17,9 @@
         <target state="translated">Путь</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NoManifestFileContainPackageId">
-        <source>Cannot find a manifest file contain the package id '{0}'.</source>
-        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
+        <source>Cannot find a manifest file that contains package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file that contains package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -17,9 +17,9 @@
         <target state="translated">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to uninstall a global tool, add `--global` to the command.</source>
-        <target state="new">If you intended to uninstall a global tool, add `--global` to the command.</target>
+      <trans-unit id="NoManifestFileContainPackageId">
+        <source>Cannot find a manifest file contain the package id '{0}'.</source>
+        <target state="new">Cannot find a manifest file contain the package id '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageIdArgumentDescription">

--- a/src/dotnet/commands/dotnet-tool/update/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/update/LocalizableStrings.resx
@@ -198,9 +198,6 @@
   <data name="UpdateToolCommandInvalidGlobalAndLocalAndToolPath" xml:space="preserve">
     <value>The local option (--local), the global option (--global), and the tool path option (--tool-path) cannot be used together. Specify only one of the options: {0}.</value>
   </data>
-  <data name="NoManifestGuide" xml:space="preserve">
-    <value>If you intended to update a global tool, use the `--global` option for the command.</value>
-  </data>
   <data name="LocalOptionDescription" xml:space="preserve">
     <value>Update the tool and update from the local tool manifest.</value>
   </data>
@@ -218,9 +215,5 @@
   </data>
   <data name="UpdateLocaToolSucceededVersionNoChange" xml:space="preserve">
     <value>Tool '{0}' is up to date (version '{1}' manifest file {2}) .</value>
-  </data>
-  <data name="SamePackageIdInOtherManifestFile" xml:space="preserve">
-    <value>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.cs.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">ID balíčku NuGet nástroje, který se má aktualizovat</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.de.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">Die NuGet-Paket-ID des zu aktualisierenden Tools.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.es.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">El id. del paquete de NuGet que se actualizará.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.fr.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">ID de package NuGet de l'outil à mettre à jour.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.it.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">ID_PACCHETTO</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">ID pacchetto NuGet dello strumento da aggiornare.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ja.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">更新するツールの NuGet パッケージ ID。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ko.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">업데이트할 도구의 NuGet 패키지 ID입니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pl.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">Identyfikator pakietu NuGet narzędzia do zaktualizowania.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">A ID do pacote do NuGet da ferramenta a ser atualizada.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ru.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">Идентификатор пакета NuGet обновляемого инструмента.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.tr.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">Güncelleştirilecek aracın NuGet Paket Kimliği.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">要更新的工具的 NuGet 包 ID。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -22,11 +22,6 @@
         <target state="new">PATH</target>
         <note />
       </trans-unit>
-      <trans-unit id="NoManifestGuide">
-        <source>If you intended to update a global tool, use the `--global` option for the command.</source>
-        <target state="new">If you intended to update a global tool, use the `--global` option for the command.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="PackageIdArgumentName">
         <source>PACKAGE_ID</source>
         <target state="translated">PACKAGE_ID</target>
@@ -35,13 +30,6 @@
       <trans-unit id="PackageIdArgumentDescription">
         <source>The NuGet Package Id of the tool to update.</source>
         <target state="translated">要更新之工具的 NuGet 套件識別碼。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SamePackageIdInOtherManifestFile">
-        <source>Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</source>
-        <target state="new">Warning: there are other manifest files in the current directory that could affect local tools. The following files are not changed:
-{0}</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifyExactlyOnePackageId">

--- a/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUninstallCommandTests.cs
@@ -2,27 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
 using FluentAssertions;
-using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.ToolPackage;
-using Microsoft.DotNet.Tools;
-using Microsoft.DotNet.Tools.Tool.Install;
 using Microsoft.DotNet.Tools.Tool.Uninstall;
-using Microsoft.DotNet.Tools.Tests.ComponentMocks;
 using Microsoft.DotNet.Tools.Test.Utilities;
-using Microsoft.Extensions.DependencyModel.Tests;
-using Microsoft.Extensions.EnvironmentAbstractions;
 using Xunit;
 using Parser = Microsoft.DotNet.Cli.Parser;
 using LocalizableStrings = Microsoft.DotNet.Tools.Tool.Uninstall.LocalizableStrings;
-using InstallLocalizableStrings = Microsoft.DotNet.Tools.Tool.Install.LocalizableStrings;
-using Microsoft.DotNet.ShellShim;
 
 namespace Microsoft.DotNet.Tests.Commands.Tool
 {

--- a/test/dotnet.Tests/CommandTests/ToolUninstallLocalCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUninstallLocalCommandTests.cs
@@ -2,28 +2,20 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
-using Microsoft.DotNet.Cli;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.DotNet.Cli.Utils;
-using Microsoft.DotNet.Tools;
 using Microsoft.DotNet.ToolPackage;
 using Microsoft.DotNet.Tools.Tool.Uninstall;
-using Microsoft.DotNet.Tools.Tests.ComponentMocks;
 using Microsoft.DotNet.Tools.Test.Utilities;
-using Microsoft.DotNet.ShellShim;
 using Microsoft.Extensions.DependencyModel.Tests;
 using Microsoft.Extensions.EnvironmentAbstractions;
 using Xunit;
 using Parser = Microsoft.DotNet.Cli.Parser;
-using System.Runtime.InteropServices;
-using NuGet.Versioning;
 using LocalizableStrings = Microsoft.DotNet.Tools.Tool.Uninstall.LocalizableStrings;
 using Microsoft.DotNet.ToolManifest;
-using NuGet.Frameworks;
 
 
 namespace Microsoft.DotNet.Tests.Commands.Tool

--- a/test/dotnet.Tests/CommandTests/ToolUninstallLocalCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolUninstallLocalCommandTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
     public class ToolUninstallLocalCommandTests
     {
         private readonly IFileSystem _fileSystem;
+        private readonly string _temporaryDirectoryParent;
         private readonly AppliedOption _appliedCommand;
         private readonly ParseResult _parseResult;
         private readonly BufferedReporter _reporter;
@@ -37,7 +38,9 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
         {
             _reporter = new BufferedReporter();
             _fileSystem = new FileSystemMockBuilder().UseCurrentSystemTemporaryDirectory().Build();
-            _temporaryDirectory = _fileSystem.Directory.CreateTemporaryDirectory().DirectoryPath;
+            _temporaryDirectoryParent = _fileSystem.Directory.CreateTemporaryDirectory().DirectoryPath;
+            _temporaryDirectory = Path.Combine(_temporaryDirectoryParent, "sub");
+            _fileSystem.Directory.CreateDirectory(_temporaryDirectory);
 
             _manifestFilePath = Path.Combine(_temporaryDirectory, "dotnet-tools.json");
             _fileSystem.File.WriteAllText(Path.Combine(_temporaryDirectory, _manifestFilePath), _jsonContent);
@@ -70,7 +73,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             a.ShouldThrow<GracefulException>()
                .And.Message.Should()
-               .Contain(LocalizableStrings.NoManifestGuide);
+               .Contain(Tools.Tool.Common.LocalizableStrings.NoManifestGuide);
 
             a.ShouldThrow<GracefulException>()
                 .And.Message.Should()
@@ -78,6 +81,19 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             a.ShouldThrow<GracefulException>()
                 .And.VerboseMessage.Should().Contain(string.Format(ToolManifest.LocalizableStrings.ListOfSearched, ""));
+        }
+
+        [Fact]
+        public void GivenNoManifestFileContainPackageIdItShouldThrow()
+        {
+            _fileSystem.File.Delete(_manifestFilePath);
+            _fileSystem.File.WriteAllText(_manifestFilePath, _jsonContentContainNoPackageId);
+
+            Action a = () => _defaultToolUninstallLocalCommand.Execute().Should().Be(0);
+
+            a.ShouldThrow<GracefulException>()
+               .And.Message.Should()
+               .Contain(string.Format(LocalizableStrings.NoManifestFileContainPackageId, _packageIdDotnsay));
         }
 
         [Fact]
@@ -136,10 +152,48 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
                         _manifestFilePath).Green());
         }
 
+        [Fact]
+        public void GivenParentDirHasManifestWithSamePackageIdWhenRunWithPackageIdItShouldOnlyChangTheClosestOne()
+        {
+            var parentManifestFilePath = Path.Combine(_temporaryDirectoryParent, "dotnet-tools.json");
+            _fileSystem.File.WriteAllText(parentManifestFilePath, _jsonContent);
+
+            _defaultToolUninstallLocalCommand.Execute();
+
+            _fileSystem.File.ReadAllText(_manifestFilePath).Should().Be(_entryRemovedJsonContent, "Change the closest one");
+            _fileSystem.File.ReadAllText(parentManifestFilePath).Should().Be(_jsonContent, "Do not change the manifest layer above");
+        }
+
+        [Fact]
+        public void GivenParentDirHasManifestWithSamePackageIdWhenRunWithPackageIdItShouldOnlyChangTheClosestOne2()
+        {
+            var parentManifestFilePath = Path.Combine(_temporaryDirectoryParent, "dotnet-tools.json");
+            _fileSystem.File.WriteAllText(parentManifestFilePath, _jsonContent);
+
+            _defaultToolUninstallLocalCommand.Execute();
+            _defaultToolUninstallLocalCommand.Execute();
+
+            _fileSystem.File.ReadAllText(parentManifestFilePath).Should().Be(
+                _entryRemovedJsonContent, 
+                "First invoke remove the one in current dir, the second invoke remove the one in parent dir.");
+        }
+
+        [Fact]
+        public void GivenParentDirHasManifestWithSamePackageIdWhenRunWithPackageIdItShouldWarningTheOtherManifests()
+        {
+            var parentManifestFilePath = Path.Combine(_temporaryDirectoryParent, "dotnet-tools.json");
+            _fileSystem.File.WriteAllText(parentManifestFilePath, _jsonContent);
+
+            _defaultToolUninstallLocalCommand.Execute();
+
+            _reporter.Lines[0].Should().Contain(parentManifestFilePath);
+            _reporter.Lines[0].Should().NotContain(_manifestFilePath);
+        }
+
         private string _jsonContent =
             @"{
    ""version"":1,
-   ""isRoot"":true,
+   ""isRoot"":false,
    ""tools"":{
       ""t-rex"":{
          ""version"":""1.0.53"",
@@ -156,10 +210,17 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
    }
 }";
 
+        private string _jsonContentContainNoPackageId =
+            @"{
+   ""version"":1,
+   ""isRoot"":false,
+   ""tools"":{}
+}";
+
         private string _entryRemovedJsonContent =
             @"{
   ""version"": 1,
-  ""isRoot"": true,
+  ""isRoot"": false,
   ""tools"": {
     ""t-rex"": {
       ""version"": ""1.0.53"",


### PR DESCRIPTION
fix https://github.com/dotnet/cli/issues/11139  , a lot of file touched. But most of them are locs

Instead of the first manifest file regardless. So, the behavior is aligned with tool update.
Extract method ToolManifestFinderExtensions from tool update. And use them in both places.

I changed the following to make it generic. Since the user just type the command, I don't think uninstall or update in the error message is significant.

"If you intended **to uninstall** on a global tool, use the `--global` option for the command." to "If you intended **to perform an action** on a global tool, use the `--global` option for the command."