### PR TITLE
[release/2.1.5xx] Publish VS insertion nupkgs to blob feed

### DIFF
--- a/build/publish/PublishNupkgToBlobFeed.targets
+++ b/build/publish/PublishNupkgToBlobFeed.targets
@@ -13,6 +13,20 @@
                            Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' " >
         <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
       </NupkgsForPublishing>
+
+      <VSNupkgsForPublishing
+        Include="$(PackagesDirectory)/VS.Redist.Common.Net.Core.SDK.$(Architecture).*.nupkg"
+        Condition=" '$(OS)' == 'Windows_NT' " />
+      <VSNupkgsForPublishing
+        Include="$(PackagesDirectory)/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.*.nupkg"
+        Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' " />
+      <VSNupkgsForPublishing
+        Include="$(PackagesDirectory)/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.swr"
+        Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' " />
+
+      <NupkgsForPublishing Include="@(VSNupkgsForPublishing)">
+        <ManifestArtifactData>NonShipping=true</ManifestArtifactData>
+      </NupkgsForPublishing>
     </ItemGroup>
 
     <ItemGroup>

--- a/build/publish/PublishNupkgToBlobFeed.targets
+++ b/build/publish/PublishNupkgToBlobFeed.targets
@@ -20,9 +20,6 @@
       <VSNupkgsForPublishing
         Include="$(PackagesDirectory)/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.*.nupkg"
         Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' " />
-      <VSNupkgsForPublishing
-        Include="$(PackagesDirectory)/VS.Redist.Common.Net.Core.SDK.MSBuildExtensions.swr"
-        Condition=" '$(OS)' == 'Windows_NT' And '$(Architecture)' == 'x64' " />
 
       <NupkgsForPublishing Include="@(VSNupkgsForPublishing)">
         <ManifestArtifactData>NonShipping=true</ManifestArtifactData>


### PR DESCRIPTION
Allows prodcon infrastructure to publish the VS insertion nupkgs.

Patterns copied from Publish.targets:

https://github.com/dotnet/cli/blob/b33df27d250772dadd4fda805ff65a3eb38a2b78/build/Publish.targets#L51-L54