### PR TITLE
Converging test and vstest verb

### DIFF
--- a/src/dotnet/commands/dotnet-test/Program.cs
+++ b/src/dotnet/commands/dotnet-test/Program.cs
@@ -95,6 +95,14 @@ namespace Microsoft.DotNet.Tools.Test
         {
             DebugHelper.HandleDebugSwitch(ref args);
 
+            // Fix for https://github.com/Microsoft/vstest/issues/1453
+            // Try to run dll/exe directly using the VSTestForwardingApp
+            if (ContainsBuiltTestSources(args))
+            {
+                var convertedArgs = new VSTestArgumentConverter().Convert(args, out var ignoredArgs);
+                return new VSTestForwardingApp(convertedArgs).Execute();
+            }
+
             // Workaround for https://github.com/Microsoft/vstest/issues/1503
             const string NodeWindowEnvironmentName = "MSBUILDENSURESTDOUTFORTASKPROCESSES";
             string previousNodeWindowSetting = Environment.GetEnvironmentVariable(NodeWindowEnvironmentName);
@@ -108,6 +116,19 @@ namespace Microsoft.DotNet.Tools.Test
             {
                 Environment.SetEnvironmentVariable(NodeWindowEnvironmentName, previousNodeWindowSetting);
             }
+        }
+
+        private static bool ContainsBuiltTestSources(string[] args)
+        {
+            foreach (var arg in args)
+            {
+                if (!(arg.StartsWith("-") || arg.StartsWith("/")) &&
+                    (arg.EndsWith("dll", StringComparison.OrdinalIgnoreCase) || arg.EndsWith("exe", StringComparison.OrdinalIgnoreCase)))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         private static string GetSemiColonEscapedString(string arg)

--- a/src/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
+++ b/src/dotnet/commands/dotnet-test/VSTestArgumentConverter.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Cli
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Converts the given arguments to vstest parsable arguments
+    /// </summary>
+    public class VSTestArgumentConverter
+    {
+        private const string verbosityString = "--logger:console;verbosity=";
+
+        private readonly Dictionary<string, string> ArgumentMapping = new Dictionary<string, string>
+        {
+            ["-h"] = "--help",
+            ["-s"] = "--settings",
+            ["-t"] = "--listtests",
+            ["-a"] = "--testadapterpath",
+            ["-l"] = "--logger",
+            ["-f"] = "--framework",
+            ["-d"] = "--diag",
+            ["--filter"] = "--testcasefilter",
+            ["--list-tests"] = "--listtests",
+            ["--test-adapter-path"] = "--testadapterpath",
+            ["--results-directory"] = "--resultsdirectory"
+        };
+
+        private readonly Dictionary<string, string> VerbosityMapping = new Dictionary<string, string>
+        {
+            ["q"] = "quiet",
+            ["m"] = "minimal",
+            ["n"] = "normal",
+            ["d"] = "detailed",
+            ["diag"] = "diagnostic"
+        };
+
+        private readonly string[] IgnoredArgumentArray = new string[]
+        {
+            "-c",
+            "--configuration",
+            "--runtime",
+            "-o",
+            "--output",
+            "--no-build",
+            "--no-restore",
+            "--interactive"
+        };
+
+        /// <summary>
+        /// Converts the given arguments to vstest parsable arguments
+        /// </summary>
+        /// <param name="args">original arguments</param>
+        /// <param name="ignoredArgs">arguments ignored by the converter</param>
+        /// <returns>list of args which can be passsed to vstest</returns>
+        public List<string> Convert(string[] args, out List<string> ignoredArgs)
+        {
+            var newArgList = new List<string>();
+            ignoredArgs = new List<string>();
+
+            string activeArgument = null;
+            foreach (var arg in args)
+            {
+                if (arg.StartsWith("-"))
+                {
+                    if (!string.IsNullOrEmpty(activeArgument))
+                    {
+                        if (IgnoredArgumentArray.Contains(activeArgument))
+                        {
+                            ignoredArgs.Add(activeArgument);
+                        }
+                        else
+                        {
+                            newArgList.Add(activeArgument);
+                        }
+                        activeArgument = null;
+                    }
+
+                    // Check if the arg contains the value separated by colon
+                    if (arg.Contains(":"))
+                    {
+                        var argValues = arg.Split(':');
+
+                        // Check if the argument is shortname
+                        if (ArgumentMapping.TryGetValue(argValues[0].ToLower(), out var longName))
+                        {
+                            argValues[0] = longName;
+                        }
+                        else if (this.IsVerbosityArg(argValues[0]))
+                        {
+                            if (argValues.Length == 2)
+                            {
+                                UpdateVerbosity(argValues[1], newArgList);
+                            }
+                            continue;
+                        }
+                        else if (IgnoredArgumentArray.Contains(argValues[0]))
+                        {
+                            ignoredArgs.Add(arg);
+                            continue;
+                        }
+
+                        newArgList.Add(string.Join(":", argValues));
+                    }
+                    else
+                    {
+                        activeArgument = arg.ToLower();
+                        if (ArgumentMapping.TryGetValue(activeArgument, out var value))
+                        {
+                            activeArgument = value;
+                        }
+                    }
+                }
+                else if (!string.IsNullOrEmpty(activeArgument))
+                {
+                    if (IsVerbosityArg(activeArgument))
+                    {
+                        UpdateVerbosity(arg, newArgList);
+                    }
+                    else if (IgnoredArgumentArray.Contains(activeArgument))
+                    {
+                        ignoredArgs.Add(activeArgument);
+                        ignoredArgs.Add(arg);
+                    }
+                    else
+                    {
+                        newArgList.Add(string.Concat(activeArgument, ":", arg));
+                    }
+
+                    activeArgument = null;
+                }
+                else
+                {
+                    newArgList.Add(arg);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(activeArgument))
+            {
+                if (IgnoredArgumentArray.Contains(activeArgument))
+                {
+                    ignoredArgs.Add(activeArgument);
+                }
+                else
+                {
+                    newArgList.Add(activeArgument);
+                }
+            }
+
+            return newArgList;
+        }
+
+        private bool IsVerbosityArg(string arg)
+        {
+            return string.Equals(arg, "-v", System.StringComparison.OrdinalIgnoreCase) || string.Equals(arg, "--verbosity", System.StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void UpdateVerbosity(string verbosity, List<string> newArgList)
+        {
+            if (VerbosityMapping.TryGetValue(verbosity.ToLower(), out string longValue))
+            {
+                newArgList.Add(verbosityString + longValue);
+            }
+            else
+            {
+                newArgList.Add(verbosityString + verbosity);
+            }
+        }
+    }
+}

--- a/test/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
+++ b/test/dotnet.Tests/ParserTests/VSTestArgumentConverterTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.DotNet.Tests.ParserTests
+{
+    using Microsoft.DotNet.Cli;
+    using System.Collections.Generic;
+    using Xunit;
+
+    public class VSTestArgumentConverterTests
+    {
+        [Theory]
+        [MemberData(nameof(DataSource.ArgTestCases), MemberType = typeof(DataSource))]
+        public void ConvertArgsShouldConvertValidArgsIntoVSTestParsableArgs(string input, string expectedString)
+        {
+            string[] args = input.Split(' ');
+            string[] expectedArgs = expectedString.Split(' ');
+
+            // Act
+            var convertedArgs = new VSTestArgumentConverter().Convert(args, out var ignoredArgs);
+
+            Assert.Equal(expectedArgs, convertedArgs);
+            Assert.True(ignoredArgs.Count == 0);
+        }
+
+        [Theory]
+        [MemberData(nameof(DataSource.VerbosityTestCases), MemberType = typeof(DataSource))]
+        public void ConvertArgshouldConvertsVerbosityArgsIntoVSTestParsableArgs(string input, string expectedString)
+        {
+            string[] args = input.Split(' ');
+            string[] expectedArgs = expectedString.Split(' ');
+
+            // Act
+            var convertedArgs = new VSTestArgumentConverter().Convert(args, out var ignoredArgs);
+
+            Assert.Equal(expectedArgs, convertedArgs);
+            Assert.True(ignoredArgs.Count == 0);
+        }
+
+        [Theory]
+        [MemberData(nameof(DataSource.IgnoredArgTestCases), MemberType = typeof(DataSource))]
+        public void ConvertArgsShouldIgnoreKnownArgsWhileConvertingArgsIntoVSTestParsableArgs(string input, string expectedArgString, string expIgnoredArgString)
+        {
+            string[] args = input.Split(' ');
+            string[] expectedArgs = expectedArgString.Split(' ');
+            string[] expIgnoredArgs = expIgnoredArgString.Split(' ');
+
+            // Act
+            var convertedArgs = new VSTestArgumentConverter().Convert(args, out var ignoredArgs);
+
+            Assert.Equal(expectedArgs, convertedArgs);
+            Assert.Equal(expIgnoredArgs, ignoredArgs);
+        }
+
+        public static class DataSource
+        {
+            private static readonly List<object[]> argTestCases = new List<object[]>
+            {
+                new object[] { "-h", "--help" },
+                new object[] { "sometest.dll -s test.settings", "sometest.dll --settings:test.settings" },
+                new object[] { "sometest.dll -t", "sometest.dll --listtests" },
+                new object[] { "sometest.dll --list-tests", "sometest.dll --listtests" },
+                new object[] { "sometest.dll --filter", "sometest.dll --testcasefilter" },
+                new object[] { "sometest.dll -l trx", "sometest.dll --logger:trx" },
+                new object[] { "sometest.dll -a c:\adapterpath\temp", "sometest.dll --testadapterpath:c:\adapterpath\temp" },
+                new object[] { "sometest.dll --test-adapter-path c:\adapterpath\temp", "sometest.dll --testadapterpath:c:\adapterpath\temp" },
+                new object[] { "sometest.dll -f net451", "sometest.dll --framework:net451" },
+                new object[] { @"sometest.dll -d c:\temp\log.txt", @"sometest.dll --diag:c:\temp\log.txt" },
+                new object[] { @"sometest.dll --results-directory c:\temp\", @"sometest.dll --resultsdirectory:c:\temp\" },
+                new object[] { @"sometest.dll -s testsettings -t -a c:\path -f net451 -d log.txt --results-directory c:\temp\", @"sometest.dll --settings:testsettings --listtests --testadapterpath:c:\path --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\" },
+                new object[] { @"sometest.dll -s:testsettings -t -a:c:\path -f:net451 -d:log.txt --results-directory:c:\temp\", @"sometest.dll --settings:testsettings --listtests --testadapterpath:c:\path --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\" },
+                new object[] { @"sometest.dll --settings testsettings -t --test-adapter-path c:\path --framework net451 --diag log.txt --results-directory c:\temp\", @"sometest.dll --settings:testsettings --listtests --testadapterpath:c:\path --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\" }
+            };
+
+            private static readonly List<object[]> verbosityTestCases = new List<object[]>
+            {
+                new object[] { "sometest.dll -v q", "sometest.dll --logger:console;verbosity=quiet" },
+                new object[] { "sometest.dll -v m", "sometest.dll --logger:console;verbosity=minimal" },
+                new object[] { "sometest.dll -v n", "sometest.dll --logger:console;verbosity=normal" },
+                new object[] { "sometest.dll -v d", "sometest.dll --logger:console;verbosity=detailed" },
+                new object[] { "sometest.dll -v diag", "sometest.dll --logger:console;verbosity=diagnostic" },
+
+                new object[] { "sometest.dll --verbosity q", "sometest.dll --logger:console;verbosity=quiet" },
+                new object[] { "sometest.dll -v:q", "sometest.dll --logger:console;verbosity=quiet" },
+                new object[] { "sometest.dll --verbosity:q", "sometest.dll --logger:console;verbosity=quiet" },
+            };
+
+            private static readonly List<object[]> ignoredTestCases = new List<object[]>
+            {
+                new object[] { "sometest.dll -c Debug", "sometest.dll", "-c Debug" },
+                new object[] { "sometest.dll --configuration Debug", "sometest.dll", "--configuration Debug" },
+                new object[] { "sometest.dll --runtime win10-x64", "sometest.dll", "--runtime win10-x64" },
+                new object[] { "sometest.dll -o c:\temp2", "sometest.dll", "-o c:\temp2" },
+                new object[] { "sometest.dll --output c:\temp2", "sometest.dll", "--output c:\temp2" },
+                new object[] { "sometest.dll --interactive", "sometest.dll", "--interactive" },
+                new object[] { "sometest.dll --no-build", "sometest.dll", "--no-build" },
+                new object[] { "sometest.dll --no-restore", "sometest.dll", "--no-restore" },
+
+                new object[] {
+                    @"sometest.dll -s testsettings -t -a c:\path -f net451 -d log.txt --configuration Debug --output C:\foo --runtime win10-x64 --results-directory c:\temp\ --no-build --no-restore --interactive",
+                    @"sometest.dll --settings:testsettings --listtests --testadapterpath:c:\path --framework:net451 --diag:log.txt --resultsdirectory:c:\temp\",
+                    @"--configuration Debug --output C:\foo --runtime win10-x64 --no-build --no-restore --interactive"
+                },
+                new object[] {
+                    @"sometest.dll --settings testsettings --list-tests -a c:\path -f net451 --diag log.txt --collect coverage --blame --configuration Debug --output C:\foo --runtime win10-x64 --results-directory c:\temp\ --no-build --no-restore --interactive",
+                    @"sometest.dll --settings:testsettings --listtests --testadapterpath:c:\path --framework:net451 --diag:log.txt --collect:coverage --blame --resultsdirectory:c:\temp\",
+                    @"--configuration Debug --output C:\foo --runtime win10-x64 --no-build --no-restore --interactive"
+                }
+            };
+
+            public static IEnumerable<object[]> ArgTestCases
+            {
+                get { return argTestCases; }
+            }
+
+            public static IEnumerable<object[]> VerbosityTestCases
+            {
+                get { return verbosityTestCases; }
+            }
+
+            public static IEnumerable<object[]> IgnoredArgTestCases
+            {
+                get { return ignoredTestCases; }
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Adding the code to make sure we are able to run dll/exe using the dotnet test command.
Convert the given args to vstest parsable args and invoke vstest.

Fixes: microsoft/vstest#1453