### PR TITLE
Use live code flow for corefx dependency and react to S.T.Json breaks

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -7,10 +7,10 @@
   </Target>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'
-                          and $(MicrosoftNETCoreAppRefPackageVersion.StartsWith('$(_TargetFrameworkVersionWithoutV)'))">
+                          and $(MicrosoftNETCoreAppPackageVersion.StartsWith('$(_TargetFrameworkVersionWithoutV)'))">
     <FrameworkReference
         Update="Microsoft.NETCore.App" 
-        TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)" 
-        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefPackageVersion)" />
+        TargetingPackVersion="$(MicrosoftNETCoreAppPackageVersion)" 
+        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,4 +5,12 @@
   <Target Name="SetTelemetryProfile">
     <SetEnvVar Name="DOTNET_CLI_TELEMETRY_PROFILE" Value="$(DOTNET_CLI_TELEMETRY_PROFILE);https://github.com/dotnet/cli;$(BuildNumber)" />
   </Target>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                          and $(MicrosoftNETCoreAppRefPackageVersion.StartsWith('$(_TargetFrameworkVersionWithoutV)'))">
+    <FrameworkReference
+        Update="Microsoft.NETCore.App" 
+        TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)" 
+        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefPackageVersion)" />
+  </ItemGroup>
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.0.0-preview7-27826-20">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview7-27826-20">
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>ee0c7ead1a46f06f98aff9102b785f532b71da9c</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="3.0.0-preview7-27826-20">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>ee0c7ead1a46f06f98aff9102b785f532b71da9c</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Cli" Version="1.0.2-beta5.19320.1">
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>cd8a65408312bf4a92de7e97948782f9f88471e6</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppRefPackageVersion>3.0.0-preview7-27826-20</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview7-27826-20</MicrosoftNETCoreAppPackageVersion>
     <DotNetCoreSdkLKGVersion>3.0.100-preview7-012358</DotNetCoreSdkLKGVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>3.0.0-preview7.19325.7</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>2.2.1</MicrosoftNETCoreDotNetHostResolverPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,6 +12,7 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
+    <MicrosoftNETCoreAppRefPackageVersion>3.0.0-preview7-27826-20</MicrosoftNETCoreAppRefPackageVersion>
     <DotNetCoreSdkLKGVersion>3.0.100-preview7-012358</DotNetCoreSdkLKGVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>3.0.0-preview7.19325.7</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>2.2.1</MicrosoftNETCoreDotNetHostResolverPackageVersion>

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -28,9 +28,6 @@ function InitializeCustomSDKToolset {
   }
 
   $cli = InitializeDotnetCli -install:$true
-  InstallDotNetSharedFramework "1.1.2"
-  InstallDotNetSharedFramework "2.0.0"
-  InstallDotNetSharedFramework "2.2.0"
 
   CreateBuildEnvScript
   CreateTestEnvScript

--- a/eng/restore-toolset.ps1
+++ b/eng/restore-toolset.ps1
@@ -28,6 +28,9 @@ function InitializeCustomSDKToolset {
   }
 
   $cli = InitializeDotnetCli -install:$true
+  InstallDotNetSharedFramework "1.1.2"
+  InstallDotNetSharedFramework "2.0.0"
+  InstallDotNetSharedFramework "2.2.0"
 
   CreateBuildEnvScript
   CreateTestEnvScript

--- a/global.json
+++ b/global.json
@@ -3,9 +3,6 @@
     "dotnet": "3.0.100-preview7-012358",
     "runtimes": {
       "dotnet": [
-        "1.1.2",
-        "2.0.0",
-        "2.2.0",
         "$(MicrosoftNETCoreAppPackageVersion)"
       ]
     }

--- a/global.json
+++ b/global.json
@@ -6,7 +6,7 @@
         "1.1.2",
         "2.0.0",
         "2.2.0",
-        "$(MicrosoftNETCoreAppRefPackageVersion)"
+        "$(MicrosoftNETCoreAppPackageVersion)"
       ]
     }
   },

--- a/global.json
+++ b/global.json
@@ -1,6 +1,14 @@
 {
   "tools": {
-    "dotnet": "3.0.100-preview7-012358"
+    "dotnet": "3.0.100-preview7-012358",
+    "runtimes": {
+      "dotnet": [
+        "1.1.2",
+        "2.0.0",
+        "2.2.0",
+        "$(MicrosoftNETCoreAppRefPackageVersion)"
+      ]
+    }
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "1.0.0-beta.19323.4"

--- a/src/dotnet/ToolManifest/JsonElementExtension.cs
+++ b/src/dotnet/ToolManifest/JsonElementExtension.cs
@@ -15,12 +15,12 @@ namespace Microsoft.DotNet.ToolManifest
             value = null;
             if (element.TryGetProperty(name, out JsonElement jsonValue))
             {
-                if (jsonValue.Type != JsonValueType.String)
+                if (jsonValue.ValueKind != JsonValueKind.String)
                 {
                     throw new ToolManifestException(
                         string.Format(
                             LocalizableStrings.UnexpectedTypeInJson,
-                            JsonValueType.String.ToString(),
+                            JsonValueKind.String.ToString(),
                             name));
                 }
                 value = jsonValue.GetString();
@@ -35,12 +35,12 @@ namespace Microsoft.DotNet.ToolManifest
             value = default;
             if (element.TryGetProperty(name, out JsonElement jsonValue))
             {
-                if (jsonValue.Type != JsonValueType.Number)
+                if (jsonValue.ValueKind != JsonValueKind.Number)
                 {
                     throw new ToolManifestException(
                         string.Format(
                             LocalizableStrings.UnexpectedTypeInJson,
-                            JsonValueType.Number.ToString(),
+                            JsonValueKind.Number.ToString(),
                             name));
                 }
                 value = jsonValue.GetInt32();
@@ -55,12 +55,12 @@ namespace Microsoft.DotNet.ToolManifest
             value = default;
             if (element.TryGetProperty(name, out JsonElement jsonValue))
             {
-                if (!(jsonValue.Type == JsonValueType.True || jsonValue.Type == JsonValueType.False))
+                if (!(jsonValue.ValueKind == JsonValueKind.True || jsonValue.ValueKind == JsonValueKind.False))
                 {
                     throw new ToolManifestException(
                         string.Format(
                             LocalizableStrings.UnexpectedTypeInJson,
-                            JsonValueType.True.ToString() + "|" + JsonValueType.False.ToString(),
+                            JsonValueKind.True.ToString() + "|" + JsonValueKind.False.ToString(),
                             name));
                 }
                 value = jsonValue.GetBoolean();

--- a/src/dotnet/ToolManifest/ToolManifestEditor.cs
+++ b/src/dotnet/ToolManifest/ToolManifestEditor.cs
@@ -164,11 +164,11 @@ namespace Microsoft.DotNet.ToolManifest
                         serializableLocalToolsManifest.Tools =
                             new List<SerializableLocalToolSinglePackage>();
 
-                        if (tools.Type != JsonValueType.Object)
+                        if (tools.ValueKind != JsonValueKind.Object)
                         {
                             throw new ToolManifestException(
                                 string.Format(LocalizableStrings.UnexpectedTypeInJson,
-                                    JsonValueType.Object.ToString(),
+                                    JsonValueKind.Object.ToString(),
                                     JsonPropertyTools));
                         }
 
@@ -184,21 +184,21 @@ namespace Microsoft.DotNet.ToolManifest
                             var commands = new List<string>();
                             if (toolJson.Value.TryGetProperty(JsonPropertyCommands, out var commandsJson))
                             {
-                                if (commandsJson.Type != JsonValueType.Array)
+                                if (commandsJson.ValueKind != JsonValueKind.Array)
                                 {
                                     throw new ToolManifestException(
                                         string.Format(LocalizableStrings.UnexpectedTypeInJson,
-                                            JsonValueType.Array.ToString(),
+                                            JsonValueKind.Array.ToString(),
                                             JsonPropertyCommands));
                                 }
 
                                 foreach (var command in commandsJson.EnumerateArray())
                                 {
-                                    if (command.Type != JsonValueType.String)
+                                    if (command.ValueKind != JsonValueKind.String)
                                     {
                                         throw new ToolManifestException(
                                             string.Format(LocalizableStrings.UnexpectedTypeInJson,
-                                                JsonValueType.String.ToString(),
+                                                JsonValueKind.String.ToString(),
                                                 "command"));
                                     }
 

--- a/src/dotnet/ToolPackage/LocalToolsResolverCache.cs
+++ b/src/dotnet/ToolPackage/LocalToolsResolverCache.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.ToolPackage
 
                     _fileSystem.File.WriteAllText(
                         packageCacheFile,
-                        JsonSerializer.ToString(existingCacheTable.Concat(diffedRow)));
+                        JsonSerializer.Serialize(existingCacheTable.Concat(diffedRow)));
                 }
                 else
                 {
@@ -64,7 +64,7 @@ namespace Microsoft.DotNet.ToolPackage
 
                     _fileSystem.File.WriteAllText(
                         packageCacheFile,
-                        JsonSerializer.ToString(rowsToAdd));
+                        JsonSerializer.Serialize(rowsToAdd));
                 }
             }
         }
@@ -96,7 +96,7 @@ namespace Microsoft.DotNet.ToolPackage
             try
             {
                 cacheTable =
-                    JsonSerializer.Parse<CacheRow[]>(_fileSystem.File.ReadAllText(packageCacheFile));
+                    JsonSerializer.Deserialize<CacheRow[]>(_fileSystem.File.ReadAllText(packageCacheFile));
             }
             catch (JsonException)
             {

--- a/src/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
+++ b/src/dotnet/commands/dotnet-run/LaunchSettings/LaunchSettingsManager.cs
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                 {
                     var model = document.RootElement;
 
-                    if (model.Type != JsonValueType.Object || !model.TryGetProperty(ProfilesKey, out var profilesObject) || profilesObject.Type != JsonValueType.Object)
+                    if (model.ValueKind != JsonValueKind.Object || !model.TryGetProperty(ProfilesKey, out var profilesObject) || profilesObject.ValueKind != JsonValueKind.Object)
                     {
                         return new LaunchSettingsApplyResult(false, LocalizableStrings.LaunchProfilesCollectionIsNotAJsonObject);
                     }
@@ -43,19 +43,19 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                     }
                     else
                     {
-                        if (!profilesObject.TryGetProperty(profileName, out profileObject) || profileObject.Type != JsonValueType.Object)
+                        if (!profilesObject.TryGetProperty(profileName, out profileObject) || profileObject.ValueKind != JsonValueKind.Object)
                         {
                             return new LaunchSettingsApplyResult(false, LocalizableStrings.LaunchProfileIsNotAJsonObject);
                         }
                     }
 
-                    if (profileObject.Type == default)
+                    if (profileObject.ValueKind == default)
                     {
                         foreach (var prop in profilesObject.EnumerateObject())
                         {
-                            if (prop.Value.Type == JsonValueType.Object)
+                            if (prop.Value.ValueKind == JsonValueKind.Object)
                             {
-                                if (prop.Value.TryGetProperty(CommandNameKey, out var commandNameElement) && commandNameElement.Type == JsonValueType.String)
+                                if (prop.Value.TryGetProperty(CommandNameKey, out var commandNameElement) && commandNameElement.ValueKind == JsonValueKind.String)
                                 {
                                     if (_providers.ContainsKey(commandNameElement.GetString()))
                                     {
@@ -67,13 +67,13 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                         }
                     }
 
-                    if (profileObject.Type == default)
+                    if (profileObject.ValueKind == default)
                     {
                         return new LaunchSettingsApplyResult(false, LocalizableStrings.UsableLaunchProfileCannotBeLocated);
                     }
 
                     if (!profileObject.TryGetProperty(CommandNameKey, out var finalCommandNameElement)
-                        || finalCommandNameElement.Type != JsonValueType.String)
+                        || finalCommandNameElement.ValueKind != JsonValueKind.String)
                     {
                         return new LaunchSettingsApplyResult(false, LocalizableStrings.UsableLaunchProfileCannotBeLocated);
                     }
@@ -100,9 +100,9 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 
         private static bool IsDefaultProfileType(JsonProperty profileProperty)
         {
-            if (profileProperty.Value.Type != JsonValueType.Object
+            if (profileProperty.Value.ValueKind != JsonValueKind.Object
                 || !profileProperty.Value.TryGetProperty(CommandNameKey, out var commandNameElement)
-                || commandNameElement.Type != JsonValueType.String)
+                || commandNameElement.ValueKind != JsonValueKind.String)
             {
                 return false;
             }

--- a/src/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
+++ b/src/dotnet/commands/dotnet-run/LaunchSettings/ProjectLaunchSettingsProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                 }
                 else if (string.Equals(property.Name, nameof(ProjectLaunchSettingsModel.EnvironmentVariables), StringComparison.OrdinalIgnoreCase))
                 {
-                    if (property.Value.Type != JsonValueType.Object)
+                    if (property.Value.ValueKind != JsonValueKind.Object)
                     {
                         return new LaunchSettingsApplyResult(false, string.Format(LocalizableStrings.ValueMustBeAnObject, property.Name));
                     }
@@ -88,15 +88,15 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 
         private static bool TryGetBooleanValue(JsonElement element, out bool value)
         {
-            switch (element.Type)
+            switch (element.ValueKind)
             {
-                case JsonValueType.True:
+                case JsonValueKind.True:
                     value = true;
                     return true;
-                case JsonValueType.False:
+                case JsonValueKind.False:
                     value = false;
                     return true;
-                case JsonValueType.Number:
+                case JsonValueKind.Number:
                     if (element.TryGetDouble(out var doubleValue))
                     {
                         value = doubleValue != 0;
@@ -104,7 +104,7 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
                     }
                     value = false;
                     return false;
-                case JsonValueType.String:
+                case JsonValueKind.String:
                     return bool.TryParse(element.GetString(), out value);
                 default:
                     value = false;
@@ -114,21 +114,21 @@ namespace Microsoft.DotNet.Tools.Run.LaunchSettings
 
         private static bool TryGetStringValue(JsonElement element, out string value)
         {
-            switch (element.Type)
+            switch (element.ValueKind)
             {
-                case JsonValueType.True:
+                case JsonValueKind.True:
                     value = bool.TrueString;
                     return true;
-                case JsonValueType.False:
+                case JsonValueKind.False:
                     value = bool.FalseString;
                     return true;
-                case JsonValueType.Null:
+                case JsonValueKind.Null:
                     value = string.Empty;
                     return true;
-                case JsonValueType.Number:
+                case JsonValueKind.Number:
                     value = element.GetRawText();
                     return false;
-                case JsonValueType.String:
+                case JsonValueKind.String:
                     value = element.GetString();
                     return true;
                 default:

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -75,6 +75,12 @@
           DestinationFiles="@(SdksContent -> '$(PublishDir)Sdks/%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 
+  <Target Name="CopyRuntimeConfiguration"
+          AfterTargets="Publish">
+     <Copy SourceFiles="$(ProjectRuntimeConfigFilePath)"
+           DestinationFiles="$(PublishDir)dotnet.runtimeconfig.json" />
+  </Target>
+
   <Target Name="ChmodPublishDir"
           AfterTargets="PublishMSBuildExtensions"
           Condition=" '$(OS)' != 'Windows_NT' ">

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/AppHostShellShimMakerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/AppHostShellShimMakerMock.cs
@@ -26,7 +26,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
 
             _fileSystem.File.WriteAllText(
                 shimPath.Value,
-                JsonSerializer.ToString(shim));
+                JsonSerializer.Serialize(shim));
         }
 
         public class FakeShim

--- a/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.ComponentMocks/ProjectRestorerMock.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Tools.Tests.ComponentMocks
                 fakeExecutablePath);
             _fileSystem.File.WriteAllText(
                 assetJsonOutput.WithFile(FakeCommandSettingsFileName).Value,
-                JsonSerializer.ToString(new {Name = feedPackage.ToolCommandName}));
+                JsonSerializer.Serialize(new {Name = feedPackage.ToolCommandName}));
         }
 
         public MockFeedPackage GetPackage(

--- a/test/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/ToolInstallGlobalOrToolPathCommandTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
             // It is hard to simulate shell behavior. Only Assert shim can point to executable dll
             _fileSystem.File.Exists(ExpectedCommandPath()).Should().BeTrue();
-            var deserializedFakeShim = JsonSerializer.Parse<AppHostShellShimMakerMock.FakeShim>(
+            var deserializedFakeShim = JsonSerializer.Deserialize<AppHostShellShimMakerMock.FakeShim>(
                 _fileSystem.File.ReadAllText(ExpectedCommandPath()));
 
             _fileSystem.File.Exists(deserializedFakeShim.ExecutablePath).Should().BeTrue();
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
             _fileSystem.File.Exists(ExpectedCommandPath())
             .Should().BeTrue();
             var deserializedFakeShim =
-                JsonSerializer.Parse<AppHostShellShimMakerMock.FakeShim>(
+                JsonSerializer.Deserialize<AppHostShellShimMakerMock.FakeShim>(
                     _fileSystem.File.ReadAllText(ExpectedCommandPath()));
             _fileSystem.File.Exists(deserializedFakeShim.ExecutablePath).Should().BeTrue();
         }


### PR DESCRIPTION
Fix #11520 -- We no longer require a cyclical stage 0 update to consume corefx changes

WIP: Tests aren't picking up the newer runtime we're acquiring yet. Also need to make similar change in toolset, and make sure darc subscriptions get updated.