### PR TITLE
Add missing host options to dotnet help.

### DIFF
--- a/src/dotnet/commands/dotnet-help/HelpUsageText.cs
+++ b/src/dotnet/commands/dotnet-help/HelpUsageText.cs
@@ -9,10 +9,12 @@ $@"{LocalizableStrings.Usage}: dotnet [runtime-options] [path-to-application] [a
 {LocalizableStrings.ExecutionUsageDescription}
 
 runtime-options:
-  --additionalprobingpath <path>   {LocalizableStrings.AdditionalprobingpathDefinition}
+  --additionalprobingpath <path>   {LocalizableStrings.AdditionalProbingPathDefinition}
   --additional-deps <path>         {LocalizableStrings.AdditionalDeps}
+  --depsfile                       {LocalizableStrings.DepsFileDefinition}
   --fx-version <version>           {LocalizableStrings.FxVersionDefinition}
   --roll-forward <setting>         {LocalizableStrings.RollForwardDefinition}
+  --runtimeconfig                  {LocalizableStrings.RuntimeConfigDefinition}
 
 path-to-application:
   {LocalizableStrings.PathToApplicationDefinition}

--- a/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-help/LocalizableStrings.resx
@@ -249,13 +249,13 @@
   <data name="RunDotnetCommandHelpForMore" xml:space="preserve">
     <value>Run 'dotnet [command] --help' for more information on a command.</value>
   </data>
-  <data name="AdditionalprobingpathDefinition" xml:space="preserve">
+  <data name="AdditionalProbingPathDefinition" xml:space="preserve">
     <value>Path containing probing policy and assemblies to probe for.</value>
   </data>
-  <data name="DepsfilDefinition" xml:space="preserve">
+  <data name="DepsFileDefinition" xml:space="preserve">
     <value>Path to &lt;application&gt;.deps.json file.</value>
   </data>
-  <data name="RuntimeconfigDefinition" xml:space="preserve">
+  <data name="RuntimeConfigDefinition" xml:space="preserve">
     <value>Path to &lt;application&gt;.runtimeconfig.json file.</value>
   </data>
   <data name="FxVersionDefinition" xml:space="preserve">

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.cs.xlf
@@ -212,17 +212,17 @@
         <target state="translated">Další informace o příkazu získáte spuštěním příkazu dotnet [příkaz] --help.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">Cesta obsahující testovací zásady a sestavení, která se mají testovat</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">Cesta k souboru &lt;aplikace&gt;.deps.json.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">Cesta k souboru &lt;aplikace&gt;.runtimeconfig.json.</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.de.xlf
@@ -212,17 +212,17 @@
         <target state="translated">Führen Sie "dotnet [command] --help" aus, um weitere Informationen zu einem Befehl zu erhalten.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">Pfad, der die Suchrichtlinie und die zu suchenden Assemblys enthält.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">Pfad zur Datei "&lt;anwendung&gt;.deps.json".</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">Pfad zur Datei "&lt;anwendung&gt;.runtimeconfig.json".</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.es.xlf
@@ -212,17 +212,17 @@
         <target state="translated">Ejecute "dotnet [comando] --help" para más información sobre un comando.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">Ruta de acceso que contiene la directiva de sondeo y los ensamblados para los que realizar el sondeo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">Ruta de acceso al archivo &lt;aplicación&gt;.deps.json.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">Ruta de acceso al archivo &lt;aplicación&gt;.runtimeconfig.json.</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.fr.xlf
@@ -212,17 +212,17 @@
         <target state="translated">Pour plus d'informations sur une commande, exécutez 'dotnet [commande] --help'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">Chemin contenant la stratégie de collecte et les assemblys à collecter.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">Chemin du fichier &lt;application&gt;.deps.json.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">Chemin du fichier &lt;application&gt;.runtimeconfig.json.</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.it.xlf
@@ -212,17 +212,17 @@
         <target state="translated">Per altre informazioni su un comando, eseguire 'dotnet [comando] --help'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">Percorso che contiene i criteri di esecuzione probe e gli assembly per cui eseguire il probe.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">Percorso del file &lt;applicazione&gt;.deps.json.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">Percorso del file &lt;applicazione&gt;.runtimeconfig.json.</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ja.xlf
@@ -212,17 +212,17 @@
         <target state="translated">コマンドに関する詳細情報については、'dotnet [command] --help' を実行します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">調査ポリシーと調査対象アセンブリを含むパス。</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">&lt;application&gt;.deps.json ファイルへのパス。</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">&lt;application&gt;.runtimeconfig.json ファイルへのパス。</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ko.xlf
@@ -212,17 +212,17 @@
         <target state="translated">명령에 대한 자세한 정보를 보려면 'dotnet [명령] --help'를 실행합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">프로브할 프로빙 정책 및 어셈블리를 포함하는 경로입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">&lt;application&gt;.deps.json 파일의 경로입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">&lt;application&gt;.runtimeconfig.json 파일의 경로입니다.</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pl.xlf
@@ -212,17 +212,17 @@
         <target state="translated">Uruchom polecenie „dotnet [polecenie] --help”, aby uzyskać więcej informacji o danym poleceniu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">Ścieżka zawierająca zasady sondowania i zestawy do sondowania.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">Ścieżka do pliku &lt;aplikacja&gt;.deps.json.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">Ścieżka do pliku &lt;aplikacja&gt;.runtimeconfig.json.</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.pt-BR.xlf
@@ -212,17 +212,17 @@
         <target state="translated">Execute 'dotnet [command] --help' para obter mais informações sobre um comando.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">Caminho contendo a política de investigação e os assemblies a investigar.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">Caminho para o arquivo &lt;application&gt;.deps.json.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">Caminho para o arquivo &lt;application&gt;. runtimeconfig.json.</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.ru.xlf
@@ -212,17 +212,17 @@
         <target state="translated">Для получения дополнительных сведений о команде выполните команду "dotnet [команда] --help".</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">Путь к политике проверки и проверяемым сборкам.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">Путь к файлу &lt;приложение&gt;.deps.json.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">Путь к файлу &lt;приложение&gt;.runtimeconfig.json.</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.tr.xlf
@@ -212,17 +212,17 @@
         <target state="translated">Bir komut hakkında daha fazla bilgi için 'dotnet [komut] --help' komutunu çalıştırın.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">Yoklama ilkesini ve yoklanacak bütünleştirilmiş kodları içeren yol.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">&lt;application&gt;.deps.json dosyasının yolu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">&lt;application&gt;.runtimeconfig.json dosyasının yolu.</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hans.xlf
@@ -212,17 +212,17 @@
         <target state="translated">运行 "dotnet [command] --help"，获取有关命令的详细信息。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">要探测的包含探测策略和程序集的路径。</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">指向 &lt;application&gt;.deps.json 文件的路径。</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">指向 &lt;application&gt;.runtimeconfig.json 文件的路径。</target>
         <note />

--- a/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-help/xlf/LocalizableStrings.zh-Hant.xlf
@@ -212,17 +212,17 @@
         <target state="translated">如需命令的詳細資訊，請執行 'dotnet [command] --help'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AdditionalprobingpathDefinition">
+      <trans-unit id="AdditionalProbingPathDefinition">
         <source>Path containing probing policy and assemblies to probe for.</source>
         <target state="translated">包含探查原則及要探查之組件的路徑。</target>
         <note />
       </trans-unit>
-      <trans-unit id="DepsfilDefinition">
+      <trans-unit id="DepsFileDefinition">
         <source>Path to &lt;application&gt;.deps.json file.</source>
         <target state="translated">&lt;application&gt;.deps.json 檔案的路徑。</target>
         <note />
       </trans-unit>
-      <trans-unit id="RuntimeconfigDefinition">
+      <trans-unit id="RuntimeConfigDefinition">
         <source>Path to &lt;application&gt;.runtimeconfig.json file.</source>
         <target state="translated">&lt;application&gt;.runtimeconfig.json 檔案的路徑。</target>
         <note />

--- a/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
+++ b/test/dotnet-help.Tests/GivenThatIWantToShowHelpForDotnetCommand.cs
@@ -21,8 +21,10 @@ Execute a .NET Core application.
 runtime-options:
   --additionalprobingpath <path>   Path containing probing policy and assemblies to probe for.
   --additional-deps <path>         Path to additional deps.json file.
+  --depsfile                       Path to <application>.deps.json file.
   --fx-version <version>           Version of the installed Shared Framework to use to run the application.
   --roll-forward <setting>         Roll forward to framework version  (LatestPatch, Minor, LatestMinor, Major, LatestMajor, Disable).
+  --runtimeconfig                  Path to <application>.runtimeconfig.json file.
 
 path-to-application:
   The path to an application .dll file to execute.


### PR DESCRIPTION
This commit adds help text for the `--depsfile` and `--runtimeconfig` host
options to `dotnet help` and `dotnet --help`.

Fixes #12444.
