### PR TITLE
Don't let dotnet-install.sh fail with 'Text file busy'

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -612,7 +612,7 @@ copy_files_or_dirs_from_list() {
         local target="$out_path/$path"
         if [ "$override" = true ] || (! ([ -d "$target" ] || [ -e "$target" ])); then
             mkdir -p "$out_path/$(dirname "$path")"
-            cp -R $override_switch "$root_path/$path" "$target"
+            cp -R --remove-destination $override_switch "$root_path/$path" "$target"
         fi
     done
 }


### PR DESCRIPTION
fixes #11626