### PR TITLE
Copy sources from Versions.props to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,5 +4,9 @@
   <packageSources>
     <clear/>
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
+    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
**TL;DR**

We need that all restore sources are located in `NuGet.config` since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)