### PR TITLE
Switch to 1ES servicing pools on release/3.1.4xx

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -43,11 +43,11 @@ stages:
       agentOs: Windows_NT
       pool:
         ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          name: NetCorePublic-Pool
-          queue: buildpool.windows.10.amd64.vs2017.open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals build.windows.10.amd64.vs2017.open
         ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          name: NetCoreInternal-Pool
-          queue: buildpool.windows.10.amd64.vs2017
+          name: NetCore1ESPool-Svc-Internal
+          demands: ImageOverride -equals build.windows.10.amd64.vs2017
       timeoutInMinutes: 180
       strategy:
         matrix:


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/core-eng/issues/14276