### PR TITLE
Add aka.ms link for failure to install tool

### DIFF
--- a/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/install/LocalizableStrings.resx
@@ -185,7 +185,9 @@ Tool '{1}' (version '{2}') was successfully installed. Entry is added to the man
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</value>
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</value>
   </data>
   <data name="ToolInstallationFailedContactAuthor" xml:space="preserve">
     <value>Tool '{0}' failed to install. Contact the tool author for assistance.</value>

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.cs.xlf
@@ -139,8 +139,10 @@ Pokud chcete vytvořit manifest, použijte příkaz dotnet new tool-manifest, ob
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">Nástroj {0} se nepodařilo nainstalovat. Možné příčiny:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">Nástroj {0} se nepodařilo nainstalovat. Možné příčiny:
 
 * Pokoušíte se nainstalovat verzi Preview, ale nespecifikovali jste ji pomocí možnosti --version.
 * Byl nalezen balíček s tímto názvem, ale není to nástroj .NET Core.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.de.xlf
@@ -139,8 +139,10 @@ Wenn Sie ein Manifest erstellen möchten, verwenden Sie "dotnet new tool-manifes
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">Fehler bei der Installation des Tools "{0}". Dieser Fehler kann folgende Ursachen haben:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">Fehler bei der Installation des Tools "{0}". Dieser Fehler kann folgende Ursachen haben:
 
 * Sie versuchen, eine Vorschauversion zu installieren und haben nicht die Option "--version" verwendet, um die Version anzugeben.
 * Ein Paket mit diesem Namen wurde gefunden, aber es handelt sich nicht um ein .NET Core-Tool.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.es.xlf
@@ -139,8 +139,10 @@ Si desea crear un manifiesto, utilice "dotnet new tool-manifest", normalmente en
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">Error al instalar la herramienta "{0}". El error puede deberse a lo siguiente:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">Error al instalar la herramienta "{0}". El error puede deberse a lo siguiente:
 
 * Está intentando instalar una versión preliminar y no usó la opción --version para especificar la versión.
 * Se encontró un paquete con este nombre, pero no era una herramienta de .NET Core.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.fr.xlf
@@ -139,8 +139,10 @@ Si vous souhaitez créer un manifeste, utilisez 'dotnet new tool-manifest', gén
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">Échec d'installation de l'outil '{0}'. Causes possibles de cet échec :
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">Échec d'installation de l'outil '{0}'. Causes possibles de cet échec :
 
 * Vous essayez d'installer une préversion, mais vous n'avez pas utilisé l'option --version pour spécifier la version.
 * Un package portant ce nom a été trouvé, mais il ne s'agit pas d'un outil .NET Core.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.it.xlf
@@ -139,8 +139,10 @@ Se si vuole creare un manifesto, usare `dotnet new tool-manifest`, in genere nel
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">Non è stato possibile installare lo strumento '{0}'. Le cause di questo errore sono le seguenti:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">Non è stato possibile installare lo strumento '{0}'. Le cause di questo errore sono le seguenti:
 
 * Si sta provando a installare una versione precedente e non è stata usata l'opzione --version per specificare la versione.
 * È stato trovato un pacchetto con questo nome, ma non corrisponde a uno strumento .NET Core.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ja.xlf
@@ -139,8 +139,10 @@ If you would like to create a manifest, use `dotnet new tool-manifest`, usually 
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">ツール '{0}' のインストールに失敗しました。この失敗は次の原因で生じた可能性があります。
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">ツール '{0}' のインストールに失敗しました。この失敗は次の原因で生じた可能性があります。
 
 * プレビュー リリースをインストールしようとしており、--version オプションを使用してバージョンを指定しなかった。
 * この名前のパッケージが見つかったが、.NET Core ツールではなかった。

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ko.xlf
@@ -139,8 +139,10 @@ If you would like to create a manifest, use `dotnet new tool-manifest`, usually 
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">'{0}' 도구를 설치하지 못했습니다. 다음과 같은 이유 때문일 수 있습니다.
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">'{0}' 도구를 설치하지 못했습니다. 다음과 같은 이유 때문일 수 있습니다.
 
 * 미리 보기 릴리스를 설치하려고 하는데 --version 옵션을 사용하여 버전을 지정하지 않았습니다.
 * 이 이름으로 패키지가 검색되었지만 .NET Core 도구가 아니었습니다.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pl.xlf
@@ -139,8 +139,10 @@ Jeśli chcesz utworzyć manifest, użyj polecenia „dotnet new tool-manifest”
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">Zainstalowanie narzędzia „{0}” nie powiodło się. To niepowodzenie może wynikać z następujących powodów:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">Zainstalowanie narzędzia „{0}” nie powiodło się. To niepowodzenie może wynikać z następujących powodów:
 
 * Próbujesz zainstalować wersję zapoznawczą bez użycia opcji --version do określenia wersji.
 * Znaleziono pakiet o tej nazwie, ale nie było to narzędzie .NET Core.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.pt-BR.xlf
@@ -139,8 +139,10 @@ Se quiser criar um manifesto, use `dotnet new tool-manifest`, normalmente no dir
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">A ferramenta '{0}' falhou ao ser instalada. Essa falha pode ter sido causada pelos seguintes motivos:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">A ferramenta '{0}' falhou ao ser instalada. Essa falha pode ter sido causada pelos seguintes motivos:
 
 * Você está tentando instalar uma versão prévia e não usou a opção --version para especificar a versão.
 * Um pacote com esse nome foi encontrado, mas ele não era uma ferramenta do .NET Core.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.ru.xlf
@@ -139,8 +139,10 @@ If you would like to create a manifest, use `dotnet new tool-manifest`, usually 
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">Не удалось установить средство "{0}". Возможные причины сбоя:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">Не удалось установить средство "{0}". Возможные причины сбоя:
 
 * Вы пытаетесь установить предварительный выпуск и не указали версию с помощью параметра --version.
 * Пакет с таким именем найден, но он не является средством .NET Core.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.tr.xlf
@@ -139,8 +139,10 @@ Bir bildirim oluşturmak istiyorsanız 'dotnet new tool-manifest' ifadesini kull
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">'{0}' aracı yüklenemedi. Bu sorun şunlardan kaynaklanıyor olabilir:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">'{0}' aracı yüklenemedi. Bu sorun şunlardan kaynaklanıyor olabilir:
 
 * Bir önizleme sürümünü yüklemeye çalışmış ancak sürümü belirtmek için --version seçeneğini kullanmamış olabilirsiniz.
 * Bu ada sahip bir paket bulunmuş olabilir, ancak bu paket bir .NET Core aracı olmayabilir.

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hans.xlf
@@ -139,8 +139,10 @@ If you would like to create a manifest, use `dotnet new tool-manifest`, usually 
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">工具 "{0}" 安装失败。此故障可能由于:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">工具 "{0}" 安装失败。此故障可能由于:
 
 * 你尝试安装预览版，但没有使用 --version 选项来指定该版本。
 * 已按此名称找到包，但是没有 .NET Core 工具。

--- a/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/install/xlf/LocalizableStrings.zh-Hant.xlf
@@ -139,8 +139,10 @@ If you would like to create a manifest, use `dotnet new tool-manifest`, usually 
 * You are attempting to install a preview release and did not use the --version option to specify the version.
 * A package by this name was found, but it was not a .NET Core tool.
 * The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
-* You mistyped the name of the tool.</source>
-        <target state="translated">工具 '{0}' 無法安裝。此失敗原因可能是因為:
+* You mistyped the name of the tool.
+
+For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool</source>
+        <target state="needs-review-translation">工具 '{0}' 無法安裝。此失敗原因可能是因為:
 
 * 您嘗試要安裝預覽版，但並未使用 --version 選項來指定版本。
 * 找到此名稱的套件，但其並非為 .NET Core 工具。


### PR DESCRIPTION
This message is discussed with Kathleen before her vacation. The aka.ms link will later be update with "add `microsoft.` if you cannot install such first party tool" info. relate https://github.com/dotnet/cli/issues/12004