### PR TITLE
Source-build fixes for 3.0.x.

### DIFF
--- a/TestAssets/Directory.Build.props
+++ b/TestAssets/Directory.Build.props
@@ -1,3 +1,5 @@
 <Project>
-  <!-- Empty Directory.Build.props file to prevent test asset projects from picking up the repo's Directory.Build.props' -->
+  <PropertyGroup>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+  </PropertyGroup>
 </Project>

--- a/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
@@ -6,6 +6,7 @@
     <!-- netcoreapp2.2 is the maximum TFM project tools support -->
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <OutputType>Exe</OutputType>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -48,7 +48,7 @@
     <MicrosoftTemplateEngineCliLocalizationPackageVersion>$(MicrosoftTemplateEngineCliPackageVersion)</MicrosoftTemplateEngineCliLocalizationPackageVersion>
     <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>$(MicrosoftTemplateEngineCliPackageVersion)</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
     <MicrosoftTemplateEngineUtilsPackageVersion>$(MicrosoftTemplateEngineCliPackageVersion)</MicrosoftTemplateEngineUtilsPackageVersion>
-    <MicrosoftTemplateEngineTemplateSearchCommonVersion>$(MicrosoftTemplateEngineCliPackageVersion)</MicrosoftTemplateEngineTemplateSearchCommonVersion>
+    <MicrosoftTemplateSearchCommonPackageVersion>$(MicrosoftTemplateEngineCliPackageVersion)</MicrosoftTemplateSearchCommonPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/CliCommandLineParser -->

--- a/src/dotnet/dotnet.csproj
+++ b/src/dotnet/dotnet.csproj
@@ -70,7 +70,7 @@
     <PackageReference Include="Microsoft.TemplateEngine.Cli.Localization" Version="$(MicrosoftTemplateEngineCliLocalizationPackageVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="$(MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion)" />
     <PackageReference Include="Microsoft.TemplateEngine.Utils" Version="$(MicrosoftTemplateEngineUtilsPackageVersion)" />
-    <PackageReference Include="Microsoft.TemplateSearch.Common" Version="$(MicrosoftTemplateEngineTemplateSearchCommonVersion)" />
+    <PackageReference Include="Microsoft.TemplateSearch.Common" Version="$(MicrosoftTemplateSearchCommonPackageVersion)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(IncludeAspNetCoreRuntime)' != 'false' ">
     <PackageReference Include="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="$(MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion)" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,5 +3,6 @@
 
   <PropertyGroup>
     <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Retargeted version of https://github.com/dotnet/cli/pull/12781.

- Fixed PackageVersion property name.
- Excluded a couple more projects from source-build.