### PR TITLE
Add Dev cert as a real dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,6 +5,10 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>757a60649f8a929f11b178301e2cbf2c6dc82c46</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-preview7.19313.10">
+      <Uri>https://github.com/aspnet/aspnetcore</Uri>
+      <Sha>8e4825fd6b9b52d487a83115cd2814bd0cc5fb5d</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19311.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <DotNetCoreSdkLKGVersion>3.0.100-preview7-012358</DotNetCoreSdkLKGVersion>
-    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>2.2.0</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
+    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>3.0.0-preview7.19313.10</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>2.2.1</MicrosoftNETCoreDotNetHostResolverPackageVersion>
     <MicrosoftApplicationInsightsPackageVersion>2.0.0</MicrosoftApplicationInsightsPackageVersion>
     <MicrosoftBuildPackageVersion>16.2.0-preview.19261.3</MicrosoftBuildPackageVersion>
@@ -43,6 +43,8 @@
     <MSTestVersion>1.3.2</MSTestVersion>
     <NUnit3TemplatesVersion>1.5.1</NUnit3TemplatesVersion>
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</CLI_NETStandardLibraryNETFrameworkVersion>
+    <MicrosoftAspNetCoreDeveloperCertificatesXPlatVersion>
+    </MicrosoftAspNetCoreDeveloperCertificatesXPlatVersion>
   </PropertyGroup>
   <PropertyGroup>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -43,8 +43,6 @@
     <MSTestVersion>1.3.2</MSTestVersion>
     <NUnit3TemplatesVersion>1.5.1</NUnit3TemplatesVersion>
     <CLI_NETStandardLibraryNETFrameworkVersion>2.0.1-servicing-26011-01</CLI_NETStandardLibraryNETFrameworkVersion>
-    <MicrosoftAspNetCoreDeveloperCertificatesXPlatVersion>
-    </MicrosoftAspNetCoreDeveloperCertificatesXPlatVersion>
   </PropertyGroup>
   <PropertyGroup>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>


### PR DESCRIPTION
Fixes a dependency on the ASP.NET Core https dev cert. We made two changes to it recently, which haven't been picked up by dotnet first-time experience.

cc @anurse 