### PR TITLE
[relelase/3.1.1xx] Re-enable SDL validation

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -177,3 +177,15 @@ stages:
   - template: /eng/common/templates/post-build/post-build.yml
     parameters:
       enableSymbolValidation: false
+      SDLValidationParameters:
+        enable: true
+        params: ' -SourceToolsList @("policheck","credscan")
+        -TsaInstanceURL $(_TsaInstanceURL)
+        -TsaProjectName $(_TsaProjectName)
+        -TsaNotificationEmail $(_TsaNotificationEmail)
+        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
+        -TsaBugAreaPath $(_TsaBugAreaPath)
+        -TsaIterationPath $(_TsaIterationPath)
+        -TsaRepositoryName "dotnet-cli"
+        -TsaCodebaseName "dotnet-cli"
+        -TsaPublish $True'


### PR DESCRIPTION
We can re-enable this now that we've gotten an arcade update