### PR TITLE
Fix resource names that regressed with move to arcade

### DIFF
--- a/build/GenerateResxSource.targets
+++ b/build/GenerateResxSource.targets
@@ -1,6 +1,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="CustomizeXlfSourceNames"
+  <Target Name="_CustomizeXlfSourceNames"
+          DependsOnTargets="_CustomizeResourceNames"
           BeforeTargets="PrepareResourceNames;GatherXlf"
           >
     <ItemGroup>

--- a/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
+++ b/test/dotnet-sln-add.Tests/GivenDotnetSlnAdd.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using Xunit;
 using Xunit.Abstractions;
+using SlnLocalizableStrings = Microsoft.DotNet.Tools.Sln;
 
 namespace Microsoft.DotNet.Cli.Sln.Add.Tests
 {
@@ -1241,7 +1242,7 @@ EndGlobal
                 .WithWorkingDirectory(solutionDirectory)
                 .ExecuteWithCapturedOutput($"sln App.sln add --solution-folder blah --in-root {projectToAdd}");
             cmd.Should().Fail();
-            cmd.StdErr.Should().Be("The --solution-folder and --in-root options cannot be used together; use only one of the options.");
+            cmd.StdErr.Should().Be(SlnLocalizableStrings.LocalizableStrings.SolutionFolderAndInRootMutuallyExclusive);
             cmd.StdOut.Should().BeVisuallyEquivalentToIfNotLocalized(HelpText);
 
             File.ReadAllText(solutionPath)


### PR DESCRIPTION
## Description

Due to a build misconfiguration, most resources in satellite assemblies have incorrect names.

## Customer Impact

`dotnet` is almost entirely unlocalized. Majority of text that should be translated is shown in English.

### Workaround

None.

## Regression?

Yes, works correctly in 2.x.  Introduced by move to arcade in early 3.0 preview.

## Testing

Found by vendors.

Validated fix using local build + DOTNET_CLI_UI_LANGUAGE=de + `dotnet help`, checked resource names in ILSpy.

## Risk
Low

-- 

The setting of EmbeddedResource.ManifestResourceName was moved to arcade, but happens too late in the build to have the desired effect.

This change adds a dependency on to the arcade target to force it to happen with correct timing.

Filed https://github.com/dotnet/xliff-tasks/issues/206 so that neither arcade nor cli need any of this build customization for this case.