### PR TITLE
Handle linux distributions without a VERSION_ID in dotnet-install.sh

### DIFF
--- a/scripts/obtain/dotnet-install.sh
+++ b/scripts/obtain/dotnet-install.sh
@@ -144,7 +144,7 @@ get_linux_platform_name() {
     else
         if [ -e /etc/os-release ]; then
             . /etc/os-release
-            echo "$ID.$VERSION_ID"
+            echo "$ID${VERSION_ID:+.${VERSION_ID}}"
             return 0
         elif [ -e /etc/redhat-release ]; then
             local redhatRelease=$(</etc/redhat-release)
@@ -202,7 +202,7 @@ get_legacy_os_name() {
     else
         if [ -e /etc/os-release ]; then
             . /etc/os-release
-            os=$(get_legacy_os_name_from_platform "$ID.$VERSION_ID" || echo "")
+            os=$(get_legacy_os_name_from_platform "$ID${VERSION_ID:+.${VERSION_ID}}" || echo "")
             if [ -n "$os" ]; then
                 echo "$os"
                 return 0


### PR DESCRIPTION
Some examples of such rolling distributions include Gentoo (`gentoo-x64` in the RID catalog) and Arch Linux.

This uses the [alternate value for a parameter expansion](https://wiki.bash-hackers.org/syntax/pe#use_an_alternate_value) syntax for bash, basically saying "if `VERSION_ID` is set and not empty, expand this value to `.${VERSION_ID}`".

cc @alucryd 
