### PR TITLE
Use Azure Artifacts instead of MyGet

### DIFF
--- a/TestAssets/TestPackages/dotnet-desktop-and-portable/NuGet.Config
+++ b/TestAssets/TestPackages/dotnet-desktop-and-portable/NuGet.Config
@@ -3,7 +3,7 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/NugetConfigFile.targets
+++ b/build/NugetConfigFile.targets
@@ -18,21 +18,21 @@
 
       <NugetConfigCLIFeeds>
         <![CDATA[
-    <add key="myget-vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
+    <add key="myget-vstest" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="BlobFeed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="aspnetcore-dev" value="https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json" />
-    <add key="templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
-  	<add key="websdk" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
-    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="aspnetcore-dev" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="templating" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="websdk" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="roslyn" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="nuget-build" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
     <add key="linux-musl-bootstrap-feed" value="https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180420-03/aspnet-inputs/index.json" />
-    <add key="dotnet-msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
-    <add key="myget-vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
+    <add key="dotnet-msbuild" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
+    <add key="myget-vstest" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
     <add key="BlobFeed-2.1.3-runtime" value="https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180725-02/final/index.json"/>
-    <add key="fsharp" value="https://dotnet.myget.org/F/fsharp/api/v3/index.json" />
+    <add key="fsharp" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json" />
         ]]>
       </NugetConfigCLIFeeds>
 

--- a/test/Microsoft.DotNet.Tools.Tests.Utilities/NuGetConfig.cs
+++ b/test/Microsoft.DotNet.Tools.Tests.Utilities/NuGetConfig.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 <packageSources>
 <!--To inherit the global NuGet package sources remove the <clear/> line below -->
 <clear />
-<add key=""dotnet-core"" value=""https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"" />
+<add key=""dotnet-core"" value=""https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json"" />
 <add key=""api.nuget.org"" value=""https://api.nuget.org/v3/index.json"" />
 </packageSources>
 </configuration>";
@@ -33,7 +33,7 @@ namespace Microsoft.DotNet.Tools.Test.Utilities
 <clear />
 <add key=""Test Source"" value=""{0}"" />
 <add key=""api.nuget.org"" value=""https://api.nuget.org/v3/index.json"" />
-<add key=""dotnet-core"" value=""https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"" />
+<add key=""dotnet-core"" value=""https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json"" />
 </packageSources>
 </configuration>";
 

--- a/test/dotnet.Tests/ParserTests/RestoreParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/RestoreParserTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tests.ParserTests
             var restore =
                 Parser.Instance
                       .Parse(
-                          @"dotnet restore --no-cache --packages ""D:\OSS\corefx\packages"" --source https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json --source https://dotnet.myget.org/F/dotnet-core/api/v3/index.json --source https://api.nuget.org/v3/index.json D:\OSS\corefx\external\runtime\runtime.depproj")
+                          @"dotnet restore --no-cache --packages ""D:\OSS\corefx\packages"" --source https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json --source https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json --source https://api.nuget.org/v3/index.json D:\OSS\corefx\external\runtime\runtime.depproj")
                       .AppliedCommand();
 
             restore
@@ -63,8 +63,8 @@ namespace Microsoft.DotNet.Tests.ParserTests
                 .Arguments
                 .Should()
                 .BeEquivalentTo(
-                    "https://dotnet.myget.org/F/dotnet-buildtools/api/v3/index.json",
-                    "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json",
+                    "https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json",
+                    "https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json",
                     "https://api.nuget.org/v3/index.json");
         }
     }


### PR DESCRIPTION
As part of [moving to Azure Artifacts from MyGet](https://github.com/dotnet/arcade/blob/master/Documentation/MigrationPlan/MyGetFeeds.md), point all MyGet feed sources to new Azure Artifacts feed.