### PR TITLE
Change to find current muxer

### DIFF
--- a/src/Microsoft.DotNet.Cli.Utils/Muxer.cs
+++ b/src/Microsoft.DotNet.Cli.Utils/Muxer.cs
@@ -2,17 +2,16 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
-using System.Reflection;
 
 namespace Microsoft.DotNet.Cli.Utils
 {
     public class Muxer
     {
         public static readonly string MuxerName = "dotnet";
-        private static readonly string s_muxerFileName = MuxerName + Constants.ExeSuffix;
 
-        private string _muxerPath;
+        private readonly string _muxerPath;
 
         internal string SharedFxVersion
         {
@@ -37,54 +36,12 @@ namespace Microsoft.DotNet.Cli.Utils
 
         public Muxer()
         {
-            if (!TryResolveMuxerFromParentDirectories())
-            {
-                TryResolverMuxerFromPath();
-            }
+            _muxerPath = Process.GetCurrentProcess().MainModule.FileName;
         }
 
         public static string GetDataFromAppDomain(string propertyName)
         {
             return AppContext.GetData(propertyName) as string;
-        }
-
-        private bool TryResolveMuxerFromParentDirectories()
-        {
-            var fxDepsFile = GetDataFromAppDomain("FX_DEPS_FILE");
-            if (string.IsNullOrEmpty(fxDepsFile))
-            {
-                return false;
-            }
-
-            var muxerDir = new FileInfo(fxDepsFile).Directory?.Parent?.Parent?.Parent;
-            if (muxerDir == null)
-            {
-                return false;
-            }
-
-            var muxerCandidate = Path.Combine(muxerDir.FullName, s_muxerFileName);
-
-            if (!File.Exists(muxerCandidate))
-            {
-                return false;
-            }
-
-            _muxerPath = muxerCandidate;
-            return true;
-        }
-
-        private bool TryResolverMuxerFromPath()
-        {
-            var muxerPath = Env.GetCommandPath(MuxerName, Constants.ExeSuffix);
-
-            if (muxerPath == null || !File.Exists(muxerPath))
-            {
-                return false;
-            }
-
-            _muxerPath = muxerPath;
-
-            return true;
         }
     }
 }


### PR DESCRIPTION
fix https://github.com/dotnet/cli/issues/11380 more discussion in the issue

Why we essentially move back to the original implementation in https://github.com/dotnet/cli/issues/2489 ?

It is more relate to the usage of corehost [CoreHost.cs](https://github.com/dotnet/cli/blob/342cf7949037a17f4bf18a59faf6fcff6a4d25b1/src/Microsoft.DotNet.Cli.Utils/CoreHost.cs)

Muxer share the same logic with Muxer.GetDataFromAppDomain, by the time majority of the logic of [Publish](https://github.com/dotnet/cli/blob/342cf7949037a17f4bf18a59faf6fcff6a4d25b1/src/dotnet/commands/dotnet-publish/PublishCommand.cs) is in CLI and it need corehost to find correct asset location.

As part of the work. It changed to the current way of finding FX location. But I believe it was a mistake to assume dotnet.exe will be in the parent directory (we did not count multi level loop up in). Since there is no more corehost.cs and publish is in SDK. We should use the simple and correct solution.

TryResolverMuxerFromPath is used when it was a separate library. And self contain app can get result from it. But it is also no longer needed.
