### PR TITLE
Use latest 3.x version of WiX to ensure embedded BA assemblies are signed

### DIFF
--- a/build/package/Installer.MSI.targets
+++ b/build/package/Installer.MSI.targets
@@ -2,7 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <!-- AcquireWix Properties -->
     <PropertyGroup>
-      <WixVersion>3.10.4</WixVersion>
+      <WixVersion>3.14.0.4118</WixVersion>
       <WixDownloadUrl>https://dotnetcli.azureedge.net/build/wix/wix.$(WixVersion).zip</WixDownloadUrl>
       <WixRoot>$(IntermediateDirectory)/WixTools/$(WixVersion)</WixRoot>
       <WixDestinationPath>$(WixRoot)/WixTools.$(WixVersion).zip</WixDestinationPath>


### PR DESCRIPTION
WiX contains embedded assemblies that were unsigned in earlier versions of 3.x. This causes Device Guard to block the installer from running. In 3.14.x, these assemblies are now signed.