### PR TITLE
Increase the time out

### DIFF
--- a/test/Microsoft.DotNet.Cli.Telemetry.PersistenceChannel.Tests/PersistenceChannelTest.cs
+++ b/test/Microsoft.DotNet.Cli.Telemetry.PersistenceChannel.Tests/PersistenceChannelTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.DotNet.Cli.Telemetry.PersistenceChannel.Tests
                 taskList.Add(task);
             }
 
-            bool completed = TaskEx.WaitAll(taskList.ToArray(), 5000);
+            bool completed = TaskEx.WaitAll(taskList.ToArray(), 50000);
             completed.Should().BeTrue("tasks did not finish. Potential deadlock problem.");
         }
 


### PR DESCRIPTION
A normal run could take 2000ms, since all tests run in parallel.
It is very likely to go over the existing limit due to not enough resource
