### PR TITLE
Update 1.x servicing versions to the latest versions.

### DIFF
--- a/build/MSBuildExtensions.targets
+++ b/build/MSBuildExtensions.targets
@@ -163,8 +163,8 @@
     </ItemGroup>
 
     <PropertyGroup>
-      <MicrosoftNETCoreAppLatestVersion1_0 Condition="'$(MicrosoftNETCoreAppLatestVersion1_0)' == ''">1.0.14</MicrosoftNETCoreAppLatestVersion1_0>
-      <MicrosoftNETCoreAppLatestVersion1_1 Condition="'$(MicrosoftNETCoreAppLatestVersion1_1)' == ''">1.1.11</MicrosoftNETCoreAppLatestVersion1_1>
+      <MicrosoftNETCoreAppLatestVersion1_0 Condition="'$(MicrosoftNETCoreAppLatestVersion1_0)' == ''">1.0.16</MicrosoftNETCoreAppLatestVersion1_0>
+      <MicrosoftNETCoreAppLatestVersion1_1 Condition="'$(MicrosoftNETCoreAppLatestVersion1_1)' == ''">1.1.13</MicrosoftNETCoreAppLatestVersion1_1>
       <MicrosoftNETCoreAppLatestVersion2_0 Condition="'$(MicrosoftNETCoreAppLatestVersion2_0)' == ''">2.0.9</MicrosoftNETCoreAppLatestVersion2_0>
     </PropertyGroup>
 


### PR DESCRIPTION
The 1.x servicing version numbers were stale and not the latest (and
final) released versions.
