### PR TITLE
--skip-duplicate added to `dotnet nuget push` parsing

### DIFF
--- a/src/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
+++ b/src/dotnet/commands/dotnet-nuget/NuGetCommandParser.cs
@@ -54,7 +54,8 @@ namespace Microsoft.DotNet.Cli
                     Create.Option("-d|--disable-buffering", Parser.CompletionOnlyDescription),
                     Create.Option("-n|--no-symbols", Parser.CompletionOnlyDescription),
                     Create.Option("--no-service-endpoint", Parser.CompletionOnlyDescription),
-                    Create.Option("--interactive", Parser.CompletionOnlyDescription)
+                    Create.Option("--interactive", Parser.CompletionOnlyDescription),
+                    Create.Option("--skip-duplicate", Parser.CompletionOnlyDescription)
                     ));
     }
 }

--- a/test/dotnet.Tests/CommandTests/CompleteCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/CompleteCommandTests.cs
@@ -177,6 +177,7 @@ namespace Microsoft.DotNet.Tests.Commands
                 "--help",
                 "--no-service-endpoint",
                 "--no-symbols",
+                "--skip-duplicate",
                 "--source",
                 "--symbol-api-key",
                 "--symbol-source",


### PR DESCRIPTION
Fix for https://github.com/NuGet/Home/issues/8778

New option --skip-duplicate needs to be added to the dotnet parser for `nuget push` to support <tab> auto-completion and telemetry.

The [NuGet code changes](https://github.com/NuGet/NuGet.Client/pull/3083) to add this command were inserted into dotnet/cli [release/3.1.1xx](https://github.com/dotnet/cli/pull/12965)

//cc @livarcocc @rrelyea