### PR TITLE
Ignore Ctrl-C for forwarding commands.

### DIFF
--- a/src/dotnet/NuGetForwardingApp.cs
+++ b/src/dotnet/NuGetForwardingApp.cs
@@ -23,6 +23,10 @@ namespace Microsoft.DotNet.Tools
 
         public int Execute()
         {
+            // Ignore Ctrl-C for the remainder of the command's execution
+            // Forwarding commands will just spawn the child process and exit
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; };
+
             return _forwardingApp.Execute();
         }
 

--- a/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
+++ b/src/dotnet/commands/dotnet-msbuild/MSBuildForwardingApp.cs
@@ -62,6 +62,10 @@ namespace Microsoft.DotNet.Tools.MSBuild
 
         public virtual int Execute()
         {
+            // Ignore Ctrl-C for the remainder of the command's execution
+            // Forwarding commands will just spawn the child process and exit
+            Console.CancelKeyPress += (sender, e) => { e.Cancel = true; };
+
             return GetProcessStartInfo().Execute();
         }
     }

--- a/src/dotnet/commands/dotnet-run/RunCommand.cs
+++ b/src/dotnet/commands/dotnet-run/RunCommand.cs
@@ -53,6 +53,10 @@ namespace Microsoft.DotNet.Tools.Run
                 {
                     return 1;
                 }
+
+                // Ignore Ctrl-C for the remainder of the command's execution
+                Console.CancelKeyPress += (sender, e) => { e.Cancel = true; };
+
                 return targetCommand.Execute().ExitCode;
             }
             catch (InvalidProjectFileException e)


### PR DESCRIPTION
This commit ignores Ctrl-C for the remainder of the dotnet process for
forwarding commands and the `run` command which simply spawn the child process
and exit with the child's exit code.

Doing this will prevent a race where SIGINT is handled after the child process
terminates but before the dotnet process terminates.  After the child process
terminates, the handler registered by the process reaper is unregistered.  If a
SIGINT occurs after this, the default signal handler will execute and the
dotnet process will exit with 130 (SIGINT) on POSIX systems.

This should hopefully fix the flakiness observed in the `ItIgnoresSIGINT` test.

Fixes #11088.
