### PR TITLE
[release/2.1.6xx] Update cli build name

### DIFF
--- a/build/Branding.props
+++ b/build/Branding.props
@@ -1,6 +1,6 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <BuildName>cli</BuildName>
+    <BuildName>cli216xx</BuildName>
     <SdkBrandName>Microsoft .NET Core SDK $(CliBrandingVersion)</SdkBrandName>
     <MSBuildExtensionsBrandName>.NET Standard Support for Visual Studio 2015</MSBuildExtensionsBrandName>
     <SharedFrameworkBrandName>Microsoft .NET Core Runtime 2.1.0 - Preview</SharedFrameworkBrandName>


### PR DESCRIPTION
Avoids manifest merge issues since we're now building both 2.1.5xx and 2.1.6xx in parallel in prodcon

- If this PR should not run tests please add text "skip[REMOVE_THIS]ci[REMOVE_THIS]please" (remove the marked text, no quotes).
- Please add description for changes you are making.
- If there is an issue related to this PR, please add the reference.
