### PR TITLE
Add Dockerfile for manpage tool and fixes

### DIFF
--- a/Documentation/manpages/tool/Dockerfile
+++ b/Documentation/manpages/tool/Dockerfile
@@ -1,0 +1,7 @@
+FROM pandoc/core:2.7.2
+
+ENTRYPOINT ["/usr/bin/env"]
+
+RUN apk add py-pip && python -m pip install pandocfilters
+
+CMD /manpages/tool/update-man-pages.sh

--- a/Documentation/manpages/tool/README.md
+++ b/Documentation/manpages/tool/README.md
@@ -2,6 +2,10 @@
 
 Utility to update dotnet-cli documentation from https://github.com/dotnet/docs.
 
+## Docker Usage
+
+If docker is installed, then simply execute `run_docker.sh` to update manpages.
+
 ## Prerequisites
 
 * Unix OS

--- a/Documentation/manpages/tool/man-pandoc-filter.py
+++ b/Documentation/manpages/tool/man-pandoc-filter.py
@@ -5,7 +5,7 @@
 #
 
 import copy
-from pandocfilters import toJSONFilters, Para, Str, Header, Space, Link
+from pandocfilters import toJSONFilters, Para, Str, Header, Space
 
 def remove_includes(key, value, format, meta):
     if key == 'Para' and value[0]['c'] == '[!INCLUDE':
@@ -37,9 +37,7 @@ def demote_net_core_1_2(key, value, format, meta):
 def remove_references(key, value, format, meta):
     if key == 'Link':
         pass
-        if value[1][0]['t'] == 'Code':
-            return value[1][0]
-        return Str(' '.join([e['c'] for e in value[1] if 'c' in e.keys()]))
+        return value[1]
     return None
 
 def main():

--- a/Documentation/manpages/tool/run_docker.sh
+++ b/Documentation/manpages/tool/run_docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+MANPAGE_TOOL_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+
+docker build -t dotnet-cli-manpage-tool "$MANPAGE_TOOL_DIR"
+
+docker run --volume="$MANPAGE_TOOL_DIR"/..:/manpages dotnet-cli-manpage-tool

--- a/Documentation/manpages/tool/run_docker.sh
+++ b/Documentation/manpages/tool/run_docker.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
+#
+# Copyright (c) .NET Foundation and contributors. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
 
 MANPAGE_TOOL_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 

--- a/Documentation/manpages/tool/update-man-pages.sh
+++ b/Documentation/manpages/tool/update-man-pages.sh
@@ -4,31 +4,27 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-MANPAGE_TOOL_DIR=$(cd $(dirname $0); pwd)
+MANPAGE_TOOL_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 
-cd $MANPAGE_TOOL_DIR/../sdk
+cd "$MANPAGE_TOOL_DIR"/../sdk || exit
 
 echo "Downloading dotnet/docs master"
 
-if [ -x "$(command -v curl)" ]; then
-  curl -sSLO https://github.com/dotnet/docs/archive/master.zip > /dev/null
-elif [ -x "$(command -v wget)" ]; then
-  wget -q https://github.com/dotnet/docs/archive/master.zip > /dev/null
+if command -v git 2>&1 /dev/null; then
+  git clone https://github.com/dotnet/docs --single-branch --branch master --depth 1 docs-master
+elif command -v curl 2>&1 /dev/null; then
+  curl -sSL https://github.com/dotnet/docs/archive/master.tar.gz | tar -xvz > /dev/null
+elif command -v wget 2>&1 /dev/null; then
+  wget -qO- https://github.com/dotnet/docs/archive/master.tar.gz | tar -xvz > /dev/null
 else
-  echo "Install curl or wget to proceed"
+  echo "Install git, curl or wget to proceed"
   exit 1
 fi
-
-echo "Extracting master.zip"
-unzip -o master.zip > /dev/null
-
-echo "Removing master.zip"
-rm master.zip*
 
 ls docs-master/docs/core/tools/dotnet*.md | while read -r line;
   do
     echo "Working on $line"
-    pandoc -s -t man -V section=1 -V header=".NET Core" --column=500 --filter $MANPAGE_TOOL_DIR/man-pandoc-filter.py "$line" -o "$(basename ${line%.md}.1)"
+    pandoc -s -t man -V section=1 -V header=".NET Core" --column=500 --filter "$MANPAGE_TOOL_DIR"/man-pandoc-filter.py "$line" -o "$(basename "${line%.md}".1)"
 done
 
 rm -rf docs-master


### PR DESCRIPTION
* Simplify usage with docker: `run_docker.sh`
* Add support for git to acquire dotnet/docs repo
* Fix bug in `remove_references` filter which was throwing on processing `dotnet-test.md`
  * filter breaks with this pattern: ``[some `code`](/path)``
  * change filter to return nested AST generated array as is (without next sibling, which is path)
    to fulfill its purpose

---

I will send separate PR for manpage update.