### PR TITLE
Fix break in dotnet-install.sh on macOS

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -612,7 +612,10 @@ copy_files_or_dirs_from_list() {
         local target="$out_path/$path"
         if [ "$override" = true ] || (! ([ -d "$target" ] || [ -e "$target" ])); then
             mkdir -p "$out_path/$(dirname "$path")"
-            cp -R --remove-destination $override_switch "$root_path/$path" "$target"
+            if [ -d "$target" ]; then
+                rm -rf "$target"
+            fi
+            cp -R $override_switch "$root_path/$path" "$target"
         fi
     done
 }


### PR DESCRIPTION
skip ci please

tried to write —remove-destination in bash because the switch doesn’t exist on macOS and is breaking PowerShell CI
https://github.com/PowerShell/PowerShell/issues/10206
