### PR TITLE
Fixed build failing for usernames with spaces

### DIFF
--- a/run-build.ps1
+++ b/run-build.ps1
@@ -24,5 +24,5 @@ if($Architecture.StartsWith("arm", [StringComparison]::OrdinalIgnoreCase))
 $ArchitectureParam="/p:Architecture=$Architecture"
 $ConfigurationParam="-configuration $Configuration"
 
-Invoke-Expression "$RepoRoot\eng\common\build.ps1 -restore -build $ConfigurationParam $ArchitectureParam $ExtraParameters"
+Invoke-Expression "& '$RepoRoot\eng\common\build.ps1' -restore -build $ConfigurationParam $ArchitectureParam $ExtraParameters"
 if($LASTEXITCODE -ne 0) { throw "Failed to build" }


### PR DESCRIPTION
I opened an issue where the build was failing because of a space in my username <Firstname Lastname>
This was caused because $PSScriptRoot is being passed to Invoke-Expression without escaping the space in the path.

Fixes #11812