### PR TITLE
Updating branding to rc2

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
   <!-- Repo Version Information -->
   <PropertyGroup>
     <VersionPrefix>3.0.100</VersionPrefix>
-    <PreReleaseVersionLabel>rc1</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>rc2</PreReleaseVersionLabel>
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>


### PR DESCRIPTION
Marking draft because we need release/3.0.1xx to be merged into release/3.0.100-preview9 before merging this PR.