### PR TITLE
Adding support for dotnet list package --deprecated

### DIFF
--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommand.cs
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommand.cs
@@ -53,45 +53,48 @@ namespace Microsoft.DotNet.Tools.List.PackageReferences
 
             if (_appliedCommand.HasOption("include-prerelease"))
             {
-                CheckForOutdated("--include-prerelease");
+                CheckForOutdatedOrDeprecated("--include-prerelease");
             }
 
             if (_appliedCommand.HasOption("highest-patch"))
             {
-                CheckForOutdated("--highest-patch");
+                CheckForOutdatedOrDeprecated("--highest-patch");
             }
 
             if (_appliedCommand.HasOption("highest-minor"))
             {
-                CheckForOutdated("--highest-minor");
+                CheckForOutdatedOrDeprecated("--highest-minor");
             }
 
             if (_appliedCommand.HasOption("config"))
             {
-                CheckForOutdated("--config");
+                CheckForOutdatedOrDeprecated("--config");
             }
 
             if (_appliedCommand.HasOption("source"))
             {
-                CheckForOutdated("--source");
+                CheckForOutdatedOrDeprecated("--source");
+            }
+
+            if (_appliedCommand.HasOption("deprecated") && _appliedCommand.HasOption("outdated"))
+            {
+                throw new GracefulException(LocalizableStrings.OutdatedAndDeprecatedOptionsCannotBeCombined);
             }
 
             return args.ToArray();
         }
 
         /// <summary>
-        /// A check for the outdated specific options. If --outdated not present,
-        /// these options must not be used, so error is thrown
+        /// A check for the outdated and deprecated specific options. If --outdated or --deprecated not present,
+        /// these options must not be used, so error is thrown.
         /// </summary>
         /// <param name="option"></param>
-        private void CheckForOutdated(string option)
+        private void CheckForOutdatedOrDeprecated(string option)
         {
-            if (!_appliedCommand.HasOption("outdated"))
+            if (!_appliedCommand.HasOption("deprecated") && !_appliedCommand.HasOption("outdated"))
             {
-                throw new GracefulException(LocalizableStrings.OutdatedOptionOnly, option);
-
+                throw new GracefulException(LocalizableStrings.OutdatedOrDeprecatedOptionOnly, option);
             }
-            
         }
 
         /// <summary>
@@ -103,7 +106,7 @@ namespace Microsoft.DotNet.Tools.List.PackageReferences
         private string GetProjectOrSolution()
         {
             string resultPath = _fileOrDirectory;
-            
+
             if (Directory.Exists(resultPath))
             {
                 var possibleSolutionPath = Directory.GetFiles(resultPath, "*.sln", SearchOption.TopDirectoryOnly);
@@ -142,12 +145,12 @@ namespace Microsoft.DotNet.Tools.List.PackageReferences
                     }
                 }
             }
-            
+
             if (!File.Exists(resultPath))
             {
                 throw new GracefulException(LocalizableStrings.FileNotFound, resultPath);
             }
-            
+
             return resultPath;
         }
     }

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/ListPackageReferencesCommandParser.cs
@@ -19,6 +19,9 @@ namespace Microsoft.DotNet.Cli
                 Create.Option("--outdated",
                               LocalizableStrings.CmdOutdatedDescription,
                               Accept.NoArguments().ForwardAs("--outdated")),
+                Create.Option("--deprecated",
+                              LocalizableStrings.CmdDeprecatedDescription,
+                              Accept.NoArguments().ForwardAs("--deprecated")),
                 Create.Option("--framework",
                               LocalizableStrings.CmdFrameworkDescription,
                               Accept.OneOrMoreArguments()

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/LocalizableStrings.resx
@@ -139,27 +139,33 @@
     <value>CONFIG_FILE</value>
   </data>
   <data name="CmdConfigDescription" xml:space="preserve">
-    <value>The path to the NuGet config file to use. Requires the '--outdated' option.</value>
+    <value>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</value>
   </data>
   <data name="CmdHighestMinorDescription" xml:space="preserve">
-    <value>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</value>
+    <value>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</value>
   </data>
   <data name="CmdHighestPatchDescription" xml:space="preserve">
-    <value>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</value>
+    <value>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</value>
   </data>
   <data name="CmdPrereleaseDescription" xml:space="preserve">
-    <value>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</value>
+    <value>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</value>
   </data>
   <data name="CmdSource" xml:space="preserve">
     <value>SOURCE</value>
   </data>
   <data name="CmdSourceDescription" xml:space="preserve">
-    <value>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</value>
-  </data>
-  <data name="OutdatedOptionOnly" xml:space="preserve">
-    <value>Option '{0}' requires the '--outdated' option to be specified.</value>
+    <value>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
     <value>Could not find file or directory '{0}'.</value>
+  </data>
+  <data name="OutdatedAndDeprecatedOptionsCannotBeCombined" xml:space="preserve">
+    <value>Option '--outdated' and '--deprecated' cannot be combined.</value>
+  </data>
+  <data name="CmdDeprecatedDescription" xml:space="preserve">
+    <value>Lists packages that have been deprecated.</value>
+  </data>
+  <data name="OutdatedOrDeprecatedOptionOnly" xml:space="preserve">
+    <value>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</value>
   </data>
 </root>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Vypíše všechny odkazy na balíčky z projektu nebo řešení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">ARCHITEKTURA | ARCHITEKTURA\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">Cesta ke konfiguračnímu souboru NuGet, který se má použít. Vyžaduje přepínač --outdated.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Cesta ke konfiguračnímu souboru NuGet, který se má použít. Vyžaduje přepínač --outdated.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Při hledání novějších balíčků se budou brát v úvahu jenom balíčky s odpovídajícím číslem hlavní verze. Vyžaduje přepínač --outdated.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Při hledání novějších balíčků se budou brát v úvahu jenom balíčky s odpovídajícím číslem hlavní verze. Vyžaduje přepínač --outdated.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Při hledání novějších balíčků se budou brát v úvahu jenom balíčky s odpovídajícími čísly hlavní verze a podverze. Vyžaduje přepínač --outdated.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Při hledání novějších balíčků se budou brát v úvahu jenom balíčky s odpovídajícími čísly hlavní verze a podverze. Vyžaduje přepínač --outdated.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Při hledání novějších balíčků se budou brát v úvahu i balíčky v předběžných verzích. Vyžaduje přepínač --outdated.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Při hledání novějších balíčků se budou brát v úvahu i balíčky v předběžných verzích. Vyžaduje přepínač --outdated.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Zdroje NuGet, které se mají použít při hledání novějších balíčků. Vyžaduje přepínač --outdated.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Zdroje NuGet, které se mají použít při hledání novějších balíčků. Vyžaduje přepínač --outdated.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">Přepínač {0} vyžaduje, aby byl zadaný také přepínač --outdated.</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">Soubor nebo adresář {0} nešlo najít.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Hiermit listen Sie alle Paketverweise des Projekts oder der Lösung auf.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">Der Pfad zu der NuGet-Konfigurationsdatei, die verwendet werden soll. Erfordert die Option "--outdated".</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Der Pfad zu der NuGet-Konfigurationsdatei, die verwendet werden soll. Erfordert die Option "--outdated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Hiermit werden bei der Suche nach neueren Paketen nur die Pakete mit übereinstimmender Hauptversionsnummer berücksichtigt. Hierfür ist die Option "--outdated" erforderlich.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Hiermit werden bei der Suche nach neueren Paketen nur die Pakete mit übereinstimmender Hauptversionsnummer berücksichtigt. Hierfür ist die Option "--outdated" erforderlich.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Hiermit werden bei der Suche nach neueren Paketen nur die Pakete mit übereinstimmender Haupt- und Nebenversionsnummer berücksichtigt. Hierfür ist die Option "--outdated" erforderlich.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Hiermit werden bei der Suche nach neueren Paketen nur die Pakete mit übereinstimmender Haupt- und Nebenversionsnummer berücksichtigt. Hierfür ist die Option "--outdated" erforderlich.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Hiermit werden bei der Suche nach neueren Pakete auch Pakete mit Vorabversionen berücksichtigt. Hierfür ist die Option "--outdated" erforderlich.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Hiermit werden bei der Suche nach neueren Pakete auch Pakete mit Vorabversionen berücksichtigt. Hierfür ist die Option "--outdated" erforderlich.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Die bei der Suche nach neueren Paketen zu verwendenden NuGet-Quellen. Hierfür ist die Option "--outdated" erforderlich.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Die bei der Suche nach neueren Paketen zu verwendenden NuGet-Quellen. Hierfür ist die Option "--outdated" erforderlich.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">Für die Option "{0}" muss die Option "--outdated" angegeben werden.</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">Die Datei oder das Verzeichnis "{0}" wurde nicht gefunden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Enumere todas las referencias de paquete del proyecto o la solución.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">MARCO | FRAMEWORK\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">La ruta al archivo de config de NuGet para utilizar. Se requiere la opción "--outdated".</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">La ruta al archivo de config de NuGet para utilizar. Se requiere la opción "--outdated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Considere solo los paquetes con un número de versión mayor coincidente al buscar nuevos paquetes. Se requiere la opción "--outdated".</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Considere solo los paquetes con un número de versión mayor coincidente al buscar nuevos paquetes. Se requiere la opción "--outdated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Considere solo los paquetes con números de versión mayor y menor coincidentes al buscar nuevos paquetes. Se requiere la opción "--outdated".</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Considere solo los paquetes con números de versión mayor y menor coincidentes al buscar nuevos paquetes. Se requiere la opción "--outdated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Considere la posibilidad de usar paquetes con versiones previas al buscar nuevos paquetes. Requiere la opción "--outdated".</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Considere la posibilidad de usar paquetes con versiones previas al buscar nuevos paquetes. Requiere la opción "--outdated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Los orígenes de NuGet para utilizar en la búsqueda de nuevos paquetes. Requiere la opción "--outdated".</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Los orígenes de NuGet para utilizar en la búsqueda de nuevos paquetes. Requiere la opción "--outdated".</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">La opción "{0}" requiere que se especifique la opción "--outdated".</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">No se pudo encontrar el archivo o directorio "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Listez toutes les références de package du projet ou de la solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">Chemin du fichier config NuGet à utiliser. Nécessite l'option '--outdated'.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Chemin du fichier config NuGet à utiliser. Nécessite l'option '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Prenez en compte uniquement les packages avec un numéro de version majeure correspondant quand vous recherchez des packages plus récents. Nécessite l'option '--outdated'.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Prenez en compte uniquement les packages avec un numéro de version majeure correspondant quand vous recherchez des packages plus récents. Nécessite l'option '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Prenez en compte uniquement les packages avec des numéros de version majeure et mineure correspondants quand vous recherchez des packages plus récents. Nécessite l'option '--outdated'.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Prenez en compte uniquement les packages avec des numéros de version majeure et mineure correspondants quand vous recherchez des packages plus récents. Nécessite l'option '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Prenez en compte les packages avec des préversions quand vous recherchez des packages plus récents. Nécessite l'option '--outdated'.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Prenez en compte les packages avec des préversions quand vous recherchez des packages plus récents. Nécessite l'option '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Sources NuGet à utiliser dans la recherche de packages plus récents. Nécessite l'option '--outdated'.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Sources NuGet à utiliser dans la recherche de packages plus récents. Nécessite l'option '--outdated'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">L'option '{0}' nécessite la spécification de l'option '--outdated'.</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">Fichier ou répertoire '{0}' introuvable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Elenca tutti i riferimenti al pacchetto del progetto o della soluzione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">Percorso del file config NuGet da usare. Richiede l'opzione '--outdated'.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Percorso del file config NuGet da usare. Richiede l'opzione '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Prende in considerazione solo i pacchetti con il numero di versione principale corrispondente quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated'.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Prende in considerazione solo i pacchetti con il numero di versione principale corrispondente quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Prende in considerazione solo i pacchetti con i numeri di versione principale e secondaria corrispondenti quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated'.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Prende in considerazione solo i pacchetti con i numeri di versione principale e secondaria corrispondenti quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Prende in considerazione i pacchetti con versioni preliminari quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated'.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Prende in considerazione i pacchetti con versioni preliminari quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Origini NuGet da usare quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated'.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Origini NuGet da usare quando si cercano i pacchetti più recenti. Richiede l'opzione '--outdated'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">Con l'opzione '{0}' è necessario specificare l'opzione '--outdated'.</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">Non è stato possibile trovare il file o la directory '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">プロジェクトまたはソリューションのすべてのパッケージ参照を一覧表示します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">フレームワーク | フレームワーク\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">使用する NuGet config ファイルのパス。'--outdated' オプションが必要です。</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">使用する NuGet config ファイルのパス。'--outdated' オプションが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">新しいパッケージを検索するときにメジャー バージョン番号が一致するパッケージのみを検討します。'--outdated' オプションが必要です。</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">新しいパッケージを検索するときにメジャー バージョン番号が一致するパッケージのみを検討します。'--outdated' オプションが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">新しいパッケージを検索するときにメジャーとマイナーのバージョン番号が一致するパッケージのみを検討します。'--outdated' オプションが必要です。</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">新しいパッケージを検索するときにメジャーとマイナーのバージョン番号が一致するパッケージのみを検討します。'--outdated' オプションが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">新しいパッケージを検索するときにプレリリース バージョンのパッケージを検討します。'--outdated' オプションが必要です。</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">新しいパッケージを検索するときにプレリリース バージョンのパッケージを検討します。'--outdated' オプションが必要です。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">新しいパッケージを検索するときに使用する NuGet ソース。'--outdated' オプションが必要です。</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">新しいパッケージを検索するときに使用する NuGet ソース。'--outdated' オプションが必要です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">オプション '{0}' では '--outdated' オプションを指定する必要があります。</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">ファイルまたはディレクトリ '{0}' が見つかりませんでした。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">프로젝트 또는 솔루션의 모든 패키지 참조를 나열합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">프레임워크 | FRAMEWORK\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">사용할 NuGet 구성 파일의 경로입니다. '--outdated' 옵션이 필요합니다.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">사용할 NuGet 구성 파일의 경로입니다. '--outdated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">최신 패키지를 검색할 때 주 버전 번호가 일치하는 패키지만 고려합니다. '--outdated' 옵션이 필요합니다.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">최신 패키지를 검색할 때 주 버전 번호가 일치하는 패키지만 고려합니다. '--outdated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">최신 패키지를 검색할 때 주 버전 번호와 부 버전 번호가 일치하는 패키지만 고려합니다. '--outdated' 옵션이 필요합니다.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">최신 패키지를 검색할 때 주 버전 번호와 부 버전 번호가 일치하는 패키지만 고려합니다. '--outdated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">최신 패키지를 검색할 때 시험판 버전이 있는 패키지를 고려합니다. '--outdated' 옵션이 필요합니다.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">최신 패키지를 검색할 때 시험판 버전이 있는 패키지를 고려합니다. '--outdated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">최신 패키지를 검색할 때 사용하는 NuGet 소스입니다. '--outdated' 옵션이 필요합니다.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">최신 패키지를 검색할 때 사용하는 NuGet 소스입니다. '--outdated' 옵션이 필요합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">'{0}' 옵션을 사용하려면 '--outdated' 옵션을 지정해야 합니다.</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">'{0}' 파일 또는 디렉터리를 찾을 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Zwróć listę wszystkich odwołań do pakietów w projekcie lub rozwiązaniu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">STRUKTURA | STRUKTURA\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">Ścieżka do pliku konfiguracji NuGet, który ma być używany. Wymaga opcji „--outdated”.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Ścieżka do pliku konfiguracji NuGet, który ma być używany. Wymaga opcji „--outdated”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Podczas wyszukiwania nowszych pakietów uwzględniaj tylko pakiety ze zgodnym numerem wersji głównej. Wymaga opcji „--outdated”.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Podczas wyszukiwania nowszych pakietów uwzględniaj tylko pakiety ze zgodnym numerem wersji głównej. Wymaga opcji „--outdated”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Podczas wyszukiwania nowszych pakietów uwzględniaj tylko pakiety ze zgodnym numerem wersji głównej i pomocniczej. Wymaga opcji „--outdated”.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Podczas wyszukiwania nowszych pakietów uwzględniaj tylko pakiety ze zgodnym numerem wersji głównej i pomocniczej. Wymaga opcji „--outdated”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Podczas wyszukiwania nowszych pakietów uwzględniaj pakiety z wersjami wstępnymi. Wymaga opcji „--outdated”.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Podczas wyszukiwania nowszych pakietów uwzględniaj pakiety z wersjami wstępnymi. Wymaga opcji „--outdated”.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Źródła NuGet do użycia podczas wyszukiwania nowszych pakietów. Wymaga opcji „--outdated”.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Źródła NuGet do użycia podczas wyszukiwania nowszych pakietów. Wymaga opcji „--outdated”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">Opcja „{0}” wymaga określenia opcji „--outdated”.</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">Nie można odnaleźć pliku lub katalogu „{0}”.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Listar todas as referências de pacote do projeto ou da solução.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">ESTRUTURA | ESTRUTURA\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">O caminho para o arquivo de configuração do NuGet a ser usado. Requer a opção '--outdated'.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">O caminho para o arquivo de configuração do NuGet a ser usado. Requer a opção '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Ao procurar pacotes mais novos, considerar apenas os pacotes com um número de versão principal correspondente. Requer a opção '--outdated'.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Ao procurar pacotes mais novos, considerar apenas os pacotes com um número de versão principal correspondente. Requer a opção '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Considerar apenas os pacotes com números de versão principal e secundária correspondentes ao procurar pacotes mais novos. Requer a opção '--outdated'.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Considerar apenas os pacotes com números de versão principal e secundária correspondentes ao procurar pacotes mais novos. Requer a opção '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Ao procurar pacotes mais novos, considere pacotes com versões de pré-lançamento. Requer a opção '--outdated'.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Ao procurar pacotes mais novos, considere pacotes com versões de pré-lançamento. Requer a opção '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">A fontes do NuGet a serem usadas ao procurar pacotes mais novos. Requer a opção '--outdated'.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">A fontes do NuGet a serem usadas ao procurar pacotes mais novos. Requer a opção '--outdated'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">A opção '{0}' requer que a opção '--outdated' seja especificada.</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">Não foi possível encontrar o arquivo ou o diretório '{0}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Вывод списка всех ссылок на пакеты для проекта или решения.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">Путь к используемому файлу NuGet. Требуется указать параметр '--outdated'.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Путь к используемому файлу NuGet. Требуется указать параметр '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Учитывает только пакеты с соответствующим номером основной версии при поиске более новых версий пакетов. Требуется указать параметр '--outdated'.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Учитывает только пакеты с соответствующим номером основной версии при поиске более новых версий пакетов. Требуется указать параметр '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Учитывать только пакеты с соответствующими номерами основной и дополнительной версий при поиске более новых версий пакетов. Требуется указать параметр "--outdated".</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Учитывать только пакеты с соответствующими номерами основной и дополнительной версий при поиске более новых версий пакетов. Требуется указать параметр "--outdated".</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Учитывает пакеты с версиями предварительных выпусков при поиске более новых версий пакетов. Требуется указать параметр '--outdated'.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Учитывает пакеты с версиями предварительных выпусков при поиске более новых версий пакетов. Требуется указать параметр '--outdated'.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Источники NuGet, используемые при поиске более новых версий пакетов. Требуется указать параметр '--outdated'.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Источники NuGet, используемые при поиске более новых версий пакетов. Требуется указать параметр '--outdated'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">Для параметра '{0}' необходимо указать параметр '--outdated'.</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">Не удалось найти файл или каталог "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Proje veya çözümdeki tüm paket başvurularını listeleyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">ÇERÇEVE | FRAMEWORK\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">Kullanılacak NuGet yapılandırma dosyasının yolu. '--outdated' seçeneğini gerektirir.</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Kullanılacak NuGet yapılandırma dosyasının yolu. '--outdated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Daha yeni paketler aranırken yalnızca eşleşen birincil sürüm numarasına sahip paketleri göz önünde bulundurun. '--outdated' seçeneğini gerektirir.</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Daha yeni paketler aranırken yalnızca eşleşen birincil sürüm numarasına sahip paketleri göz önünde bulundurun. '--outdated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Daha yeni paketler aranırken yalnızca eşleşen birincil ve ikincil sürüm numaralarına sahip paketleri değerlendirin. '--outdated' seçeneğini gerektirir.</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Daha yeni paketler aranırken yalnızca eşleşen birincil ve ikincil sürüm numaralarına sahip paketleri değerlendirin. '--outdated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Daha yeni paketleri ararken yayın öncesi sürümlere sahip olan paketleri göz önünde bulundurun. '--outdated' seçeneğini gerektirir.</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Daha yeni paketleri ararken yayın öncesi sürümlere sahip olan paketleri göz önünde bulundurun. '--outdated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">Daha yeni paketler aranırken kullanılacak NuGet kaynakları. '--outdated' seçeneğini gerektirir.</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">Daha yeni paketler aranırken kullanılacak NuGet kaynakları. '--outdated' seçeneğini gerektirir.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">'{0}' seçeneği '--outdated' seçeneğinin belirtilmesini gerektirir.</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">'{0}' dosyası veya dizini bulunamadı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">列出项目或解决方案的所有包引用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">框架 | FRAMEWORK\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">要使用的 NuGet 配置文件的路径。需要 "--outdated" 选项。</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">要使用的 NuGet 配置文件的路径。需要 "--outdated" 选项。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">在搜索较新的包时，仅考虑具有匹配的主要版本号的包。需要 "--outdated" 选项。</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">在搜索较新的包时，仅考虑具有匹配的主要版本号的包。需要 "--outdated" 选项。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">在搜索较新的包时，仅考虑具有匹配的主要和次要版本号的包。需要 "--outdated" 选项。</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">在搜索较新的包时，仅考虑具有匹配的主要和次要版本号的包。需要 "--outdated" 选项。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">在搜索较新的包时，请考虑使用具有预发行版本的包。需要 "--outdated" 选项。</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">在搜索较新的包时，请考虑使用具有预发行版本的包。需要 "--outdated" 选项。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">搜索较新的包时要使用的 NuGet 源。需要 "--outdated" 选项。</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">搜索较新的包时要使用的 NuGet 源。需要 "--outdated" 选项。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">选项“{0}”要求指定 "--outdated" 选项。</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">找不到文件或目录“{0}”。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-list/dotnet-list-package/xlf/LocalizableStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">列出專案或解決方案的所有套件參考。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CmdDeprecatedDescription">
+        <source>Lists packages that have been deprecated.</source>
+        <target state="new">Lists packages that have been deprecated.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CmdFramework">
         <source>FRAMEWORK | FRAMEWORK\RID</source>
         <target state="translated">FRAMEWORK | FRAMEWORK\RID</target>
@@ -38,23 +43,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdConfigDescription">
-        <source>The path to the NuGet config file to use. Requires the '--outdated' option.</source>
-        <target state="translated">要使用的 NuGet 組態檔路徑。需要使用 '--outdated’ 選項。</target>
+        <source>The path to the NuGet config file to use. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">要使用的 NuGet 組態檔路徑。需要使用 '--outdated’ 選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestMinorDescription">
-        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">在搜尋較新的套件時，建議只搜尋主要版本號碼相符的套件。需要使用 '--outdated' 選項。</target>
+        <source>Consider only the packages with a matching major version number when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">在搜尋較新的套件時，建議只搜尋主要版本號碼相符的套件。需要使用 '--outdated' 選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdHighestPatchDescription">
-        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">在搜尋較新套件時，建議只搜尋主要和次要版本號碼相符的套件。需要使用 '--outdated’ 選項。</target>
+        <source>Consider only the packages with a matching major and minor version numbers when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">在搜尋較新套件時，建議只搜尋主要和次要版本號碼相符的套件。需要使用 '--outdated’ 選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdPrereleaseDescription">
-        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">在搜尋較新套件時，建議搜尋具有發行前版本的套件。需要使用 '--outdated' 選項。</target>
+        <source>Consider packages with prerelease versions when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">在搜尋較新套件時，建議搜尋具有發行前版本的套件。需要使用 '--outdated' 選項。</target>
         <note />
       </trans-unit>
       <trans-unit id="CmdSource">
@@ -63,18 +68,23 @@
         <note />
       </trans-unit>
       <trans-unit id="CmdSourceDescription">
-        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' option.</source>
-        <target state="translated">搜尋較新套件時要使用的 NuGet 來源。需要使用 '--outdated' 選項。</target>
+        <source>The NuGet sources to use when searching for newer packages. Requires the '--outdated' or '--deprecated' option.</source>
+        <target state="needs-review-translation">搜尋較新套件時要使用的 NuGet 來源。需要使用 '--outdated' 選項。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OutdatedOptionOnly">
-        <source>Option '{0}' requires the '--outdated' option to be specified.</source>
-        <target state="translated">選項 '{0}' 需要指定 '--outdated' 選項。</target>
+      <trans-unit id="OutdatedAndDeprecatedOptionsCannotBeCombined">
+        <source>Option '--outdated' and '--deprecated' cannot be combined.</source>
+        <target state="new">Option '--outdated' and '--deprecated' cannot be combined.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileNotFound">
         <source>Could not find file or directory '{0}'.</source>
         <target state="translated">找不到檔案或目錄 ‘{0}’。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OutdatedOrDeprecatedOptionOnly">
+        <source>Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</source>
+        <target state="new">Option '{0}' requires the '--outdated' or '--deprecated' option to be specified.</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Adds support for `dotnet list package --deprecated` command forwarding to NuGet xplat as per [spec](https://github.com/NuGet/Home/wiki/Deprecate-packages#cli).

Fixes https://github.com/dotnet/cli/issues/11969
