### PR TITLE
Update warning message for dotnet tool update and uninstall

### DIFF
--- a/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/uninstall/LocalizableStrings.resx
@@ -136,7 +136,12 @@
     <value>Tool '{0}' (version '{1}') was successfully uninstalled.</value>
   </data>
   <data name="ToolNotInstalled" xml:space="preserve">
-    <value>Tool '{0}' is not currently installed.</value>
+    <value>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</value>
   </data>
   <data name="ToolHasMultipleVersionsInstalled" xml:space="preserve">
     <value>Tool '{0}' has multiple versions installed and cannot be uninstalled.</value>

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.cs.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Nástroj {0} není momentálně nainstalovaný.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Nástroj {0} není momentálně nainstalovaný.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.de.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Das Tool "{0}" ist aktuell nicht installiert.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Das Tool "{0}" ist aktuell nicht installiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.es.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">La herramienta "{0}" no está instalada actualmente.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">La herramienta "{0}" no está instalada actualmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.fr.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">L'outil '{0}' n'est pas installé actuellement.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">L'outil '{0}' n'est pas installé actuellement.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.it.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Lo strumento '{0}' non è attualmente installato.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Lo strumento '{0}' non è attualmente installato.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ja.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">ツール '{0}' は現在、インストールされていません。</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">ツール '{0}' は現在、インストールされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ko.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">도구 '{0}'이(가) 현재 설치되어 있지 않습니다.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">도구 '{0}'이(가) 현재 설치되어 있지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pl.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Narzędzie „{0}” nie jest obecnie zainstalowane.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Narzędzie „{0}” nie jest obecnie zainstalowane.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">A ferramenta '{0}' não está instalada no momento.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">A ferramenta '{0}' não está instalada no momento.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.ru.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Инструмент "{0}" сейчас не установлен.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Инструмент "{0}" сейчас не установлен.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.tr.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">'{0}' aracı şu anda yüklü değil.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">'{0}' aracı şu anda yüklü değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">工具“{0}”目前尚未安装。</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">工具“{0}”目前尚未安装。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -58,8 +58,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">目前未安裝工具 '{0}'。</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are uninstalled using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">目前未安裝工具 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ToolHasMultipleVersionsInstalled">

--- a/src/dotnet/commands/dotnet-tool/update/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/update/LocalizableStrings.resx
@@ -175,7 +175,12 @@
     <value>Tool '{0}' has multiple versions installed and cannot be updated.</value>
   </data>
   <data name="ToolNotInstalled" xml:space="preserve">
-    <value>Tool '{0}' is not currently installed.</value>
+    <value>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</value>
   </data>
   <data name="UpdateSucceededVersionNoChange" xml:space="preserve">
     <value>Tool '{0}' was reinstalled with the latest stable version (version '{1}').</value>

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.cs.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Nástroj {0} není momentálně nainstalovaný.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Nástroj {0} není momentálně nainstalovaný.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.de.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Das Tool "{0}" ist aktuell nicht installiert.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Das Tool "{0}" ist aktuell nicht installiert.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.es.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">La herramienta "{0}" no está instalada actualmente.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">La herramienta "{0}" no está instalada actualmente.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.fr.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">L'outil '{0}' n'est pas installé actuellement.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">L'outil '{0}' n'est pas installé actuellement.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.it.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Lo strumento '{0}' non è attualmente installato.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Lo strumento '{0}' non è attualmente installato.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ja.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">ツール '{0}' は現在、インストールされていません。</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">ツール '{0}' は現在、インストールされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ko.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">도구 '{0}'이(가) 현재 설치되어 있지 않습니다.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">도구 '{0}'이(가) 현재 설치되어 있지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pl.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Narzędzie „{0}” nie jest obecnie zainstalowane.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Narzędzie „{0}” nie jest obecnie zainstalowane.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.pt-BR.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">A ferramenta '{0}' não está instalada no momento.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">A ferramenta '{0}' não está instalada no momento.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.ru.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">Инструмент "{0}" сейчас не установлен.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">Инструмент "{0}" сейчас не установлен.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.tr.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">'{0}' aracı şu anda yüklü değil.</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">'{0}' aracı şu anda yüklü değil.</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hans.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">工具“{0}”目前尚未安装。</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">工具“{0}”目前尚未安装。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">

--- a/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/update/xlf/LocalizableStrings.zh-Hant.xlf
@@ -118,8 +118,13 @@
         <note />
       </trans-unit>
       <trans-unit id="ToolNotInstalled">
-        <source>Tool '{0}' is not currently installed.</source>
-        <target state="translated">目前未安裝工具 '{0}'。</target>
+        <source>A tool with the package Id '{0}' could not be found. 
+
+Tools are updated using their package Id which may be different 
+from the tool name you use when calling the tool. You can find the tool names 
+and the corresponding package Ids for installed tools using the command
+'dotnet tool list'.</source>
+        <target state="needs-review-translation">目前未安裝工具 '{0}'。</target>
         <note />
       </trans-unit>
       <trans-unit id="UpdateSucceededVersionNoChange">


### PR DESCRIPTION
Fixes #9650
Changed warning message when tool is not found to include more information about package Ids and tool names.