### PR TITLE
Update FirstRun search logic for templates.

### DIFF
--- a/src/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -131,13 +131,12 @@ namespace Microsoft.DotNet.Tools.New
         {
             IDictionary<string, (string path, SemanticVersion version)> bestVersionsByBucket = new Dictionary<string, (string path, SemanticVersion version)>();
 
-            var version = typeof(NewCommandShim).Assembly.GetName().Version;
-            SemanticVersion.TryParse($"{version.Major}.{version.Minor}", out SemanticVersion currentVersion);
-
+            var sdkVersion = typeof(NewCommandShim).Assembly.GetName().Version;
             foreach (KeyValuePair<string, SemanticVersion> dirInfo in versionDirInfo)
             {
-                // restrict the results to not include from higher versions
-                if (dirInfo.Value.CompareTo(currentVersion) <= 0)
+                Version majorMinorDirVersion = new Version(dirInfo.Value.Major, dirInfo.Value.Minor);
+                // restrict the results to not include from higher versions of the runtime/templates then the SDK
+                if (majorMinorDirVersion <= sdkVersion)
                 {
                     string coreAppVersion = $"{dirInfo.Value.Major}.{dirInfo.Value.Minor}";
                     if (!bestVersionsByBucket.TryGetValue(coreAppVersion, out (string path, SemanticVersion version) currentHighest)


### PR DESCRIPTION
This will account for templates being installed into the dotnet/templates/M.m versioned folders.
Templates will be applied in ascending order based on the M.m version (where M.m) corresponds with the
version of netcoreapp which the templates target. Additionaly, any templates shipped in
the dotnet/sdk/version/Templates folder will also be installed.


