### PR TITLE
Remove using the explicit Build target with `dotnet build`.

### DIFF
--- a/TestAssets/TestProjects/NonDefaultTarget/NonDefaultTarget.csproj
+++ b/TestAssets/TestProjects/NonDefaultTarget/NonDefaultTarget.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Target Name="PrintMessage">
+    <Message Importance="High" Text="Hello World" />
+  </Target>
+
+</Project>

--- a/src/dotnet/commands/dotnet-build/BuildCommand.cs
+++ b/src/dotnet/commands/dotnet-build/BuildCommand.cs
@@ -43,10 +43,6 @@ namespace Microsoft.DotNet.Tools.Build
             {
                 msbuildArgs.Add("-target:Rebuild");
             }
-            else
-            {
-                msbuildArgs.Add("-target:Build");
-            }
 
             msbuildArgs.AddRange(appliedBuildOptions.OptionValuesToBeForwarded());
 

--- a/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
+++ b/test/dotnet-build.Tests/GivenDotnetBuildBuildsCsproj.cs
@@ -40,6 +40,23 @@ namespace Microsoft.DotNet.Cli.Build.Tests
         }
 
         [Fact]
+        public void ItBuildsOnlyTheSpecifiedTarget()
+        {
+            var testAppName = "NonDefaultTarget";
+            var testInstance = TestAssets.Get(testAppName)
+                .CreateInstance(testAppName)
+                .WithSourceFiles();
+
+            new BuildCommand()
+                .WithWorkingDirectory(testInstance.Root)
+                .Execute("--no-restore --nologo /t:PrintMessage")
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World");
+        }
+
+        [Fact]
         public void ItImplicitlyRestoresAProjectWhenBuilding()
         {
             var testAppName = "MSBuildTestApp";

--- a/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet-msbuild.Tests/GivenDotnetBuildInvocation.cs
@@ -18,22 +18,23 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             TestPathUtilities.FormatAbsolutePath(nameof(GivenDotnetBuildInvocation));
 
         [Theory]
-        [InlineData(new string[] { }, "-target:Build")]
-        [InlineData(new string[] { "-o", "foo" }, "-target:Build -property:OutputPath=<cwd>foo")]
-        [InlineData(new string[] { "-property:Verbosity=diag" }, "-target:Build -property:Verbosity=diag")]
-        [InlineData(new string[] { "--output", "foo" }, "-target:Build -property:OutputPath=<cwd>foo")]
-        [InlineData(new string[] { "-o", "foo1 foo2" }, "-target:Build \"-property:OutputPath=<cwd>foo1 foo2\"")]
+        [InlineData(new string[] { }, "")]
+        [InlineData(new string[] { "-o", "foo" }, "-property:OutputPath=<cwd>foo")]
+        [InlineData(new string[] { "-property:Verbosity=diag" }, "-property:Verbosity=diag")]
+        [InlineData(new string[] { "--output", "foo" }, "-property:OutputPath=<cwd>foo")]
+        [InlineData(new string[] { "-o", "foo1 foo2" }, "\"-property:OutputPath=<cwd>foo1 foo2\"")]
         [InlineData(new string[] { "--no-incremental" }, "-target:Rebuild")]
-        [InlineData(new string[] { "-r", "rid" }, "-target:Build -property:RuntimeIdentifier=rid")]
-        [InlineData(new string[] { "--runtime", "rid" }, "-target:Build -property:RuntimeIdentifier=rid")]
-        [InlineData(new string[] { "-c", "config" }, "-target:Build -property:Configuration=config")]
-        [InlineData(new string[] { "--configuration", "config" }, "-target:Build -property:Configuration=config")]
-        [InlineData(new string[] { "--version-suffix", "mysuffix" }, "-target:Build -property:VersionSuffix=mysuffix")]
-        [InlineData(new string[] { "--no-dependencies" }, "-target:Build -property:BuildProjectReferences=false")]
-        [InlineData(new string[] { "-v", "diag" }, "-target:Build -verbosity:diag")]
-        [InlineData(new string[] { "--verbosity", "diag" }, "-target:Build -verbosity:diag")]
+        [InlineData(new string[] { "-r", "rid" }, "-property:RuntimeIdentifier=rid")]
+        [InlineData(new string[] { "--runtime", "rid" }, "-property:RuntimeIdentifier=rid")]
+        [InlineData(new string[] { "-c", "config" }, "-property:Configuration=config")]
+        [InlineData(new string[] { "--configuration", "config" }, "-property:Configuration=config")]
+        [InlineData(new string[] { "--version-suffix", "mysuffix" }, "-property:VersionSuffix=mysuffix")]
+        [InlineData(new string[] { "--no-dependencies" }, "-property:BuildProjectReferences=false")]
+        [InlineData(new string[] { "-v", "diag" }, "-verbosity:diag")]
+        [InlineData(new string[] { "--verbosity", "diag" }, "-verbosity:diag")]
         [InlineData(new string[] { "--no-incremental", "-o", "myoutput", "-r", "myruntime", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
                                   "-target:Rebuild -property:OutputPath=<cwd>myoutput -property:RuntimeIdentifier=myruntime -verbosity:diag /ArbitrarySwitchForMSBuild")]
+        [InlineData(new string[] { "/t:CustomTarget" }, "/t:CustomTarget")]
         public void MsbuildInvocationIsCorrect(string[] args, string expectedAdditionalArgs)
         {
             CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
@@ -54,10 +55,10 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [Theory]
-        [InlineData(new string[] { "-f", "tfm" }, "-target:Restore", "-target:Build -property:TargetFramework=tfm")]
+        [InlineData(new string[] { "-f", "tfm" }, "-target:Restore", "-property:TargetFramework=tfm")]
         [InlineData(new string[] { "-o", "myoutput", "-f", "tfm", "-v", "diag", "/ArbitrarySwitchForMSBuild" },
                                   "-target:Restore -property:OutputPath=<cwd>myoutput -verbosity:diag /ArbitrarySwitchForMSBuild",
-                                  "-target:Build -property:OutputPath=<cwd>myoutput -property:TargetFramework=tfm -verbosity:diag /ArbitrarySwitchForMSBuild")]
+                                  "-property:OutputPath=<cwd>myoutput -property:TargetFramework=tfm -verbosity:diag /ArbitrarySwitchForMSBuild")]
         public void MsbuildInvocationIsCorrectForSeparateRestore(
             string[] args, 
             string expectedAdditionalArgsForRestore, 


### PR DESCRIPTION
This commit prevents the `dotnet build` command from always passing the
`/t:Build` option to MSBuild.

Users expect `dotnet build /t:<target>` to work like MSBuild does.  However,
because `dotnet build` was implicitly adding `/t:Build`, instead of only the
user's target being run, the `Build` target runs first and then the user's
target runs.

This change makes the `dotnet build` command more consistent with
`dotnet msbuild` and desktop MSBuild.

Note: this is a breaking change, although it only impacts projects that do not
use `Build` as the default target, which will now be the target invoked by
`dotnet build`.  The workaround for those projects would be to pass `/t:Build`
to `dotnet build` to restore the previous behavior.

Fixes #4815.