### PR TITLE
Switch to label.N form for pre-release label

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,8 @@
   <!-- Repo Version Information -->
   <PropertyGroup>
     <VersionPrefix>5.0.100</VersionPrefix>
-    <PreReleaseVersionLabel>alpha1</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
   </PropertyGroup>
   <!-- Production Dependencies -->
   <PropertyGroup>


### PR DESCRIPTION
In order to facilitate better preview sorting, switch to label.N form for the pre-release label.
