### PR TITLE
[release/2.1.5xx] Update feed tasks versions

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -76,7 +76,7 @@
 
   <!-- infrastructure and test only dependencies -->
   <PropertyGroup>
-    <BuildTasksFeedToolVersion>2.1.0-rc1-03130-05</BuildTasksFeedToolVersion>
+    <BuildTasksFeedToolVersion>2.1.0-rc1-04626-02</BuildTasksFeedToolVersion>
     <VersionToolsVersion>$(BuildTasksFeedToolVersion)</VersionToolsVersion>
     <DotnetDebToolVersion>2.0.0</DotnetDebToolVersion>
   </PropertyGroup>


### PR DESCRIPTION
Fix up the feed task version to match core-setup's 2.1 branch. Going on the hunch that the errors seen are not seen in core-setup.