### PR TITLE
fix typo in RuntimeFrameworkVersion under FrameworkReference

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,6 +11,6 @@
     <FrameworkReference
         Update="Microsoft.NETCore.App" 
         TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimePackageersion)" />
+        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimePackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
`MicrosoftNETCoreAppRuntimePackageVersion` is used by `RuntimeFrameworkVersion` under `FrameworkReference` in `Directory.Build.targets` as well as `global.json`'s tools.runtimes.dotnet. It is defined in Versions.props below

https://github.com/dotnet/cli/blob/edb240070dbac6ca80122d06dad51bf9221df62f/eng/Versions.props#L21-L22

However, it was incorrectly typed in `RuntimeFrameworkVersion` under `FrameworkReference` in `Directory.Build.targets`. This PR fixes that typo
