### PR TITLE
Read default language for `dotnet new` from env var

### DIFF
--- a/src/dotnet/commands/dotnet-new/NewCommandShim.cs
+++ b/src/dotnet/commands/dotnet-new/NewCommandShim.cs
@@ -63,9 +63,12 @@ namespace Microsoft.DotNet.Tools.New
                 typeof(NupkgUpdater).GetTypeInfo().Assembly
             });
 
+            string preferredLangEnvVar = Environment.GetEnvironmentVariable("DOTNET_NEW_PREFERRED_LANG");
+            string preferredLang = string.IsNullOrWhiteSpace(preferredLangEnvVar)? "C#" : preferredLangEnvVar;
+
             var preferences = new Dictionary<string, string>
             {
-                { "prefs:language", "C#" },
+                { "prefs:language", preferredLang },
                 { "dotnet-cli-version", Product.Version },
                 { "RuntimeFrameworkVersion", new Muxer().SharedFxVersion },
                 { "NetStandardImplicitPackageVersion", new FrameworkDependencyFile().GetNetStandardLibraryVersion() },

--- a/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
+++ b/test/dotnet-new.Tests/GivenThatIWantANewApp.cs
@@ -35,5 +35,49 @@ namespace Microsoft.DotNet.New.Tests
 
             result.Should().Fail();
         }
+
+        [Fact]
+        public void When_dotnet_new_is_invoked_with_preferred_lang_env_var_set()
+        {
+            var rootPath = TestAssets.CreateTestDirectory().FullName;
+
+            new NewCommand()
+                .WithWorkingDirectory(rootPath)
+                .WithEnvironmentVariable("DOTNET_NEW_PREFERRED_LANG", "F#")
+                .Execute($"console --debug:ephemeral-hive --no-restore -n f1")
+                .Should().Pass();
+
+            string expectedFsprojPath = Path.Combine(rootPath, "f1", "f1.fsproj");
+            Assert.True(File.Exists(expectedFsprojPath), $"expected '{expectedFsprojPath}' but was not found");
+        }
+
+        [Fact]
+        public void When_dotnet_new_is_invoked_default_is_csharp()
+        {
+            var rootPath = TestAssets.CreateTestDirectory().FullName;
+
+            new NewCommand()
+                .WithWorkingDirectory(rootPath)
+                .Execute($"console --debug:ephemeral-hive --no-restore -n c1")
+                .Should().Pass();
+
+            string expectedCsprojPath = Path.Combine(rootPath, "c1", "c1.csproj");
+            Assert.True(File.Exists(expectedCsprojPath), $"expected '{expectedCsprojPath}' but was not found");
+        }
+
+        [Fact]
+        public void When_dotnet_new_is_invoked_with_preferred_lang_env_var_empty()
+        {
+            var rootPath = TestAssets.CreateTestDirectory().FullName;
+
+            new NewCommand()
+                .WithWorkingDirectory(rootPath)
+                .WithEnvironmentVariable("DOTNET_NEW_PREFERRED_LANG", "")
+                .Execute($"console --debug:ephemeral-hive --no-restore -n c1")
+                .Should().Pass();
+
+            string expectedCsprojPath = Path.Combine(rootPath, "c1", "c1.csproj");
+            Assert.True(File.Exists(expectedCsprojPath), $"expected '{expectedCsprojPath}' but was not found");
+        }
     }
 }


### PR DESCRIPTION
Read `DOTNET_NEW_PREFERRED_LANG` as default language for `dotnet new`.
If not set, the default continue to be `C#`

Currently to create F# projects, we need to specify `-lang f#` foreach `dotnet new` invocation.
It's really annoying, and atm `dotnet new` doesnt yet support set the preference property.

This option can be removed later, when `dotnet new` support set the default language (as normal config)

With this pr

```batch
set DOTNET_NEW_PREFERRED_LANG=F#
dotnet new console
dotnet new lib
```

/cc @cartermp

ref https://github.com/dotnet/sdk/issues/4224
