### PR TITLE
Manual DARC update from core-setup

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,9 +5,9 @@
       <Uri>https://github.com/dotnet/templating</Uri>
       <Sha>3ce7695b54e89523ff6e116742472e3c5f4d19bb</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview8-27901-07">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview7-27901-06">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>f8c97c34e80df0ce59dbdb36bfa11b1457842e9c</Sha>
+      <Sha>df2b1489de5d4b8211c5e132d299a83523ce742a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="3.0.0-preview7.19351.10">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview8-27901-07</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>3.0.0-preview7-27901-06</MicrosoftNETCoreAppPackageVersion>
     <DotNetCoreSdkLKGVersion>3.0.100-preview7-012712</DotNetCoreSdkLKGVersion>
     <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>3.0.0-preview7.19351.10</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>2.2.1</MicrosoftNETCoreDotNetHostResolverPackageVersion>


### PR DESCRIPTION
We took a `preview8` core-setup dependency from master during the code merge yesterday, and manually triggering a darc update didn't do anything (I'm guessing because DARC reads a `preview8` dependency as being newer than a `preview7` dependency, so it doesn't think it has anything to do, even though the latest dependency on the channel is `preview7` - @riarenas @JohnTortugo can you confirm?)

CC @livarcocc 