### PR TITLE
Unpin DependencyModel

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,10 +13,9 @@
       <Uri>https://github.com/dotnet/core-setup</Uri>
       <Sha>fbe24089c59a9f330dfb7c4db4ae97a293685510</Sha>
     </Dependency>
-    <!-- Pinned pending fix for https://github.com/dotnet/core-setup/issues/7137 -->
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview-27324-5" Pinned="true">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="3.0.0-preview8-27917-07">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>705a6d8ce1a073d58fffa8ab9f25a7b8112d6b6b</Sha>
+      <Sha>fbe24089c59a9f330dfb7c4db4ae97a293685510</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="3.0.0-preview8-27917-07">
       <Uri>https://github.com/dotnet/core-setup</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,7 +19,7 @@
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
     <MicrosoftNETCoreAppPackageVersion>3.0.0-preview8-27917-07</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>3.0.0-preview8-27917-07</MicrosoftDotNetPlatformAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview-27324-5</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>3.0.0-preview8-27917-07</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftNETCoreDotNetHostResolverPackageVersion>3.0.0-preview8-27917-07</MicrosoftNETCoreDotNetHostResolverPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -90,7 +90,7 @@
      <Copy SourceFiles="$(ProjectRuntimeConfigFilePath)"
            DestinationFiles="$(PublishDir)dotnet.runtimeconfig.json" />
      <Copy SourceFiles="$(ProjectRuntimeConfigFilePath)"
-           DestinationFiles="$(PublishDir)msbuild.runtimeconfig.json" />
+           DestinationFiles="$(PublishDir)MSBuild.runtimeconfig.json" />
   </Target>
 
   <Target Name="ChmodPublishDir"

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -89,6 +89,8 @@
           AfterTargets="Publish">
      <Copy SourceFiles="$(ProjectRuntimeConfigFilePath)"
            DestinationFiles="$(PublishDir)dotnet.runtimeconfig.json" />
+     <Copy SourceFiles="$(ProjectRuntimeConfigFilePath)"
+           DestinationFiles="$(PublishDir)msbuild.runtimeconfig.json" />
   </Target>
 
   <Target Name="ChmodPublishDir"


### PR DESCRIPTION
dotnet/core-setup#7137 is fixed and so we can now unpin DependencyModel

Also, it turns out that we were running msbuild on the stage0 runtime during tests, instead of the incoming runtime from core-setup, which is now fixed. This showed up as a missing method exception during local testing of this change.